### PR TITLE
Refactor duckdb connectors

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -4,6 +4,28 @@ This document provides detailed guidance for upgrading between different version
 
 When upgrading, please follow the version-specific instructions below that apply to your project. If you encounter any issues during the upgrade process, please refer to our [GitHub issues](https://github.com/sqlrooms/sqlrooms/issues) or contact support.
 
+## 0.17.0
+
+### @sqlrooms/duckdb
+
+The `BaseDuckDbConnector` and `WasmDuckDbConnector` are now provided as factory functions rather than classes. Use `createWasmDuckDbConnector()` or the generic `createDuckDbConnector({type: 'wasm'})` to obtain a connector instance.
+
+#### Before
+
+```typescript
+import {WasmDuckDbConnector} from '@sqlrooms/duckdb';
+
+const connector = new WasmDuckDbConnector();
+```
+
+#### After
+
+```typescript
+import {createWasmDuckDbConnector} from '@sqlrooms/duckdb';
+
+const connector = createWasmDuckDbConnector();
+```
+
 ## 0.16.0
 
 ### @sqlrooms/duckdb

--- a/examples/deckgl-discuss/src/store.ts
+++ b/examples/deckgl-discuss/src/store.ts
@@ -4,7 +4,7 @@ import {
   DiscussSliceConfig,
   DiscussSliceState,
 } from '@sqlrooms/discuss';
-import {WasmDuckDbConnector} from '@sqlrooms/duckdb';
+import {createWasmDuckDbConnector} from '@sqlrooms/duckdb';
 import {
   BaseProjectConfig,
   createProjectBuilderSlice,
@@ -40,7 +40,7 @@ export const {projectStore, useProjectStore} = createProjectBuilderStore<
       ...createDiscussSlice({userId: 'user1'})(set, get, store),
 
       ...createProjectBuilderSlice<AppConfig>({
-        connector: new WasmDuckDbConnector({
+        connector: createWasmDuckDbConnector({
           initializationQuery: 'LOAD spatial',
         }),
         config: {

--- a/packages/duckdb/README_query_cancellation.md
+++ b/packages/duckdb/README_query_cancellation.md
@@ -21,9 +21,9 @@ interface QueryHandle<T = any> {
 ### Basic Query with Cancellation
 
 ```typescript
-import {WasmDuckDbConnector} from './connectors/WasmDuckDbConnector';
+import {createWasmDuckDbConnector} from './connectors/createDuckDbConnector';
 
-const connector = new WasmDuckDbConnector();
+const connector = createWasmDuckDbConnector();
 await connector.initialize();
 
 // Start a query and get immediate access to cancellation

--- a/packages/duckdb/src/DuckDbSlice.ts
+++ b/packages/duckdb/src/DuckDbSlice.ts
@@ -9,7 +9,7 @@ import {produce} from 'immer';
 import {z} from 'zod';
 import {StateCreator} from 'zustand';
 import {DuckDbConnector, QueryHandle} from './connectors/DuckDbConnector';
-import {WasmDuckDbConnector} from './connectors/WasmDuckDbConnector';
+import {createWasmDuckDbConnector} from './connectors/createDuckDbConnector';
 import {
   escapeId,
   escapeVal,
@@ -239,7 +239,7 @@ export type DuckDbSliceState = {
  * Create a DuckDB slice for managing the connector
  */
 export function createDuckDbSlice({
-  connector = new WasmDuckDbConnector(),
+  connector = createWasmDuckDbConnector(),
 }: {
   connector?: DuckDbConnector;
 }): StateCreator<DuckDbSliceState> {

--- a/packages/duckdb/src/connectors/BaseDuckDbConnector.ts
+++ b/packages/duckdb/src/connectors/BaseDuckDbConnector.ts
@@ -6,182 +6,199 @@ import {
 import * as arrow from 'apache-arrow';
 import {TypeMap} from 'apache-arrow';
 import {DuckDbConnector, QueryHandle, QueryOptions} from './DuckDbConnector';
-import {load, loadObjects, loadSpatial} from './load/load';
+import {load, loadObjects as loadObjectsSql, loadSpatial} from './load/load';
 import {createTypedRowAccessor} from '../typedRowAccessor';
 
-export abstract class BaseDuckDbConnector implements DuckDbConnector {
-  protected dbPath: string;
-  protected initializationQuery: string;
-  protected initialized = false;
-  protected initializing: Promise<void> | null = null;
-  protected activeQueries = new Map<string, AbortController>();
+export interface BaseDuckDbConnectorOptions {
+  dbPath?: string;
+  initializationQuery?: string;
+}
 
-  constructor({
-    initializationQuery = '',
-    dbPath = ':memory:',
-  }: {
-    dbPath?: string;
-    initializationQuery?: string;
-  } = {}) {
-    this.dbPath = dbPath;
-    this.initializationQuery = initializationQuery;
-  }
-
-  async initialize(): Promise<void> {
-    if (this.initialized) {
-      return;
-    }
-    if (this.initializing) {
-      return this.initializing;
-    }
-    this.initializing = this.initializeInternal();
-    return this.initializing;
-  }
-
-  protected async initializeInternal(): Promise<void> {
-    // To be implemented by subclasses
-  }
-
-  async destroy(): Promise<void> {
-    // To be implemented by subclasses
-  }
-
-  protected async ensureInitialized(): Promise<void> {
-    if (!this.initialized && this.initializing) {
-      await this.initializing;
-    }
-  }
-
-  /**
-   * Cancel a query by its internal ID
-   * @param queryId Internal query ID to cancel
-   */
-  protected async cancelQueryInternal(queryId: string): Promise<void> {
-    const abortController = this.activeQueries.get(queryId);
-    if (abortController) {
-      abortController.abort();
-      this.activeQueries.delete(queryId);
-    }
-    // Subclasses can override this for additional cleanup
-  }
-
-  /**
-   * Abstract method for executing a query with abort signal support.
-   * Subclasses must implement this to handle the actual query execution.
-   */
-  protected abstract executeQueryInternal<T extends TypeMap = any>(
+export interface BaseDuckDbConnectorImpl {
+  initializeInternal?(): Promise<void>;
+  destroyInternal?(): Promise<void>;
+  executeQueryInternal<T extends TypeMap = any>(
     query: string,
     signal: AbortSignal,
     queryId?: string,
   ): Promise<arrow.Table<T>>;
-
-  /**
-   * Creates a QueryHandle with common signal handling logic.
-   * This method handles the AbortController setup, signal chaining, and cleanup.
-   */
-  protected createQueryHandleInternal<T>(
-    queryPromiseFactory: (signal: AbortSignal, queryId: string) => Promise<T>,
-    options?: QueryOptions,
-  ): QueryHandle<T> {
-    const abortController = new AbortController();
-    const queryId = this.generateQueryId();
-
-    // If user provided a signal, listen for its abort event
-    if (options?.signal) {
-      const userSignal = options.signal;
-      if (userSignal.aborted) {
-        abortController.abort();
-      } else {
-        userSignal.addEventListener('abort', () => {
-          abortController.abort();
-        });
-      }
-    }
-
-    this.activeQueries.set(queryId, abortController);
-
-    // Execute the query with abort signal support
-    const resultPromise = queryPromiseFactory(abortController.signal, queryId).finally(
-      () => {
-        this.activeQueries.delete(queryId);
-      },
-    );
-
-    return {
-      result: resultPromise,
-      signal: abortController.signal,
-      cancel: async () => {
-        await this.cancelQueryInternal(queryId);
-      },
-    };
-  }
-
-  execute(sql: string, options?: QueryOptions): QueryHandle {
-    return this.createQueryHandleInternal(
-      (signal, queryId) => this.executeQueryInternal(sql, signal, queryId),
-      options,
-    );
-  }
-
-  query<T extends TypeMap = any>(
-    query: string,
-    options?: QueryOptions,
-  ): QueryHandle<arrow.Table<T>> {
-    return this.createQueryHandleInternal(
-      (signal, queryId) => this.executeQueryInternal<T>(query, signal, queryId),
-      options,
-    );
-  }
-
-  queryJson<T = Record<string, any>>(
-    query: string,
-    options?: QueryOptions,
-  ): QueryHandle<Iterable<T>> {
-    return this.createQueryHandleInternal(async (signal, queryId) => {
-      const table = await this.executeQueryInternal(query, signal, queryId);
-      return createTypedRowAccessor({arrowTable: table});
-    }, options);
-  }
-
-  async loadFile(
+  cancelQueryInternal?(queryId: string): Promise<void>;
+  loadArrowInternal?(
+    file: arrow.Table | Uint8Array,
+    tableName: string,
+    opts?: {schema?: string},
+  ): Promise<void>;
+  loadObjectsInternal?(
+    file: Record<string, unknown>[],
+    tableName: string,
+    opts?: StandardLoadOptions,
+  ): Promise<void>;
+  loadFileInternal?(
     file: string | File,
     tableName: string,
     opts?: LoadFileOptions,
-  ) {
+  ): Promise<void>;
+}
+
+export function createBaseDuckDbConnector(
+  {
+    dbPath = ':memory:',
+    initializationQuery = '',
+  }: BaseDuckDbConnectorOptions = {},
+  impl: BaseDuckDbConnectorImpl,
+): DuckDbConnector {
+  const state = {
+    dbPath,
+    initializationQuery,
+    initialized: false,
+    initializing: null as Promise<void> | null,
+    activeQueries: new Map<string, AbortController>(),
+  };
+
+  const ensureInitialized = async () => {
+    if (!state.initialized && state.initializing) {
+      await state.initializing;
+    }
+  };
+
+  const initialize = async () => {
+    if (state.initialized) {
+      return;
+    }
+    if (state.initializing) {
+      return state.initializing;
+    }
+    state.initializing = (async () => {
+      await impl.initializeInternal?.();
+      state.initialized = true;
+      state.initializing = null;
+    })().catch((err) => {
+      state.initialized = false;
+      state.initializing = null;
+      throw err;
+    });
+    return state.initializing;
+  };
+
+  const destroy = async () => {
+    await impl.destroyInternal?.();
+    state.initialized = false;
+    state.initializing = null;
+  };
+
+  const generateQueryId = () =>
+    `q_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+
+  const cancelQuery = async (queryId: string) => {
+    const abortController = state.activeQueries.get(queryId);
+    if (abortController) {
+      abortController.abort();
+      state.activeQueries.delete(queryId);
+    }
+    await impl.cancelQueryInternal?.(queryId);
+  };
+
+  const createQueryHandle = <T>(
+    queryPromiseFactory: (signal: AbortSignal, queryId: string) => Promise<T>,
+    options?: QueryOptions,
+  ): QueryHandle<T> => {
+    const abortController = new AbortController();
+    const queryId = generateQueryId();
+    if (options?.signal) {
+      const userSignal = options.signal;
+      if (userSignal.aborted) abortController.abort();
+      else userSignal.addEventListener('abort', () => abortController.abort());
+    }
+    state.activeQueries.set(queryId, abortController);
+    const resultPromise = queryPromiseFactory(
+      abortController.signal,
+      queryId,
+    ).finally(() => {
+      state.activeQueries.delete(queryId);
+    });
+    return {
+      result: resultPromise,
+      signal: abortController.signal,
+      cancel: async () => cancelQuery(queryId),
+    };
+  };
+
+  const execute = (sql: string, options?: QueryOptions): QueryHandle =>
+    createQueryHandle(
+      (signal, id) => impl.executeQueryInternal(sql, signal, id),
+      options,
+    );
+
+  const query = <T extends TypeMap = any>(
+    queryStr: string,
+    options?: QueryOptions,
+  ): QueryHandle<arrow.Table<T>> =>
+    createQueryHandle(
+      (signal, id) => impl.executeQueryInternal<T>(queryStr, signal, id),
+      options,
+    );
+
+  const queryJson = <T = Record<string, any>>(
+    queryStr: string,
+    options?: QueryOptions,
+  ): QueryHandle<Iterable<T>> =>
+    createQueryHandle(async (signal, id) => {
+      const table = await impl.executeQueryInternal(queryStr, signal, id);
+      return createTypedRowAccessor({arrowTable: table});
+    }, options);
+
+  const loadFile = async (
+    file: string | File,
+    tableName: string,
+    opts?: LoadFileOptions,
+  ) => {
+    if (impl.loadFileInternal) {
+      return impl.loadFileInternal(file, tableName, opts);
+    }
     if (file instanceof File) {
       throw new Error('Not implemented', {cause: {file, tableName, opts}});
     }
     const fileName = file;
+    await ensureInitialized();
     if (opts && isSpatialLoadFileOptions(opts)) {
-      const queryHandle = this.query(loadSpatial(tableName, fileName, opts));
-      await queryHandle.result;
+      await query(loadSpatial(tableName, fileName, opts)).result;
     } else {
-      const queryHandle = this.query(
-        load(opts?.method ?? 'auto', tableName, fileName, opts),
-      );
-      await queryHandle.result;
+      await query(load(opts?.method ?? 'auto', tableName, fileName, opts))
+        .result;
     }
-  }
+  };
 
-  async loadArrow(
+  const loadArrow = async (
     file: arrow.Table | Uint8Array,
     tableName: string,
-    opts?: {schema?: string}
-  ): Promise<void> {
+    opts?: {schema?: string},
+  ): Promise<void> => {
+    if (impl.loadArrowInternal) {
+      return impl.loadArrowInternal(file, tableName, opts);
+    }
     throw new Error('Not implemented');
-  }
+  };
 
-  async loadObjects(
+  const loadObjects = async (
     file: Record<string, unknown>[],
     tableName: string,
     opts?: StandardLoadOptions,
-  ) {
-    await this.ensureInitialized();
-    const queryHandle = this.query(loadObjects(tableName, file, opts));
-    await queryHandle.result;
-  }
+  ) => {
+    if (impl.loadObjectsInternal) {
+      return impl.loadObjectsInternal(file, tableName, opts);
+    }
+    await ensureInitialized();
+    await query(loadObjectsSql(tableName, file, opts)).result;
+  };
 
-  protected generateQueryId(): string {
-    return `q_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
-  }
+  return {
+    initialize,
+    destroy,
+    execute,
+    query,
+    queryJson,
+    loadFile,
+    loadArrow,
+    loadObjects,
+  };
 }

--- a/packages/duckdb/src/connectors/WasmDuckDbConnector.ts
+++ b/packages/duckdb/src/connectors/WasmDuckDbConnector.ts
@@ -3,257 +3,217 @@ import {DuckDBDataProtocol, DuckDBQueryConfig} from '@duckdb/duckdb-wasm';
 import {LoadFileOptions, StandardLoadOptions} from '@sqlrooms/project-config';
 import {splitFilePath} from '@sqlrooms/utils';
 import * as arrow from 'apache-arrow';
-import {BaseDuckDbConnector} from './BaseDuckDbConnector';
-import {loadObjects} from './load/load';
+import {
+  createBaseDuckDbConnector,
+  BaseDuckDbConnectorImpl,
+} from './BaseDuckDbConnector';
+import {loadObjects as loadObjectsSql} from './load/load';
+import {DuckDbConnector} from './DuckDbConnector';
 
-export class WasmDuckDbConnector extends BaseDuckDbConnector {
-  private logging: boolean;
-  private db: duckdb.AsyncDuckDB | null = null;
-  private conn: duckdb.AsyncDuckDBConnection | null = null;
-  private worker: Worker | null = null;
-  private queryConfig?: DuckDBQueryConfig;
+export interface WasmDuckDbConnectorOptions {
+  dbPath?: string;
+  queryConfig?: DuckDBQueryConfig;
+  initializationQuery?: string;
+  logging?: boolean;
+}
 
-  constructor({
+export interface WasmDuckDbConnector extends DuckDbConnector {
+  getDb(): duckdb.AsyncDuckDB;
+  getConnection(): duckdb.AsyncDuckDBConnection;
+  readonly type: 'wasm';
+}
+
+export function createWasmDuckDbConnector(
+  options: WasmDuckDbConnectorOptions = {},
+): WasmDuckDbConnector {
+  const {
     logging = false,
     initializationQuery = '',
     dbPath = ':memory:',
     queryConfig,
-  }: {
-    dbPath?: string;
-    queryConfig?: DuckDBQueryConfig;
-    initializationQuery?: string;
-    logging?: boolean;
-  } = {}) {
-    super({dbPath, initializationQuery});
-    this.queryConfig = queryConfig;
-    this.logging = logging;
-  }
+  } = options;
 
-  protected async initializeInternal(): Promise<void> {
-    if (!globalThis.Worker) {
-      throw new Error('No Worker support in this environment');
-    }
+  let db: duckdb.AsyncDuckDB | null = null;
+  let conn: duckdb.AsyncDuckDBConnection | null = null;
+  let worker: Worker | null = null;
 
-    try {
-      const allBundles = duckdb.getJsDelivrBundles();
-      const bestBundle = await duckdb.selectBundle(allBundles);
-      if (!bestBundle.mainWorker) {
-        throw new Error('No best bundle found for DuckDB worker');
+  const impl: BaseDuckDbConnectorImpl = {
+    async initializeInternal() {
+      if (!globalThis.Worker) {
+        throw new Error('No Worker support in this environment');
       }
-      const workerUrl = URL.createObjectURL(
-        new Blob([`importScripts("${bestBundle.mainWorker}");`], {
-          type: 'text/javascript',
-        }),
-      );
-
-      const worker = new window.Worker(workerUrl);
-      const logger = this.logging
-        ? new duckdb.ConsoleLogger()
-        : {
-            // Silently log
-            log: () => {
-              /* do nothing */
-            },
-          };
-
-      const db = new (class extends duckdb.AsyncDuckDB {
-        onError(event: ErrorEvent) {
-          super.onError(event);
-          console.error('DuckDB worker error:', event);
+      try {
+        const allBundles = duckdb.getJsDelivrBundles();
+        const bestBundle = await duckdb.selectBundle(allBundles);
+        if (!bestBundle.mainWorker) {
+          throw new Error('No best bundle found for DuckDB worker');
         }
-      })(logger, worker);
+        const workerUrl = URL.createObjectURL(
+          new Blob([`importScripts("${bestBundle.mainWorker}");`], {
+            type: 'text/javascript',
+          }),
+        );
 
-      await db.instantiate(bestBundle.mainModule, bestBundle.pthreadWorker);
-      URL.revokeObjectURL(workerUrl);
+        worker = new window.Worker(workerUrl);
+        const logger = logging ? new duckdb.ConsoleLogger() : {log: () => {}};
 
-      await db.open({
-        path: this.dbPath,
-        query: this.queryConfig,
+        db = new (class extends duckdb.AsyncDuckDB {
+          onError(event: ErrorEvent) {
+            super.onError(event);
+            console.error('DuckDB worker error:', event);
+          }
+        })(logger, worker);
+
+        await db.instantiate(bestBundle.mainModule, bestBundle.pthreadWorker);
+        URL.revokeObjectURL(workerUrl);
+
+        await db.open({
+          path: dbPath,
+          query: queryConfig,
+        });
+
+        conn = augmentConnectionQueryError(await db.connect());
+        if (initializationQuery) {
+          await conn.query(initializationQuery);
+        }
+      } catch (err) {
+        db = null;
+        conn = null;
+        worker = null;
+        throw err;
+      }
+    },
+
+    async destroyInternal() {
+      if (conn) {
+        await conn.close();
+        conn = null;
+      }
+      if (db) {
+        await db.terminate();
+        db = null;
+      }
+      if (worker) {
+        worker.terminate();
+        worker = null;
+      }
+    },
+
+    async executeQueryInternal<T extends arrow.TypeMap = any>(
+      query: string,
+      signal: AbortSignal,
+    ): Promise<arrow.Table<T>> {
+      if (!db) {
+        throw new Error('DuckDB not initialized');
+      }
+
+      if (signal.aborted) {
+        throw new Error('Query aborted before execution');
+      }
+
+      const localConn = augmentConnectionQueryError(await db.connect());
+      const streamPromise = localConn.send<T>(query, true);
+      let reader: arrow.RecordBatchReader<T> | null = null;
+
+      const buildTable = async () => {
+        reader = await streamPromise;
+        const batches: arrow.RecordBatch<T>[] = [];
+        let rowCount = 0;
+        for await (const batch of reader) {
+          if (batch.numRows === 0) continue;
+          batches.push(batch);
+          rowCount += batch.numRows;
+        }
+        if (rowCount === 0) {
+          return arrow.tableFromArrays({}) as unknown as arrow.Table<T>;
+        }
+        return new arrow.Table(batches);
+      };
+
+      let abortHandler: (() => void) | undefined;
+      const abortPromise = new Promise<never>((_, reject) => {
+        abortHandler = () => {
+          localConn.cancelSent().catch(() => {});
+          reader?.cancel?.();
+          reject(new Error('Query cancelled'));
+        };
+        signal.addEventListener('abort', abortHandler);
       });
 
-      const conn = augmentConnectionQueryError(await db.connect());
-      if (this.initializationQuery) {
-        await conn.query(this.initializationQuery);
-      }
-
-      this.db = db;
-      this.conn = conn;
-      this.worker = worker;
-      this.initialized = true;
-    } catch (err) {
-      this.initialized = false;
-      this.initializing = null;
-      throw err;
-    }
-  }
-
-  async destroy(): Promise<void> {
-    try {
-      if (this.conn) {
-        await this.conn.close();
-        this.conn = null;
-      }
-
-      if (this.db) {
-        await this.db.terminate();
-        this.db = null;
-      }
-
-      if (this.worker) {
-        this.worker.terminate();
-        this.worker = null;
-      }
-
-      this.initialized = false;
-      this.initializing = null;
-    } catch (err) {
-      console.error('Error during DuckDB shutdown:', err);
-      throw err;
-    }
-  }
-
-  protected async executeQueryInternal<T extends arrow.TypeMap = any>(
-    query: string,
-    signal: AbortSignal,
-  ): Promise<arrow.Table<T>> {
-    // Make sure the WASM runtime is ready.
-    await this.ensureInitialized();
-    if (!this.db) {
-      throw new Error('DuckDB not initialized');
-    }
-
-    // Short‑circuit if the caller already aborted.
-    if (signal.aborted) {
-      throw new Error('Query aborted before execution');
-    }
-
-    // 👉  Open a *fresh* connection dedicated to this request.
-    const conn = augmentConnectionQueryError(await this.db.connect());
-
-    // 1️⃣ Kick‑off the statement using the *cancellable* streaming API
-    const streamPromise = conn.send<T>(query, /* allowStreamResult */ true);
-
-    // Handle to the Arrow reader so we can cancel it later.
-    let reader: arrow.RecordBatchReader<T> | null = null;
-
-    // 2️⃣ Helper to materialise all batches into one Arrow Table.
-    const buildTable = async () => {
-      reader = await streamPromise;
-
-      const batches: arrow.RecordBatch<T>[] = [];
-      let rowCount = 0;
-
-      for await (const batch of reader) {
-        // DuckDB‑wasm may emit an empty placeholder batch when connections
-        // race.  Ignore any batch whose `numRows` is zero.
-        if (batch.numRows === 0) continue;
-
-        batches.push(batch);
-        rowCount += batch.numRows;
-      }
-
-      if (rowCount === 0) {
-        return arrow.tableFromArrays({}) as unknown as arrow.Table<T>;
-      }
-      return new arrow.Table(batches);
-    };
-
-    // 3️⃣ Wire the AbortSignal → DuckDB interrupt.
-    let abortHandler: (() => void) | undefined;
-    const abortPromise = new Promise<never>((_, reject) => {
-      abortHandler = () => {
-        // Interrupt DuckDB *and* stop the Arrow stream
-        conn.cancelSent().catch(() => {
-          /* ignore if nothing to cancel */
-        });
-        reader?.cancel?.();
-        reject(new Error('Query cancelled'));
-      };
-      signal.addEventListener('abort', abortHandler);
-    });
-
-    try {
-      // Whichever finishes first (query or cancel) wins.
-      return await Promise.race([buildTable(), abortPromise]);
-    } finally {
-      if (abortHandler) {
-        signal.removeEventListener('abort', abortHandler);
-      }
-      // Always close the per‑query connection.
-      await conn.close();
-    }
-  }
-
-  protected async cancelQueryInternal(queryId: string): Promise<void> {
-    // First, invoke the base‑class logic (removes AbortController listeners, etc.)
-    await super.cancelQueryInternal(queryId);
-
-    // Then, interrupt the running statement on the DuckDB side.
-    if (this.conn) {
       try {
-        await this.conn.cancelSent();
-      } catch (err) {
-        // If no statement is active or interrupt fails, just log and move on.
-        console.warn('DuckDB cancelSent failed:', err);
+        return await Promise.race([buildTable(), abortPromise]);
+      } finally {
+        if (abortHandler) {
+          signal.removeEventListener('abort', abortHandler);
+        }
+        await localConn.close();
       }
-    }
-  }
+    },
 
-  async loadFile(
-    file: string | File,
-    tableName: string,
-    opts?: LoadFileOptions,
-  ) {
-    await this.withTempRegisteredFile(file, async (fileName) => {
-      await super.loadFile(fileName, tableName, opts);
-    });
-  }
+    async cancelQueryInternal() {
+      if (conn) {
+        try {
+          await conn.cancelSent();
+        } catch (err) {
+          console.warn('DuckDB cancelSent failed:', err);
+        }
+      }
+    },
 
-  async loadArrow(
-    file: arrow.Table | Uint8Array,
-    tableName: string,
-    opts?: {schema?: string},
-  ) {
-    await this.ensureInitialized();
-    if (!this.conn) {
-      throw new Error('DuckDB connection not initialized');
-    }
-    const options = {name: tableName, schema: opts?.schema};
-    if (file instanceof arrow.Table) {
-      await this.conn.insertArrowTable(file, options);
-    } else {
-      await this.conn.insertArrowFromIPCStream(file, options);
-    }
-  }
+    async loadFileInternal(
+      file: string | File,
+      tableName: string,
+      opts?: LoadFileOptions,
+    ) {
+      await withTempRegisteredFile(file, async (fileName) => {
+        await base.loadFile(fileName, tableName, opts);
+      });
+    },
 
-  async loadObjects(
-    file: Record<string, unknown>[],
-    tableName: string,
-    opts?: StandardLoadOptions,
-  ) {
-    await this.ensureInitialized();
-    if (!this.conn) {
-      throw new Error('DuckDB connection not initialized');
-    }
-    await this.conn.query(loadObjects(tableName, file, opts));
-  }
+    async loadArrowInternal(
+      file: arrow.Table | Uint8Array,
+      tableName: string,
+      opts?: {schema?: string},
+    ) {
+      if (!conn) {
+        throw new Error('DuckDB connection not initialized');
+      }
+      const options = {name: tableName, schema: opts?.schema};
+      if (file instanceof arrow.Table) {
+        await conn.insertArrowTable(file, options);
+      } else {
+        await conn.insertArrowFromIPCStream(file, options);
+      }
+    },
 
-  private async withTempRegisteredFile(
+    async loadObjectsInternal(
+      file: Record<string, unknown>[],
+      tableName: string,
+      opts?: StandardLoadOptions,
+    ) {
+      if (!conn) {
+        throw new Error('DuckDB connection not initialized');
+      }
+      await conn.query(loadObjectsSql(tableName, file, opts));
+    },
+  };
+
+  const base = createBaseDuckDbConnector({dbPath, initializationQuery}, impl);
+
+  async function withTempRegisteredFile(
     file: string | File,
     action: (fileName: string) => Promise<void>,
   ) {
-    await this.ensureInitialized();
-    if (!this.conn || !this.db) {
+    if (!conn || !db) {
       throw new Error('DuckDB connection not initialized');
     }
     let fileName: string;
     let tempFileName: string | undefined = undefined;
     if (file instanceof File) {
-      // Extension might help DuckDB determine the file type
       const {ext} = splitFilePath(file.name);
       tempFileName = `${Math.random().toString(36).substring(2, 15)}${ext ? `.${ext}` : ''}`;
       fileName = tempFileName;
-      await this.db.registerFileHandle(
+      await db.registerFileHandle(
         fileName,
         file,
         DuckDBDataProtocol.BROWSER_FILEREADER,
@@ -264,36 +224,33 @@ export class WasmDuckDbConnector extends BaseDuckDbConnector {
     }
     try {
       await action(fileName);
-    } catch (err) {
-      console.error(`Error during file loading "${fileName}":`, err);
-      throw err;
     } finally {
       if (tempFileName) {
-        await this.db.dropFile(tempFileName);
+        await db!.dropFile(tempFileName);
       }
     }
   }
 
-  getDb(): duckdb.AsyncDuckDB {
-    if (!this.db) {
-      throw new Error('DuckDB not initialized');
-    }
-    return this.db;
-  }
-
-  getConnection(): duckdb.AsyncDuckDBConnection {
-    if (!this.conn) {
-      throw new Error('DuckDB connection not initialized');
-    }
-    return this.conn;
-  }
+  return {
+    ...base,
+    getDb() {
+      if (!db) {
+        throw new Error('DuckDB not initialized');
+      }
+      return db;
+    },
+    getConnection() {
+      if (!conn) {
+        throw new Error('DuckDB connection not initialized');
+      }
+      return conn;
+    },
+    get type() {
+      return 'wasm' as const;
+    },
+  };
 }
 
-/**
- * Augment the connection query method to include the full query and stack trace in the error.
- * @param conn - The connection to augment.
- * @returns The augmented connection.
- */
 function augmentConnectionQueryError(conn: duckdb.AsyncDuckDBConnection) {
   const originalQuery = conn.query;
   conn.query = (async (q: string) => {
@@ -326,7 +283,6 @@ export class DuckQueryError extends Error {
     );
   }
   getMessageForUser() {
-    const {message} = this;
-    return message;
+    return this.message;
   }
 }

--- a/packages/duckdb/src/connectors/createDuckDbConnector.ts
+++ b/packages/duckdb/src/connectors/createDuckDbConnector.ts
@@ -1,0 +1,33 @@
+import {DuckDbConnector} from './DuckDbConnector';
+import {
+  createWasmDuckDbConnector,
+  WasmDuckDbConnectorOptions,
+  WasmDuckDbConnector,
+} from './WasmDuckDbConnector';
+
+export type DuckDbConnectorType = 'wasm';
+
+export type DuckDbConnectorOptions = {
+  type: DuckDbConnectorType;
+} & WasmDuckDbConnectorOptions;
+
+export function createDuckDbConnector(
+  options: DuckDbConnectorOptions,
+): DuckDbConnector {
+  const {type, ...rest} = options;
+  switch (type) {
+    case 'wasm':
+      return createWasmDuckDbConnector(rest);
+    default:
+      throw new Error(`Unsupported DuckDB connector type: ${type}`);
+  }
+}
+
+export {createWasmDuckDbConnector};
+export type {WasmDuckDbConnector};
+
+export function isWasmDuckDbConnector(
+  connector: DuckDbConnector,
+): connector is WasmDuckDbConnector {
+  return (connector as any).type === 'wasm';
+}

--- a/packages/duckdb/src/index.ts
+++ b/packages/duckdb/src/index.ts
@@ -21,7 +21,12 @@ export {
 } from './DuckDbSlice';
 export * from './connectors/DuckDbConnector';
 export * from './connectors/BaseDuckDbConnector';
-export * from './connectors/WasmDuckDbConnector';
+export {
+  createDuckDbConnector,
+  createWasmDuckDbConnector,
+  isWasmDuckDbConnector,
+  type WasmDuckDbConnector,
+} from './connectors/createDuckDbConnector';
 export * from './connectors/load/load';
 export * from './duckdb-utils';
 export {

--- a/packages/mosaic/src/use-mosaic.ts
+++ b/packages/mosaic/src/use-mosaic.ts
@@ -1,7 +1,7 @@
 import {
   DuckDbConnector,
   useDuckDb,
-  WasmDuckDbConnector,
+  isWasmDuckDbConnector,
 } from '@sqlrooms/duckdb';
 import {coordinator, wasmConnector} from '@uwdata/mosaic-core';
 import {useEffect, useState} from 'react';
@@ -20,7 +20,7 @@ async function getMosaicConnector(duckDb: DuckDbConnector) {
   if (mosaicConnector) {
     return mosaicConnector;
   }
-  if (!(duckDb instanceof WasmDuckDbConnector)) {
+  if (!isWasmDuckDbConnector(duckDb)) {
     throw new Error('Only WasmDuckDbConnector is currently supported');
   }
   await duckDb.initialize();


### PR DESCRIPTION
## Summary
- refactor connectors into factory functions
- provide `createDuckDbConnector` and `createWasmDuckDbConnector`
- update default usage in `DuckDbSlice`
- adjust Mosaic and example imports
- document change in upgrade guide

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: parameter implicit any, missing module)*
- `pnpm build` *(fails: cannot find module `@radix-ui/react-slot`)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684d34e371e88321b2a4b4b7cd97e39f