### PR TITLE
fix: SQL editor function suggestions backward compatibility

### DIFF
--- a/packages/sql-editor/src/constants/functionSuggestions.ts
+++ b/packages/sql-editor/src/constants/functionSuggestions.ts
@@ -13,8 +13,7 @@ const getFunctionSuggestionsImpl = async (
   limit = 100,
 ): Promise<Iterable<{name: string; documentation: string}>> => {
   const result = await connector.query(
-    `SELECT *, 'qq' as examples
-     FROM duckdb_functions()
+    `SELECT * FROM duckdb_functions()
      WHERE function_name ILIKE ${escapeVal(
        wordBeforeCursor.replace(/([%_\\])/g, '\\$1') + '%',
      )} ESCAPE '\\'

--- a/packages/sql-editor/src/constants/functionSuggestions.ts
+++ b/packages/sql-editor/src/constants/functionSuggestions.ts
@@ -5,7 +5,7 @@ import {
   DuckDbConnector,
   escapeVal,
 } from '@sqlrooms/duckdb';
-import { memoizeOnce } from '@sqlrooms/utils';
+import {memoizeOnce} from '@sqlrooms/utils';
 
 const getFunctionSuggestionsImpl = async (
   connector: DuckDbConnector,
@@ -13,20 +13,13 @@ const getFunctionSuggestionsImpl = async (
   limit = 100,
 ): Promise<Iterable<{name: string; documentation: string}>> => {
   const result = await connector.query(
-    `SELECT     
-      function_name as name,
-      function_type as type,
-      return_type as returnType,
-      examples,
-      parameters,
-      parameter_types as parameterTypes,
-      description
+    `SELECT *, 'qq' as examples
      FROM duckdb_functions()
-     WHERE name ILIKE ${escapeVal(
+     WHERE function_name ILIKE ${escapeVal(
        wordBeforeCursor.replace(/([%_\\])/g, '\\$1') + '%',
      )} ESCAPE '\\'
-     AND REGEXP_MATCHES(name,'^[A-Z]', 'i')
-     ORDER BY name
+     AND REGEXP_MATCHES(function_name, '^[A-Z]', 'i')
+     ORDER BY function_name
      LIMIT ${limit}
      `,
   );
@@ -34,12 +27,30 @@ const getFunctionSuggestionsImpl = async (
   return Array.from(
     groupFunctionsByName(
       Array.from(createTypedRowAccessor({arrowTable: result})).map(
-        (row: FunctionRow) => {
+        ({
+          function_name,
+          function_type,
+          return_type,
+          example, // older DuckDB versions
+          examples,
+          parameters,
+          parameter_types,
+          description,
+        }: Record<string, any>) => {
           return {
-            ...row,
-            parameterTypes: Array.from(row.parameterTypes),
-            parameters: Array.from(row.parameters),
-            examples: Array.from(row.examples),
+            name: function_name,
+            type: function_type,
+            returnType: return_type,
+            examples:
+              // older DuckDB versions have `example` string instead of `examples` array
+              typeof examples === 'object' && 'toArray' in examples
+                ? examples.toArray()
+                : typeof example === 'string'
+                  ? [example]
+                  : [],
+            parameters: Array.from(parameters),
+            parameterTypes: Array.from(parameter_types),
+            description: description,
           };
         },
       ),

--- a/packages/sql-editor/src/constants/functionSuggestions.ts
+++ b/packages/sql-editor/src/constants/functionSuggestions.ts
@@ -42,7 +42,7 @@ const getFunctionSuggestionsImpl = async (
             returnType: return_type,
             examples:
               // older DuckDB versions have `example` string instead of `examples` array
-              typeof examples === 'object' && 'toArray' in examples
+              examples?.toArray instanceof Function
                 ? examples.toArray()
                 : typeof example === 'string'
                   ? [example]


### PR DESCRIPTION
Fixing error in SQL editor function suggestions with older DuckDB versions.

The result of `SELECT * FROM duckdb_functions()` used to have `example` string in DuckDB 1.1.1 and is now an `examples` array.
 
