### PR TITLE
fix: Memoize function suggestions in SqlMonacoEditor to avoid infinite loop

### DIFF
--- a/packages/sql-editor/src/components/QueryEditorPanelEditor.tsx
+++ b/packages/sql-editor/src/components/QueryEditorPanelEditor.tsx
@@ -1,11 +1,21 @@
-import {cn} from '@sqlrooms/ui';
+import { cn } from '@sqlrooms/ui';
 import type * as Monaco from 'monaco-editor';
-import {useCallback, useRef} from 'react';
-import {useStoreWithSqlEditor} from '../SqlEditorSlice';
-import {SqlMonacoEditor} from '../SqlMonacoEditor';
+import { useCallback, useRef } from 'react';
+import { useStoreWithSqlEditor } from '../SqlEditorSlice';
+import { SqlMonacoEditor } from '../SqlMonacoEditor';
 
 type EditorInstance = Monaco.editor.IStandaloneCodeEditor;
 type MonacoInstance = typeof Monaco;
+
+const MONACO_OPTIONS = {
+  scrollBeyondLastLine: false,
+  automaticLayout: true,
+  minimap: { enabled: false },
+  wordWrap: 'on',
+  quickSuggestions: true,
+  suggestOnTriggerCharacters: true,
+};
+
 
 export const QueryEditorPanelEditor: React.FC<{
   className?: string;
@@ -37,7 +47,7 @@ export const QueryEditorPanelEditor: React.FC<{
 
   // Handle editor mount
   const handleEditorMount = useCallback(
-    (editor: EditorInstance, monaco: MonacoInstance, queryId: string) => {
+    (editor: EditorInstance, monaco: MonacoInstance) => {
       editorRef.current[queryId] = editor;
       // Add keyboard shortcut for running query
       editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => {
@@ -59,17 +69,8 @@ export const QueryEditorPanelEditor: React.FC<{
       value={queryText ?? ''}
       onChange={handleUpdateQuery}
       className={cn('h-full w-full flex-grow', className)}
-      options={{
-        scrollBeyondLastLine: false,
-        automaticLayout: true,
-        minimap: {enabled: false},
-        wordWrap: 'on',
-        quickSuggestions: true,
-        suggestOnTriggerCharacters: true,
-      }}
-      onMount={(editor: EditorInstance, monaco: MonacoInstance) => {
-        handleEditorMount(editor, monaco, queryId);
-      }}
+      options={MONACO_OPTIONS}
+      onMount={handleEditorMount}
       tableSchemas={tableSchemas}
     />
   );

--- a/packages/sql-editor/src/constants/functionSuggestions.ts
+++ b/packages/sql-editor/src/constants/functionSuggestions.ts
@@ -5,12 +5,13 @@ import {
   DuckDbConnector,
   escapeVal,
 } from '@sqlrooms/duckdb';
+import { memoizeOnce } from '@sqlrooms/utils';
 
-export async function getFunctionSuggestions(
+const getFunctionSuggestionsImpl = async (
   connector: DuckDbConnector,
   wordBeforeCursor: string,
   limit = 100,
-): Promise<Iterable<{name: string; documentation: string}>> {
+): Promise<Iterable<{name: string; documentation: string}>> => {
   const result = await connector.query(
     `SELECT     
       function_name as name,
@@ -46,7 +47,10 @@ export async function getFunctionSuggestions(
   ).map(([name, rows]) => {
     return {name, documentation: formatDocumentation(rows)};
   });
-}
+};
+
+// Memoized version of the function
+export const getFunctionSuggestions = memoizeOnce(getFunctionSuggestionsImpl);
 
 type FunctionRow = {
   name: string;

--- a/packages/utils/__tests__/memoization.test.ts
+++ b/packages/utils/__tests__/memoization.test.ts
@@ -1,0 +1,204 @@
+import { memoizeOnce } from '../src/memoization';
+
+describe('memoizeOnce', () => {
+  test('returns the same result for identical arguments', () => {
+    let callCount = 0;
+    const fn = (a: number, b: string) => {
+      callCount++;
+      return `${a}-${b}-${callCount}`;
+    };
+    
+    const memoized = memoizeOnce(fn);
+    
+    const result1 = memoized(1, 'test');
+    const result2 = memoized(1, 'test');
+    
+    expect(result1).toBe(result2);
+    expect(result1).toBe('1-test-1');
+    expect(callCount).toBe(1); // Function should only be called once
+  });
+
+  test('calls function again when arguments change', () => {
+    let callCount = 0;
+    const fn = (a: number) => {
+      callCount++;
+      return a * 2;
+    };
+    
+    const memoized = memoizeOnce(fn);
+    
+    const result1 = memoized(5);
+    const result2 = memoized(10); // Different argument
+    const result3 = memoized(10); // Same as result2
+    
+    expect(result1).toBe(10);
+    expect(result2).toBe(20);
+    expect(result3).toBe(20);
+    expect(callCount).toBe(2); // Called twice: for 5 and for 10
+  });
+
+  test('invalidates cache when any argument changes', () => {
+    let callCount = 0;
+    const fn = (a: number, b: string, c: boolean) => {
+      callCount++;
+      return `${a}-${b}-${c}`;
+    };
+    
+    const memoized = memoizeOnce(fn);
+    
+    memoized(1, 'test', true);
+    memoized(1, 'test', true); // Same arguments, should use cache
+    memoized(1, 'test', false); // Different last argument
+    memoized(1, 'different', true); // Different middle argument
+    memoized(2, 'test', true); // Different first argument
+    
+    expect(callCount).toBe(4); // Called 4 times due to different arguments
+  });
+
+  test('works with async functions', async () => {
+    let callCount = 0;
+    const asyncFn = async (value: string) => {
+      callCount++;
+      await new Promise(resolve => setTimeout(resolve, 1)); // Small delay
+      return `async-${value}-${callCount}`;
+    };
+    
+    const memoized = memoizeOnce(asyncFn);
+    
+    const result1 = await memoized('test');
+    const result2 = await memoized('test');
+    
+    expect(result1).toBe(result2);
+    expect(result1).toBe('async-test-1');
+    expect(callCount).toBe(1);
+  });
+
+  test('handles different argument types correctly', () => {
+    let callCount = 0;
+    const fn = (...args: any[]) => {
+      callCount++;
+      return JSON.stringify(args) + `-${callCount}`;
+    };
+    
+    const memoized = memoizeOnce(fn);
+    
+    // Test with objects
+    const obj = { key: 'value' };
+    const result1 = memoized(obj, [1, 2, 3]);
+    const result2 = memoized(obj, [1, 2, 3]); // Same references
+    
+    expect(result1).toBe(result2);
+    expect(callCount).toBe(1);
+    
+    // Test with different object (different reference, same content)
+    const obj2 = { key: 'value' };
+    const result3 = memoized(obj2, [1, 2, 3]); // Different object reference
+    
+    expect(result3).not.toBe(result1);
+    expect(callCount).toBe(2);
+  });
+
+  test('handles no arguments', () => {
+    let callCount = 0;
+    const fn = () => {
+      callCount++;
+      return `no-args-${callCount}`;
+    };
+    
+    const memoized = memoizeOnce(fn);
+    
+    const result1 = memoized();
+    const result2 = memoized();
+    
+    expect(result1).toBe(result2);
+    expect(result1).toBe('no-args-1');
+    expect(callCount).toBe(1);
+  });
+
+  test('handles undefined and null arguments', () => {
+    let callCount = 0;
+    const fn = (a: any, b: any) => {
+      callCount++;
+      return `${a}-${b}-${callCount}`;
+    };
+    
+    const memoized = memoizeOnce(fn);
+    
+    const result1 = memoized(undefined, null);
+    const result2 = memoized(undefined, null);
+    const result3 = memoized(null, undefined); // Different order
+    
+    expect(result1).toBe(result2);
+    expect(result1).toBe('undefined-null-1');
+    expect(result3).toBe('null-undefined-2');
+    expect(callCount).toBe(2);
+  });
+
+  test('preserves function context and return values', () => {
+    const fn = function(this: any, multiplier: number) {
+      return this.value * multiplier;
+    };
+    
+    const context = { value: 10 };
+    const memoized = memoizeOnce(fn);
+    
+    const result1 = memoized.call(context, 3);
+    const result2 = memoized.call(context, 3);
+    
+    expect(result1).toBe(30);
+    expect(result2).toBe(30);
+  });
+
+  test('works correctly when switching between different argument sets', () => {
+    let callCount = 0;
+    const fn = (a: string, b: number) => {
+      callCount++;
+      return `${a}-${b}-${callCount}`;
+    };
+    
+    const memoized = memoizeOnce(fn);
+    
+    // First set of arguments
+    const result1a = memoized('hello', 1);
+    const result1b = memoized('hello', 1); // Should use cache
+    
+    // Second set of arguments  
+    const result2a = memoized('world', 2);
+    const result2b = memoized('world', 2); // Should use cache
+    
+    // Back to first set - should execute again (cache only holds last result)
+    const result1c = memoized('hello', 1);
+    
+    expect(result1a).toBe('hello-1-1');
+    expect(result1b).toBe('hello-1-1'); // Same as result1a
+    expect(result2a).toBe('world-2-2');
+    expect(result2b).toBe('world-2-2'); // Same as result2a
+    expect(result1c).toBe('hello-1-3'); // New execution, not cached
+    expect(callCount).toBe(3);
+  });
+
+  test('handles array arguments correctly', () => {
+    let callCount = 0;
+    const fn = (arr: number[]) => {
+      callCount++;
+      return arr.reduce((sum, val) => sum + val, 0);
+    };
+    
+    const memoized = memoizeOnce(fn);
+    
+    const array1 = [1, 2, 3];
+    const result1 = memoized(array1);
+    const result2 = memoized(array1); // Same array reference
+    
+    expect(result1).toBe(6);
+    expect(result2).toBe(6);
+    expect(callCount).toBe(1);
+    
+    // Different array with same content
+    const array2 = [1, 2, 3];
+    const result3 = memoized(array2);
+    
+    expect(result3).toBe(6);
+    expect(callCount).toBe(2); // Should execute again due to different reference
+  });
+}); 

--- a/packages/utils/__tests__/memoization.test.ts
+++ b/packages/utils/__tests__/memoization.test.ts
@@ -1,4 +1,4 @@
-import { memoizeOnce } from '../src/memoization';
+import {memoizeOnce} from '../src/memoization';
 
 describe('memoizeOnce', () => {
   test('returns the same result for identical arguments', () => {
@@ -7,12 +7,12 @@ describe('memoizeOnce', () => {
       callCount++;
       return `${a}-${b}-${callCount}`;
     };
-    
+
     const memoized = memoizeOnce(fn);
-    
+
     const result1 = memoized(1, 'test');
     const result2 = memoized(1, 'test');
-    
+
     expect(result1).toBe(result2);
     expect(result1).toBe('1-test-1');
     expect(callCount).toBe(1); // Function should only be called once
@@ -24,13 +24,13 @@ describe('memoizeOnce', () => {
       callCount++;
       return a * 2;
     };
-    
+
     const memoized = memoizeOnce(fn);
-    
+
     const result1 = memoized(5);
     const result2 = memoized(10); // Different argument
     const result3 = memoized(10); // Same as result2
-    
+
     expect(result1).toBe(10);
     expect(result2).toBe(20);
     expect(result3).toBe(20);
@@ -43,15 +43,15 @@ describe('memoizeOnce', () => {
       callCount++;
       return `${a}-${b}-${c}`;
     };
-    
+
     const memoized = memoizeOnce(fn);
-    
+
     memoized(1, 'test', true);
     memoized(1, 'test', true); // Same arguments, should use cache
     memoized(1, 'test', false); // Different last argument
     memoized(1, 'different', true); // Different middle argument
     memoized(2, 'test', true); // Different first argument
-    
+
     expect(callCount).toBe(4); // Called 4 times due to different arguments
   });
 
@@ -59,15 +59,15 @@ describe('memoizeOnce', () => {
     let callCount = 0;
     const asyncFn = async (value: string) => {
       callCount++;
-      await new Promise(resolve => setTimeout(resolve, 1)); // Small delay
+      await new Promise((resolve) => setTimeout(resolve, 1)); // Small delay
       return `async-${value}-${callCount}`;
     };
-    
+
     const memoized = memoizeOnce(asyncFn);
-    
+
     const result1 = await memoized('test');
     const result2 = await memoized('test');
-    
+
     expect(result1).toBe(result2);
     expect(result1).toBe('async-test-1');
     expect(callCount).toBe(1);
@@ -79,21 +79,22 @@ describe('memoizeOnce', () => {
       callCount++;
       return JSON.stringify(args) + `-${callCount}`;
     };
-    
+
     const memoized = memoizeOnce(fn);
-    
+
     // Test with objects
-    const obj = { key: 'value' };
-    const result1 = memoized(obj, [1, 2, 3]);
-    const result2 = memoized(obj, [1, 2, 3]); // Same references
-    
+    const obj = {key: 'value'};
+    const arr = [1, 2, 3]; // Store array in variable to reuse same reference
+    const result1 = memoized(obj, arr);
+    const result2 = memoized(obj, arr); // Same references
+
     expect(result1).toBe(result2);
     expect(callCount).toBe(1);
-    
+
     // Test with different object (different reference, same content)
-    const obj2 = { key: 'value' };
-    const result3 = memoized(obj2, [1, 2, 3]); // Different object reference
-    
+    const obj2 = {key: 'value'};
+    const result3 = memoized(obj2, arr); // Different object reference
+
     expect(result3).not.toBe(result1);
     expect(callCount).toBe(2);
   });
@@ -104,12 +105,12 @@ describe('memoizeOnce', () => {
       callCount++;
       return `no-args-${callCount}`;
     };
-    
+
     const memoized = memoizeOnce(fn);
-    
+
     const result1 = memoized();
     const result2 = memoized();
-    
+
     expect(result1).toBe(result2);
     expect(result1).toBe('no-args-1');
     expect(callCount).toBe(1);
@@ -121,13 +122,13 @@ describe('memoizeOnce', () => {
       callCount++;
       return `${a}-${b}-${callCount}`;
     };
-    
+
     const memoized = memoizeOnce(fn);
-    
+
     const result1 = memoized(undefined, null);
     const result2 = memoized(undefined, null);
     const result3 = memoized(null, undefined); // Different order
-    
+
     expect(result1).toBe(result2);
     expect(result1).toBe('undefined-null-1');
     expect(result3).toBe('null-undefined-2');
@@ -135,16 +136,16 @@ describe('memoizeOnce', () => {
   });
 
   test('preserves function context and return values', () => {
-    const fn = function(this: any, multiplier: number) {
+    const fn = function (this: any, multiplier: number) {
       return this.value * multiplier;
     };
-    
-    const context = { value: 10 };
+
+    const context = {value: 10};
     const memoized = memoizeOnce(fn);
-    
+
     const result1 = memoized.call(context, 3);
     const result2 = memoized.call(context, 3);
-    
+
     expect(result1).toBe(30);
     expect(result2).toBe(30);
   });
@@ -155,20 +156,20 @@ describe('memoizeOnce', () => {
       callCount++;
       return `${a}-${b}-${callCount}`;
     };
-    
+
     const memoized = memoizeOnce(fn);
-    
+
     // First set of arguments
     const result1a = memoized('hello', 1);
     const result1b = memoized('hello', 1); // Should use cache
-    
-    // Second set of arguments  
+
+    // Second set of arguments
     const result2a = memoized('world', 2);
     const result2b = memoized('world', 2); // Should use cache
-    
+
     // Back to first set - should execute again (cache only holds last result)
     const result1c = memoized('hello', 1);
-    
+
     expect(result1a).toBe('hello-1-1');
     expect(result1b).toBe('hello-1-1'); // Same as result1a
     expect(result2a).toBe('world-2-2');
@@ -183,22 +184,62 @@ describe('memoizeOnce', () => {
       callCount++;
       return arr.reduce((sum, val) => sum + val, 0);
     };
-    
+
     const memoized = memoizeOnce(fn);
-    
+
     const array1 = [1, 2, 3];
     const result1 = memoized(array1);
     const result2 = memoized(array1); // Same array reference
-    
+
     expect(result1).toBe(6);
     expect(result2).toBe(6);
     expect(callCount).toBe(1);
-    
+
     // Different array with same content
     const array2 = [1, 2, 3];
     const result3 = memoized(array2);
-    
+
     expect(result3).toBe(6);
     expect(callCount).toBe(2); // Should execute again due to different reference
   });
-}); 
+
+  test('handles concurrent async calls correctly', async () => {
+    let callCount = 0;
+    let resolvePromise: (value: string) => void;
+
+    const asyncFn = async (value: string) => {
+      callCount++;
+      // Create a Promise that we can control when it resolves
+      const result = await new Promise<string>((resolve) => {
+        resolvePromise = resolve;
+      });
+      return `async-${value}-${result}`;
+    };
+
+    const memoized = memoizeOnce(asyncFn);
+
+    // Make two concurrent calls with the same arguments
+    const promise1 = memoized('test');
+    const promise2 = memoized('test');
+
+    // Both calls should return the same Promise instance
+    expect(promise1).toBe(promise2);
+    expect(callCount).toBe(1); // Function should only be called once
+
+    // Resolve the promise
+    resolvePromise!('completed');
+
+    // Both promises should resolve to the same value
+    const [result1, result2] = await Promise.all([promise1, promise2]);
+
+    expect(result1).toBe('async-test-completed');
+    expect(result2).toBe('async-test-completed');
+    expect(result1).toBe(result2);
+    expect(callCount).toBe(1); // Still only called once
+
+    // Subsequent calls should use the cached result
+    const result3 = await memoized('test');
+    expect(result3).toBe('async-test-completed');
+    expect(callCount).toBe(1); // Still only called once
+  });
+});

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -12,3 +12,4 @@ export * from './str';
 export * from './xhr';
 export * from './filepaths';
 export {safeJsonParse} from './json';
+export {memoizeOnce} from './memoization';

--- a/packages/utils/src/memoization.ts
+++ b/packages/utils/src/memoization.ts
@@ -1,46 +1,46 @@
 /**
  * Creates a memoized version of a function that caches only the last result.
  * The cache is invalidated when any of the arguments change.
- * 
- * This is useful for expensive operations that are likely to be called 
+ *
+ * This is useful for expensive operations that are likely to be called
  * multiple times with the same arguments, like database queries or API calls.
- * 
+ *
  * @param fn - The function to memoize
  * @returns A memoized version of the function
- * 
+ *
  * @example
  * ```ts
  * const expensiveQuery = async (userId: string, limit: number) => {
  *   return await database.query(`SELECT * FROM users WHERE id = ? LIMIT ?`, [userId, limit]);
  * };
- * 
+ *
  * const memoizedQuery = memoizeOnce(expensiveQuery);
- * 
+ *
  * // First call executes the function
  * const result1 = await memoizedQuery("123", 10);
- * 
+ *
  * // Second call with same arguments returns cached result
  * const result2 = await memoizedQuery("123", 10); // Uses cache
- * 
+ *
  * // Call with different arguments invalidates cache and executes function
  * const result3 = await memoizedQuery("456", 10); // Executes function
  * ```
  */
 export function memoizeOnce<TArgs extends readonly unknown[], TReturn>(
-  fn: (...args: TArgs) => TReturn
+  fn: (...args: TArgs) => TReturn,
 ): (...args: TArgs) => TReturn {
   let lastArgs: TArgs | undefined;
   let lastResult: TReturn;
   let hasResult = false;
 
-  return (...args: TArgs): TReturn => {
+  return function (this: any, ...args: TArgs): TReturn {
     // Check if we have a cached result and arguments haven't changed
     if (hasResult && lastArgs && argsEqual(lastArgs, args)) {
       return lastResult;
     }
 
-    // Call the function and cache the result
-    lastResult = fn(...args);
+    // Call the function with the correct context and cache the result
+    lastResult = fn.apply(this, args as unknown as any[]);
     lastArgs = args;
     hasResult = true;
 

--- a/packages/utils/src/memoization.ts
+++ b/packages/utils/src/memoization.ts
@@ -1,0 +1,57 @@
+/**
+ * Creates a memoized version of a function that caches only the last result.
+ * The cache is invalidated when any of the arguments change.
+ * 
+ * This is useful for expensive operations that are likely to be called 
+ * multiple times with the same arguments, like database queries or API calls.
+ * 
+ * @param fn - The function to memoize
+ * @returns A memoized version of the function
+ * 
+ * @example
+ * ```ts
+ * const expensiveQuery = async (userId: string, limit: number) => {
+ *   return await database.query(`SELECT * FROM users WHERE id = ? LIMIT ?`, [userId, limit]);
+ * };
+ * 
+ * const memoizedQuery = memoizeOnce(expensiveQuery);
+ * 
+ * // First call executes the function
+ * const result1 = await memoizedQuery("123", 10);
+ * 
+ * // Second call with same arguments returns cached result
+ * const result2 = await memoizedQuery("123", 10); // Uses cache
+ * 
+ * // Call with different arguments invalidates cache and executes function
+ * const result3 = await memoizedQuery("456", 10); // Executes function
+ * ```
+ */
+export function memoizeOnce<TArgs extends readonly unknown[], TReturn>(
+  fn: (...args: TArgs) => TReturn
+): (...args: TArgs) => TReturn {
+  let lastArgs: TArgs | undefined;
+  let lastResult: TReturn;
+  let hasResult = false;
+
+  return (...args: TArgs): TReturn => {
+    // Check if we have a cached result and arguments haven't changed
+    if (hasResult && lastArgs && argsEqual(lastArgs, args)) {
+      return lastResult;
+    }
+
+    // Call the function and cache the result
+    lastResult = fn(...args);
+    lastArgs = args;
+    hasResult = true;
+
+    return lastResult;
+  };
+}
+
+/**
+ * Shallow comparison of two arrays to check if all elements are equal
+ */
+function argsEqual<T extends readonly unknown[]>(a: T, b: T): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((val, index) => val === b[index]);
+}


### PR DESCRIPTION
- Adding memoizeOnce util function
- `getFunctionSuggestions` is memoized to avoid infinite query loop
