### PR TITLE
feat: Add @sqlrooms/pyodide with custom duckdb connector

### DIFF
--- a/examples/query-pyodide/README.md
+++ b/examples/query-pyodide/README.md
@@ -1,0 +1,4 @@
+Pyodide DuckDB Query Editor example.
+
+It loads Pyodide in the browser, installs `duckdb` and `pyarrow` via `micropip`, and uses `@sqlrooms/pyodide` to run queries.
+

--- a/examples/query-pyodide/eslint.config.js
+++ b/examples/query-pyodide/eslint.config.js
@@ -1,0 +1,29 @@
+import js from '@eslint/js';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+
+export default [
+  js.configs.recommended,
+  {
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: 'module',
+        ecmaFeatures: {jsx: true},
+      },
+    },
+    plugins: {
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh,
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      'react-refresh/only-export-components': [
+        'warn',
+        {allowConstantExport: true},
+      ],
+    },
+  },
+];
+

--- a/examples/query-pyodide/index.html
+++ b/examples/query-pyodide/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SQLRooms – Pyodide DuckDB</title>
+    <!-- Load Pyodide from CDN -->
+    <script defer src="https://cdn.jsdelivr.net/pyodide/v0.26.4/full/pyodide.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+  </html>
+

--- a/examples/query-pyodide/package.json
+++ b/examples/query-pyodide/package.json
@@ -15,6 +15,7 @@
     "@sqlrooms/utils": "workspace:*",
     "@sqlrooms/sql-editor": "workspace:*",
     "@sqlrooms/ui": "workspace:*",
+    "@sqlrooms/monaco-editor": "workspace:*",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "lucide-react": "0.501.0",
@@ -22,8 +23,7 @@
     "react-dom": "19.1.0",
     "zod": "^3.25.73",
     "zustand": "5.0.5",
-    "monaco-editor": "^0.52.2",
-    "@sqlrooms/monaco-editor": "workspace:*"
+    "monaco-editor": "^0.52.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.28.0",
@@ -42,4 +42,3 @@
     "vite-plugin-pwa": "^0.18.1"
   }
 }
-

--- a/examples/query-pyodide/package.json
+++ b/examples/query-pyodide/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "sqlrooms-query-pyodide",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@sqlrooms/room-shell": "workspace:*",
+    "@sqlrooms/pyodide": "workspace:*",
+    "@sqlrooms/utils": "workspace:*",
+    "@sqlrooms/sql-editor": "workspace:*",
+    "@sqlrooms/ui": "workspace:*",
+    "class-variance-authority": "0.7.1",
+    "clsx": "2.1.1",
+    "lucide-react": "0.501.0",
+    "react": "19.1.0",
+    "react-dom": "19.1.0",
+    "zod": "^3.25.73",
+    "zustand": "5.0.5",
+    "monaco-editor": "^0.52.2",
+    "@sqlrooms/monaco-editor": "workspace:*"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.28.0",
+    "@types/react": "^19.1.7",
+    "@types/react-dom": "^19.1.6",
+    "@vitejs/plugin-react": "^4.5.2",
+    "eslint": "^9.28.0",
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-refresh": "^0.4.20",
+    "globals": "^16.2.0",
+    "postcss": "^8.5.4",
+    "tailwindcss": "^3.4.17",
+    "typescript": "5.8.3",
+    "typescript-eslint": "^8.34.0",
+    "vite": "^6.3.5",
+    "vite-plugin-pwa": "^0.18.1"
+  }
+}
+

--- a/examples/query-pyodide/postcss.config.js
+++ b/examples/query-pyodide/postcss.config.js
@@ -1,0 +1,7 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+

--- a/examples/query-pyodide/src/App.tsx
+++ b/examples/query-pyodide/src/App.tsx
@@ -1,0 +1,73 @@
+import {ThemeProvider} from '@sqlrooms/ui';
+import {useEffect, useState} from 'react';
+import {Room} from './Room';
+
+export const App = () => {
+  const [ready, setReady] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const init = async () => {
+      try {
+        // Wait for global pyodide loader
+        const waitForPyodide = () =>
+          new Promise<void>((resolve) => {
+            const check = () => {
+              if ((window as any).loadPyodide) resolve();
+              else setTimeout(check, 50);
+            };
+            check();
+          });
+        await waitForPyodide();
+
+        // Initialize pyodide
+        const pyodide = await (window as any).loadPyodide({
+          indexURL: 'https://cdn.jsdelivr.net/pyodide/v0.26.4/full/',
+        });
+        (window as any).pyodide = pyodide;
+        // Ensure micropip and required packages
+        await pyodide.loadPackage('micropip');
+        await pyodide.runPythonAsync(`
+import micropip
+try:
+    await micropip.install(['duckdb', 'pyarrow'])
+except Exception:
+    # If wheels already present or networking blocked, attempt import
+    pass
+import duckdb, pyarrow
+`);
+        if (!cancelled) setReady(true);
+      } catch (e: any) {
+        if (!cancelled) setError(e?.message ?? String(e));
+      }
+    };
+    init();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (error) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <div className="text-red-600">Error: {error}</div>
+      </div>
+    );
+  }
+
+  if (!ready) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <div>Loading Pyodide and dependencies...</div>
+      </div>
+    );
+  }
+
+  return (
+    <ThemeProvider defaultTheme="light" storageKey="sqlrooms-ui-theme">
+      <Room />
+    </ThemeProvider>
+  );
+};
+

--- a/examples/query-pyodide/src/App.tsx
+++ b/examples/query-pyodide/src/App.tsx
@@ -1,73 +1,10 @@
 import {ThemeProvider} from '@sqlrooms/ui';
-import {useEffect, useState} from 'react';
 import {Room} from './Room';
 
 export const App = () => {
-  const [ready, setReady] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    const init = async () => {
-      try {
-        // Wait for global pyodide loader
-        const waitForPyodide = () =>
-          new Promise<void>((resolve) => {
-            const check = () => {
-              if ((window as any).loadPyodide) resolve();
-              else setTimeout(check, 50);
-            };
-            check();
-          });
-        await waitForPyodide();
-
-        // Initialize pyodide
-        const pyodide = await (window as any).loadPyodide({
-          indexURL: 'https://cdn.jsdelivr.net/pyodide/v0.26.4/full/',
-        });
-        (window as any).pyodide = pyodide;
-        // Ensure micropip and required packages
-        await pyodide.loadPackage('micropip');
-        await pyodide.runPythonAsync(`
-import micropip
-try:
-    await micropip.install(['duckdb', 'pyarrow'])
-except Exception:
-    # If wheels already present or networking blocked, attempt import
-    pass
-import duckdb, pyarrow
-`);
-        if (!cancelled) setReady(true);
-      } catch (e: any) {
-        if (!cancelled) setError(e?.message ?? String(e));
-      }
-    };
-    init();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  if (error) {
-    return (
-      <div className="flex h-screen items-center justify-center">
-        <div className="text-red-600">Error: {error}</div>
-      </div>
-    );
-  }
-
-  if (!ready) {
-    return (
-      <div className="flex h-screen items-center justify-center">
-        <div>Loading Pyodide and dependencies...</div>
-      </div>
-    );
-  }
-
   return (
     <ThemeProvider defaultTheme="light" storageKey="sqlrooms-ui-theme">
       <Room />
     </ThemeProvider>
   );
 };
-

--- a/examples/query-pyodide/src/DataPanel.tsx
+++ b/examples/query-pyodide/src/DataPanel.tsx
@@ -1,0 +1,19 @@
+import {Button} from '@sqlrooms/ui';
+import {useRoomStore} from './store';
+
+export const DataPanel = () => {
+  const runQuery = useRoomStore((s) => s.sql.runQuery);
+  const setDefaultQuery = useRoomStore((s) => s.sql.setQuery);
+  const onLoadSample = () => {
+    setDefaultQuery(`select 42 as answer`);
+    runQuery();
+  };
+  return (
+    <div className="p-2">
+      <Button onClick={onLoadSample} size="sm">
+        Run sample query
+      </Button>
+    </div>
+  );
+};
+

--- a/examples/query-pyodide/src/MainView.tsx
+++ b/examples/query-pyodide/src/MainView.tsx
@@ -1,0 +1,17 @@
+import {useRoomStore} from './store';
+
+export const MainView = () => {
+  const lastError = useRoomStore((s) => s.sql.lastError);
+  return (
+    <div className="flex h-full items-center justify-center p-6">
+      <div className="text-center text-sm text-muted-foreground">
+        <div className="mb-2 font-medium">Pyodide DuckDB Example</div>
+        <div>Type SQL on the editor panel to run queries.</div>
+        {lastError ? (
+          <div className="mt-2 text-red-600">{String(lastError)}</div>
+        ) : null}
+      </div>
+    </div>
+  );
+};
+

--- a/examples/query-pyodide/src/Room.tsx
+++ b/examples/query-pyodide/src/Room.tsx
@@ -9,6 +9,10 @@ export const Room = () => {
     roomStoreRef.current = createRoomStore();
   }
 
+  // if (!roomStoreRef.current.getState().room.initialized) {
+  //   return <div>Loading...</div>;
+  // }
+
   return (
     <RoomShell className="h-screen" roomStore={roomStoreRef.current}>
       <RoomShell.Sidebar>
@@ -18,4 +22,3 @@ export const Room = () => {
     </RoomShell>
   );
 };
-

--- a/examples/query-pyodide/src/Room.tsx
+++ b/examples/query-pyodide/src/Room.tsx
@@ -1,0 +1,21 @@
+import {RoomShell, RoomStore} from '@sqlrooms/room-shell';
+import {ThemeSwitch} from '@sqlrooms/ui';
+import {useRef} from 'react';
+import {createRoomStore, RoomConfig} from './store';
+
+export const Room = () => {
+  const roomStoreRef = useRef<RoomStore<RoomConfig>>(null);
+  if (!roomStoreRef.current) {
+    roomStoreRef.current = createRoomStore();
+  }
+
+  return (
+    <RoomShell className="h-screen" roomStore={roomStoreRef.current}>
+      <RoomShell.Sidebar>
+        <ThemeSwitch />
+      </RoomShell.Sidebar>
+      <RoomShell.LayoutComposer />
+    </RoomShell>
+  );
+};
+

--- a/examples/query-pyodide/src/index.css
+++ b/examples/query-pyodide/src/index.css
@@ -1,0 +1,8 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html, body, #root {
+  height: 100%;
+}
+

--- a/examples/query-pyodide/src/index.css
+++ b/examples/query-pyodide/src/index.css
@@ -1,8 +1,63 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import '@sqlrooms/ui/tailwind-preset.css';
 
-html, body, #root {
-  height: 100%;
+#root {
+  width: 100vw;
+  height: 100vh;
 }
 
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 84% 4.9%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 222.2 84% 4.9%;
+    --primary: 221.2 83.2% 53.3%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --accent: 210 40% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --ring: 221.2 83.2% 53.3%;
+    --radius: 0.5rem;
+    --chart-1: 12 76% 61%;
+    --chart-2: 173 58% 39%;
+    --chart-3: 197 37% 24%;
+    --chart-4: 43 74% 66%;
+    --chart-5: 27 87% 67%;
+  }
+
+  .dark {
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+    --popover: 222.2 84% 4.9%;
+    --popover-foreground: 210 40% 98%;
+    --primary: 217.2 91.2% 59.8%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+    --accent: 217.2 32.6% 17.5%;
+    --accent-foreground: 210 40% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 224.3 76.3% 48%;
+    --chart-1: 220 70% 50%;
+    --chart-2: 160 60% 45%;
+    --chart-3: 30 80% 55%;
+    --chart-4: 280 65% 60%;
+    --chart-5: 340 75% 55%;
+  }
+}

--- a/examples/query-pyodide/src/main.tsx
+++ b/examples/query-pyodide/src/main.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import {App} from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);
+

--- a/examples/query-pyodide/src/store.ts
+++ b/examples/query-pyodide/src/store.ts
@@ -1,0 +1,87 @@
+import {createPyodideDuckDbConnector} from '@sqlrooms/pyodide';
+import {
+  BaseRoomConfig,
+  createRoomShellSlice,
+  LayoutTypes,
+  RoomShellSliceState,
+  StateCreator,
+} from '@sqlrooms/room-shell';
+import {createRoomStoreCreator} from '@sqlrooms/room-store';
+import {
+  createDefaultSqlEditorConfig,
+  createSqlEditorSlice,
+  SqlEditorSliceConfig,
+  SqlEditorSliceState,
+} from '@sqlrooms/sql-editor';
+import {DatabaseIcon} from 'lucide-react';
+import {z} from 'zod';
+import {persist} from 'zustand/middleware';
+import {DataPanel} from './DataPanel';
+import {MainView} from './MainView';
+
+export const RoomPanelTypes = z.enum(['data', 'main'] as const);
+export type RoomPanelTypes = z.infer<typeof RoomPanelTypes>;
+
+/**
+ * Room config for saving
+ */
+export const RoomConfig = BaseRoomConfig.merge(SqlEditorSliceConfig);
+export type RoomConfig = z.infer<typeof RoomConfig>;
+
+/**
+ * Room state
+ */
+export type RoomState = RoomShellSliceState<RoomConfig> & SqlEditorSliceState;
+
+const {createRoomStore, useRoomStore} = createRoomStoreCreator<RoomState>()(
+  () =>
+    persist(
+      (set, get, store) => ({
+        ...createRoomShellSlice<RoomConfig>({
+          connector: createPyodideDuckDbConnector({}),
+          config: {
+            layout: {
+              type: LayoutTypes.enum.mosaic,
+              nodes: {
+                first: RoomPanelTypes.enum['data'],
+                second: RoomPanelTypes.enum['main'],
+                direction: 'row',
+                splitPercentage: 30,
+              },
+            },
+
+            ...createDefaultSqlEditorConfig(),
+          },
+          room: {
+            panels: {
+              [RoomPanelTypes.enum['main']]: {
+                component: MainView,
+                placement: 'main',
+              },
+              [RoomPanelTypes.enum['data']]: {
+                title: 'Data',
+                component: DataPanel,
+                icon: DatabaseIcon,
+                placement: 'sidebar',
+              },
+            },
+          },
+        })(set, get, store),
+
+        // Sql editor slice
+        ...createSqlEditorSlice()(set, get, store),
+      }),
+      // Persist settings
+      {
+        // Local storage key
+        name: 'pyodide-sql-editor-example-app-state-storage',
+        // Subset of the state to persist
+        partialize: (state) => ({
+          config: RoomConfig.parse(state.config),
+        }),
+      },
+    ) as StateCreator<RoomState>,
+);
+
+export {createRoomStore, useRoomStore};
+

--- a/examples/query-pyodide/src/store.ts
+++ b/examples/query-pyodide/src/store.ts
@@ -35,10 +35,11 @@ export type RoomState = RoomShellSliceState<RoomConfig> & SqlEditorSliceState;
 
 const {createRoomStore, useRoomStore} = createRoomStoreCreator<RoomState>()(
   () =>
+    // @ts-ignore
     persist(
       (set, get, store) => ({
         ...createRoomShellSlice<RoomConfig>({
-          connector: createPyodideDuckDbConnector({}),
+          connector: createPyodideDuckDbConnector(),
           config: {
             layout: {
               type: LayoutTypes.enum.mosaic,
@@ -84,4 +85,3 @@ const {createRoomStore, useRoomStore} = createRoomStoreCreator<RoomState>()(
 );
 
 export {createRoomStore, useRoomStore};
-

--- a/examples/query-pyodide/src/vite-env.d.ts
+++ b/examples/query-pyodide/src/vite-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="vite/client" />
+

--- a/examples/query-pyodide/tailwind.config.ts
+++ b/examples/query-pyodide/tailwind.config.ts
@@ -1,11 +1,13 @@
+import {sqlroomsTailwindPreset} from '@sqlrooms/ui';
 import type {Config} from 'tailwindcss';
 
-export default {
-  darkMode: ['class'],
-  content: ['./index.html', './src/**/*.{ts,tsx}'],
-  theme: {
-    extend: {},
-  },
-  plugins: [],
+const config = {
+  presets: [sqlroomsTailwindPreset({})],
+  content: [
+    'src/**/*.{ts,tsx}',
+    './node_modules/@sqlrooms/*/dist/**/*.js',
+    '../../node_modules/@sqlrooms/*/dist/**/*.js',
+  ],
 } satisfies Config;
 
+export default config;

--- a/examples/query-pyodide/tailwind.config.ts
+++ b/examples/query-pyodide/tailwind.config.ts
@@ -1,0 +1,11 @@
+import type {Config} from 'tailwindcss';
+
+export default {
+  darkMode: ['class'],
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+} satisfies Config;
+

--- a/examples/query-pyodide/tsconfig.app.json
+++ b/examples/query-pyodide/tsconfig.app.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}
+

--- a/examples/query-pyodide/tsconfig.json
+++ b/examples/query-pyodide/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "files": [],
+  "references": [{ "path": "./tsconfig.app.json" }]
+}
+

--- a/examples/query-pyodide/tsconfig.node.json
+++ b/examples/query-pyodide/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}
+

--- a/examples/query-pyodide/vite.config.ts
+++ b/examples/query-pyodide/vite.config.ts
@@ -1,0 +1,11 @@
+import {defineConfig} from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: true,
+  },
+});
+

--- a/packages/layout/src/LayoutSlice.ts
+++ b/packages/layout/src/LayoutSlice.ts
@@ -14,6 +14,7 @@ import {
   DEFAULT_MOSAIC_LAYOUT,
   MAIN_VIEW,
   isMosaicLayoutParent,
+  MosaicLayoutConfig,
 } from '@sqlrooms/layout-config';
 
 export type RoomPanelInfo = {
@@ -24,10 +25,7 @@ export type RoomPanelInfo = {
 };
 
 export const LayoutSliceConfig = z.object({
-  layout: z
-    .any()
-    .describe('Mosaic layout configuration.')
-    .default(DEFAULT_MOSAIC_LAYOUT),
+  layout: MosaicLayoutConfig, // TODO: add more layout types
 });
 
 export type LayoutSliceConfig = z.infer<typeof LayoutSliceConfig>;
@@ -41,7 +39,7 @@ export function createDefaultLayoutConfig(): LayoutSliceConfig {
 export type LayoutSliceState = {
   layout: {
     panels: Record<string, RoomPanelInfo>;
-    setLayout(layout: LayoutConfig): void;
+    setLayout(layout: LayoutConfig | undefined): void;
     togglePanel: (panel: string, show?: boolean) => void;
     togglePanelPin: (panel: string) => void;
   };
@@ -60,7 +58,7 @@ export function createLayoutSlice<
       setLayout: (layout) =>
         set((state) =>
           produce(state, (draft) => {
-            draft.config.layout = layout;
+            draft.config.layout = layout ?? DEFAULT_MOSAIC_LAYOUT;
           }),
         ),
       togglePanel: (panel, show) => {
@@ -136,7 +134,7 @@ export function createLayoutSlice<
         set((state) =>
           produce(state, (draft) => {
             const layout = draft.config.layout;
-            const pinned = layout.pinned ?? [];
+            const pinned = layout?.pinned ?? [];
             if (pinned.includes(panel)) {
               layout.pinned = pinned.filter((p: string) => p !== panel);
             } else {

--- a/packages/layout/src/LayoutSlice.ts
+++ b/packages/layout/src/LayoutSlice.ts
@@ -25,7 +25,7 @@ export type RoomPanelInfo = {
 };
 
 export const LayoutSliceConfig = z.object({
-  layout: MosaicLayoutConfig, // TODO: add more layout types
+  layout: MosaicLayoutConfig,
 });
 
 export type LayoutSliceConfig = z.infer<typeof LayoutSliceConfig>;

--- a/packages/pyodide/README.md
+++ b/packages/pyodide/README.md
@@ -1,0 +1,10 @@
+This package integrates DuckDB running inside Pyodide with SQLRooms.
+
+It exposes a `createPyodideDuckDbConnector` function that provides the `DuckDbConnector` interface backed by Pyodide.
+
+Notes:
+- You must initialize Pyodide and install the `duckdb` Python package inside the Pyodide environment before using the connector.
+- Query results are returned as Arrow tables via Arrow IPC (pyarrow required) or via `to_arrow_table()` if available.
+
+Example usage will be added to the examples once stabilized.
+

--- a/packages/pyodide/eslint.config.js
+++ b/packages/pyodide/eslint.config.js
@@ -1,0 +1,5 @@
+import {config} from '@sqlrooms/preset-eslint/base';
+
+/** @type {import("eslint").Linter.Config} */
+export default config;
+

--- a/packages/pyodide/eslint.config.js
+++ b/packages/pyodide/eslint.config.js
@@ -2,4 +2,3 @@ import {config} from '@sqlrooms/preset-eslint/base';
 
 /** @type {import("eslint").Linter.Config} */
 export default config;
-

--- a/packages/pyodide/package.json
+++ b/packages/pyodide/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@sqlrooms/pyodide",
+  "version": "0.24.18",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "module": "dist/index.js",
+  "type": "module",
+  "author": "Ilya Boyandin <ilya@boyandin.me>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sqlrooms/sqlrooms.git"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@sqlrooms/duckdb": "workspace:*",
+    "apache-arrow": "^17.0.0"
+  },
+  "peerDependencies": {
+    "pyodide": "^0.26.0"
+  },
+  "scripts": {
+    "dev": "tsc -w",
+    "build": "tsc",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
+    "typedoc": "typedoc"
+  }
+}
+

--- a/packages/pyodide/src/index.ts
+++ b/packages/pyodide/src/index.ts
@@ -1,0 +1,12 @@
+/**
+ * {@include ../README.md}
+ * @packageDocumentation
+ */
+
+export {
+  createPyodideDuckDbConnector,
+  isPyodideDuckDbConnector,
+  type PyodideDuckDbConnector,
+  type PyodideDuckDbConnectorOptions,
+} from './pyodide/PyodideDuckDbConnector';
+

--- a/packages/pyodide/src/pyodide/PyodideDuckDbConnector.ts
+++ b/packages/pyodide/src/pyodide/PyodideDuckDbConnector.ts
@@ -1,0 +1,166 @@
+import * as arrow from 'apache-arrow';
+import {
+  BaseDuckDbConnectorImpl,
+  createBaseDuckDbConnector,
+  DuckDbConnector,
+} from '@sqlrooms/duckdb';
+
+/**
+ * Literal type tag identifying the Pyodide-backed DuckDB connector.
+ */
+export type PyodideDuckDbConnectorType = 'pyodide';
+
+/**
+ * Options to configure the Pyodide DuckDB connector.
+ */
+export interface PyodideDuckDbConnectorOptions {
+  /** SQL string executed after the connection is initialized. */
+  initializationQuery?: string;
+  /** Name of the Python module to import for DuckDB. Defaults to 'duckdb'. */
+  duckdbModuleName?: string;
+  /** Optional Python code executed during initialization (e.g., package installs). */
+  initializationPy?: string;
+  /** Explicit Pyodide instance. If omitted, uses globalThis.pyodide. */
+  pyodide?: any;
+}
+
+/**
+ * DuckDB connector implementation that runs inside a Pyodide environment.
+ *
+ * It conforms to the `DuckDbConnector` interface so it can be plugged into
+ * SQLRooms seamlessly. Queries are executed in Python via DuckDB and results
+ * are transferred as Arrow IPC to JavaScript.
+ */
+export interface PyodideDuckDbConnector extends DuckDbConnector {
+  /** Returns the underlying Pyodide instance. */
+  getPyodide(): any;
+  /** Returns the Python-side DuckDB connection proxy. */
+  getPyDuckDbConn(): any;
+  /** Connector type tag. */
+  readonly type: PyodideDuckDbConnectorType;
+}
+
+/**
+ * Create a DuckDB connector backed by Pyodide.
+ *
+ * Requirements on the Pyodide side:
+ * - `duckdb` Python package installed in the environment
+ * - `pyarrow` Python package available for Arrow IPC
+ */
+/**
+ * Create a DuckDB connector backed by Pyodide.
+ *
+ * Requirements in the Pyodide environment:
+ * - Python packages `duckdb` and `pyarrow` must be available
+ * - Provide a Pyodide instance or ensure `globalThis.pyodide` is set
+ */
+export function createPyodideDuckDbConnector(
+  options: PyodideDuckDbConnectorOptions = {},
+): PyodideDuckDbConnector {
+  const {
+    initializationQuery = '',
+    duckdbModuleName = 'duckdb',
+    initializationPy,
+    pyodide: providedPyodide,
+  } = options;
+
+  let pyodide: any | null = providedPyodide ?? (globalThis as any).pyodide ?? null;
+  let pyConn: any | null = null;
+
+  const impl: BaseDuckDbConnectorImpl = {
+    async initializeInternal() {
+      if (!pyodide) {
+        pyodide = (globalThis as any).pyodide;
+      }
+      if (!pyodide) {
+        throw new Error('Pyodide instance not available. Pass via options.pyodide or ensure globalThis.pyodide is set.');
+      }
+
+      if (initializationPy) {
+        await pyodide.runPythonAsync(initializationPy);
+      }
+
+      const pyCode = `
+import importlib
+duckdb = importlib.import_module('${duckdbModuleName}')
+try:
+  import pyarrow as pa
+  have_pa = True
+except Exception:
+  have_pa = False
+con = duckdb.connect()
+`;
+      await pyodide.runPythonAsync(pyCode);
+      pyConn = pyodide.globals.get('con');
+    },
+
+    async destroyInternal() {
+      try {
+        if (pyConn) {
+          await pyodide.runPythonAsync('con.close()');
+          pyConn = null;
+        }
+      } finally {
+        // keep pyodide alive; user owns lifecycle
+      }
+    },
+
+    async executeQueryInternal(query: string, signal: AbortSignal): Promise<arrow.Table> {
+      if (!pyodide || !pyConn) {
+        throw new Error('Pyodide DuckDB not initialized');
+      }
+
+      if (signal.aborted) {
+        throw new DOMException('Query was cancelled', 'AbortError');
+      }
+
+      // We use Arrow IPC to transfer results from Pyodide to JS efficiently
+      // Requires pyarrow in the Pyodide environment
+      const py = `
+import io
+import pyarrow as pa
+tbl = con.execute(r"""${query.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}""").arrow()
+sink = io.BytesIO()
+with pa.ipc.new_file(sink, tbl.schema) as writer:
+  writer.write_table(tbl)
+sink.getvalue()
+`;
+
+      const proxy = await pyodide.runPythonAsync(py);
+      try {
+        // Convert Python bytes to Uint8Array
+        const buffer: Uint8Array = proxy.toJs({create_proxies: false});
+        return arrow.tableFromIPC(buffer);
+      } finally {
+        proxy.destroy?.();
+      }
+    },
+  };
+
+  const base = createBaseDuckDbConnector({initializationQuery}, impl);
+
+  return {
+    ...base,
+    getPyodide() {
+      if (!pyodide) throw new Error('Pyodide not available');
+      return pyodide;
+    },
+    getPyDuckDbConn() {
+      if (!pyConn) throw new Error('Pyodide DuckDB connection not initialized');
+      return pyConn;
+    },
+    get type() {
+      return 'pyodide' as const;
+    },
+  };
+}
+
+/**
+ * Type guard for `PyodideDuckDbConnector`.
+ */
+export function isPyodideDuckDbConnector(
+  connector: DuckDbConnector,
+): connector is PyodideDuckDbConnector {
+  return (connector as any).type === 'pyodide';
+}
+

--- a/packages/pyodide/tsconfig.json
+++ b/packages/pyodide/tsconfig.json
@@ -6,4 +6,3 @@
   "include": ["src"],
   "exclude": ["node_modules", "dist"]
 }
-

--- a/packages/pyodide/tsconfig.json
+++ b/packages/pyodide/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@sqlrooms/preset-typescript/base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}
+

--- a/packages/pyodide/typedoc.js
+++ b/packages/pyodide/typedoc.js
@@ -1,0 +1,4 @@
+import config from '@sqlrooms/preset-typedoc';
+
+export default config(import.meta.url);
+

--- a/packages/room-config/src/BaseRoomConfig.ts
+++ b/packages/room-config/src/BaseRoomConfig.ts
@@ -1,20 +1,20 @@
+import {LayoutConfig} from '@sqlrooms/layout-config';
 import {z} from 'zod';
 import {DataSource} from './DataSource';
-import {DEFAULT_MOSAIC_LAYOUT, LayoutConfig} from '@sqlrooms/layout-config';
 
-export const DEFAULT_ROOM_TITLE = 'Untitled room';
+export const DEFAULT_ROOM_TITLE = 'Untitled';
 
 export const BaseRoomConfig = z
   .object({
-    title: z.string().default(DEFAULT_ROOM_TITLE).describe('Room title.'),
+    title: z.string().describe('Room title.').optional(),
     description: z.string().nullable().optional().describe('Room description.'),
-    layout: LayoutConfig.default(DEFAULT_MOSAIC_LAYOUT).describe(
+    layout: LayoutConfig.describe(
       'Layout specifies how views are arranged on the screen.',
-    ),
+    ).optional(),
     dataSources: z
       .array(DataSource)
-      .default([])
-      .describe('Data sources. Each data source must have a unique tableName.'),
+      .describe('Data sources. Each data source must have a unique tableName.')
+      .optional(),
   })
   .describe('Room configuration.');
 

--- a/packages/room-shell/src/RoomBuilder.tsx
+++ b/packages/room-shell/src/RoomBuilder.tsx
@@ -23,7 +23,7 @@ export const RoomShell: React.FC = () => {
   const handleLayoutChange = useCallback(
     (nodes: MosaicNode<string> | null) => {
       // Keep layout properties, e.g. 'pinned' and 'fixed'
-      setLayout({...layout, nodes});
+      setLayout(layout ? {...layout, nodes} : undefined);
     },
     [setLayout, layout],
   );

--- a/packages/room-shell/src/RoomShell.tsx
+++ b/packages/room-shell/src/RoomShell.tsx
@@ -70,7 +70,7 @@ export const LayoutComposer: FC<{
   const handleLayoutChange = useCallback(
     (nodes: MosaicNode<string> | null) => {
       // Keep layout properties, e.g. 'pinned' and 'fixed'
-      setLayout({...layout, nodes});
+      setLayout(layout ? {...layout, nodes} : undefined);
     },
     [setLayout, layout],
   );

--- a/packages/room-shell/src/panels/RoomPanelHeader.tsx
+++ b/packages/room-shell/src/panels/RoomPanelHeader.tsx
@@ -18,7 +18,7 @@ const RoomPanelHeader: FC<{
     (state) => state.layout.togglePanelPin,
   );
   const pinnedPanels = useBaseRoomShellStore(
-    (state) => state.config.layout.pinned,
+    (state) => state.config.layout?.pinned,
   );
   const isPinned = useMemo(
     () => pinnedPanels?.includes(type),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1058,6 +1058,94 @@ importers:
         specifier: ^0.18.1
         version: 0.18.2(vite@6.3.5(@types/node@24.0.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(yaml@2.8.0))(workbox-build@7.3.0(@types/babel__core@7.20.5))(workbox-window@7.3.0)
 
+  examples/query-pyodide:
+    dependencies:
+      '@sqlrooms/monaco-editor':
+        specifier: workspace:*
+        version: link:../../packages/monaco-editor
+      '@sqlrooms/pyodide':
+        specifier: workspace:*
+        version: link:../../packages/pyodide
+      '@sqlrooms/room-shell':
+        specifier: workspace:*
+        version: link:../../packages/room-shell
+      '@sqlrooms/sql-editor':
+        specifier: workspace:*
+        version: link:../../packages/sql-editor
+      '@sqlrooms/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
+      '@sqlrooms/utils':
+        specifier: workspace:*
+        version: link:../../packages/utils
+      class-variance-authority:
+        specifier: 0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: 2.1.1
+        version: 2.1.1
+      lucide-react:
+        specifier: 0.501.0
+        version: 0.501.0(react@19.1.0)
+      monaco-editor:
+        specifier: ^0.52.2
+        version: 0.52.2
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+      zod:
+        specifier: ^3.25.73
+        version: 3.25.73
+      zustand:
+        specifier: 5.0.5
+        version: 5.0.5(@types/react@19.1.7)(immer@10.1.1)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0))
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.28.0
+        version: 9.28.0
+      '@types/react':
+        specifier: ^19.1.7
+        version: 19.1.7
+      '@types/react-dom':
+        specifier: ^19.1.6
+        version: 19.1.7(@types/react@19.1.7)
+      '@vitejs/plugin-react':
+        specifier: ^4.5.2
+        version: 4.5.2(vite@6.3.5(@types/node@24.0.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(yaml@2.8.0))
+      eslint:
+        specifier: ^9.28.0
+        version: 9.28.0(jiti@2.4.2)
+      eslint-plugin-react-hooks:
+        specifier: ^5.2.0
+        version: 5.2.0(eslint@9.28.0(jiti@2.4.2))
+      eslint-plugin-react-refresh:
+        specifier: ^0.4.20
+        version: 0.4.20(eslint@9.28.0(jiti@2.4.2))
+      globals:
+        specifier: ^16.2.0
+        version: 16.2.0
+      postcss:
+        specifier: ^8.5.4
+        version: 8.5.4
+      tailwindcss:
+        specifier: ^3.4.17
+        version: 3.4.17
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+      typescript-eslint:
+        specifier: ^8.34.0
+        version: 8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)
+      vite:
+        specifier: ^6.3.5
+        version: 6.3.5(@types/node@24.0.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(yaml@2.8.0)
+      vite-plugin-pwa:
+        specifier: ^0.18.1
+        version: 0.18.2(vite@6.3.5(@types/node@24.0.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(yaml@2.8.0))(workbox-build@7.3.0(@types/babel__core@7.20.5))(workbox-window@7.3.0)
+
   packages/ai:
     dependencies:
       '@ai-sdk/provider':
@@ -1489,6 +1577,18 @@ importers:
         version: 1.1.2(typedoc-plugin-markdown@4.4.2(typedoc@0.28.5(typescript@5.8.3)))
 
   packages/preset-typescript: {}
+
+  packages/pyodide:
+    dependencies:
+      '@sqlrooms/duckdb':
+        specifier: workspace:*
+        version: link:../duckdb
+      apache-arrow:
+        specifier: ^17.0.0
+        version: 17.0.0
+      pyodide:
+        specifier: ^0.26.0
+        version: 0.26.4
 
   packages/recharts:
     dependencies:
@@ -2131,6 +2231,7 @@ packages:
 
   '@arcgis/lumina@4.33.0-next.158':
     resolution: {integrity: sha512-UM0+h+3CMvlN74EZr5bsbSTtluDICMfhtPEERj9TstH2Vk7YHXlkA7or4BUL3msSjEfqPftouDizvFmAHtVRnQ==}
+    deprecated: This version is no longer supported. Upgrade to @latest
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -9570,6 +9671,10 @@ packages:
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  pyodide@0.26.4:
+    resolution: {integrity: sha512-z2CHsjVlhhJi5tYBF0AYAfNEPo3zq/z+xOpFtk1tweJkRaTqU4UK/7pLvo8DBU2VDPH31vB3pSI+8fnoqrVrFg==}
+    engines: {node: '>=18.0.0'}
 
   quadbin@0.4.2:
     resolution: {integrity: sha512-1NFzjFVM23Um51/ttD6lFDqGtUHNS5Ky1slZHk3YPwMbC+7Jl3ULLb4QvDo6+Nerv8b8SgUV+ysOhziUh4B5cQ==}
@@ -21610,6 +21715,13 @@ snapshots:
   punycode@2.3.1: {}
 
   pure-rand@6.1.0: {}
+
+  pyodide@0.26.4:
+    dependencies:
+      ws: 8.18.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   quadbin@0.4.2:
     dependencies:


### PR DESCRIPTION
Add new `@sqlrooms/pyodide` package with `PyodideDuckDbConnector` to integrate DuckDB running in Pyodide with SQLRooms.

---
<a href="https://cursor.com/background-agent?bcId=bc-36f1525b-e034-426d-9763-999b0a478835">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-36f1525b-e034-426d-9763-999b0a478835">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

