### PR TITLE
enh: improve toggle in LayoutSlice

### DIFF
--- a/packages/layout/src/LayoutSlice.ts
+++ b/packages/layout/src/LayoutSlice.ts
@@ -15,6 +15,7 @@ import {
   MAIN_VIEW,
   isMosaicLayoutParent,
 } from '@sqlrooms/layout-config';
+import type {MosaicPath} from 'react-mosaic-component';
 
 export type RoomPanelInfo = {
   title?: string;
@@ -23,27 +24,52 @@ export type RoomPanelInfo = {
   placement: 'sidebar' | 'sidebar-bottom' | 'main' | 'top-bar';
 };
 
-export const LayoutSliceConfig = z.object({
+export type PanelBehavior = {
+  canToggle: boolean; // Whether this panel can be toggled on/off
+  isFixed: boolean; // Whether this panel is always visible and can't be moved
+  toggleTargetPath?: MosaicPath; // Preferred mosaic path location when showing
+};
+
+export const LayoutSliceConfigSchema = z.object({
   layout: z
     .any()
     .describe('Mosaic layout configuration.')
     .default(DEFAULT_MOSAIC_LAYOUT),
+  panelBehaviors: z
+    .record(
+      z.string(),
+      z.object({
+        canToggle: z.boolean(),
+        isFixed: z.boolean(),
+        toggleTargetPath: z
+          .array(z.union([z.literal('first'), z.literal('second')]))
+          .optional(),
+      }),
+    )
+    .describe('Configuration for panel behavior.')
+    .default({}),
 });
 
-export type LayoutSliceConfig = z.infer<typeof LayoutSliceConfig>;
+export type LayoutSliceConfig = z.infer<typeof LayoutSliceConfigSchema>;
 
 export function createDefaultLayoutConfig(): LayoutSliceConfig {
   return {
     layout: DEFAULT_MOSAIC_LAYOUT,
+    panelBehaviors: {},
   };
 }
 
 export type LayoutSliceState = {
   layout: {
     panels: Record<string, RoomPanelInfo>;
+    panelBehaviors: Record<string, PanelBehavior>;
     setLayout(layout: LayoutConfig): void;
+    setPanelBehaviors(behaviors: Record<string, PanelBehavior>): void;
     togglePanel: (panel: string, show?: boolean) => void;
     togglePanelPin: (panel: string) => void;
+    getPanelBehaviors(): Record<string, PanelBehavior>;
+    canPanelToggle(panel: string): boolean;
+    isPanelFixed(panel: string): boolean;
   };
 };
 
@@ -51,16 +77,26 @@ export function createLayoutSlice<
   PC extends BaseRoomConfig & LayoutSliceConfig,
 >({
   panels = {},
+  panelBehaviors = {},
 }: {
   panels?: Record<string, RoomPanelInfo>;
+  panelBehaviors?: Record<string, PanelBehavior>;
 } = {}): StateCreator<LayoutSliceState> {
   return createBaseSlice<PC, LayoutSliceState>((set, get) => ({
     layout: {
       panels,
+      panelBehaviors,
       setLayout: (layout) =>
         set((state) =>
           produce(state, (draft) => {
             draft.config.layout = layout;
+          }),
+        ),
+      setPanelBehaviors: (behaviors) =>
+        set((state) =>
+          produce(state, (draft) => {
+            draft.config.panelBehaviors = behaviors;
+            draft.layout.panelBehaviors = behaviors;
           }),
         ),
       togglePanel: (panel, show) => {
@@ -69,6 +105,13 @@ export function createLayoutSlice<
           // don't hide the view if it's the only one
           return;
         }
+
+        // Check if panel can be toggled
+        if (!get().layout.canPanelToggle(panel)) {
+          console.warn(`Panel ${panel} cannot be toggled`);
+          return;
+        }
+
         const result = removeMosaicNodeByKey(config.layout?.nodes, panel);
         const isShown = result.success;
         if (isShown) {
@@ -90,15 +133,67 @@ export function createLayoutSlice<
           if (show === false) {
             return;
           }
+
           set((state) =>
             produce(state, (draft) => {
               const layout = draft.config.layout;
               const root = layout.nodes;
               const placement = get().layout.panels[panel]?.placement;
+
+              // Get the panel's configured behavior
+              const panelConfig = get().layout.panelBehaviors[panel];
+
+              // Use react-mosaic's native concepts for placement
               const side = placement === 'sidebar' ? 'first' : 'second';
+
+              // If a toggleTargetPath is provided, attempt to place at that path
+              const targetPath = panelConfig?.toggleTargetPath;
+              if (
+                targetPath &&
+                Array.isArray(targetPath) &&
+                targetPath.length > 0
+              ) {
+                try {
+                  let current = root;
+                  let pathValid = true;
+                  for (let i = 0; i < targetPath.length - 1; i++) {
+                    const seg = targetPath[i];
+                    if (
+                      (seg === 'first' || seg === 'second') &&
+                      isMosaicLayoutParent(current)
+                    ) {
+                      current = (current as any)[seg];
+                    } else {
+                      pathValid = false;
+                      break;
+                    }
+                  }
+                  if (pathValid && isMosaicLayoutParent(current)) {
+                    const last = targetPath[targetPath.length - 1];
+                    if (last === 'first' || last === 'second') {
+                      const targetNode = (current as any)[last];
+                      if (
+                        targetNode &&
+                        !isMosaicLayoutParent(targetNode) &&
+                        targetNode !== MAIN_VIEW &&
+                        !layout.fixed?.includes(targetNode) &&
+                        !layout.pinned?.includes(targetNode)
+                      ) {
+                        (current as any)[last] = panel;
+                        return;
+                      }
+                    }
+                  }
+                } catch (err) {
+                  // fall through to default logic
+                }
+              }
+
+              // fallback to old logic for backwards compatibility
               const toReplace = isMosaicLayoutParent(root)
                 ? root[side]
                 : undefined;
+
               if (
                 toReplace &&
                 isMosaicLayoutParent(root) &&
@@ -110,12 +205,14 @@ export function createLayoutSlice<
                 // replace first un-pinned leaf
                 root[side] = panel;
               } else {
+                // Use simple stacking with default weights
                 const panelNode = {node: panel, weight: 1};
                 const restNode = {
                   node: config.layout?.nodes,
                   weight: 3,
                 };
-                // add to to the left
+
+                // Create stack using react-mosaic's native makeMosaicStack
                 layout.nodes = makeMosaicStack(
                   placement === 'sidebar-bottom' ? 'column' : 'row',
                   side === 'first'
@@ -144,6 +241,17 @@ export function createLayoutSlice<
             }
           }),
         );
+      },
+      getPanelBehaviors: () => {
+        return get().layout.panelBehaviors;
+      },
+      canPanelToggle: (panel: string) => {
+        const config = get().layout.panelBehaviors[panel];
+        return config ? config.canToggle : true; // Default to true if no config
+      },
+      isPanelFixed: (panel: string) => {
+        const config = get().layout.panelBehaviors[panel];
+        return config ? config.isFixed : false; // Default to false if no config
       },
     },
   }));


### PR DESCRIPTION
The current toggle behavior in LayoutSlice:
- doesn't work correctly put panel back to its original position
- doesn't support e.g. 3 columns layout

For example, the following 3 columns layout

```js
{
  type: 'mosaic',
  nodes: {
    direction: 'row',
    first: 'left-root',
    second: {
      direction: 'row',
      first: {
        direction: 'column',
        first: 'main',   // middle top
        second: 'cli',   // middle bottom
      },
      second: 'right-root',
    },
  },
}
```

The 'cli' can not be toggled back to its initial spot under 'main'. It only looks at the root side (from placement) and either replaces root[side] if it’s a leaf or rebuilds a top‑level stack. It won’t navigate back to ['second','first','second'].

One solution is to introduce additional panel behaviors, e.g. 

```js
panelBehaviors: {
  // Left column
  'panel-a': { canToggle: true,  isFixed: false, toggleTargetPath: ['first'] },
  'panel-b': { canToggle: true,  isFixed: false, toggleTargetPath: ['first'] },
  'panel-c': { canToggle: true,  isFixed: false, toggleTargetPath: ['first'] },

  // Middle column
  'main':    { canToggle: false, isFixed: true,  toggleTargetPath: ['second','first','first'] },
  'cli':     { canToggle: true,  isFixed: false, toggleTargetPath: ['second','first','second'] },

  // Right column
  'panel-d': { canToggle: true,  isFixed: false, toggleTargetPath: ['second','second'] },
  'panel-e': { canToggle: true,  isFixed: false, toggleTargetPath: ['second','second'] },
}
```

So, users can control e.g. 
- A/B/C panels can be toggled inside left column;
- 'main' panel cannot be toggled
- 'cli' panel can be toggled below 'main' panel
- D/E panels can be toggled inside right column