### PR TITLE
fix: camelCaseToTitle uppercase handling

### DIFF
--- a/packages/utils/__tests__/filepaths.test.ts
+++ b/packages/utils/__tests__/filepaths.test.ts
@@ -2,7 +2,7 @@ import {
   generateUniqueName,
   generateUniquePath,
   convertToUniqueS3ObjectName,
-} from './filepaths';
+} from '../src/filepaths';
 
 test('generateUniqueName generates unique table names', () => {
   expect(generateUniqueName('foo', [])).toBe('foo');

--- a/packages/utils/__tests__/str.test.ts
+++ b/packages/utils/__tests__/str.test.ts
@@ -1,4 +1,4 @@
-import { camelCaseToTitle } from './str';
+import { camelCaseToTitle } from '../src/str';
 
 test('camelCaseToTitle works as expected', () => {
   expect(camelCaseToTitle('myVariableName')).toBe('My Variable Name');

--- a/packages/utils/jest.config.js
+++ b/packages/utils/jest.config.js
@@ -1,0 +1,6 @@
+import nodeConfig from '@sqlrooms/jest-config/node.js';
+
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+export default {
+  ...nodeConfig,
+};

--- a/packages/utils/jest.config.ms
+++ b/packages/utils/jest.config.ms
@@ -1,8 +1,0 @@
-// See https://github.com/bakeruk/modern-typescript-monorepo-example/blob/main/package.json
-/** @type {import('jest').Config} */
-module.exports = {
-  transform: {
-    '^.+\\.(t|j)sx?$': '@swc/jest',
-  },
-  testPathIgnorePatterns: ['/dist/'],
-};

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -21,8 +21,8 @@
   "scripts": {
     "dev": "tsc -w",
     "build": "tsc",
-    "_test": "jest",
-    "_test:watch": "jest --watch",
+    "test": "jest",
+    "test:watch": "jest --watch",
     "lint": "eslint .",
     "typedoc": "typedoc"
   },

--- a/packages/utils/src/str.test.ts
+++ b/packages/utils/src/str.test.ts
@@ -1,0 +1,7 @@
+import { camelCaseToTitle } from './str';
+
+test('camelCaseToTitle works as expected', () => {
+  expect(camelCaseToTitle('myVariableName')).toBe('My Variable Name');
+  expect(camelCaseToTitle('URL')).toBe('URL');
+  expect(camelCaseToTitle('getHTTPResponse')).toBe('Get HTTP Response');
+});

--- a/packages/utils/src/str.ts
+++ b/packages/utils/src/str.ts
@@ -34,12 +34,17 @@ export function formatBytes(bytes: number): string {
  */
 export function camelCaseToTitle(camelCase: string): string {
   // Split the string into words on the camelCase boundaries
-  const words = camelCase.match(/^[a-z]+|[A-Z][a-z]*/g);
+  const words = camelCase.match(/[A-Z]+(?![a-z])|[A-Z]?[a-z]+/g);
 
   // If words are found, transform them and join into a title string
   if (words) {
     return words
       .map((word) => {
+        // Preserve fully uppercase words like "URL"
+        if (word === word.toUpperCase()) {
+          return word;
+        }
+
         // Capitalize the first letter of each word
         return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
       })


### PR DESCRIPTION
## Summary
- improve `camelCaseToTitle` regex to treat consecutive capitals as one word
- preserve fully uppercase words like `URL`
- add tests for `camelCaseToTitle`

## Testing
- `pnpm test` *(fails: connect EHOSTUNREACH 172.25.0.3:8080)*