### PR TITLE
feat: Add bundled DuckDB wasm option

### DIFF
--- a/examples/query/package.json
+++ b/examples/query/package.json
@@ -12,6 +12,8 @@
   "dependencies": {
     "@sqlrooms/dropzone": "^0.16.2",
     "@sqlrooms/room-shell": "workspace:*",
+    "@sqlrooms/duckdb": "workspace:*",
+    "@sqlrooms/utils": "workspace:*",
     "@sqlrooms/sql-editor": "workspace:*",
     "@sqlrooms/ui": "workspace:*",
     "class-variance-authority": "0.7.1",

--- a/examples/query/src/store.ts
+++ b/examples/query/src/store.ts
@@ -13,6 +13,7 @@ import {
   SqlEditorSliceState,
 } from '@sqlrooms/sql-editor';
 import {DatabaseIcon} from 'lucide-react';
+import {createWasmDuckDbConnector} from '@sqlrooms/duckdb';
 import {z} from 'zod';
 import {persist} from 'zustand/middleware';
 import {DataPanel} from './DataPanel';
@@ -44,6 +45,7 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomConfig, RoomState>(
     (set, get, store) => ({
       // Base room slice
       ...createRoomShellSlice<RoomConfig>({
+        connector: createWasmDuckDbConnector({useJsDelivrBundles: false}),
         config: {
           layout: {
             type: LayoutTypes.enum.mosaic,

--- a/packages/discuss/package.json
+++ b/packages/discuss/package.json
@@ -20,7 +20,8 @@
     "@sqlrooms/ui": "workspace:*",
     "@sqlrooms/utils": "workspace:*",
     "immer": "^10.1.1",
-    "zod": "^3.25.57"
+    "zod": "^3.25.57",
+    "lucide-react": "^0.474.0"
   },
   "peerDependencies": {
     "react": ">=18",

--- a/packages/duckdb/package.json
+++ b/packages/duckdb/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@duckdb/duckdb-wasm": "1.29.1-dev204.0",
     "@sqlrooms/core": "workspace:*",
+    "@sqlrooms/room-config": "workspace:*",
     "@sqlrooms/utils": "workspace:*",
     "fast-deep-equal": "^3.1.3",
     "immer": "^10.1.1",

--- a/packages/duckdb/src/duckdb-wasm.d.ts
+++ b/packages/duckdb/src/duckdb-wasm.d.ts
@@ -1,0 +1,9 @@
+declare module '@duckdb/duckdb-wasm/dist/*.wasm?url' {
+  const url: string;
+  export default url;
+}
+
+declare module '@duckdb/duckdb-wasm/dist/*.worker.js?url' {
+  const url: string;
+  export default url;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -819,6 +819,9 @@ importers:
       '@sqlrooms/dropzone':
         specifier: ^0.16.2
         version: 0.16.2(@types/react-dom@19.1.6(@types/react@19.1.7))(@types/react@19.1.7)(autoprefixer@10.4.21(postcss@8.5.4))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.17)
+      '@sqlrooms/duckdb':
+        specifier: workspace:*
+        version: link:../../packages/duckdb
       '@sqlrooms/room-shell':
         specifier: workspace:*
         version: link:../../packages/room-shell
@@ -828,6 +831,9 @@ importers:
       '@sqlrooms/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@sqlrooms/utils':
+        specifier: workspace:*
+        version: link:../../packages/utils
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -1042,6 +1048,9 @@ importers:
       immer:
         specifier: ^10.1.1
         version: 10.1.1
+      lucide-react:
+        specifier: ^0.474.0
+        version: 0.474.0(react@19.1.0)
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -1072,6 +1081,9 @@ importers:
       '@sqlrooms/core':
         specifier: workspace:*
         version: link:../core
+      '@sqlrooms/room-config':
+        specifier: workspace:*
+        version: link:../room-config
       '@sqlrooms/utils':
         specifier: workspace:*
         version: link:../utils


### PR DESCRIPTION
## Summary
- add `useJsDelivrBundles` option to `WasmDuckDbConnector`
- support local bundles when CDN usage is disabled
- use the new option in the `query` example
- declare module definitions for bundler imports
- include `room-config` dependency for duckdb package
- fix builds by adding missing dependencies

## Testing
- `pnpm build`
- `pnpm --filter=sqlrooms-query build`


------
https://chatgpt.com/codex/tasks/task_e_68553077d5b48321a6c66c1663f0b875