### PR TITLE
feat: Slice initialization improvements

### DIFF
--- a/examples/minimal/src/room.tsx
+++ b/examples/minimal/src/room.tsx
@@ -28,7 +28,7 @@ export type RoomState = RoomShellSliceState<RoomConfig> & {
  * Create the room store. You can combine your custom state and logic
  * with the slices from the SQLRooms modules.
  */
-export const {roomStore, useRoomStore} = createRoomStore<RoomConfig, RoomState>(
+const {roomStore, useRoomStore} = createRoomStore<RoomConfig, RoomState>(
   (set, get, store) => ({
     ...createRoomShellSlice<RoomConfig>({
       config: {

--- a/examples/query-motherduck/index.html
+++ b/examples/query-motherduck/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <link rel="manifest" href="/manifest.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>SQLRooms Query Workbench</title>
   </head>

--- a/examples/query-motherduck/src/Room.tsx
+++ b/examples/query-motherduck/src/Room.tsx
@@ -1,17 +1,20 @@
-import {RoomShell} from '@sqlrooms/room-shell';
+import {RoomShell, RoomStore} from '@sqlrooms/room-shell';
 import {ThemeSwitch} from '@sqlrooms/ui';
-import {createRoomStore} from './store';
-import {useMemo} from 'react';
+import {useRef} from 'react';
+import {createRoomStore, RoomConfig} from './store';
 
 interface RoomProps {
   mdToken: string;
 }
 
 export const Room = ({mdToken}: RoomProps) => {
-  const roomStore = useMemo(() => createRoomStore(mdToken), [mdToken]);
+  const roomStoreRef = useRef<RoomStore<RoomConfig>>(null);
+  if (!roomStoreRef.current) {
+    roomStoreRef.current = createRoomStore(mdToken);
+  }
 
   return (
-    <RoomShell className="h-screen" roomStore={roomStore}>
+    <RoomShell className="h-screen" roomStore={roomStoreRef.current}>
       <RoomShell.Sidebar>
         <ThemeSwitch />
       </RoomShell.Sidebar>

--- a/examples/query-motherduck/src/store.ts
+++ b/examples/query-motherduck/src/store.ts
@@ -40,6 +40,7 @@ const {createRoomStore, useRoomStore} = createRoomStoreCreator<RoomState>()(
         return {
           ...createRoomShellSlice<RoomConfig>({
             connector: createWasmMotherDuckDbConnector({
+              initializationQuery: `QQ`,
               mdToken,
             }),
             config: {

--- a/examples/query-motherduck/src/store.ts
+++ b/examples/query-motherduck/src/store.ts
@@ -36,46 +36,43 @@ export type RoomState = RoomShellSliceState<RoomConfig> & SqlEditorSliceState;
 const {createRoomStore, useRoomStore} = createRoomStoreCreator<RoomState>()(
   (mdToken: string) =>
     persist(
-      (set, get, store) => {
-        return {
-          ...createRoomShellSlice<RoomConfig>({
-            connector: createWasmMotherDuckDbConnector({
-              initializationQuery: `QQ`,
-              mdToken,
-            }),
-            config: {
-              layout: {
-                type: LayoutTypes.enum.mosaic,
-                nodes: {
-                  first: RoomPanelTypes.enum['data'],
-                  second: RoomPanelTypes.enum['main'],
-                  direction: 'row',
-                  splitPercentage: 30,
-                },
-              },
-
-              ...createDefaultSqlEditorConfig(),
-            },
-            room: {
-              panels: {
-                [RoomPanelTypes.enum['main']]: {
-                  component: MainView,
-                  placement: 'main',
-                },
-                [RoomPanelTypes.enum['data']]: {
-                  title: 'Data',
-                  component: DataPanel,
-                  icon: DatabaseIcon,
-                  placement: 'sidebar',
-                },
+      (set, get, store) => ({
+        ...createRoomShellSlice<RoomConfig>({
+          connector: createWasmMotherDuckDbConnector({
+            mdToken,
+          }),
+          config: {
+            layout: {
+              type: LayoutTypes.enum.mosaic,
+              nodes: {
+                first: RoomPanelTypes.enum['data'],
+                second: RoomPanelTypes.enum['main'],
+                direction: 'row',
+                splitPercentage: 30,
               },
             },
-          })(set, get, store),
 
-          // Sql editor slice
-          ...createSqlEditorSlice()(set, get, store),
-        };
-      },
+            ...createDefaultSqlEditorConfig(),
+          },
+          room: {
+            panels: {
+              [RoomPanelTypes.enum['main']]: {
+                component: MainView,
+                placement: 'main',
+              },
+              [RoomPanelTypes.enum['data']]: {
+                title: 'Data',
+                component: DataPanel,
+                icon: DatabaseIcon,
+                placement: 'sidebar',
+              },
+            },
+          },
+        })(set, get, store),
+
+        // Sql editor slice
+        ...createSqlEditorSlice()(set, get, store),
+      }),
       // Persist settings
       {
         // Local storage key

--- a/packages/duckdb/src/connectors/BaseDuckDbConnector.ts
+++ b/packages/duckdb/src/connectors/BaseDuckDbConnector.ts
@@ -70,6 +70,12 @@ export function createBaseDuckDbConnector(
     }
     state.initializing = (async () => {
       await impl.initializeInternal?.();
+      if (initializationQuery) {
+        await impl.executeQueryInternal(
+          initializationQuery,
+          new AbortController().signal,
+        );
+      }
       state.initialized = true;
       state.initializing = null;
     })().catch((err) => {

--- a/packages/duckdb/src/connectors/WasmDuckDbConnector.ts
+++ b/packages/duckdb/src/connectors/WasmDuckDbConnector.ts
@@ -95,9 +95,6 @@ export function createWasmDuckDbConnector(
         });
 
         conn = augmentConnectionQueryError(await db.connect());
-        if (initializationQuery) {
-          await conn.query(initializationQuery);
-        }
       } catch (err) {
         db = null;
         conn = null;

--- a/packages/motherduck/src/WasmMotherDuckDbConnector.ts
+++ b/packages/motherduck/src/WasmMotherDuckDbConnector.ts
@@ -38,9 +38,6 @@ export function createWasmMotherDuckDbConnector(
     async initializeInternal() {
       connection = MDConnection.create(params);
       await connection.isInitialized();
-      if (initializationQuery) {
-        await connection.evaluateQuery(initializationQuery);
-      }
     },
 
     async destroyInternal() {

--- a/packages/room-shell/src/RoomShellStore.ts
+++ b/packages/room-shell/src/RoomShellStore.ts
@@ -110,6 +110,7 @@ export type RoomShellSliceStateActions<PC extends BaseRoomConfig> =
   };
 
 export type RoomShellSliceState<PC extends BaseRoomConfig> = RoomState<PC> & {
+  initialize?: () => Promise<void>;
   config: PC;
   room: RoomShellSliceStateProps<PC> & RoomShellSliceStateActions<PC>;
 } & DuckDbSliceState &
@@ -193,6 +194,10 @@ export function createRoomShellSlice<PC extends BaseRoomConfig>(
             if (isRoomSliceWithInitialize(slice)) {
               await slice.initialize();
             }
+          }
+          const state = store.getState();
+          if (isRoomSliceWithInitialize(state)) {
+            await state.initialize();
           }
 
           setTaskProgress(INIT_ROOM_TASK, undefined);

--- a/packages/room-shell/src/RoomShellStore.ts
+++ b/packages/room-shell/src/RoomShellStore.ts
@@ -26,10 +26,10 @@ import {
 import {
   RoomState,
   RoomStateActions,
-  RoomStateContext,
   RoomStateProps,
   createRoomSlice,
   isRoomSliceWithInitialize,
+  useBaseRoomStore,
 } from '@sqlrooms/room-store';
 import {ErrorBoundary} from '@sqlrooms/ui';
 import {
@@ -39,8 +39,8 @@ import {
   downloadFile,
 } from '@sqlrooms/utils';
 import {castDraft, produce} from 'immer';
-import {ReactNode, useContext} from 'react';
-import {StateCreator, StoreApi, useStore} from 'zustand';
+import {ReactNode} from 'react';
+import {StateCreator, StoreApi} from 'zustand';
 import {
   DataSourceState,
   DataSourceStatus,
@@ -630,11 +630,7 @@ export function useBaseRoomShellStore<
   PS extends RoomShellSliceState<PC>,
   T,
 >(selector: (state: RoomShellSliceState<PC>) => T): T {
-  const store = useContext(RoomStateContext);
-  if (!store) {
-    throw new Error('Missing RoomStateProvider in the tree');
-  }
-  return useStore(store as unknown as StoreApi<PS>, selector);
+  return useBaseRoomStore<PC, PS, T>(selector as (state: RoomState<PC>) => T);
 }
 
 export function createSlice<PC extends BaseRoomConfig, S>(

--- a/packages/room-store/src/RoomStore.ts
+++ b/packages/room-store/src/RoomStore.ts
@@ -38,7 +38,7 @@ export type RoomStateActions<PC> = {
    * To be overridden by the custom project state.
    * @param config - The project config to save.
    */
-  onConfigChanged?: (config: PC) => Promise<void> | undefined;
+  onSaveConfig?: (config: PC) => Promise<void> | undefined;
 
   setTaskProgress: (id: string, taskProgress: TaskProgress | undefined) => void;
   getLoadingProgress: () => TaskProgress | undefined;
@@ -203,8 +203,8 @@ export function createRoomStoreCreator<TState extends RoomState<any>>() {
             // Subscribe to the project store changes after initialization
             store.subscribe(async (state) => {
               const {room} = state;
-              if (room.onConfigChanged && room.hasUnsavedChanges()) {
-                room.onConfigChanged(state.config);
+              if (room.onSaveConfig && room.hasUnsavedChanges()) {
+                room.onSaveConfig(state.config);
               }
             });
           } catch (error) {

--- a/packages/room-store/src/RoomStore.ts
+++ b/packages/room-store/src/RoomStore.ts
@@ -154,13 +154,13 @@ export function createRoomStore<PC, RS extends RoomState<PC>>(
   return {roomStore, useRoomStore};
 }
 
-export interface RooomSlice {
+export interface RoomSlice {
   initialize?: () => Promise<void>;
 }
 
 export function isRoomSliceWithInitialize(
   slice: unknown,
-): slice is RooomSlice & Required<Pick<RooomSlice, 'initialize'>> {
+): slice is RoomSlice & Required<Pick<RoomSlice, 'initialize'>> {
   return (
     typeof slice === 'object' &&
     slice !== null &&

--- a/packages/room-store/src/index.ts
+++ b/packages/room-store/src/index.ts
@@ -20,7 +20,7 @@ export {
   type RoomStore,
   type TaskProgress,
   createBaseSlice,
-  type RooomSlice,
+  type RoomSlice,
   isRoomSliceWithInitialize,
 } from './RoomStore';
 

--- a/packages/room-store/src/index.ts
+++ b/packages/room-store/src/index.ts
@@ -20,6 +20,8 @@ export {
   type RoomStore,
   type TaskProgress,
   createBaseSlice,
+  type RooomSlice,
+  isRoomSliceWithInitialize,
 } from './RoomStore';
 
 export * from '@sqlrooms/room-config';


### PR DESCRIPTION
- Added top-level store `.initialize()` 
- `RoomShellStore.initialize()` now calls `.initialize` in all slices which have it defined.
- Added `RoomStore.initialized` set to true one all slices' `.initialize()` functions have been called
- Added `RoomStore.onSaveConfig` which is called when the project config gets changed. Intended for config saving.
- `BaseDuckDbConnector` will execute `initializationQuery` if provided