### PR TITLE
docs: Fix typo in upgrade guide

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -20,7 +20,7 @@ When upgrading, please follow the version-specific instructions below that apply
 
 - `INITIAL_BASE_PROJECT_STATE` renamed into `INITIAL_PROJECT_BUILDER_STATE`
 
-- A number of project store props amnd moved from `.project` to `.db`:
+- A number of project store props and moved from `.project` to `.db`:
 
   - `.tables`
   - `.addTable`


### PR DESCRIPTION
## Summary
- fix typo `amnd` -> `and` in docs

## Testing
- `pnpm test` *(fails: error when fetching pnpm package)*