### PR TITLE
fix: splitFilePath to support both Windows and Unix path separators

### DIFF
--- a/packages/utils/src/filepaths.ts
+++ b/packages/utils/src/filepaths.ts
@@ -1,9 +1,11 @@
 /**
  * Splits a file path into its directory, name, and extension components.
+ * Preserves the original path separator style (Windows backslashes or Unix forward slashes).
  * @param filePath - The full file path to split
- * @returns An object containing the directory path, file name (without extension), and extension
+ * @returns An object containing the directory path, file name (without extension), extension, and full filename
  * @example
- * splitFilePath("path/to/file.txt") // returns { dir: "path/to", name: "file", ext: "txt" }
+ * splitFilePath("path/to/file.txt") // returns { dir: "path/to", name: "file", ext: "txt", filename: "file.txt" }
+ * splitFilePath("C:\\Users\\file.txt") // returns { dir: "C:\\Users", name: "file", ext: "txt", filename: "file.txt" }
  */
 export function splitFilePath(filePath: string): {
   dir: string;
@@ -11,17 +13,33 @@ export function splitFilePath(filePath: string): {
   ext: string;
   filename: string;
 } {
-  const pathParts = filePath.split('/');
+  // Detect the original separator used
+  const hasBackslash = filePath.includes('\\');
+  const hasForwardSlash = filePath.includes('/');
+  const separator = hasBackslash && !hasForwardSlash ? '\\' : '/';
+
+  // Handle both Windows backslashes and Unix forward slashes
+  const pathParts = filePath.split(/[/\\]/);
   const file = pathParts.pop() || '';
 
   const dotIndex = file.lastIndexOf('.');
   if (dotIndex === -1 || dotIndex === 0)
-    return {dir: pathParts.join('/'), name: file, ext: '', filename: file};
+    return {
+      dir: pathParts.join(separator),
+      name: file,
+      ext: '',
+      filename: file,
+    };
 
   const name = file.substring(0, dotIndex);
   const ext = file.substring(dotIndex + 1);
 
-  return {dir: pathParts.join('/'), name, ext, filename: `${name}.${ext}`};
+  return {
+    dir: pathParts.join(separator),
+    name,
+    ext,
+    filename: `${name}.${ext}`,
+  };
 }
 
 /**

--- a/packages/utils/src/filepaths.ts
+++ b/packages/utils/src/filepaths.ts
@@ -13,10 +13,8 @@ export function splitFilePath(filePath: string): {
   ext: string;
   filename: string;
 } {
-  // Detect the original separator used
-  const hasBackslash = filePath.includes('\\');
-  const hasForwardSlash = filePath.includes('/');
-  const separator = hasBackslash && !hasForwardSlash ? '\\' : '/';
+  // If backslash appears, assume Windows filesystem (backslash is not a valid path separator on Unix)
+  const separator = filePath.includes('\\') ? '\\' : '/';
 
   // Handle both Windows backslashes and Unix forward slashes
   const pathParts = filePath.split(/[/\\]/);
@@ -38,7 +36,7 @@ export function splitFilePath(filePath: string): {
     dir: pathParts.join(separator),
     name,
     ext,
-    filename: `${name}.${ext}`,
+    filename: file,
   };
 }
 


### PR DESCRIPTION
This pull request updates the `splitFilePath` utility function to better handle file paths across different operating systems. The function now preserves the original path separator style (Windows ` or Unix `/`) and returns additional information about the file.

See issue: https://github.com/sqlrooms/sqlrooms/issues/107

Improvements to file path handling:

* `packages/utils/src/filepaths.ts`: Enhanced the `splitFilePath` function to:
  - Detect and preserve the original path separator style (Windows or Unix).
  - Return a new `filename` property (the full file name with extension).
  - Ensure the `dir` property uses the appropriate separator for the input path.