### PR TITLE
feat: Adding row click handlers to QueryResultPanel

### DIFF
--- a/packages/data-table/src/DataTablePaginated.tsx
+++ b/packages/data-table/src/DataTablePaginated.tsx
@@ -30,6 +30,7 @@ import {
   ColumnDef,
   PaginationState,
   SortingState,
+  Row,
   flexRender,
   getCoreRowModel,
   getSortedRowModel,
@@ -52,6 +53,20 @@ export type DataTablePaginatedProps<Data extends object> = {
   footerActions?: React.ReactNode;
   onPaginationChange?: (pagination: PaginationState) => void;
   onSortingChange?: (sorting: SortingState) => void;
+  /**
+   * Called when a row is clicked.
+   */
+  onRowClick?: (args: {
+    row: Row<Data>;
+    event: React.MouseEvent<HTMLTableRowElement>;
+  }) => void;
+  /**
+   * Called when a row is double-clicked.
+   */
+  onRowDoubleClick?: (args: {
+    row: Row<Data>;
+    event: React.MouseEvent<HTMLTableRowElement>;
+  }) => void;
 };
 
 /**
@@ -71,6 +86,8 @@ export default function DataTablePaginated<Data extends object>({
   onSortingChange,
   footerActions,
   isFetching,
+  onRowClick,
+  onRowDoubleClick,
 }: DataTablePaginatedProps<Data>) {
   const defaultData = useMemo(() => [], []);
   const pageCount =
@@ -171,7 +188,20 @@ export default function DataTablePaginated<Data extends object>({
             </TableHeader>
             <TableBody>
               {table.getRowModel().rows.map((row, i) => (
-                <TableRow key={row.id} className="hover:bg-muted bg-background">
+                <TableRow
+                  key={row.id}
+                  className="hover:bg-muted bg-background"
+                  onClick={(event) => {
+                    event.preventDefault();
+                    console.log('onClick', row);
+                    onRowClick?.({row: row as Row<Data>, event});
+                  }}
+                  onDoubleClick={(event) => {
+                    event.preventDefault();
+                    console.log('onDoubleClick', row);
+                    onRowDoubleClick?.({row: row as Row<Data>, event});
+                  }}
+                >
                   <TableCell
                     className={`bg-background text-muted-foreground sticky left-0 border-r text-center ${fontSize}`}
                   >

--- a/packages/sql-editor/src/SqlEditor.tsx
+++ b/packages/sql-editor/src/SqlEditor.tsx
@@ -25,12 +25,27 @@ export type SqlEditorProps = {
   isOpen: boolean;
   /** Optional component to render SQL documentation in the side panel */
   documentationPanel?: React.ReactNode;
+  /** Options for the result limit dropdown in `QueryResultPanel` */
+  queryResultLimitOptions?: number[];
+  /**
+   * Props forwarded to `QueryResultPanel` to configure result behavior.
+   * This provides a single entry point for table interactions.
+   */
+  queryResultProps?: Pick<
+    React.ComponentProps<typeof QueryResultPanel>,
+    'queryResultLimitOptions' | 'onRowClick' | 'onRowDoubleClick'
+  >;
   /** Callback fired when the SQL editor should be closed */
   onClose: () => void;
 };
 
-const SqlEditorBase: React.FC<SqlEditorProps> = (props) => {
-  const {schema = '*', documentationPanel} = props;
+const SqlEditor = React.memo<SqlEditorProps>((props) => {
+  const {
+    schema = '*',
+    documentationPanel,
+    queryResultLimitOptions,
+    queryResultProps,
+  } = props;
 
   // Store access
   const addOrUpdateSqlQueryDataSource = useBaseRoomShellStore(
@@ -89,6 +104,12 @@ const SqlEditorBase: React.FC<SqlEditorProps> = (props) => {
               <ResizableHandle withHandle />
               <ResizablePanel defaultSize={50}>
                 <QueryResultPanel
+                  queryResultLimitOptions={
+                    queryResultProps?.queryResultLimitOptions ??
+                    queryResultLimitOptions
+                  }
+                  onRowClick={queryResultProps?.onRowClick}
+                  onRowDoubleClick={queryResultProps?.onRowDoubleClick}
                   renderActions={() => (
                     <div className="flex gap-2">
                       <Button size="xs" onClick={handleCreateTable}>
@@ -119,9 +140,6 @@ const SqlEditorBase: React.FC<SqlEditorProps> = (props) => {
       />
     </div>
   );
-};
-
-// Wrap with React.memo to prevent unnecessary re-renders
-const SqlEditor = React.memo(SqlEditorBase);
+});
 
 export default SqlEditor;

--- a/packages/sql-editor/src/components/QueryResultPanel.tsx
+++ b/packages/sql-editor/src/components/QueryResultPanel.tsx
@@ -1,8 +1,5 @@
-import {
-  DataTablePaginated,
-  DataTablePaginatedProps,
-  useArrowDataTable,
-} from '@sqlrooms/data-table';
+import {DataTablePaginated, useArrowDataTable} from '@sqlrooms/data-table';
+import type {Row} from '@tanstack/react-table';
 import {
   cn,
   Select,
@@ -21,13 +18,29 @@ export interface QueryResultPanelProps {
   /** Custom actions to render in the query result panel */
   renderActions?: (query: string) => React.ReactNode;
   /** Custom font size for the table e.g. text-xs, text-sm, text-md, text-lg, text-base */
-  fontSize?: DataTablePaginatedProps<any>['fontSize'];
+  fontSize?: string;
+  /**
+   * Called when a row in the results table is clicked.
+   */
+  onRowClick?: (args: {
+    row: Row<any>;
+    event: React.MouseEvent<HTMLTableRowElement>;
+  }) => void;
+  /**
+   * Called when a row in the results table is double-clicked.
+   */
+  onRowDoubleClick?: (args: {
+    row: Row<any>;
+    event: React.MouseEvent<HTMLTableRowElement>;
+  }) => void;
 }
 
 export const QueryResultPanel: React.FC<QueryResultPanelProps> = ({
   className,
   renderActions,
   fontSize = 'text-xs',
+  onRowClick,
+  onRowDoubleClick,
 }) => {
   const queryResult = useStoreWithSqlEditor((s) => s.sqlEditor.queryResult);
   const setQueryResultLimit = useStoreWithSqlEditor(
@@ -80,6 +93,8 @@ export const QueryResultPanel: React.FC<QueryResultPanelProps> = ({
               className="flex-grow overflow-hidden"
               fontSize={fontSize}
               isFetching={false}
+              onRowClick={onRowClick}
+              onRowDoubleClick={onRowDoubleClick}
             />
             <div className="bg-background flex w-full items-center gap-2 px-4 py-1">
               {queryResult.result ? (

--- a/packages/sql-editor/src/components/QueryResultPanel.tsx
+++ b/packages/sql-editor/src/components/QueryResultPanel.tsx
@@ -20,6 +20,11 @@ export interface QueryResultPanelProps {
   /** Custom font size for the table e.g. text-xs, text-sm, text-md, text-lg, text-base */
   fontSize?: string;
   /**
+   * Options for the result limit dropdown. Defaults to [100, 500, 1000].
+   * If the current limit isn't present, it will be added to the list.
+   */
+  queryResultLimitOptions?: number[];
+  /**
    * Called when a row in the results table is clicked.
    */
   onRowClick?: (args: {
@@ -39,6 +44,7 @@ export const QueryResultPanel: React.FC<QueryResultPanelProps> = ({
   className,
   renderActions,
   fontSize = 'text-xs',
+  queryResultLimitOptions = [100, 500, 1000],
   onRowClick,
   onRowDoubleClick,
 }) => {
@@ -49,6 +55,12 @@ export const QueryResultPanel: React.FC<QueryResultPanelProps> = ({
   const queryResultLimit = useStoreWithSqlEditor(
     (s) => s.sqlEditor.queryResultLimit,
   );
+  const limitOptions = React.useMemo(() => {
+    const merged = Array.from(
+      new Set<number>([...queryResultLimitOptions, queryResultLimit]),
+    );
+    return merged.sort((a, b) => a - b);
+  }, [queryResultLimitOptions, queryResultLimit]);
   const arrowTableData = useArrowDataTable(
     isQueryWithResult(queryResult) ? queryResult.result : undefined,
   );
@@ -115,7 +127,7 @@ export const QueryResultPanel: React.FC<QueryResultPanelProps> = ({
                       </div>
                     </SelectTrigger>
                     <SelectContent>
-                      {[100, 500, 1000].map((limit) => (
+                      {limitOptions.map((limit) => (
                         <SelectItem key={limit} value={limit.toString()}>
                           {`${formatCount(limit)} rows`}
                         </SelectItem>


### PR DESCRIPTION
- [x] QueryResultPanel: onClick and `onRowDoubleClick` propagated to DataTablePaginated
- [x] SqlEditor takes queryResultProps 
- [x] SqlEditorSlice: configurable result limit options `[100, 500, 1000]` (`queryResultLimitOptions` can be passed to `createSqlEditorSlice`)
