### PR TITLE
refactor: Separate discuss config

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -8,6 +8,24 @@ This document provides detailed guidance for upgrading between different version
 
 When upgrading, please follow the version-specific instructions below that apply to your project. If you encounter any issues during the upgrade process, please refer to our [GitHub issues](https://github.com/sqlrooms/sqlrooms/issues) or contact support.
 
+## 0.25.0
+
+- Discuss config separated from RoomConfig to make it easier to persist separately and to simplify typing (`state.discuss.config` instead of `state.config.discuss`)
+
+```tsx
+const discussConfig = useRoomStore((state) => state.discuss.config);
+```
+
+After:
+
+```tsx
+const discussConfig = useRoomStore((state) => state.config.discuss);
+```
+
+If you were persisting this state, you will likely need a migration.
+
+You should also remove `.merge(DiscussSliceConfig)` when defining your `RoomConfig`
+
 ## 0.19.0
 
 We are trying to make the package structure more logical, especially, for new users of the SQLRooms framework. Sorry for the more renaming.

--- a/examples/deckgl-discuss/src/components/DiscussionPanel.tsx
+++ b/examples/deckgl-discuss/src/components/DiscussionPanel.tsx
@@ -11,7 +11,7 @@ import {RoomPanelTypes, useRoomStore} from '../store';
  * with highlighting functionality.
  */
 const DiscussionPanel = () => {
-  const discussions = useRoomStore((state) => state.config.discuss.discussions);
+  const discussions = useRoomStore((state) => state.discuss.config.discussions);
 
   const table = useRoomStore((s) => s.db.findTableByName('airports'));
   const {data} = useSql<{name: string; abbrev: string}>({

--- a/examples/deckgl-discuss/src/components/MapView.tsx
+++ b/examples/deckgl-discuss/src/components/MapView.tsx
@@ -45,14 +45,14 @@ export const MapView: FC<{features: AirportFeature[]}> = ({features}) => {
   const [commentText, setCommentText] = useState('');
 
   // Get state from store
-  const discussions = useRoomStore((state) => state.config.discuss.discussions);
+  const discussions = useRoomStore((state) => state.discuss.config.discussions);
   const addDiscussion = useRoomStore((state) => state.discuss.addDiscussion);
   const setReplyToItem = useRoomStore((state) => state.discuss.setReplyToItem);
   const setHighlightedDiscussionId = useRoomStore(
     (state) => state.discuss.setHighlightedDiscussionId,
   );
   const highlightedDiscussion = useRoomStore((state) =>
-    state.config.discuss.discussions.find(
+    state.discuss.config.discussions.find(
       (d) => d.id === state.discuss.highlightedDiscussionId,
     ),
   );

--- a/examples/deckgl-discuss/src/store.ts
+++ b/examples/deckgl-discuss/src/store.ts
@@ -1,5 +1,4 @@
 import {
-  createDefaultDiscussConfig,
   createDiscussSlice,
   DiscussSliceConfig,
   DiscussSliceState,
@@ -9,22 +8,22 @@ import {
   BaseRoomConfig,
   createRoomShellSlice,
   createRoomStore,
-  RoomShellSliceState,
-  StateCreator,
   LayoutTypes,
   MAIN_VIEW,
+  RoomShellSliceState,
+  StateCreator,
 } from '@sqlrooms/room-shell';
-import {MessageCircleIcon} from 'lucide-react';
-import {z} from 'zod';
-import {persist} from 'zustand/middleware';
-import DiscussionPanel from './components/DiscussionPanel';
-import {MainView} from './components/MainView';
 import {
   createDefaultSqlEditorConfig,
   createSqlEditorSlice,
   SqlEditorSliceConfig,
   SqlEditorSliceState,
 } from '@sqlrooms/sql-editor';
+import {MessageCircleIcon} from 'lucide-react';
+import {z} from 'zod';
+import {persist} from 'zustand/middleware';
+import DiscussionPanel from './components/DiscussionPanel';
+import {MainView} from './components/MainView';
 
 export const RoomPanelTypes = z.enum([
   'data-sources',
@@ -33,13 +32,12 @@ export const RoomPanelTypes = z.enum([
 ] as const);
 export type RoomPanelTypes = z.infer<typeof RoomPanelTypes>;
 
-export const RoomConfig =
-  BaseRoomConfig.merge(DiscussSliceConfig).merge(SqlEditorSliceConfig);
+export const RoomConfig = BaseRoomConfig.merge(SqlEditorSliceConfig);
 export type RoomConfig = z.infer<typeof RoomConfig>;
 
 export type RoomState = RoomShellSliceState<RoomConfig> &
-  DiscussSliceState &
-  SqlEditorSliceState;
+  SqlEditorSliceState &
+  DiscussSliceState;
 
 export const {roomStore, useRoomStore} = createRoomStore<RoomConfig, RoomState>(
   persist(
@@ -55,7 +53,6 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomConfig, RoomState>(
           initializationQuery: 'LOAD spatial',
         }),
         config: {
-          ...createDefaultDiscussConfig(),
           layout: {
             type: LayoutTypes.enum.mosaic,
             nodes: {
@@ -103,7 +100,17 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomConfig, RoomState>(
       name: 'discuss-example-app-state-storage',
       // Subset of the state to persist
       partialize: (state) => ({
-        config: RoomConfig.parse(state.config),
+        roomConfig: RoomConfig.parse(state.config),
+        discussConfig: DiscussSliceConfig.parse(state.discuss.config),
+      }),
+      // Combining the persisted state with the current one
+      merge: (persistedState: any, currentState) => ({
+        ...currentState,
+        config: RoomConfig.parse(persistedState.roomConfig),
+        discuss: {
+          ...currentState.discuss,
+          config: DiscussSliceConfig.parse(persistedState.discussConfig),
+        },
       }),
     },
   ) as StateCreator<RoomState>,

--- a/packages/discuss/README.md
+++ b/packages/discuss/README.md
@@ -126,7 +126,7 @@ import {useStoreWithDiscussion} from '@sqlrooms/discuss';
 function MyComponent() {
   // Get discussions
   const discussions = useStoreWithDiscussion(
-    (state) => state.config.discuss.discussions,
+    (state) => state.discuss.config.discussions,
   );
 
   // Get actions
@@ -160,7 +160,7 @@ import {formatTimeRelative} from '@sqlrooms/utils';
 
 const DiscussionPanel = () => {
   const discussions = useStoreWithDiscussion(
-    (state) => state.config.discuss.discussions,
+    (state) => state.discuss.config.discussions,
   );
 
   return (
@@ -226,7 +226,7 @@ function DataVisualization() {
   // Highlight related discussion when hovering over data
   const handleDataPointHover = (dataId: string) => {
     const discussions =
-      useStoreWithDiscussion.getState().config.discuss.discussions;
+      useStoreWithDiscussion.getState().discuss.config.discussions;
     const relatedDiscussion = discussions.find((d) => d.anchorId === dataId);
     if (relatedDiscussion) {
       setHighlightedDiscussionId(relatedDiscussion.id);

--- a/packages/discuss/src/DiscussionList.tsx
+++ b/packages/discuss/src/DiscussionList.tsx
@@ -38,7 +38,7 @@ export const DiscussionList = forwardRef<HTMLDivElement, DiscussionListProps>(
       (state) => state.discuss.highlightedDiscussionId,
     );
     const discussions = useStoreWithDiscussion(
-      (state) => state.config.discuss.discussions,
+      (state) => state.discuss.config.discussions,
     );
     const replyToItem = useStoreWithDiscussion(
       (state) => state.discuss.replyToItem,


### PR DESCRIPTION
Discuss config separated from RoomConfig to make it easier to persist separately and to simplify typing (`state.discuss.config` instead of `state.config.discuss`)

Check the [upgrade guide](https://sqlrooms.org/upgrade-guide.html#_0-25-0)