### PR TITLE
fix: Create table initial query wasn't properly set

### DIFF
--- a/packages/data-table/src/DataTableModal.tsx
+++ b/packages/data-table/src/DataTableModal.tsx
@@ -54,7 +54,7 @@ const DataTableModal: FC<{
         aria-describedby="data-table-modal"
       >
         <DialogHeader>
-          <DialogTitle>{title ? `Table "${title}"` : ''}</DialogTitle>
+          <DialogTitle>{title ?? ''}</DialogTitle>
           <DialogDescription className="hidden">{title}</DialogDescription>
         </DialogHeader>
         <div className="bg-muted flex-1 overflow-hidden">

--- a/packages/data-table/src/DataTablePaginated.tsx
+++ b/packages/data-table/src/DataTablePaginated.tsx
@@ -61,7 +61,7 @@ export type DataTablePaginatedProps<Data extends object> = {
  */
 export default function DataTablePaginated<Data extends object>({
   className,
-  fontSize = 'text-base',
+  fontSize = 'text-xs',
   data,
   columns,
   numRows,

--- a/packages/data-table/src/QueryDataTable.tsx
+++ b/packages/data-table/src/QueryDataTable.tsx
@@ -19,7 +19,7 @@ export type QueryDataTableProps = {
 
 const QueryDataTable: FC<QueryDataTableProps> = ({
   className,
-  fontSize = 'text-base',
+  fontSize = 'text-xs',
   query,
   renderActions = (query) => <QueryDataTableActionsMenu query={query} />,
 }) => {

--- a/packages/schema-tree/src/nodes/TableTreeNode.tsx
+++ b/packages/schema-tree/src/nodes/TableTreeNode.tsx
@@ -1,8 +1,10 @@
 // Copyright 2022 Foursquare Labs, Inc. All Rights Reserved.
 
-import {TableNodeObject} from '@sqlrooms/duckdb';
-import {CopyIcon, SquareTerminalIcon, TableIcon} from 'lucide-react';
+import {makeQualifiedTableName, TableNodeObject} from '@sqlrooms/duckdb';
+import {CopyIcon, EyeIcon, SquareTerminalIcon, TableIcon} from 'lucide-react';
 import {FC} from 'react';
+import {useDisclosure} from '@sqlrooms/ui';
+import DataTableModal from '@sqlrooms/data-table/src/DataTableModal';
 import {BaseTreeNode} from './BaseTreeNode';
 import {
   TreeNodeActionsMenu,
@@ -11,17 +13,28 @@ import {
 
 export const defaultRenderTableNodeMenuItems = (
   nodeObject: TableNodeObject,
+  tableModal: ReturnType<typeof useDisclosure>,
 ) => {
   const {database, schema, name} = nodeObject;
+  const qualifiedTableName = makeQualifiedTableName({
+    database,
+    schema,
+    table: name,
+  });
   return (
     <>
       <TreeNodeActionsMenuItem
         onClick={() => {
-          navigator.clipboard.writeText(
-            nodeObject.schema == 'main'
-              ? nodeObject.name
-              : `${nodeObject.schema}.${nodeObject.name}`,
-          );
+          tableModal.onOpen();
+        }}
+      >
+        <EyeIcon width="15px" />
+        View table
+      </TreeNodeActionsMenuItem>
+
+      <TreeNodeActionsMenuItem
+        onClick={() => {
+          navigator.clipboard.writeText(qualifiedTableName.table);
         }}
       >
         <CopyIcon width="15px" />
@@ -30,14 +43,16 @@ export const defaultRenderTableNodeMenuItems = (
 
       <TreeNodeActionsMenuItem
         onClick={() => {
-          navigator.clipboard.writeText(
-            [
-              `SELECT * FROM `,
-              database === 'memory' ? '' : `${database}.`,
-              schema === 'main' ? '' : `${schema}.`,
-              name,
-            ].join(''),
-          );
+          navigator.clipboard.writeText(qualifiedTableName.toString());
+        }}
+      >
+        <CopyIcon width="15px" />
+        Copy qualified table name
+      </TreeNodeActionsMenuItem>
+
+      <TreeNodeActionsMenuItem
+        onClick={() => {
+          navigator.clipboard.writeText(`SELECT * FROM ${qualifiedTableName}`);
         }}
       >
         <SquareTerminalIcon width="15px" />
@@ -50,20 +65,42 @@ export const defaultRenderTableNodeMenuItems = (
 export const TableTreeNode: FC<{
   className?: string;
   nodeObject: TableNodeObject;
-  renderMenuItems?: (nodeObject: TableNodeObject) => React.ReactNode;
+  renderMenuItems?: (
+    nodeObject: TableNodeObject,
+    tableModal: ReturnType<typeof useDisclosure>,
+  ) => React.ReactNode;
 }> = (props) => {
   const {
     className,
     nodeObject,
     renderMenuItems = defaultRenderTableNodeMenuItems,
   } = props;
+
+  const tableModal = useDisclosure();
+  const {database, schema, name} = nodeObject;
+  const qualifiedTableName = makeQualifiedTableName({
+    database,
+    schema,
+    table: name,
+  });
+  const sqlQuery = `SELECT * FROM ${qualifiedTableName}`;
+
   return (
-    <BaseTreeNode asChild className={className} nodeObject={nodeObject}>
-      <div className="flex w-full items-center space-x-2">
-        <TableIcon size="16px" className="shrink-0 text-blue-500" />
-        <span className="text-sm">{nodeObject.name}</span>
-      </div>
-      <TreeNodeActionsMenu>{renderMenuItems(nodeObject)}</TreeNodeActionsMenu>
-    </BaseTreeNode>
+    <>
+      <BaseTreeNode asChild className={className} nodeObject={nodeObject}>
+        <div className="flex w-full items-center space-x-2">
+          <TableIcon size="16px" className="shrink-0 text-blue-500" />
+          <span className="text-sm">{nodeObject.name}</span>
+        </div>
+        <TreeNodeActionsMenu>
+          {renderMenuItems(nodeObject, tableModal)}
+        </TreeNodeActionsMenu>
+      </BaseTreeNode>
+      <DataTableModal
+        title={qualifiedTableName.table}
+        query={sqlQuery}
+        tableModal={tableModal}
+      />
+    </>
   );
 };

--- a/packages/sql-editor/src/components/CreateTableModal.tsx
+++ b/packages/sql-editor/src/components/CreateTableModal.tsx
@@ -169,12 +169,19 @@ const CreateTableForm: FC<CreateTableFormProps> = ({
 };
 
 const CreateTableModal: FC<CreateTableModalProps> = (props) => {
-  const {isOpen, onClose} = props;
+  const {isOpen, onClose, query, editDataSource, onAddOrUpdateSqlQuery} = props;
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
       <DialogContent className="sm:max-w-[800px]">
-        {isOpen && <CreateTableForm {...props} />}
+        {isOpen && (
+          <CreateTableForm
+            query={query}
+            onClose={onClose}
+            editDataSource={editDataSource}
+            onAddOrUpdateSqlQuery={onAddOrUpdateSqlQuery}
+          />
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/packages/sql-editor/src/components/CreateTableModal.tsx
+++ b/packages/sql-editor/src/components/CreateTableModal.tsx
@@ -49,16 +49,30 @@ export type CreateTableModalProps = {
   ) => Promise<void>;
 };
 
-const CreateTableModal: FC<CreateTableModalProps> = (props) => {
-  const {editDataSource, isOpen, onClose, onAddOrUpdateSqlQuery} = props;
+type CreateTableFormProps = {
+  query: string;
+  onClose: () => void;
+  editDataSource?: SqlQueryDataSource;
+  onAddOrUpdateSqlQuery: (
+    tableName: string,
+    query: string,
+    oldTableName?: string,
+  ) => Promise<void>;
+};
 
+const CreateTableForm: FC<CreateTableFormProps> = ({
+  query,
+  onClose,
+  editDataSource,
+  onAddOrUpdateSqlQuery,
+}) => {
   const connector = useStoreWithSqlEditor((state) => state.db.connector);
   const form = useForm<z.infer<typeof formSchema>>({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     resolver: zodResolver(formSchema as any),
     defaultValues: {
       tableName: editDataSource?.tableName ?? '',
-      query: editDataSource?.sqlQuery ?? props.query.trim(),
+      query: editDataSource?.sqlQuery ?? query.trim(),
     },
   });
 
@@ -81,80 +95,86 @@ const CreateTableModal: FC<CreateTableModalProps> = (props) => {
   );
 
   return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <DialogHeader>
+          <DialogTitle>
+            {editDataSource ? 'Edit table query' : 'Create table from query'}
+          </DialogTitle>
+          {!editDataSource && (
+            <DialogDescription>
+              Create a new table from the results of an SQL query.
+            </DialogDescription>
+          )}
+        </DialogHeader>
+
+        {form.formState.errors.root && (
+          <Alert variant="destructive">
+            <AlertDescription className="whitespace-pre-wrap font-mono text-xs">
+              {form.formState.errors.root.message}
+            </AlertDescription>
+          </Alert>
+        )}
+
+        <FormField
+          control={form.control}
+          name="tableName"
+          render={({field}) => (
+            <FormItem>
+              <FormLabel>Table name:</FormLabel>
+              <FormControl>
+                <Input {...field} className="font-mono" autoFocus />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="query"
+          render={({field}) => (
+            <FormItem className="flex flex-col">
+              <FormLabel>SQL query:</FormLabel>
+              <FormControl>
+                <SqlMonacoEditor
+                  connector={connector}
+                  value={field.value}
+                  onChange={field.onChange}
+                  className="h-[200px] w-full"
+                  options={{
+                    scrollBeyondLastLine: false,
+                    automaticLayout: true,
+                    minimap: {enabled: false},
+                    wordWrap: 'on',
+                  }}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={form.formState.isSubmitting}>
+            {editDataSource ? 'Update' : 'Create'}
+          </Button>
+        </DialogFooter>
+      </form>
+    </Form>
+  );
+};
+
+const CreateTableModal: FC<CreateTableModalProps> = (props) => {
+  const {isOpen, onClose} = props;
+
+  return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
       <DialogContent className="sm:max-w-[800px]">
-        <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-            <DialogHeader>
-              <DialogTitle>
-                {editDataSource
-                  ? 'Edit table query'
-                  : 'Create table from query'}
-              </DialogTitle>
-              {!editDataSource && (
-                <DialogDescription>
-                  Create a new table from the results of an SQL query.
-                </DialogDescription>
-              )}
-            </DialogHeader>
-
-            {form.formState.errors.root && (
-              <Alert variant="destructive">
-                <AlertDescription className="whitespace-pre-wrap font-mono text-xs">
-                  {form.formState.errors.root.message}
-                </AlertDescription>
-              </Alert>
-            )}
-
-            <FormField
-              control={form.control}
-              name="tableName"
-              render={({field}) => (
-                <FormItem>
-                  <FormLabel>Table name:</FormLabel>
-                  <FormControl>
-                    <Input {...field} className="font-mono" autoFocus />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="query"
-              render={({field}) => (
-                <FormItem className="flex flex-col">
-                  <FormLabel>SQL query:</FormLabel>
-                  <FormControl>
-                    <SqlMonacoEditor
-                      connector={connector}
-                      value={field.value}
-                      onChange={field.onChange}
-                      className="h-[200px] w-full"
-                      options={{
-                        scrollBeyondLastLine: false,
-                        automaticLayout: true,
-                        minimap: {enabled: false},
-                        wordWrap: 'on',
-                      }}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <DialogFooter>
-              <Button type="button" variant="outline" onClick={onClose}>
-                Cancel
-              </Button>
-              <Button type="submit" disabled={form.formState.isSubmitting}>
-                {editDataSource ? 'Update' : 'Create'}
-              </Button>
-            </DialogFooter>
-          </form>
-        </Form>
+        {isOpen && <CreateTableForm {...props} />}
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
Create table initial query will now use the last executed statement:

<img width="556" height="249" alt="image" src="https://github.com/user-attachments/assets/bd538ca0-1181-425a-b830-242148f8338d" />


Also adding more default table actions:

<img width="470" height="268" alt="image" src="https://github.com/user-attachments/assets/c0d9424b-6354-48f0-b602-48840c225252" />
