### PR TITLE
fix: Making base config props optional to avoid type errors for certain tsconfig

### DIFF
--- a/packages/layout/src/LayoutSlice.ts
+++ b/packages/layout/src/LayoutSlice.ts
@@ -14,6 +14,7 @@ import {
   DEFAULT_MOSAIC_LAYOUT,
   MAIN_VIEW,
   isMosaicLayoutParent,
+  MosaicLayoutConfig,
 } from '@sqlrooms/layout-config';
 
 export type RoomPanelInfo = {
@@ -24,10 +25,7 @@ export type RoomPanelInfo = {
 };
 
 export const LayoutSliceConfig = z.object({
-  layout: z
-    .any()
-    .describe('Mosaic layout configuration.')
-    .default(DEFAULT_MOSAIC_LAYOUT),
+  layout: MosaicLayoutConfig, // TODO: add more layout types
 });
 
 export type LayoutSliceConfig = z.infer<typeof LayoutSliceConfig>;
@@ -41,7 +39,7 @@ export function createDefaultLayoutConfig(): LayoutSliceConfig {
 export type LayoutSliceState = {
   layout: {
     panels: Record<string, RoomPanelInfo>;
-    setLayout(layout: LayoutConfig): void;
+    setLayout(layout: LayoutConfig | undefined): void;
     togglePanel: (panel: string, show?: boolean) => void;
     togglePanelPin: (panel: string) => void;
   };
@@ -60,7 +58,7 @@ export function createLayoutSlice<
       setLayout: (layout) =>
         set((state) =>
           produce(state, (draft) => {
-            draft.config.layout = layout;
+            draft.config.layout = layout ?? DEFAULT_MOSAIC_LAYOUT;
           }),
         ),
       togglePanel: (panel, show) => {
@@ -136,7 +134,7 @@ export function createLayoutSlice<
         set((state) =>
           produce(state, (draft) => {
             const layout = draft.config.layout;
-            const pinned = layout.pinned ?? [];
+            const pinned = layout?.pinned ?? [];
             if (pinned.includes(panel)) {
               layout.pinned = pinned.filter((p: string) => p !== panel);
             } else {

--- a/packages/room-config/src/BaseRoomConfig.ts
+++ b/packages/room-config/src/BaseRoomConfig.ts
@@ -1,20 +1,20 @@
+import {LayoutConfig} from '@sqlrooms/layout-config';
 import {z} from 'zod';
 import {DataSource} from './DataSource';
-import {DEFAULT_MOSAIC_LAYOUT, LayoutConfig} from '@sqlrooms/layout-config';
 
-export const DEFAULT_ROOM_TITLE = 'Untitled room';
+export const DEFAULT_ROOM_TITLE = 'Untitled';
 
 export const BaseRoomConfig = z
   .object({
-    title: z.string().default(DEFAULT_ROOM_TITLE).describe('Room title.'),
+    title: z.string().describe('Room title.').optional(),
     description: z.string().nullable().optional().describe('Room description.'),
-    layout: LayoutConfig.default(DEFAULT_MOSAIC_LAYOUT).describe(
+    layout: LayoutConfig.describe(
       'Layout specifies how views are arranged on the screen.',
-    ),
+    ).optional(),
     dataSources: z
       .array(DataSource)
-      .default([])
-      .describe('Data sources. Each data source must have a unique tableName.'),
+      .describe('Data sources. Each data source must have a unique tableName.')
+      .optional(),
   })
   .describe('Room configuration.');
 

--- a/packages/room-shell/src/RoomBuilder.tsx
+++ b/packages/room-shell/src/RoomBuilder.tsx
@@ -23,7 +23,7 @@ export const RoomShell: React.FC = () => {
   const handleLayoutChange = useCallback(
     (nodes: MosaicNode<string> | null) => {
       // Keep layout properties, e.g. 'pinned' and 'fixed'
-      setLayout({...layout, nodes});
+      setLayout(layout ? {...layout, nodes} : undefined);
     },
     [setLayout, layout],
   );

--- a/packages/room-shell/src/RoomShell.tsx
+++ b/packages/room-shell/src/RoomShell.tsx
@@ -70,7 +70,7 @@ export const LayoutComposer: FC<{
   const handleLayoutChange = useCallback(
     (nodes: MosaicNode<string> | null) => {
       // Keep layout properties, e.g. 'pinned' and 'fixed'
-      setLayout({...layout, nodes});
+      setLayout(layout ? {...layout, nodes} : undefined);
     },
     [setLayout, layout],
   );

--- a/packages/room-shell/src/panels/RoomPanelHeader.tsx
+++ b/packages/room-shell/src/panels/RoomPanelHeader.tsx
@@ -18,7 +18,7 @@ const RoomPanelHeader: FC<{
     (state) => state.layout.togglePanelPin,
   );
   const pinnedPanels = useBaseRoomShellStore(
-    (state) => state.config.layout.pinned,
+    (state) => state.config.layout?.pinned,
   );
   const isPinned = useMemo(
     () => pinnedPanels?.includes(type),


### PR DESCRIPTION
e.g. using these in a vite example:

`tsconfig.json`:
```
{
  "files": [],
  "references": [{ "path": "./tsconfig.app.json" }]
}
```
`tsconfig.app.json`:
```
{
  "compilerOptions": {
    "target": "ES2020",
    "useDefineForClassFields": true,
    "lib": ["ES2020", "DOM", "DOM.Iterable"],
    "module": "ESNext",
    "skipLibCheck": true,
    "moduleResolution": "bundler",
    "resolveJsonModule": true,
    "isolatedModules": true,
    "noEmit": true,
    "jsx": "react-jsx",
    "types": ["vite/client"]
  },
  "include": ["src"]
}
```

`tsconfig.node.json`: 
```{
  "compilerOptions": {
    "composite": true,
    "skipLibCheck": true,
    "module": "ESNext",
    "moduleResolution": "bundler",
    "allowSyntheticDefaultImports": true
  },
  "include": ["vite.config.ts"]
}
```