### PR TITLE
[fix] kepler-integration: pass mapboxapi token to plot container

### DIFF
--- a/packages/kepler/src/components/KeplerPlotContainer.tsx
+++ b/packages/kepler/src/components/KeplerPlotContainer.tsx
@@ -25,6 +25,7 @@ export const KeplerPlotContainer: FC<{mapId: string}> = ({mapId}) => {
       keplerState !== undefined
         ? {
             ...KEPLER_PROPS,
+            mapboxApiAccessToken: KEPLER_PROPS.mapboxApiAccessToken || keplerState?.mapStyle?.mapboxApiAccessToken || '',
             ...keplerState,
             ...keplerActions,
             id: mapId,


### PR DESCRIPTION
- KEPLER_PROPS above defines `mapboxApiAccessToken` as an empty string (''), to be replaced with actual token.
- but there is no way to override `mapboxApiAccessToken` from an external module.

- This PR uses access token from `keplerState?.mapStyle` if `KEPLER_PROPS.mapboxApiAccessToken` isn't defined