### PR TITLE
fix: String escaping in literalToSQL

### DIFF
--- a/packages/duckdb/__tests__/sql-from.test.ts
+++ b/packages/duckdb/__tests__/sql-from.test.ts
@@ -12,6 +12,7 @@ describe('sql-from', () => {
     it('should convert strings correctly', () => {
       expect(literalToSQL('hello')).toBe("'hello'");
       expect(literalToSQL("O'Neil")).toBe("'O''Neil'"); // Escapes single quotes
+      expect(literalToSQL("a'b'c")).toBe("'a''b''c'");
     });
 
     it('should convert booleans correctly', () => {

--- a/packages/duckdb/src/connectors/load/sql-from.ts
+++ b/packages/duckdb/src/connectors/load/sql-from.ts
@@ -47,7 +47,7 @@ export function literalToSQL(value: unknown) {
     case 'number':
       return Number.isFinite(value) ? `${value}` : 'NULL';
     case 'string':
-      return `'${value.replace(`'`, `''`)}'`;
+      return `'${value.replace(/'/g, "''")}'`;
     case 'boolean':
       return value ? 'TRUE' : 'FALSE';
     default:


### PR DESCRIPTION
## Summary
- fix escaping of single quotes in `literalToSQL`
- expand unit test for string escaping

## Testing
- `pnpm test` *(fails: connect EHOSTUNREACH 172.25.0.3:8080)*