### PR TITLE
feat: QueryHandle is now PromiseLike

### DIFF
--- a/packages/ai/src/analysis.ts
+++ b/packages/ai/src/analysis.ts
@@ -90,7 +90,7 @@ async function getQuerySummary(connector: DuckDbConnector, sqlQuery: string) {
   try {
     const viewName = `temp_result_${Date.now()}`; // unique view name to avoid conflicts
     await connector.query(`CREATE TEMPORARY VIEW ${viewName} AS ${sqlQuery}`);
-    const summaryResult = await connector.query(`SUMMARIZE ${viewName}`).result;
+    const summaryResult = await connector.query(`SUMMARIZE ${viewName}`);
     const summaryData = arrowTableToJson(summaryResult);
     await connector.query(`DROP VIEW IF EXISTS ${viewName}`);
     return summaryData;
@@ -225,7 +225,7 @@ If a query fails, please don't try to run it again with the same syntax.`,
         try {
           const connector = await store.getState().db.getConnector();
           // TODO use options.abortSignal: maybe call db.cancelPendingQuery
-          const result = await connector.query(sqlQuery).result;
+          const result = await connector.query(sqlQuery);
           // Only get summary if the query isn't already a SUMMARIZE query
           const summaryData = sqlQuery.toLowerCase().includes('summarize')
             ? arrowTableToJson(result)

--- a/packages/duckdb/src/DuckDbSlice.ts
+++ b/packages/duckdb/src/DuckDbSlice.ts
@@ -306,7 +306,7 @@ export function createDuckDbSlice({
               `CREATE OR REPLACE TABLE ${qualifiedName} AS (
               ${statements[0]}
             )`,
-            ).result,
+            ),
           );
           return {tableName, rowCount};
         },
@@ -349,7 +349,7 @@ export function createDuckDbSlice({
               database,
               table,
             })}`,
-          ).result;
+          );
           return getColValAsNumber(result);
         },
 
@@ -380,7 +380,7 @@ export function createDuckDbSlice({
                     .join(' AND ')}`
                 : ''
             }`,
-          ).result;
+          );
 
           const newTables: DataTable[] = [];
           for (let i = 0; i < describeResults.numRows; i++) {
@@ -427,8 +427,7 @@ export function createDuckDbSlice({
           const qualifiedTable = isQualifiedTableName(tableName)
             ? tableName
             : makeQualifiedTableName({table: tableName});
-          await connector.query(`DROP TABLE IF EXISTS ${qualifiedTable};`)
-            .result;
+          await connector.query(`DROP TABLE IF EXISTS ${qualifiedTable};`);
           await get().db.refreshTableSchemas();
         },
 
@@ -498,7 +497,7 @@ export function createDuckDbSlice({
             const connector = await get().db.getConnector();
             const result = await connector.query(
               `SELECT current_schema() AS schema, current_database() AS database`,
-            ).result;
+            );
             set((state) =>
               produce(state, (draft) => {
                 draft.db.currentSchema = result.getChild('schema')?.get(0);
@@ -533,7 +532,7 @@ export function createDuckDbSlice({
           const parsedQuery = (
             await connector.query(
               `SELECT json_serialize_sql(${escapeVal(sql)})`,
-            ).result
+            )
           )
             .getChildAt(0)
             ?.get(0);

--- a/packages/duckdb/src/connectors/BaseDuckDbConnector.ts
+++ b/packages/duckdb/src/connectors/BaseDuckDbConnector.ts
@@ -116,11 +116,15 @@ export function createBaseDuckDbConnector(
     ).finally(() => {
       state.activeQueries.delete(queryId);
     });
-    return {
+    const handle: QueryHandle<T> = {
       result: resultPromise,
       signal: abortController.signal,
       cancel: async () => cancelQuery(queryId),
-    };
+      then: resultPromise.then.bind(resultPromise),
+      catch: resultPromise.catch.bind(resultPromise),
+      finally: resultPromise.finally?.bind(resultPromise),
+    } as unknown as QueryHandle<T>;
+    return handle;
   };
 
   const execute = (sql: string, options?: QueryOptions): QueryHandle =>

--- a/packages/duckdb/src/connectors/BaseDuckDbConnector.ts
+++ b/packages/duckdb/src/connectors/BaseDuckDbConnector.ts
@@ -165,10 +165,9 @@ export function createBaseDuckDbConnector(
     const fileName = file;
     await ensureInitialized();
     if (opts && isSpatialLoadFileOptions(opts)) {
-      await query(loadSpatial(tableName, fileName, opts)).result;
+      await query(loadSpatial(tableName, fileName, opts));
     } else {
-      await query(load(opts?.method ?? 'auto', tableName, fileName, opts))
-        .result;
+      await query(load(opts?.method ?? 'auto', tableName, fileName, opts));
     }
   };
 
@@ -192,7 +191,7 @@ export function createBaseDuckDbConnector(
       return impl.loadObjectsInternal(file, tableName, opts);
     }
     await ensureInitialized();
-    await query(loadObjectsSql(tableName, file, opts)).result;
+    await query(loadObjectsSql(tableName, file, opts));
   };
 
   return {

--- a/packages/duckdb/src/connectors/DuckDbConnector.ts
+++ b/packages/duckdb/src/connectors/DuckDbConnector.ts
@@ -24,6 +24,7 @@ export interface QueryOptions {
  *  • `await handle.result` – kept for backwards-compatibility.
  *
  * Additional capabilities:
+ *  • Standard Promise API: `.then()`, `.catch()`, `.finally()`
  *  • `handle.cancel()` – cancel the running query.
  *  • `handle.signal` – `AbortSignal` that fires when the query is cancelled.
  *
@@ -93,6 +94,12 @@ export type QueryHandle<T = any> = PromiseLike<T> & {
    * ```
    */
   signal: AbortSignal;
+
+  /** Attach a callback for only the rejection of the Promise */
+  catch: Promise<T>['catch'];
+
+  /** Attach a callback that's invoked when the Promise is settled (fulfilled or rejected) */
+  finally: Promise<T>['finally'];
 };
 
 /**

--- a/packages/duckdb/src/connectors/DuckDbConnector.ts
+++ b/packages/duckdb/src/connectors/DuckDbConnector.ts
@@ -231,8 +231,7 @@ export interface DuckDbConnector {
    * @example
    * ```typescript
    * // Basic query
-   * const handle = connector.query('SELECT * FROM users WHERE active = true');
-   * const table = await handle.result;
+   * const handle = await connector.query('SELECT * FROM users WHERE active = true');
    * console.log(`Found ${table.numRows} active users`);
    *
    * // Query with timeout
@@ -244,7 +243,7 @@ export interface DuckDbConnector {
    * });
    *
    * try {
-   *   const result = await handle.result;
+   *   const result = await handle;
    *   console.log('Query completed within timeout');
    * } catch (error) {
    *   if (error.name === 'AbortError') {
@@ -271,8 +270,7 @@ export interface DuckDbConnector {
    * @example
    * ```typescript
    * // Simple JSON query
-   * const handle = connector.queryJson('SELECT name, email FROM users LIMIT 10');
-   * const users = await handle.result;
+   * const users = await connector.queryJson('SELECT name, email FROM users LIMIT 10');
    * for (const user of users) {
    *   console.log(`${user.name}: ${user.email}`);
    * }

--- a/packages/duckdb/src/exportToCsv.ts
+++ b/packages/duckdb/src/exportToCsv.ts
@@ -15,7 +15,7 @@ export function useExportToCsv() {
         const currentQuery = `(
           ${query}
         ) LIMIT ${pageSize} OFFSET ${offset}`;
-        const results = await dbConnector.query(currentQuery).result;
+        const results = await dbConnector.query(currentQuery);
 
         // Check if we received any results; if not, we are done.
         if (results.numRows === 0) {

--- a/packages/duckdb/src/useDuckDb.ts
+++ b/packages/duckdb/src/useDuckDb.ts
@@ -3,10 +3,13 @@ import {useStoreWithDuckDb} from './DuckDbSlice';
 import {DuckDbConnector} from './connectors/DuckDbConnector';
 
 /**
- * @deprecated DuckConn is deprecated, use DuckDb instead
+ * @deprecated
  */
 export type DuckConn = DuckDb;
 
+/**
+ * @deprecated
+ */
 export type DuckDb = {
   db: duckdb.AsyncDuckDB;
   conn: duckdb.AsyncDuckDBConnection;

--- a/packages/duckdb/src/useSql.ts
+++ b/packages/duckdb/src/useSql.ts
@@ -220,7 +220,7 @@ export function useSql<
           return;
         }
 
-        const result = await queryHandle.result;
+        const result = await queryHandle;
         if (!isMounted) {
           return;
         }

--- a/packages/sql-editor/src/SqlEditorSlice.tsx
+++ b/packages/sql-editor/src/SqlEditorSlice.tsx
@@ -371,7 +371,7 @@ export function createSqlEditorSlice<
               if (signal.aborted) {
                 throw new Error('Query aborted');
               }
-              await connector.query(statement, {signal}).result;
+              await connector.query(statement, {signal});
             }
 
             if (signal.aborted) {
@@ -394,7 +394,7 @@ export function createSqlEditorSlice<
                   limit: get().sqlEditor.queryResultLimit,
                 }),
                 {signal},
-              ).result;
+              );
               queryResult = {
                 status: 'success',
                 type: 'select',
@@ -412,9 +412,9 @@ export function createSqlEditorSlice<
                 );
               }
 
-              const result = await connector.query(lastQueryStatement, {signal})
-                .result;
-
+              const result = await connector.query(lastQueryStatement, {
+                signal,
+              });
               // EXPLAIN and PRAGMA are not detected as select queries
               // and we cannot wrap them in a SELECT * FROM,
               // but we can still execute them and return the result

--- a/packages/vega/src/VegaLiteChart.tsx
+++ b/packages/vega/src/VegaLiteChart.tsx
@@ -99,7 +99,7 @@ export const VegaLiteChart: React.FC<{
 
   useEffect(() => {
     const fetchData = async () => {
-      const result = await connector.query(sqlQuery).result;
+      const result = await connector.query(sqlQuery);
       setData({[DATA_NAME]: arrowTableToJson(result)});
     };
     fetchData();


### PR DESCRIPTION
The following code

```await connector.query('select * from people')```

is now equivalent to

```await connector.query('select * from people').result```

so no need for `.result` which was easy to overlook