### PR TITLE
fix: Set variable doesn't work in SqlEditor

### DIFF
--- a/examples/query-motherduck/src/MainView.tsx
+++ b/examples/query-motherduck/src/MainView.tsx
@@ -44,29 +44,28 @@ export const MainView: FC = () => {
   return (
     <>
       <div className="bg-muted flex h-full flex-col">
+        <div className="bg-background flex items-center justify-end gap-2 pb-2">
+          <Button
+            variant="ghost"
+            size="xs"
+            className="h-8"
+            onClick={confirmClearTokenModal.onOpen}
+          >
+            Forget MotherDuck token
+            <XCircleIcon className="h-4 w-4" />
+          </Button>
+          <SqlReferenceButton
+            variant="ghost"
+            className="h-8"
+            url="https://motherduck.com/docs/sql-reference/"
+          />
+        </div>
         <ResizablePanelGroup direction="vertical">
           <ResizablePanel
             defaultSize={50}
             // this is for Monaco's completion menu to not being cut off
             className="!overflow-visible"
           >
-            <div className="bg-background flex items-center justify-end gap-2 pb-2">
-              <Button
-                variant="ghost"
-                size="xs"
-                className="h-8"
-                onClick={confirmClearTokenModal.onOpen}
-              >
-                Forget MotherDuck token
-                <XCircleIcon className="h-4 w-4" />
-              </Button>
-              <SqlReferenceButton
-                variant="ghost"
-                className="h-8"
-                url="https://motherduck.com/docs/sql-reference/"
-              />
-            </div>
-
             <QueryEditorPanel />
           </ResizablePanel>
           <ResizableHandle withHandle />

--- a/packages/sql-editor/src/SqlEditorSlice.tsx
+++ b/packages/sql-editor/src/SqlEditorSlice.tsx
@@ -353,16 +353,14 @@ export function createSqlEditorSlice<
 
             if (isValidSelectQuery) {
               // Add limit to the last statement
-              const result = await connector.query(
-                [
-                  ...allButLastStatements,
-                  makeLimitQuery(lastQueryStatement, {
-                    sanitize: false, // should already be sanitized
-                    limit: get().sqlEditor.queryResultLimit,
-                  }),
-                ].join(';\n'),
-                {signal},
-              );
+              const queryWithLimit = [
+                ...allButLastStatements,
+                makeLimitQuery(lastQueryStatement, {
+                  sanitize: false, // should already be sanitized
+                  limit: get().sqlEditor.queryResultLimit,
+                }),
+              ].join(';\n');
+              const result = await connector.query(queryWithLimit, {signal});
               queryResult = {
                 status: 'success',
                 type: 'select',
@@ -381,9 +379,7 @@ export function createSqlEditorSlice<
                 );
               }
 
-              const result = await connector.query(query, {
-                signal,
-              });
+              const result = await connector.query(query, {signal});
               // EXPLAIN and PRAGMA are not detected as select queries
               // and we cannot wrap them in a SELECT * FROM,
               // but we can still execute them and return the result
@@ -423,7 +419,6 @@ export function createSqlEditorSlice<
           } catch (e) {
             console.error(e);
             const errorMessage = e instanceof Error ? e.message : String(e);
-
             if (
               errorMessage === 'Query aborted' ||
               queryController.signal.aborted

--- a/packages/sql-editor/src/SqlEditorSlice.tsx
+++ b/packages/sql-editor/src/SqlEditorSlice.tsx
@@ -338,14 +338,6 @@ export function createSqlEditorSlice<
               throw new Error('Empty query');
             }
 
-            // Execute all but the last statements with cancellation support
-            for (const statement of allButLastStatements) {
-              if (signal.aborted) {
-                throw new Error('Query aborted');
-              }
-              await connector.query(statement, {signal});
-            }
-
             if (signal.aborted) {
               throw new Error('Query aborted');
             }
@@ -360,6 +352,7 @@ export function createSqlEditorSlice<
             const isValidSelectQuery = !parsedLastStatement.error;
 
             if (isValidSelectQuery) {
+              // Add limit to the last statement
               const result = await connector.query(
                 [
                   ...allButLastStatements,
@@ -377,6 +370,7 @@ export function createSqlEditorSlice<
                 result,
               };
             } else {
+              // Run the complete query as it is
               if (
                 parsedLastStatement.error &&
                 parsedLastStatement.error_type !== 'not implemented'

--- a/packages/sql-editor/src/SqlEditorSlice.tsx
+++ b/packages/sql-editor/src/SqlEditorSlice.tsx
@@ -361,10 +361,13 @@ export function createSqlEditorSlice<
 
             if (isValidSelectQuery) {
               const result = await connector.query(
-                makeLimitQuery(lastQueryStatement, {
-                  sanitize: false, // should already be sanitized
-                  limit: get().sqlEditor.queryResultLimit,
-                }),
+                [
+                  ...allButLastStatements,
+                  makeLimitQuery(lastQueryStatement, {
+                    sanitize: false, // should already be sanitized
+                    limit: get().sqlEditor.queryResultLimit,
+                  }),
+                ].join(';\n'),
                 {signal},
               );
               queryResult = {
@@ -384,7 +387,7 @@ export function createSqlEditorSlice<
                 );
               }
 
-              const result = await connector.query(lastQueryStatement, {
+              const result = await connector.query(query, {
                 signal,
               });
               // EXPLAIN and PRAGMA are not detected as select queries

--- a/packages/sql-editor/src/components/QueryResultPanel.tsx
+++ b/packages/sql-editor/src/components/QueryResultPanel.tsx
@@ -58,7 +58,7 @@ export const QueryResultPanel: React.FC<QueryResultPanelProps> = ({
   if (queryResult?.status === 'error') {
     return (
       <div className="h-full w-full overflow-auto p-5">
-        <pre className="whitespace-pre-line text-xs leading-tight text-red-500">
+        <pre className="whitespace-pre-wrap text-xs leading-tight text-red-500">
           {queryResult.error}
         </pre>
       </div>

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -69,7 +69,7 @@ console.log(result); // { name: 'John', age: 30 }
 
 // Handle invalid JSON gracefully
 const invalid = safeJsonParse('{"name": "John", age: 30}');
-console.log(invalid); // null
+console.log(invalid); // undefined
 ```
 
 ### Formatting Utilities

--- a/packages/utils/src/json.ts
+++ b/packages/utils/src/json.ts
@@ -1,15 +1,16 @@
 /**
  * Parse a JSON string and return the parsed object.
- * If the string is not valid JSON, return null.
+ * If the string is not valid JSON, return undefined.
  * @param json - The JSON string to parse.
- * @returns The parsed object or null if the string is not valid JSON.
+ * @returns The parsed object or undefined if the string is not valid JSON.
  */
-export function safeJsonParse<T>(json: string | undefined | null): T | null {
-  if (!json) return null;
+export function safeJsonParse<T>(
+  json: string | undefined | null,
+): T | undefined {
+  if (!json) return undefined;
   try {
     return JSON.parse(json) as T;
-  } catch (error) {
-    console.error('Failed to parse JSON:', error);
-    return null;
+  } catch {
+    return undefined;
   }
 }


### PR DESCRIPTION
Running `SET VARIABLE my_var = 30; SELECT getvariable('my_var') ` in SqlEditor returned `NULL` due to the statements being executed separately in distinct connections.

The fix makes sure we execute the whole query as a single statement (but we are still adding a LIMIT clause to the last statement if it's a SELECT)