### PR TITLE
feat: Add to DataTable: estimated rowCount, create table DDL and comment

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "repository": "git@github.com:sqlrooms/sqlrooms.git",
   "author": "Ilya Boyandin <ilya@boyandin.me>",
   "private": true,
-  "packageManager": "pnpm@10.13.1",
+  "packageManager": "pnpm@10.15.0",
   "workspaces": [
     "packages/*",
     "examples/*"

--- a/packages/duckdb/src/DuckDbSlice.ts
+++ b/packages/duckdb/src/DuckDbSlice.ts
@@ -431,7 +431,12 @@ export function createDuckDbSlice({
               sql,
               comment,
               isView: Boolean(isView),
-              rowCount: Number(estimatedSize),
+              rowCount:
+                typeof estimatedSize === 'bigint'
+                  ? Number(estimatedSize)
+                  : estimatedSize === null
+                    ? undefined
+                    : estimatedSize,
             });
           }
           return newTables;

--- a/packages/duckdb/src/schemaTree.ts
+++ b/packages/duckdb/src/schemaTree.ts
@@ -18,7 +18,7 @@ export function createDbSchemaTrees(tables: DataTable[]): DbSchemaNode[] {
       createColumnNode(schema, tableName, column.name, column.type),
     );
 
-    const tableNode = createTableNode(database, schema, tableName, columnNodes);
+    const tableNode = createTableNode(table, columnNodes);
 
     if (!databaseMap.has(database)) {
       databaseMap.set(database, new Map<string, DbSchemaNode[]>());
@@ -61,18 +61,15 @@ function createColumnNode(
 }
 
 function createTableNode(
-  database: string,
-  schema: string,
-  tableName: string,
+  table: DataTable,
   columnNodes: DbSchemaNode[],
 ): DbSchemaNode {
   return {
-    key: `${schema}.${tableName}`,
+    key: `${table.schema}.${table.tableName}`,
     object: {
       type: 'table',
-      schema,
-      database,
-      name: tableName,
+      ...table,
+      name: table.tableName,
     },
     isInitialOpen: false,
     children: columnNodes,

--- a/packages/duckdb/src/types.ts
+++ b/packages/duckdb/src/types.ts
@@ -54,9 +54,7 @@ export type ColumnNodeObject = BaseNodeObject & {
 
 export type TableNodeObject = BaseNodeObject & {
   type: 'table';
-  schema: string;
-  database: string;
-};
+} & DataTable;
 
 export type SchemaNodeObject = BaseNodeObject & {
   type: 'schema';

--- a/packages/duckdb/src/types.ts
+++ b/packages/duckdb/src/types.ts
@@ -7,6 +7,7 @@ export type TableColumn = {
 
 export type DataTable = {
   table: QualifiedTableName;
+  isView: boolean;
   /** @deprecated Use table.database instead */
   database?: string;
   /** @deprecated Use table.schema instead */

--- a/packages/duckdb/src/types.ts
+++ b/packages/duckdb/src/types.ts
@@ -16,6 +16,8 @@ export type DataTable = {
   columns: TableColumn[];
   rowCount?: number;
   inputFileName?: string;
+  sql?: string;
+  comment?: string;
 };
 export type ColumnTypeCategory =
   | 'number'

--- a/packages/room-shell/src/RoomShell.tsx
+++ b/packages/room-shell/src/RoomShell.tsx
@@ -1,4 +1,4 @@
-import {RoomStateProvider, RoomStore} from '../../room-store/dist';
+import {RoomStateProvider, RoomStore} from '@sqlrooms/room-store';
 import {MosaicLayout} from '@sqlrooms/layout';
 import {BaseRoomConfig} from '@sqlrooms/room-config';
 import {

--- a/packages/room-shell/src/data-sources/TableCard.tsx
+++ b/packages/room-shell/src/data-sources/TableCard.tsx
@@ -32,6 +32,7 @@ const TableCard: FC<{
   if (!value) return null;
 
   const numRows = value.rowCount ?? rowCount;
+  console.log(value, numRows);
   return (
     <Card
       className={cn(
@@ -94,7 +95,8 @@ const TableCard: FC<{
               </Tooltip>
             ))}
           </div>
-          {numRows !== undefined && Number.isFinite(numRows) && (
+          {(typeof numRows === 'bigint' ||
+            (numRows !== undefined && Number.isFinite(numRows))) && (
             <div className="mt-1 text-right text-xs">
               {`${formatNumber(numRows)} rows`}
             </div>

--- a/packages/schema-tree/package.json
+++ b/packages/schema-tree/package.json
@@ -27,6 +27,7 @@
     "@sqlrooms/data-table": "workspace:*",
     "@sqlrooms/duckdb": "workspace:*",
     "@sqlrooms/ui": "workspace:*",
+    "@sqlrooms/utils": "workspace:*",
     "lucide-react": "^0.474.0"
   },
   "peerDependencies": {

--- a/packages/schema-tree/src/nodes/BaseTreeNode.tsx
+++ b/packages/schema-tree/src/nodes/BaseTreeNode.tsx
@@ -13,7 +13,7 @@ export function BaseTreeNode<T>(
   return (
     <Comp
       className={cn(
-        'hover:bg-foreground/10 w-full flex-grow cursor-pointer rounded-sm p-[1px] select-none',
+        'hover:bg-foreground/10 h-[22px] w-full flex-grow cursor-pointer select-none rounded-sm p-[1px]',
         className,
       )}
     >
@@ -23,7 +23,7 @@ export function BaseTreeNode<T>(
           className,
         )}
       >
-        {children}
+        <div className="absolute h-full w-full items-center">{children}</div>
       </div>
     </Comp>
   );

--- a/packages/schema-tree/src/nodes/ColumnTreeNode.tsx
+++ b/packages/schema-tree/src/nodes/ColumnTreeNode.tsx
@@ -9,6 +9,7 @@ import {
   TreeNodeActionsMenu,
   TreeNodeActionsMenuItem,
 } from './TreeNodeActionsMenu';
+import {cn} from '@sqlrooms/ui';
 
 export const ColumnTreeNode: FC<{
   className?: string;
@@ -17,7 +18,11 @@ export const ColumnTreeNode: FC<{
 }> = (props) => {
   const {className, nodeObject, additionalMenuItems} = props;
   return (
-    <BaseTreeNode asChild className={className} nodeObject={nodeObject}>
+    <BaseTreeNode
+      asChild
+      className={cn(className, 'h-[18px]')}
+      nodeObject={nodeObject}
+    >
       <div className="flex w-full items-center space-x-2">
         <ColumnTypeBadge
           className="opacity-50"

--- a/packages/schema-tree/src/nodes/TableTreeNode.tsx
+++ b/packages/schema-tree/src/nodes/TableTreeNode.tsx
@@ -15,7 +15,7 @@ export const defaultRenderTableNodeMenuItems = (
   nodeObject: TableNodeObject,
   viewTableModal?: ReturnType<typeof useDisclosure>,
 ) => {
-  const {database, schema, name} = nodeObject;
+  const {database, schema, name, sql} = nodeObject;
   const qualifiedTableName = makeQualifiedTableName({
     database,
     schema,
@@ -56,8 +56,20 @@ export const defaultRenderTableNodeMenuItems = (
           navigator.clipboard.writeText(`SELECT * FROM ${qualifiedTableName}`);
         }}
       >
-        <SquareTerminalIcon width="15px" />
+        <CopyIcon width="15px" />
         Copy SELECT query
+      </TreeNodeActionsMenuItem>
+
+      <TreeNodeActionsMenuItem
+        onClick={() => {
+          if (sql) {
+            navigator.clipboard.writeText(sql);
+          }
+        }}
+        disabled={!sql}
+      >
+        <CopyIcon width="15px" />
+        Copy CREATE query
       </TreeNodeActionsMenuItem>
     </>
   );

--- a/packages/schema-tree/src/nodes/TableTreeNode.tsx
+++ b/packages/schema-tree/src/nodes/TableTreeNode.tsx
@@ -1,10 +1,10 @@
 // Copyright 2022 Foursquare Labs, Inc. All Rights Reserved.
 
-import {makeQualifiedTableName, TableNodeObject} from '@sqlrooms/duckdb';
-import {CopyIcon, EyeIcon, SquareTerminalIcon, TableIcon} from 'lucide-react';
-import {FC} from 'react';
-import {useDisclosure} from '@sqlrooms/ui';
 import {DataTableModal} from '@sqlrooms/data-table';
+import {makeQualifiedTableName, TableNodeObject} from '@sqlrooms/duckdb';
+import {useDisclosure} from '@sqlrooms/ui';
+import {CopyIcon, EyeIcon, TableIcon, ViewIcon} from 'lucide-react';
+import {FC} from 'react';
 import {BaseTreeNode} from './BaseTreeNode';
 import {
   TreeNodeActionsMenu,
@@ -15,7 +15,7 @@ export const defaultRenderTableNodeMenuItems = (
   nodeObject: TableNodeObject,
   viewTableModal?: ReturnType<typeof useDisclosure>,
 ) => {
-  const {database, schema, name, sql} = nodeObject;
+  const {database, schema, name, sql, isView} = nodeObject;
   const qualifiedTableName = makeQualifiedTableName({
     database,
     schema,
@@ -30,7 +30,7 @@ export const defaultRenderTableNodeMenuItems = (
           }}
         >
           <EyeIcon width="15px" />
-          View table
+          View data
         </TreeNodeActionsMenuItem>
       )}
       <TreeNodeActionsMenuItem
@@ -39,7 +39,7 @@ export const defaultRenderTableNodeMenuItems = (
         }}
       >
         <CopyIcon width="15px" />
-        Copy table name
+        Copy {isView ? 'view' : 'table'} name
       </TreeNodeActionsMenuItem>
 
       <TreeNodeActionsMenuItem
@@ -48,7 +48,7 @@ export const defaultRenderTableNodeMenuItems = (
         }}
       >
         <CopyIcon width="15px" />
-        Copy qualified table name
+        Copy qualified {isView ? 'view' : 'table'} name
       </TreeNodeActionsMenuItem>
 
       <TreeNodeActionsMenuItem
@@ -69,7 +69,7 @@ export const defaultRenderTableNodeMenuItems = (
         disabled={!sql}
       >
         <CopyIcon width="15px" />
-        Copy CREATE TABLE
+        Copy CREATE {isView ? 'VIEW' : 'TABLE'}
       </TreeNodeActionsMenuItem>
     </>
   );
@@ -102,7 +102,11 @@ export const TableTreeNode: FC<{
     <>
       <BaseTreeNode asChild className={className} nodeObject={nodeObject}>
         <div className="flex w-full items-center space-x-2">
-          <TableIcon size="16px" className="shrink-0 text-blue-500" />
+          {nodeObject.isView ? (
+            <ViewIcon size="16px" className="shrink-0 text-blue-500" />
+          ) : (
+            <TableIcon size="16px" className="shrink-0 text-blue-500" />
+          )}
           <span className="text-sm">{nodeObject.name}</span>
         </div>
         <TreeNodeActionsMenu>

--- a/packages/schema-tree/src/nodes/TableTreeNode.tsx
+++ b/packages/schema-tree/src/nodes/TableTreeNode.tsx
@@ -69,7 +69,7 @@ export const defaultRenderTableNodeMenuItems = (
         disabled={!sql}
       >
         <CopyIcon width="15px" />
-        Copy CREATE query
+        Copy CREATE TABLE
       </TreeNodeActionsMenuItem>
     </>
   );

--- a/packages/schema-tree/src/nodes/TableTreeNode.tsx
+++ b/packages/schema-tree/src/nodes/TableTreeNode.tsx
@@ -3,6 +3,7 @@
 import {DataTableModal} from '@sqlrooms/data-table';
 import {makeQualifiedTableName, TableNodeObject} from '@sqlrooms/duckdb';
 import {useDisclosure} from '@sqlrooms/ui';
+import {formatCount} from '@sqlrooms/utils';
 import {CopyIcon, EyeIcon, TableIcon, ViewIcon} from 'lucide-react';
 import {FC} from 'react';
 import {BaseTreeNode} from './BaseTreeNode';
@@ -90,7 +91,7 @@ export const TableTreeNode: FC<{
   } = props;
 
   const tableModal = useDisclosure();
-  const {database, schema, name} = nodeObject;
+  const {database, schema, name, rowCount, isView} = nodeObject;
   const qualifiedTableName = makeQualifiedTableName({
     database,
     schema,
@@ -101,13 +102,20 @@ export const TableTreeNode: FC<{
   return (
     <>
       <BaseTreeNode asChild className={className} nodeObject={nodeObject}>
-        <div className="flex w-full items-center space-x-2">
-          {nodeObject.isView ? (
+        <div className="relative flex w-full items-center space-x-2">
+          {isView ? (
             <ViewIcon size="16px" className="shrink-0 text-blue-500" />
           ) : (
             <TableIcon size="16px" className="shrink-0 text-blue-500" />
           )}
-          <span className="text-sm">{nodeObject.name}</span>
+          <div className="flex w-full items-center justify-between gap-2">
+            <span className="text-sm">{name}</span>
+            {rowCount !== undefined && (
+              <span className="text-muted-foreground/50 ml-1 whitespace-nowrap pr-5 text-xs">
+                {formatCount(rowCount)} {rowCount === 1 ? 'row' : 'rows'}
+              </span>
+            )}
+          </div>
         </div>
         <TreeNodeActionsMenu>
           {renderMenuItems(nodeObject, tableModal)}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1515,6 +1515,9 @@ importers:
       '@sqlrooms/ui':
         specifier: workspace:*
         version: link:../ui
+      '@sqlrooms/utils':
+        specifier: workspace:*
+        version: link:../utils
       lucide-react:
         specifier: ^0.474.0
         version: 0.474.0(react@19.1.0)


### PR DESCRIPTION
- Add to DataTable: estimated rowCount, create table DDL and comment
- Add Copy CREATE TABLE table tree menu item
- Distinguishing between views and tables in the tree:

<img width="412" height="248" alt="image" src="https://github.com/user-attachments/assets/5e0aad6a-67ae-483b-ba0c-149075bf31a0" />

- Showing number of rows in the tree
<img width="297" height="344" alt="image" src="https://github.com/user-attachments/assets/47956668-5dd1-4d2b-a2a1-2ecf1d2a3345" />
