### PR TITLE
feat: Adding execute and queryJson to DuckDbConnector

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "react-dom": "^18.0.0",
     "remove": "^0.1.5",
     "shx": "^0.3.4",
-    "turbo": "^2.4.4",
+    "turbo": "^2.5.3",
     "typedoc": "^0.27.9",
     "typescript": "^5.8.2",
     "vitepress": "^1.6.3"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "repository": "git@github.com:sqlrooms/sqlrooms.git",
   "author": "Ilya Boyandin <ilya@boyandin.me>",
   "private": true,
-  "packageManager": "pnpm@10.7.0",
+  "packageManager": "pnpm@10.10.0",
   "workspaces": [
     "packages/*",
     "examples/*"

--- a/packages/duckdb/src/connectors/BaseDuckDbConnector.ts
+++ b/packages/duckdb/src/connectors/BaseDuckDbConnector.ts
@@ -6,6 +6,7 @@ import {
 import * as arrow from 'apache-arrow';
 import {DuckDbConnector} from './DuckDbConnector';
 import {load, loadObjects, loadSpatial} from './load/load';
+import {createTypedRowAccessor} from '../useSql';
 
 export class BaseDuckDbConnector implements DuckDbConnector {
   protected dbPath: string;
@@ -49,9 +50,21 @@ export class BaseDuckDbConnector implements DuckDbConnector {
     }
   }
 
+  async execute(query: string): Promise<void> {
+    await this.query(query);
+  }
+
   async query(query: string): Promise<arrow.Table> {
     // To be implemented by subclasses
     throw new Error('Not implemented', {cause: query});
+  }
+
+  async queryJson(query: string): Promise<Record<string, unknown>[]> {
+    const result = await this.query(query);
+    const rowAccessor = createTypedRowAccessor({
+      arrowTable: result,
+    });
+    return rowAccessor.toArray() as Record<string, unknown>[];
   }
 
   async loadFile(

--- a/packages/duckdb/src/connectors/DuckDbConnector.ts
+++ b/packages/duckdb/src/connectors/DuckDbConnector.ts
@@ -13,10 +13,22 @@ export interface DuckDbConnector {
   destroy(): Promise<void>;
 
   /**
+   * Execute a SQL query without returning a result
+   * @param sql SQL query to execute
+   */
+  execute(sql: string): Promise<void>;
+
+  /**
    * Execute a SQL query and return the result as an Arrow table
    * @param query SQL query to execute
    */
   query(query: string): Promise<arrow.Table>;
+
+  /**
+   * Execute a SQL query and return the result as a JSON object
+   * @param query SQL query to execute
+   */
+  queryJson(query: string): Promise<Record<string, unknown>[]>;
 
   /**
    * Load a file into DuckDB and create a table

--- a/packages/duckdb/src/connectors/DuckDbConnector.ts
+++ b/packages/duckdb/src/connectors/DuckDbConnector.ts
@@ -1,5 +1,6 @@
 import {LoadFileOptions, StandardLoadOptions} from '@sqlrooms/project-config';
 import * as arrow from 'apache-arrow';
+import {TypeMap} from 'apache-arrow';
 
 export interface DuckDbConnector {
   /**
@@ -22,13 +23,13 @@ export interface DuckDbConnector {
    * Execute a SQL query and return the result as an Arrow table
    * @param query SQL query to execute
    */
-  query(query: string): Promise<arrow.Table>;
+  query<T extends TypeMap = any>(query: string): Promise<arrow.Table<T>>;
 
   /**
    * Execute a SQL query and return the result as a JSON object
-   * @param query SQL query to execute
+   * @param query
    */
-  queryJson(query: string): Promise<Record<string, unknown>[]>;
+  queryJson<T = Record<string, any>>(query: string): Promise<Iterable<T>>;
 
   /**
    * Load a file into DuckDB and create a table

--- a/packages/duckdb/src/connectors/WasmDuckDbConnector.ts
+++ b/packages/duckdb/src/connectors/WasmDuckDbConnector.ts
@@ -124,14 +124,6 @@ export class WasmDuckDbConnector extends BaseDuckDbConnector {
     }
   }
 
-  async query(query: string): Promise<arrow.Table> {
-    await this.ensureInitialized();
-    if (!this.conn) {
-      throw new Error('DuckDB connection not initialized');
-    }
-    return await this.conn.query(query);
-  }
-
   async loadFile(
     file: string | File,
     tableName: string,

--- a/packages/duckdb/src/connectors/WasmDuckDbConnector.ts
+++ b/packages/duckdb/src/connectors/WasmDuckDbConnector.ts
@@ -124,6 +124,16 @@ export class WasmDuckDbConnector extends BaseDuckDbConnector {
     }
   }
 
+  async query<T extends arrow.TypeMap = any>(
+    query: string,
+  ): Promise<arrow.Table<T>> {
+    await this.ensureInitialized();
+    if (!this.conn) {
+      throw new Error('DuckDB connection not initialized');
+    }
+    return await this.conn.query(query);
+  }
+
   async loadFile(
     file: string | File,
     tableName: string,

--- a/packages/duckdb/src/index.ts
+++ b/packages/duckdb/src/index.ts
@@ -24,3 +24,7 @@ export {
   SpatialLoadFileOptions,
   isSpatialLoadFileOptions,
 } from '@sqlrooms/project-config';
+export {
+  type TypedRowAccessor,
+  createTypedRowAccessor,
+} from './typedRowAccessor';

--- a/packages/duckdb/src/typedRowAccessor.ts
+++ b/packages/duckdb/src/typedRowAccessor.ts
@@ -1,0 +1,66 @@
+import * as arrow from 'apache-arrow';
+import {TypeMap} from 'apache-arrow';
+
+export interface TypedRowAccessor<T> extends Iterable<T> {
+  /** Returns a typed row at the specified index by converting on demand */
+  getRow(index: number): T;
+  /** Number of rows in the table */
+  length: number;
+  /** Returns an iterator that yields each row in the table */
+  rows(): IterableIterator<T>;
+  /** Returns an array containing all rows in the table */
+  toArray(): T[];
+}
+
+/**
+ * Creates a row accessor wrapper around an Arrow table that provides typed row access.
+ */
+export function createTypedRowAccessor<T extends TypeMap = any>({
+  arrowTable,
+  validate,
+}: {
+  arrowTable: arrow.Table<T>;
+  validate?: (row: unknown) => T;
+}): TypedRowAccessor<T> {
+  let cachedArray: T[] | undefined;
+
+  return {
+    get length() {
+      return arrowTable.numRows;
+    },
+    getRow(index: number): T {
+      const row: Record<string, unknown> = {};
+      arrowTable.schema.fields.forEach((field: arrow.Field) => {
+        const column = arrowTable.getChild(field.name);
+        if (column) {
+          row[field.name] = column.get(index);
+        }
+      });
+
+      // If a validator is provided, use it to validate/parse the row
+      if (validate) {
+        return validate(row);
+      }
+      return row as T;
+    },
+    *rows(): IterableIterator<T> {
+      for (let i = 0; i < this.length; i++) {
+        yield this.getRow(i);
+      }
+    },
+    toArray(): T[] {
+      if (cachedArray) {
+        return cachedArray;
+      }
+      const result: T[] = [];
+      for (let i = 0; i < this.length; i++) {
+        result.push(this.getRow(i));
+      }
+      cachedArray = result;
+      return result;
+    },
+    [Symbol.iterator](): IterableIterator<T> {
+      return this.rows();
+    },
+  };
+}

--- a/packages/duckdb/src/useSql.ts
+++ b/packages/duckdb/src/useSql.ts
@@ -28,7 +28,7 @@ export type DuckDbQueryResult<T> = UseSqlQueryResult<T>;
 /**
  * Creates a row accessor wrapper around an Arrow table that provides typed row access.
  */
-function createTypedRowAccessor<T>({
+export function createTypedRowAccessor<T>({
   arrowTable,
   validate,
 }: {

--- a/packages/duckdb/src/useSql.ts
+++ b/packages/duckdb/src/useSql.ts
@@ -2,79 +2,21 @@ import * as arrow from 'apache-arrow';
 import {useEffect, useState} from 'react';
 import {z} from 'zod';
 import {useStoreWithDuckDb} from './DuckDbSlice';
+import {createTypedRowAccessor, TypedRowAccessor} from './typedRowAccessor';
 
 /**
  * A wrapper interface that exposes the underlying Arrow table,
  * a typed row accessor, and the number of rows.
  */
-export interface UseSqlQueryResult<T> {
+export interface UseSqlQueryResult<T> extends TypedRowAccessor<T> {
   /** The underlying Arrow table */
   arrowTable: arrow.Table;
-  /** Returns a typed row at the specified index by converting on demand */
-  getRow(index: number): T;
-  /** Number of rows in the table */
-  length: number;
-  /** Returns an iterator that yields each row in the table */
-  rows(): IterableIterator<T>;
-  /** Returns an array containing all rows in the table */
-  toArray(): T[];
 }
 
 /**
  * @deprecated Use UseSqlQueryResult instead
  */
 export type DuckDbQueryResult<T> = UseSqlQueryResult<T>;
-
-/**
- * Creates a row accessor wrapper around an Arrow table that provides typed row access.
- */
-export function createTypedRowAccessor<T>({
-  arrowTable,
-  validate,
-}: {
-  arrowTable: arrow.Table;
-  validate?: (row: unknown) => T;
-}): UseSqlQueryResult<T> {
-  let cachedArray: T[] | undefined;
-
-  return {
-    arrowTable,
-    get length() {
-      return arrowTable.numRows;
-    },
-    getRow(index: number): T {
-      const row: Record<string, unknown> = {};
-      arrowTable.schema.fields.forEach((field: arrow.Field) => {
-        const column = arrowTable.getChild(field.name);
-        if (column) {
-          row[field.name] = column.get(index);
-        }
-      });
-
-      // If a validator is provided, use it to validate/parse the row
-      if (validate) {
-        return validate(row);
-      }
-      return row as T;
-    },
-    *rows(): IterableIterator<T> {
-      for (let i = 0; i < this.length; i++) {
-        yield this.getRow(i);
-      }
-    },
-    toArray(): T[] {
-      if (cachedArray) {
-        return cachedArray;
-      }
-      const result: T[] = [];
-      for (let i = 0; i < this.length; i++) {
-        result.push(this.getRow(i));
-      }
-      cachedArray = result;
-      return result;
-    },
-  };
-}
 
 /**
  * A React hook for executing SQL queries with automatic state management.
@@ -213,7 +155,7 @@ export function createTypedRowAccessor<T>({
  * @returns Object containing the query result, loading state, and any error
  *
  * @template Schema The Zod schema type that defines the shape and validation of each row
- * @param schema A Zod schema that defines the expected shape and validation rules for each row
+ * @param zodSchema A Zod schema that defines the expected shape and validation rules for each row
  * @param options Configuration object containing the query and execution control
  * @returns Object containing the validated query result, loading state, and any error
  */
@@ -224,7 +166,7 @@ export function useSql<Row>(options: {query: string; enabled?: boolean}): {
 };
 
 export function useSql<Schema extends z.ZodType>(
-  schema: Schema,
+  zodSchema: Schema,
   options: {
     query: string;
     enabled?: boolean;
@@ -238,16 +180,19 @@ export function useSql<Schema extends z.ZodType>(
 /**
  * Implementation of useSql that handles both overloads
  */
-export function useSql<Row, Schema extends z.ZodType = z.ZodType>(
-  schemaOrOptions: Schema | {query: string; enabled?: boolean},
+export function useSql<
+  Row extends arrow.TypeMap,
+  Schema extends z.ZodType = z.ZodType,
+>(
+  zodSchemaOrOptions: Schema | {query: string; enabled?: boolean},
   maybeOptions?: {query: string; enabled?: boolean},
 ) {
   // Determine if we're using the schema overload
-  const hasSchema = maybeOptions !== undefined;
-  const options = hasSchema
+  const hasZodSchema = maybeOptions !== undefined;
+  const options = hasZodSchema
     ? maybeOptions
-    : (schemaOrOptions as {query: string; enabled?: boolean});
-  const schema = hasSchema ? (schemaOrOptions as Schema) : undefined;
+    : (zodSchemaOrOptions as {query: string; enabled?: boolean});
+  const schema = hasZodSchema ? (zodSchemaOrOptions as Schema) : undefined;
 
   const [data, setData] = useState<UseSqlQueryResult<Row> | undefined>(
     undefined,
@@ -278,7 +223,7 @@ export function useSql<Row, Schema extends z.ZodType = z.ZodType>(
         });
 
         if (isMounted) {
-          setData(rowAccessor);
+          setData({...rowAccessor, arrowTable: result});
         }
       } catch (err) {
         if (isMounted) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,8 +98,8 @@ importers:
         specifier: ^0.3.4
         version: 0.3.4
       turbo:
-        specifier: ^2.4.4
-        version: 2.4.4
+        specifier: ^2.5.3
+        version: 2.5.3
       typedoc:
         specifier: ^0.27.9
         version: 0.27.9(typescript@5.8.2)
@@ -456,28 +456,28 @@ importers:
         version: 10.1.1
       lucide-react:
         specifier: ^0.474.0
-        version: 0.474.0(react@19.0.0)
+        version: 0.474.0(react@18.3.1)
       react:
         specifier: '*'
-        version: 19.0.0
+        version: 18.3.1
       react-dom:
         specifier: '*'
-        version: 19.0.0(react@19.0.0)
+        version: 18.3.1(react@18.3.1)
       react-dropzone:
         specifier: ^14.3.5
-        version: 14.3.8(react@19.0.0)
+        version: 14.3.8(react@18.3.1)
       react-icons:
         specifier: ^5.4.0
-        version: 5.5.0(react@19.0.0)
+        version: 5.5.0(react@18.3.1)
       react-mosaic-component:
         specifier: 5.3.0
-        version: 5.3.0(@types/node@22.13.9)(@types/react@18.3.18)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 5.3.0(@types/node@22.13.9)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       zod:
         specifier: ^3.24.1
         version: 3.24.2
       zustand:
         specifier: ^5.0.3
-        version: 5.0.3(@types/react@18.3.18)(immer@10.1.1)(react@19.0.0)(use-sync-external-store@1.4.0(react@19.0.0))
+        version: 5.0.3(@types/react@18.3.18)(immer@10.1.1)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
     devDependencies:
       '@eslint/js':
         specifier: ^9.17.0
@@ -593,13 +593,13 @@ importers:
     dependencies:
       '@ai-sdk/provider':
         specifier: ^1.0.7
-        version: 1.0.10
+        version: 1.1.0
       '@duckdb/duckdb-wasm':
         specifier: 1.29.0
         version: 1.29.0
       '@openassistant/core':
         specifier: ^0.2.7
-        version: 0.2.7(@ai-sdk/anthropic@1.2.1(zod@3.24.2))(@ai-sdk/google@1.2.3(zod@3.24.2))(openai@4.89.0(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2))(react@19.0.0)
+        version: 0.2.7(@ai-sdk/anthropic@1.2.1(zod@3.24.2))(@ai-sdk/google@1.2.3(zod@3.24.2))(openai@4.89.0(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2))(react@18.3.1)
       '@paralleldrive/cuid2':
         specifier: ^2.2.2
         version: 2.2.2
@@ -626,22 +626,22 @@ importers:
         version: link:../utils
       ai:
         specifier: ^4.1.28
-        version: 4.1.53(react@19.0.0)(zod@3.24.2)
+        version: 4.1.53(react@18.3.1)(zod@3.24.2)
       immer:
         specifier: ^10.1.1
         version: 10.1.1
       lucide-react:
         specifier: ^0.475.0
-        version: 0.475.0(react@19.0.0)
+        version: 0.475.0(react@18.3.1)
       react:
         specifier: '*'
-        version: 19.0.0
+        version: 18.3.1
       react-dom:
         specifier: '*'
-        version: 19.0.0(react@19.0.0)
+        version: 18.3.1(react@18.3.1)
       react-markdown:
         specifier: ^9.0.3
-        version: 9.1.0(@types/react@18.3.18)(react@19.0.0)
+        version: 9.1.0(@types/react@18.3.18)(react@18.3.1)
       zod:
         specifier: ^3.24.1
         version: 3.24.2
@@ -665,25 +665,25 @@ importers:
         version: 10.1.1
       lucide-react:
         specifier: ^0.474.0
-        version: 0.474.0(react@19.0.0)
+        version: 0.474.0(react@18.3.1)
       react:
         specifier: '*'
-        version: 19.0.0
+        version: 18.3.1
       react-dom:
         specifier: '*'
-        version: 19.0.0(react@19.0.0)
+        version: 18.3.1(react@18.3.1)
       zod:
         specifier: ^3.24.1
         version: 3.24.2
       zustand:
         specifier: ^5.0.3
-        version: 5.0.3(@types/react@18.3.18)(immer@10.1.1)(react@19.0.0)(use-sync-external-store@1.4.0(react@19.0.0))
+        version: 5.0.3(@types/react@18.3.18)(immer@10.1.1)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
 
   packages/data-table:
     dependencies:
       '@heroicons/react':
         specifier: '*'
-        version: 2.2.0(react@19.0.0)
+        version: 2.2.0(react@18.3.1)
       '@sqlrooms/duckdb':
         specifier: workspace:*
         version: link:../duckdb
@@ -695,7 +695,7 @@ importers:
         version: link:../utils
       '@tanstack/react-table':
         specifier: ^8.10.7
-        version: 8.21.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 8.21.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/table-core':
         specifier: ^8.10.7
         version: 8.21.2
@@ -704,13 +704,13 @@ importers:
         version: 18.1.0
       react:
         specifier: '*'
-        version: 19.0.0
+        version: 18.3.1
       react-dom:
         specifier: '*'
-        version: 19.0.0(react@19.0.0)
+        version: 18.3.1(react@18.3.1)
       react-virtual:
         specifier: 2.10.4
-        version: 2.10.4(react@19.0.0)
+        version: 2.10.4(react@18.3.1)
 
   packages/dropzone:
     dependencies:
@@ -792,7 +792,7 @@ importers:
         version: 5.2.0(eslint@9.21.0(jiti@2.4.2))
       eslint-plugin-turbo:
         specifier: ^2.3.0
-        version: 2.4.4(eslint@9.21.0(jiti@2.4.2))(turbo@2.4.4)
+        version: 2.4.4(eslint@9.21.0(jiti@2.4.2))(turbo@2.5.3)
       globals:
         specifier: ^15.12.0
         version: 15.15.0
@@ -837,16 +837,16 @@ importers:
         version: link:../ui
       react:
         specifier: '*'
-        version: 19.0.0
+        version: 18.3.1
       react-mosaic-component:
         specifier: 5.3.0
-        version: 5.3.0(@types/node@22.13.9)(@types/react@18.3.18)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 5.3.0(@types/node@22.13.9)(@types/react@18.3.18)(react-dom@19.0.0(react@18.3.1))(react@18.3.1)
 
   packages/monaco-editor:
     dependencies:
       '@monaco-editor/react':
         specifier: ^4.7.0
-        version: 4.7.0(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 4.7.0(monaco-editor@0.52.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@sqlrooms/ui':
         specifier: workspace:*
         version: link:../ui
@@ -855,16 +855,16 @@ importers:
         version: 0.52.2
       react:
         specifier: '*'
-        version: 19.0.0
+        version: 18.3.1
       react-dom:
         specifier: '*'
-        version: 19.0.0(react@19.0.0)
+        version: 18.3.1(react@18.3.1)
 
   packages/mosaic:
     dependencies:
       '@ai-sdk/provider':
         specifier: ^1.0.7
-        version: 1.0.10
+        version: 1.1.0
       '@sqlrooms/duckdb':
         specifier: workspace:*
         version: link:../duckdb
@@ -879,10 +879,10 @@ importers:
         version: 0.12.2
       react:
         specifier: '*'
-        version: 19.0.0
+        version: 18.3.1
       react-dom:
         specifier: '*'
-        version: 19.0.0(react@19.0.0)
+        version: 18.3.1(react@18.3.1)
 
   packages/project:
     dependencies:
@@ -891,13 +891,13 @@ importers:
         version: 10.1.1
       react:
         specifier: '*'
-        version: 19.0.0
+        version: 18.3.1
       zod:
         specifier: ^3.24.1
         version: 3.24.2
       zustand:
         specifier: ^5.0.3
-        version: 5.0.3(@types/react@18.3.18)(immer@10.1.1)(react@19.0.0)(use-sync-external-store@1.4.0(react@19.0.0))
+        version: 5.0.3(@types/react@18.3.18)(immer@10.1.1)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
 
   packages/project-builder:
     dependencies:
@@ -933,19 +933,19 @@ importers:
         version: 10.1.1
       lucide-react:
         specifier: ^0.474.0
-        version: 0.474.0(react@19.0.0)
+        version: 0.474.0(react@18.3.1)
       react:
         specifier: '*'
-        version: 19.0.0
+        version: 18.3.1
       react-mosaic-component:
         specifier: 5.3.0
-        version: 5.3.0(@types/node@22.13.9)(@types/react@18.3.18)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 5.3.0(@types/node@22.13.9)(@types/react@18.3.18)(react-dom@19.0.0(react@18.3.1))(react@18.3.1)
       zod:
         specifier: ^3.24.1
         version: 3.24.2
       zustand:
         specifier: ^5.0.3
-        version: 5.0.3(@types/react@18.3.18)(immer@10.1.1)(react@19.0.0)(use-sync-external-store@1.4.0(react@19.0.0))
+        version: 5.0.3(@types/react@18.3.18)(immer@10.1.1)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
 
   packages/project-config:
     dependencies:
@@ -984,10 +984,10 @@ importers:
         version: link:../utils
       lucide-react:
         specifier: ^0.474.0
-        version: 0.474.0(react@19.0.0)
+        version: 0.474.0(react@18.3.1)
       react:
         specifier: '*'
-        version: 19.0.0
+        version: 18.3.1
       zod:
         specifier: ^3.24.1
         version: 3.24.2
@@ -996,10 +996,10 @@ importers:
     dependencies:
       '@hookform/resolvers':
         specifier: ^3.10.0
-        version: 3.10.0(react-hook-form@7.54.2(react@19.0.0))
+        version: 3.10.0(react-hook-form@7.54.2(react@18.3.1))
       '@monaco-editor/react':
         specifier: ^4.7.0
-        version: 4.7.0(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 4.7.0(monaco-editor@0.52.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@sqlrooms/data-table':
         specifier: workspace:*
         version: link:../data-table
@@ -1038,25 +1038,25 @@ importers:
         version: 10.1.1
       lucide-react:
         specifier: ^0.474.0
-        version: 0.474.0(react@19.0.0)
+        version: 0.474.0(react@18.3.1)
       monaco-editor:
         specifier: ^0.52.2
         version: 0.52.2
       react:
         specifier: '*'
-        version: 19.0.0
+        version: 18.3.1
       react-dom:
         specifier: '*'
-        version: 19.0.0(react@19.0.0)
+        version: 18.3.1(react@18.3.1)
       react-hook-form:
         specifier: ^7.54.2
-        version: 7.54.2(react@19.0.0)
+        version: 7.54.2(react@18.3.1)
       zod:
         specifier: ^3.24.1
         version: 3.24.2
       zustand:
         specifier: ^5.0.3
-        version: 5.0.3(@types/react@18.3.18)(immer@10.1.1)(react@19.0.0)(use-sync-external-store@1.4.0(react@19.0.0))
+        version: 5.0.3(@types/react@18.3.18)(immer@10.1.1)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
     devDependencies:
       '@types/d3-dsv':
         specifier: ^3.0.7
@@ -1132,7 +1132,7 @@ importers:
         version: 1.2.3(@types/react-dom@19.1.1(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-slot':
         specifier: ^1.1.1
-        version: 1.1.2(@types/react@18.3.18)(react@19.0.0)
+        version: 1.2.0(@types/react@18.3.18)(react@19.0.0)
       '@radix-ui/react-switch':
         specifier: ^1.1.2
         version: 1.1.3(@types/react-dom@19.1.1(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -1153,7 +1153,7 @@ importers:
         version: 1.1.8(@types/react-dom@19.1.1(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@tailwindcss/typography':
         specifier: ^0.5.16
-        version: 0.5.16
+        version: 0.5.16(tailwindcss@3.4.17)
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.5.3)
@@ -1186,7 +1186,7 @@ importers:
         version: 3.4.17
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7
+        version: 1.0.7(tailwindcss@3.4.17)
       usehooks-ts:
         specifier: ^3.1.1
         version: 3.1.1(react@19.0.0)
@@ -1247,13 +1247,13 @@ importers:
         version: link:../utils
       react:
         specifier: '*'
-        version: 19.0.0
+        version: 18.3.1
       react-dom:
         specifier: '*'
-        version: 19.0.0(react@19.0.0)
+        version: 18.3.1(react@18.3.1)
       react-vega:
         specifier: ^7.6.0
-        version: 7.6.0(react@19.0.0)(vega-lite@5.23.0(vega@5.32.0(encoding@0.1.13)))(vega@5.32.0(encoding@0.1.13))
+        version: 7.6.0(react@18.3.1)(vega-lite@5.23.0(vega@5.32.0(encoding@0.1.13)))(vega@5.32.0(encoding@0.1.13))
       vega:
         specifier: ^5.31.0
         version: 5.32.0(encoding@0.1.13)
@@ -6872,6 +6872,7 @@ packages:
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
 
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -8247,38 +8248,38 @@ packages:
     resolution: {integrity: sha512-GwIJau9XaA8nLVbUXsN3IlFi7WmQ48gBUrl3FTkkL/XLu/POhBzfmX9hd33FNMX1qAsfl6ozO1iMmW9NC8YniA==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
-  turbo-darwin-64@2.4.4:
-    resolution: {integrity: sha512-5kPvRkLAfmWI0MH96D+/THnDMGXlFNmjeqNRj5grLKiry+M9pKj3pRuScddAXPdlxjO5Ptz06UNaOQrrYGTx1g==}
+  turbo-darwin-64@2.5.3:
+    resolution: {integrity: sha512-YSItEVBUIvAGPUDpAB9etEmSqZI3T6BHrkBkeSErvICXn3dfqXUfeLx35LfptLDEbrzFUdwYFNmt8QXOwe9yaw==}
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@2.4.4:
-    resolution: {integrity: sha512-/gtHPqbGQXDFhrmy+Q/MFW2HUTUlThJ97WLLSe4bxkDrKHecDYhAjbZ4rN3MM93RV9STQb3Tqy4pZBtsd4DfCw==}
+  turbo-darwin-arm64@2.5.3:
+    resolution: {integrity: sha512-5PefrwHd42UiZX7YA9m1LPW6x9YJBDErXmsegCkVp+GjmWrADfEOxpFrGQNonH3ZMj77WZB2PVE5Aw3gA+IOhg==}
     cpu: [arm64]
     os: [darwin]
 
-  turbo-linux-64@2.4.4:
-    resolution: {integrity: sha512-SR0gri4k0bda56hw5u9VgDXLKb1Q+jrw4lM7WAhnNdXvVoep4d6LmnzgMHQQR12Wxl3KyWPbkz9d1whL6NTm2Q==}
+  turbo-linux-64@2.5.3:
+    resolution: {integrity: sha512-M9xigFgawn5ofTmRzvjjLj3Lqc05O8VHKuOlWNUlnHPUltFquyEeSkpQNkE/vpPdOR14AzxqHbhhxtfS4qvb1w==}
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@2.4.4:
-    resolution: {integrity: sha512-COXXwzRd3vslQIfJhXUklgEqlwq35uFUZ7hnN+AUyXx7hUOLIiD5NblL+ETrHnhY4TzWszrbwUMfe2BYWtaPQg==}
+  turbo-linux-arm64@2.5.3:
+    resolution: {integrity: sha512-auJRbYZ8SGJVqvzTikpg1bsRAsiI9Tk0/SDkA5Xgg0GdiHDH/BOzv1ZjDE2mjmlrO/obr19Dw+39OlMhwLffrw==}
     cpu: [arm64]
     os: [linux]
 
-  turbo-windows-64@2.4.4:
-    resolution: {integrity: sha512-PV9rYNouGz4Ff3fd6sIfQy5L7HT9a4fcZoEv8PKRavU9O75G7PoDtm8scpHU10QnK0QQNLbE9qNxOAeRvF0fJg==}
+  turbo-windows-64@2.5.3:
+    resolution: {integrity: sha512-arLQYohuHtIEKkmQSCU9vtrKUg+/1TTstWB9VYRSsz+khvg81eX6LYHtXJfH/dK7Ho6ck+JaEh5G+QrE1jEmCQ==}
     cpu: [x64]
     os: [win32]
 
-  turbo-windows-arm64@2.4.4:
-    resolution: {integrity: sha512-403sqp9t5sx6YGEC32IfZTVWkRAixOQomGYB8kEc6ZD+//LirSxzeCHCnM8EmSXw7l57U1G+Fb0kxgTcKPU/Lg==}
+  turbo-windows-arm64@2.5.3:
+    resolution: {integrity: sha512-3JPn66HAynJ0gtr6H+hjY4VHpu1RPKcEwGATvGUTmLmYSYBQieVlnGDRMMoYN066YfyPqnNGCfhYbXfH92Cm0g==}
     cpu: [arm64]
     os: [win32]
 
-  turbo@2.4.4:
-    resolution: {integrity: sha512-N9FDOVaY3yz0YCOhYIgOGYad7+m2ptvinXygw27WPLQvcZDl3+0Sa77KGVlLSiuPDChOUEnTKE9VJwLSi9BPGQ==}
+  turbo@2.5.3:
+    resolution: {integrity: sha512-iHuaNcq5GZZnr3XDZNuu2LSyCzAOPwDuo5Qt+q64DfsTP1i3T2bKfxJhni2ZQxsvAoxRbuUK5QetJki4qc5aYA==}
     hasBin: true
 
   tw-animate-css@1.2.5:
@@ -8997,6 +8998,16 @@ snapshots:
   '@ai-sdk/provider@1.1.0':
     dependencies:
       json-schema: 0.4.0
+
+  '@ai-sdk/react@1.1.21(react@18.3.1)(zod@3.24.2)':
+    dependencies:
+      '@ai-sdk/provider-utils': 2.1.11(zod@3.24.2)
+      '@ai-sdk/ui-utils': 1.1.17(zod@3.24.2)
+      swr: 2.3.2(react@18.3.1)
+      throttleit: 2.1.0
+    optionalDependencies:
+      react: 18.3.1
+      zod: 3.24.2
 
   '@ai-sdk/react@1.1.21(react@19.0.0)(zod@3.24.2)':
     dependencies:
@@ -10061,9 +10072,13 @@ snapshots:
       '@shikijs/types': 1.29.2
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@heroicons/react@2.2.0(react@19.0.0)':
+  '@heroicons/react@2.2.0(react@18.3.1)':
     dependencies:
-      react: 19.0.0
+      react: 18.3.1
+
+  '@hookform/resolvers@3.10.0(react-hook-form@7.54.2(react@18.3.1))':
+    dependencies:
+      react-hook-form: 7.54.2(react@18.3.1)
 
   '@hookform/resolvers@3.10.0(react-hook-form@7.54.2(react@19.0.0))':
     dependencies:
@@ -10605,12 +10620,12 @@ snapshots:
     dependencies:
       state-local: 1.0.7
 
-  '@monaco-editor/react@4.7.0(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@monaco-editor/react@4.7.0(monaco-editor@0.52.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@monaco-editor/loader': 1.5.0
       monaco-editor: 0.52.2
-      react: 19.0.0
-      react-dom: 19.0.0(react@19.0.0)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@next/env@15.2.4': {}
 
@@ -10856,15 +10871,15 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 23.0.1
 
-  '@openassistant/core@0.2.7(@ai-sdk/anthropic@1.2.1(zod@3.24.2))(@ai-sdk/google@1.2.3(zod@3.24.2))(openai@4.89.0(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2))(react@19.0.0)':
+  '@openassistant/core@0.2.7(@ai-sdk/anthropic@1.2.1(zod@3.24.2))(@ai-sdk/google@1.2.3(zod@3.24.2))(openai@4.89.0(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2))(react@18.3.1)':
     dependencies:
       '@ai-sdk/openai': 1.3.2(zod@3.24.2)
-      '@ai-sdk/react': 1.1.21(react@19.0.0)(zod@3.24.2)
+      '@ai-sdk/react': 1.1.21(react@18.3.1)(zod@3.24.2)
       '@ai-sdk/ui-utils': 1.1.17(zod@3.24.2)
       '@langchain/core': 0.3.43(openai@4.89.0(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2))
-      ai: 4.1.53(react@19.0.0)(zod@3.24.2)
+      ai: 4.1.53(react@18.3.1)(zod@3.24.2)
       openai-zod-functions: 0.1.2(openai@4.89.0(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2))
-      react: 19.0.0
+      react: 18.3.1
       zod: 3.24.2
       zod-to-json-schema: 3.24.3(zod@3.24.2)
     optionalDependencies:
@@ -12088,18 +12103,19 @@ snapshots:
       postcss: 8.5.3
       tailwindcss: 4.1.3
 
-  '@tailwindcss/typography@0.5.16':
+  '@tailwindcss/typography@0.5.16(tailwindcss@3.4.17)':
     dependencies:
       lodash.castarray: 4.4.0
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       postcss-selector-parser: 6.0.10
+      tailwindcss: 3.4.17
 
-  '@tanstack/react-table@8.21.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@tanstack/react-table@8.21.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@tanstack/table-core': 8.21.2
-      react: 19.0.0
-      react-dom: 19.0.0(react@19.0.0)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@tanstack/table-core@8.21.2': {}
 
@@ -12613,6 +12629,18 @@ snapshots:
     dependencies:
       clean-stack: 2.2.0
       indent-string: 4.0.0
+
+  ai@4.1.53(react@18.3.1)(zod@3.24.2):
+    dependencies:
+      '@ai-sdk/provider': 1.0.10
+      '@ai-sdk/provider-utils': 2.1.11(zod@3.24.2)
+      '@ai-sdk/react': 1.1.21(react@18.3.1)(zod@3.24.2)
+      '@ai-sdk/ui-utils': 1.1.17(zod@3.24.2)
+      '@opentelemetry/api': 1.9.0
+      jsondiffpatch: 0.6.0
+    optionalDependencies:
+      react: 18.3.1
+      zod: 3.24.2
 
   ai@4.1.53(react@19.0.0)(zod@3.24.2):
     dependencies:
@@ -13855,11 +13883,11 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-turbo@2.4.4(eslint@9.21.0(jiti@2.4.2))(turbo@2.4.4):
+  eslint-plugin-turbo@2.4.4(eslint@9.21.0(jiti@2.4.2))(turbo@2.5.3):
     dependencies:
       dotenv: 16.0.3
       eslint: 9.21.0(jiti@2.4.2)
-      turbo: 2.4.4
+      turbo: 2.5.3
 
   eslint-scope@8.2.0:
     dependencies:
@@ -15428,9 +15456,9 @@ snapshots:
     dependencies:
       react: 19.0.0
 
-  lucide-react@0.475.0(react@19.0.0):
+  lucide-react@0.475.0(react@18.3.1):
     dependencies:
-      react: 19.0.0
+      react: 18.3.1
 
   lucide-react@0.487.0(react@19.0.0):
     dependencies:
@@ -16382,37 +16410,49 @@ snapshots:
     dependencies:
       dnd-core: 14.0.1
 
-  react-dnd-multi-backend@6.0.2(react-dnd-html5-backend@14.1.0)(react-dnd-touch-backend@14.1.1)(react-dnd@14.0.5(@types/node@22.13.9)(@types/react@18.3.18)(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  react-dnd-multi-backend@6.0.2(react-dnd-html5-backend@14.1.0)(react-dnd-touch-backend@14.1.1)(react-dnd@14.0.5(@types/node@22.13.9)(@types/react@18.3.18)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       dnd-multi-backend: 6.0.0
       prop-types: 15.8.1
-      react: 19.0.0
+      react: 18.3.1
       react-dnd-html5-backend: 14.1.0
-      react-dnd-preview: 6.0.2(react-dnd@14.0.5(@types/node@22.13.9)(@types/react@18.3.18)(react@19.0.0))(react@19.0.0)
+      react-dnd-preview: 6.0.2(react-dnd@14.0.5(@types/node@22.13.9)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
       react-dnd-touch-backend: 14.1.1
-      react-dom: 19.0.0(react@19.0.0)
+      react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
       - react-dnd
 
-  react-dnd-preview@6.0.2(react-dnd@14.0.5(@types/node@22.13.9)(@types/react@18.3.18)(react@19.0.0))(react@19.0.0):
+  react-dnd-multi-backend@6.0.2(react-dnd-html5-backend@14.1.0)(react-dnd-touch-backend@14.1.1)(react-dnd@14.0.5(@types/node@22.13.9)(@types/react@18.3.18)(react@18.3.1))(react-dom@19.0.0(react@18.3.1))(react@18.3.1):
+    dependencies:
+      dnd-multi-backend: 6.0.0
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dnd-html5-backend: 14.1.0
+      react-dnd-preview: 6.0.2(react-dnd@14.0.5(@types/node@22.13.9)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
+      react-dnd-touch-backend: 14.1.1
+      react-dom: 19.0.0(react@18.3.1)
+    transitivePeerDependencies:
+      - react-dnd
+
+  react-dnd-preview@6.0.2(react-dnd@14.0.5(@types/node@22.13.9)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1):
     dependencies:
       prop-types: 15.8.1
-      react: 19.0.0
-      react-dnd: 14.0.5(@types/node@22.13.9)(@types/react@18.3.18)(react@19.0.0)
+      react: 18.3.1
+      react-dnd: 14.0.5(@types/node@22.13.9)(@types/react@18.3.18)(react@18.3.1)
 
   react-dnd-touch-backend@14.1.1:
     dependencies:
       '@react-dnd/invariant': 2.0.0
       dnd-core: 14.0.1
 
-  react-dnd@14.0.5(@types/node@22.13.9)(@types/react@18.3.18)(react@19.0.0):
+  react-dnd@14.0.5(@types/node@22.13.9)(@types/react@18.3.18)(react@18.3.1):
     dependencies:
       '@react-dnd/invariant': 2.0.0
       '@react-dnd/shallowequal': 2.0.0
       dnd-core: 14.0.1
       fast-deep-equal: 3.1.3
       hoist-non-react-statics: 3.3.2
-      react: 19.0.0
+      react: 18.3.1
     optionalDependencies:
       '@types/node': 22.13.9
       '@types/react': 18.3.18
@@ -16423,10 +16463,22 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
+  react-dom@19.0.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      scheduler: 0.25.0
+
   react-dom@19.0.0(react@19.0.0):
     dependencies:
       react: 19.0.0
       scheduler: 0.25.0
+
+  react-dropzone@14.3.8(react@18.3.1):
+    dependencies:
+      attr-accept: 2.2.5
+      file-selector: 2.1.2
+      prop-types: 15.8.1
+      react: 18.3.1
 
   react-dropzone@14.3.8(react@19.0.0):
     dependencies:
@@ -16435,13 +16487,17 @@ snapshots:
       prop-types: 15.8.1
       react: 19.0.0
 
+  react-hook-form@7.54.2(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
   react-hook-form@7.54.2(react@19.0.0):
     dependencies:
       react: 19.0.0
 
-  react-icons@5.5.0(react@19.0.0):
+  react-icons@5.5.0(react@18.3.1):
     dependencies:
-      react: 19.0.0
+      react: 18.3.1
 
   react-is@16.13.1: {}
 
@@ -16449,7 +16505,7 @@ snapshots:
 
   react-is@18.3.1: {}
 
-  react-markdown@9.1.0(@types/react@18.3.18)(react@19.0.0):
+  react-markdown@9.1.0(@types/react@18.3.18)(react@18.3.1):
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
@@ -16458,7 +16514,7 @@ snapshots:
       hast-util-to-jsx-runtime: 2.3.6
       html-url-attributes: 3.0.1
       mdast-util-to-hast: 13.2.0
-      react: 19.0.0
+      react: 18.3.1
       remark-parse: 11.0.0
       remark-rehype: 11.1.1
       unified: 11.0.5
@@ -16467,16 +16523,34 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-mosaic-component@5.3.0(@types/node@22.13.9)(@types/react@18.3.18)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  react-mosaic-component@5.3.0(@types/node@22.13.9)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       classnames: 2.5.1
       immutability-helper: 3.1.1
       lodash: 4.17.21
       prop-types: 15.8.1
-      react: 19.0.0
-      react-dnd: 14.0.5(@types/node@22.13.9)(@types/react@18.3.18)(react@19.0.0)
+      react: 18.3.1
+      react-dnd: 14.0.5(@types/node@22.13.9)(@types/react@18.3.18)(react@18.3.1)
       react-dnd-html5-backend: 14.1.0
-      react-dnd-multi-backend: 6.0.2(react-dnd-html5-backend@14.1.0)(react-dnd-touch-backend@14.1.1)(react-dnd@14.0.5(@types/node@22.13.9)(@types/react@18.3.18)(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react-dnd-multi-backend: 6.0.2(react-dnd-html5-backend@14.1.0)(react-dnd-touch-backend@14.1.1)(react-dnd@14.0.5(@types/node@22.13.9)(@types/react@18.3.18)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-dnd-touch-backend: 14.1.1
+      uuid: 3.4.0
+    transitivePeerDependencies:
+      - '@types/hoist-non-react-statics'
+      - '@types/node'
+      - '@types/react'
+      - react-dom
+
+  react-mosaic-component@5.3.0(@types/node@22.13.9)(@types/react@18.3.18)(react-dom@19.0.0(react@18.3.1))(react@18.3.1):
+    dependencies:
+      classnames: 2.5.1
+      immutability-helper: 3.1.1
+      lodash: 4.17.21
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dnd: 14.0.5(@types/node@22.13.9)(@types/react@18.3.18)(react@18.3.1)
+      react-dnd-html5-backend: 14.1.0
+      react-dnd-multi-backend: 6.0.2(react-dnd-html5-backend@14.1.0)(react-dnd-touch-backend@14.1.1)(react-dnd@14.0.5(@types/node@22.13.9)(@types/react@18.3.18)(react@18.3.1))(react-dom@19.0.0(react@18.3.1))(react@18.3.1)
       react-dnd-touch-backend: 14.1.1
       uuid: 3.4.0
     transitivePeerDependencies:
@@ -16536,20 +16610,20 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  react-vega@7.6.0(react@19.0.0)(vega-lite@5.23.0(vega@5.32.0(encoding@0.1.13)))(vega@5.32.0(encoding@0.1.13)):
+  react-vega@7.6.0(react@18.3.1)(vega-lite@5.23.0(vega@5.32.0(encoding@0.1.13)))(vega@5.32.0(encoding@0.1.13)):
     dependencies:
       '@types/react': 18.3.18
       fast-deep-equal: 3.1.3
       prop-types: 15.8.1
-      react: 19.0.0
+      react: 18.3.1
       vega: 5.32.0(encoding@0.1.13)
       vega-embed: 6.29.0(vega-lite@5.23.0(vega@5.32.0(encoding@0.1.13)))(vega@5.32.0(encoding@0.1.13))
       vega-lite: 5.23.0(vega@5.32.0(encoding@0.1.13))
 
-  react-virtual@2.10.4(react@19.0.0):
+  react-virtual@2.10.4(react@18.3.1):
     dependencies:
       '@reach/observe-rect': 1.2.0
-      react: 19.0.0
+      react: 18.3.1
 
   react@18.3.1:
     dependencies:
@@ -17178,6 +17252,12 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  swr@2.3.2(react@18.3.1):
+    dependencies:
+      dequal: 2.0.3
+      react: 18.3.1
+      use-sync-external-store: 1.4.0(react@18.3.1)
+
   swr@2.3.2(react@19.0.0):
     dependencies:
       dequal: 2.0.3
@@ -17195,7 +17275,9 @@ snapshots:
 
   tailwind-merge@2.6.0: {}
 
-  tailwindcss-animate@1.0.7: {}
+  tailwindcss-animate@1.0.7(tailwindcss@3.4.17):
+    dependencies:
+      tailwindcss: 3.4.17
 
   tailwindcss@3.4.17:
     dependencies:
@@ -17365,32 +17447,32 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  turbo-darwin-64@2.4.4:
+  turbo-darwin-64@2.5.3:
     optional: true
 
-  turbo-darwin-arm64@2.4.4:
+  turbo-darwin-arm64@2.5.3:
     optional: true
 
-  turbo-linux-64@2.4.4:
+  turbo-linux-64@2.5.3:
     optional: true
 
-  turbo-linux-arm64@2.4.4:
+  turbo-linux-arm64@2.5.3:
     optional: true
 
-  turbo-windows-64@2.4.4:
+  turbo-windows-64@2.5.3:
     optional: true
 
-  turbo-windows-arm64@2.4.4:
+  turbo-windows-arm64@2.5.3:
     optional: true
 
-  turbo@2.4.4:
+  turbo@2.5.3:
     optionalDependencies:
-      turbo-darwin-64: 2.4.4
-      turbo-darwin-arm64: 2.4.4
-      turbo-linux-64: 2.4.4
-      turbo-linux-arm64: 2.4.4
-      turbo-windows-64: 2.4.4
-      turbo-windows-arm64: 2.4.4
+      turbo-darwin-64: 2.5.3
+      turbo-darwin-arm64: 2.5.3
+      turbo-linux-64: 2.5.3
+      turbo-linux-arm64: 2.5.3
+      turbo-windows-64: 2.5.3
+      turbo-windows-arm64: 2.5.3
 
   tw-animate-css@1.2.5: {}
 
@@ -17589,7 +17671,6 @@ snapshots:
   use-sync-external-store@1.4.0(react@18.3.1):
     dependencies:
       react: 18.3.1
-    optional: true
 
   use-sync-external-store@1.4.0(react@19.0.0):
     dependencies:


### PR DESCRIPTION
- Adding execute and queryJson to DuckDbConnector
- `query` and `queryJson` can now be typed