### PR TITLE
chore: upgrade react-markdown to v10

### DIFF
--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -32,7 +32,7 @@
     "ai": "^4.3.19",
     "immer": "^10.1.1",
     "lucide-react": "^0.475.0",
-    "react-markdown": "^9.1.0",
+    "react-markdown": "^10.1.0",
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.0",
     "zod": "^3.25.73"

--- a/packages/ai/src/components/AnalysisAnswer.tsx
+++ b/packages/ai/src/components/AnalysisAnswer.tsx
@@ -185,17 +185,18 @@ export const AnalysisAnswer = React.memo(function AnalysisAnswer(
         type={props.isAnswer ? 'answer' : 'thinking'}
         content={props}
       >
-        <Markdown
-          className="prose dark:prose-invert max-w-none text-sm"
-          remarkPlugins={[remarkGfm]}
-          rehypePlugins={[rehypeRaw]}
-          components={{
-            // @ts-expect-error - Custom HTML element not in react-markdown types
-            'think-block': thinkBlockComponent,
-          }}
-        >
-          {processedContent}
-        </Markdown>
+        <div className="prose dark:prose-invert max-w-none text-sm">
+          <Markdown
+            remarkPlugins={[remarkGfm]}
+            rehypePlugins={[rehypeRaw]}
+            components={{
+              // @ts-expect-error - Custom HTML element not in react-markdown types
+              'think-block': thinkBlockComponent,
+            }}
+          >
+            {processedContent}
+          </Markdown>
+        </div>
       </MessageContainer>
     </div>
   );

--- a/packages/ai/src/components/ErrorMessage.tsx
+++ b/packages/ai/src/components/ErrorMessage.tsx
@@ -5,12 +5,9 @@ import {MessageContainer} from './MessageContainer';
 export function ErrorMessage(props: {errorMessage: string}) {
   return (
     <MessageContainer isSuccess={false} type="error" content={props}>
-      <Markdown
-        className="prose dark:prose-invert max-w-none text-sm"
-        remarkPlugins={[remarkGfm]}
-      >
-        {props.errorMessage}
-      </Markdown>
+      <div className="prose dark:prose-invert max-w-none text-sm">
+        <Markdown remarkPlugins={[remarkGfm]}>{props.errorMessage}</Markdown>
+      </div>
     </MessageContainer>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1051,8 +1051,8 @@ importers:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
       react-markdown:
-        specifier: ^9.1.0
-        version: 9.1.0(@types/react@19.1.7)(react@19.1.0)
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.1.7)(react@19.1.0)
       rehype-raw:
         specifier: ^7.0.0
         version: 7.0.0
@@ -9540,8 +9540,8 @@ packages:
       maplibre-gl:
         optional: true
 
-  react-markdown@9.1.0:
-    resolution: {integrity: sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==}
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
     peerDependencies:
       '@types/react': '>=18'
       react: 19.1.0
@@ -20981,7 +20981,7 @@ snapshots:
     optionalDependencies:
       maplibre-gl: 5.6.0
 
-  react-markdown@9.1.0(@types/react@19.1.7)(react@19.1.0):
+  react-markdown@10.1.0(@types/react@19.1.7)(react@19.1.0):
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4


### PR DESCRIPTION
The newer versions of react-markdown (v10+) no longer support the className prop directly on the Markdown component. See https://github.com/remarkjs/react-markdown/blob/main/changelog.md#remove-classname


Before:
```js
<Markdown className="markdown-body">{markdown}</Markdown>
```

After:

```js
<div className="markdown-body">
  <Markdown>{markdown}</Markdown>
</div>
```