### PR TITLE
refactor: Separate ai config

### DIFF
--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -95,7 +95,6 @@ SQLRooms uses [Zod](https://zod.dev/) for runtime type validation. When combinin
 Here's an example from the AI example application showing how to combine configuration types:
 
 ```typescript
-import {AiSliceConfig} from '@sqlrooms/ai';
 import {BaseRoomConfig} from '@sqlrooms/room-config';
 import {SqlEditorSliceConfig} from '@sqlrooms/sql-editor';
 import {z} from 'zod';
@@ -103,13 +102,11 @@ import {z} from 'zod';
 /**
  * Room config for saving - combining multiple slice configs
  */
-export const RoomConfig = BaseRoomConfig.merge(AiSliceConfig)
-  .merge(SqlEditorSliceConfig)
-  .merge(
-    z.object({
-      // Custom app config
-    }),
-  );
+export const RoomConfig = BaseRoomConfig.merge(SqlEditorSliceConfig).merge(
+  z.object({
+    // Custom app config
+  }),
+);
 export type RoomConfig = z.infer<typeof RoomConfig>;
 ```
 
@@ -126,8 +123,6 @@ When using the combined configuration type in your store, you can ensure that al
 // Using the combined RoomConfig in the store
 ...createRoomShellSlice<RoomConfig>({
   config: {
-    // AI slice configuration
-    ...createDefaultAiConfig(),
     // SQL Editor slice configuration
     ...createDefaultSqlEditorConfig(),
     // Other configuration properties...

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -75,7 +75,7 @@ export const MyCustomView: React.FC = () => {
   const isDataAvailable = useRoomStore((state) => state.room.isDataAvailable);
 
   // Access AI slice config (persistable state)
-  const currentSessionId = useRoomStore((s) => s.config.ai.currentSessionId);
+  const currentSessionId = useRoomStore((s) => s.ai.config.currentSessionId);
 
   // Access custom app state
   const apiKey = useRoomStore((s) => s.apiKey);

--- a/examples/ai/src/components/MainView.tsx
+++ b/examples/ai/src/components/MainView.tsx
@@ -14,7 +14,7 @@ import {useRoomStore} from '../store';
 
 export const MainView: React.FC = () => {
   const currentSessionId = useRoomStore(
-    (s) => s.config.ai.currentSessionId || null,
+    (s) => s.ai.config.currentSessionId || null,
   );
   const isDataAvailable = useRoomStore((state) => state.room.initialized);
   const aiSettings = useRoomStore((s) => s.aiSettings.config);

--- a/examples/ai/src/store.ts
+++ b/examples/ai/src/store.ts
@@ -5,7 +5,6 @@ import {
   AiSliceState,
   createAiSettingsSlice,
   createAiSlice,
-  createDefaultAiConfig,
   createDefaultAiSettingsConfig,
 } from '@sqlrooms/ai';
 import {

--- a/examples/ai/src/store.ts
+++ b/examples/ai/src/store.ts
@@ -44,8 +44,7 @@ export type RoomPanelTypes = z.infer<typeof RoomPanelTypes>;
 /**
  * Room config for saving
  */
-export const RoomConfig =
-  BaseRoomConfig.merge(AiSliceConfig).merge(SqlEditorSliceConfig);
+export const RoomConfig = BaseRoomConfig.merge(SqlEditorSliceConfig);
 export type RoomConfig = z.infer<typeof RoomConfig>;
 
 export type RoomState = RoomShellSliceState<RoomConfig> &
@@ -78,9 +77,6 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomConfig, RoomState>(
               url: 'https://raw.githubusercontent.com/keplergl/kepler.gl-data/refs/heads/master/earthquakes/data.csv',
             },
           ],
-          ...createDefaultAiConfig(
-            AiSliceConfig.shape.ai.parse(exampleSessions),
-          ),
           ...createDefaultAiSettingsConfig(AI_SETTINGS),
           ...createDefaultSqlEditorConfig(),
         },
@@ -111,6 +107,8 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomConfig, RoomState>(
 
       // Ai slice
       ...createAiSlice({
+        config: AiSliceConfig.parse(exampleSessions),
+
         // You can configure the Api key in the Ai Settings panel,
         // or (optional) provide API key with your own custom logic here
         // getApiKey: (modelProvider: string) => {
@@ -175,12 +173,17 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomConfig, RoomState>(
       // Subset of the state to persist
       partialize: (state) => ({
         config: RoomConfig.parse(state.config),
+        ai: AiSliceConfig.parse(state.ai.config),
         aiSettings: AiSettingsSliceConfig.parse(state.aiSettings.config),
       }),
       // Combining the persisted state with the current one when loading from local storage
       merge: (persistedState: any, currentState) => ({
         ...currentState,
         config: RoomConfig.parse(persistedState.config),
+        ai: {
+          ...currentState.ai,
+          config: AiSliceConfig.parse(persistedState.ai),
+        },
         aiSettings: {
           ...currentState.aiSettings,
           config: AiSettingsSliceConfig.parse(persistedState.aiSettings),

--- a/examples/canvas/src/example-canvas.json
+++ b/examples/canvas/src/example-canvas.json
@@ -1,90 +1,88 @@
 {
-  "canvas": {
-    "viewport": {
-      "x": 108.19750748399463,
-      "y": 157.10285126250642,
-      "zoom": 0.6020686906157079
+  "viewport": {
+    "x": 108.19750748399463,
+    "y": 157.10285126250642,
+    "zoom": 0.6020686906157079
+  },
+  "nodes": [
+    {
+      "id": "i83p6y6aqz2luzr1mr62g0cr",
+      "position": {"x": 100, "y": 100},
+      "type": "sql",
+      "data": {
+        "title": "Query",
+        "type": "sql",
+        "sql": "SELECT * FROM earthquakes"
+      },
+      "width": 800,
+      "height": 600
     },
-    "nodes": [
-      {
-        "id": "i83p6y6aqz2luzr1mr62g0cr",
-        "position": {"x": 100, "y": 100},
+    {
+      "id": "bnu61kaq2975k8otchw25dkl",
+      "position": {"x": 980.0687194218185, "y": -179.0379280945404},
+      "type": "sql",
+      "data": {
+        "title": "Query 1",
         "type": "sql",
-        "data": {
-          "title": "Query",
-          "type": "sql",
-          "sql": "SELECT * FROM earthquakes"
-        },
-        "width": 800,
-        "height": 600
+        "sql": "SELECT * FROM canvas.\"Query\""
       },
-      {
-        "id": "bnu61kaq2975k8otchw25dkl",
-        "position": {"x": 980.0687194218185, "y": -179.0379280945404},
-        "type": "sql",
-        "data": {
-          "title": "Query 1",
-          "type": "sql",
-          "sql": "SELECT * FROM canvas.\"Query\""
-        },
-        "width": 800,
-        "height": 600
-      },
-      {
-        "id": "jl5dlsn83zifpy2f0bdajine",
-        "position": {"x": 1900, "y": 100},
+      "width": 800,
+      "height": 600
+    },
+    {
+      "id": "jl5dlsn83zifpy2f0bdajine",
+      "position": {"x": 1900, "y": 100},
+      "type": "vega",
+      "data": {
+        "title": "Chart",
         "type": "vega",
-        "data": {
-          "title": "Chart",
-          "type": "vega",
-          "vegaSpec": {
-            "description": "A simple bar chart",
-            "mark": "bar",
-            "encoding": {
-              "x": {"field": "category", "type": "ordinal"},
-              "y": {"field": "value", "type": "quantitative"}
-            },
-            "data": {
-              "values": [
-                {"category": "A", "value": 28},
-                {"category": "B", "value": 55},
-                {"category": "C", "value": 43}
-              ]
-            }
+        "vegaSpec": {
+          "description": "A simple bar chart",
+          "mark": "bar",
+          "encoding": {
+            "x": {"field": "category", "type": "ordinal"},
+            "y": {"field": "value", "type": "quantitative"}
+          },
+          "data": {
+            "values": [
+              {"category": "A", "value": 28},
+              {"category": "B", "value": 55},
+              {"category": "C", "value": 43}
+            ]
           }
-        },
-        "width": 800,
-        "height": 600
+        }
       },
-      {
-        "id": "f1173uk33s5w3yxm86n931zk",
-        "position": {"x": 1003.3218800963637, "y": 563.4022734427189},
+      "width": 800,
+      "height": 600
+    },
+    {
+      "id": "f1173uk33s5w3yxm86n931zk",
+      "position": {"x": 1003.3218800963637, "y": 563.4022734427189},
+      "type": "sql",
+      "data": {
+        "title": "Query 2",
         "type": "sql",
-        "data": {
-          "title": "Query 2",
-          "type": "sql",
-          "sql": "SELECT * FROM canvas.\"Query\""
-        },
-        "width": 800,
-        "height": 600
-      }
-    ],
-    "edges": [
-      {
-        "id": "i83p6y6aqz2luzr1mr62g0cr-bnu61kaq2975k8otchw25dkl",
-        "source": "i83p6y6aqz2luzr1mr62g0cr",
-        "target": "bnu61kaq2975k8otchw25dkl"
+        "sql": "SELECT * FROM canvas.\"Query\""
       },
-      {
-        "id": "bnu61kaq2975k8otchw25dkl-jl5dlsn83zifpy2f0bdajine",
-        "source": "bnu61kaq2975k8otchw25dkl",
-        "target": "jl5dlsn83zifpy2f0bdajine"
-      },
-      {
-        "id": "i83p6y6aqz2luzr1mr62g0cr-f1173uk33s5w3yxm86n931zk",
-        "source": "i83p6y6aqz2luzr1mr62g0cr",
-        "target": "f1173uk33s5w3yxm86n931zk"
-      }
-    ]
-  }
+      "width": 800,
+      "height": 600
+    }
+  ],
+  "edges": [
+    {
+      "id": "i83p6y6aqz2luzr1mr62g0cr-bnu61kaq2975k8otchw25dkl",
+      "source": "i83p6y6aqz2luzr1mr62g0cr",
+      "target": "bnu61kaq2975k8otchw25dkl"
+    },
+    {
+      "id": "bnu61kaq2975k8otchw25dkl-jl5dlsn83zifpy2f0bdajine",
+      "source": "bnu61kaq2975k8otchw25dkl",
+      "target": "jl5dlsn83zifpy2f0bdajine"
+    },
+    {
+      "id": "i83p6y6aqz2luzr1mr62g0cr-f1173uk33s5w3yxm86n931zk",
+      "source": "i83p6y6aqz2luzr1mr62g0cr",
+      "target": "f1173uk33s5w3yxm86n931zk"
+    }
+  ]
 }

--- a/examples/canvas/src/store.ts
+++ b/examples/canvas/src/store.ts
@@ -3,7 +3,6 @@ import {
   CanvasSliceConfig,
   CanvasSliceState,
   createCanvasSlice,
-  createDefaultCanvasConfig,
 } from '@sqlrooms/canvas';
 import {
   BaseRoomConfig,
@@ -13,17 +12,12 @@ import {
   RoomShellSliceState,
   StateCreator,
 } from '@sqlrooms/room-shell';
+import {DatabaseIcon} from 'lucide-react';
 import {z} from 'zod';
 import {persist} from 'zustand/middleware';
 import {DataSourcesPanel} from './DataSourcesPanel';
-import {DatabaseIcon} from 'lucide-react';
-import exampleCanvas from './example-canvas.json';
-import {createVegaChartTool} from '../../../packages/vega/dist/VegaChartTool';
 
-export const RoomConfig = BaseRoomConfig.merge(CanvasSliceConfig);
-export type RoomConfig = z.infer<typeof RoomConfig>;
-
-export type RoomState = RoomShellSliceState<RoomConfig> &
+export type RoomState = RoomShellSliceState &
   CanvasSliceState & {
     apiKey: string;
     setApiKey: (apiKey: string) => void;
@@ -31,13 +25,14 @@ export type RoomState = RoomShellSliceState<RoomConfig> &
 export const RoomPanelTypes = z.enum(['main', 'data'] as const);
 export type RoomPanelTypes = z.infer<typeof RoomPanelTypes>;
 
-export const {roomStore, useRoomStore} = createRoomStore<RoomConfig, RoomState>(
+export const {roomStore, useRoomStore} = createRoomStore<
+  BaseRoomConfig,
+  RoomState
+>(
   persist(
     (set, get, store) => ({
-      ...createRoomShellSlice<RoomConfig>({
+      ...createRoomShellSlice({
         config: {
-          ...createDefaultCanvasConfig(),
-          // CanvasSliceConfig.parse(exampleCanvas).canvas,
           layout: {
             type: LayoutTypes.enum.mosaic,
             nodes: {
@@ -73,12 +68,14 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomConfig, RoomState>(
         },
       })(set, get, store),
 
-      ...createCanvasSlice<RoomConfig>({
-        getApiKey: () => get().apiKey,
-        toolsOptions: {
-          numberOfRowsToShareWithLLM: 2,
+      ...createCanvasSlice({
+        ai: {
+          getApiKey: () => get().apiKey,
+          toolsOptions: {
+            numberOfRowsToShareWithLLM: 2,
+          },
+          defaultModel: 'gpt-4.1-mini',
         },
-        defaultModel: 'gpt-4.1-mini',
       })(set, get, store),
 
       apiKey: '',
@@ -92,7 +89,17 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomConfig, RoomState>(
       // Subset of the state to persist
       partialize: (state) => ({
         apiKey: state.apiKey,
-        config: RoomConfig.parse(state.config),
+        config: BaseRoomConfig.parse(state.config),
+        canvas: CanvasSliceConfig.parse(state.canvas.config),
+      }),
+      merge: (persistedState: any, currentState) => ({
+        ...currentState,
+        apiKey: persistedState.apiKey,
+        config: BaseRoomConfig.parse(persistedState.config),
+        canvas: {
+          ...currentState.canvas,
+          config: CanvasSliceConfig.parse(persistedState.canvas),
+        },
       }),
     },
   ) as StateCreator<RoomState>,

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -60,7 +60,7 @@ npm install ollama-ai-provider-v2
 ### Setting Up AI Integration
 
 ```tsx
-import {createAiSlice, createDefaultAiConfig} from '@sqlrooms/ai';
+import {createAiSlice} from '@sqlrooms/ai';
 import {createRoomStore} from '@sqlrooms/room-shell';
 
 // Create a room store with AI capabilities
@@ -69,7 +69,6 @@ const {roomStore, useRoomStore} = createRoomStore({
   ...createRoomShellSlice({
     config: {
       // Your room configuration
-      ...createDefaultAiConfig(), // Default AI configuration
     },
   }),
   // Add AI slice
@@ -104,11 +103,7 @@ function MyApp() {
 For more complex applications, you can combine multiple slices:
 
 ```tsx
-import {
-  createAiSlice,
-  createDefaultAiConfig,
-  AiSliceConfig,
-} from '@sqlrooms/ai';
+import {createAiSlice} from '@sqlrooms/ai';
 import {
   createSqlEditorSlice,
   createDefaultSqlEditorConfig,
@@ -126,26 +121,25 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomConfig, RoomState>(
     // Base room slice
     ...createRoomShellSlice({
       config: {
-        // Your base configuration
-        ...createDefaultAiConfig({
-          // Optional: Pre-configured AI sessions
-          sessions: [
-            {
-              id: 'default-session',
-              name: 'Default Analysis',
-              modelProvider: 'openai',
-              model: 'gpt-4o',
-              analysisResults: [],
-              createdAt: new Date(),
-            },
-          ],
-          currentSessionId: 'default-session',
-        }),
         ...createDefaultSqlEditorConfig(),
       },
     }),
     // AI slice
     ...createAiSlice({
+      config: {
+        // Optional: Pre-configured AI sessions
+        sessions: [
+          {
+            id: 'default-session',
+            name: 'Default Analysis',
+            modelProvider: 'openai',
+            model: 'gpt-4o',
+            analysisResults: [],
+            createdAt: new Date(),
+          },
+        ],
+        currentSessionId: 'default-session',
+      }
       getApiKey: (modelProvider) => {
         // Return API key based on provider
         return apiKeys[modelProvider] || '';

--- a/packages/ai/src/components/session/DeleteSessionButton.tsx
+++ b/packages/ai/src/components/session/DeleteSessionButton.tsx
@@ -24,8 +24,8 @@ export interface DeleteSessionButtonProps {
 export const DeleteSessionButton: React.FC<DeleteSessionButtonProps> = ({
   className,
 }) => {
-  const sessions = useStoreWithAi((s) => s.config.ai.sessions);
-  const currentSessionId = useStoreWithAi((s) => s.config.ai.currentSessionId);
+  const sessions = useStoreWithAi((s) => s.ai.config.sessions);
+  const currentSessionId = useStoreWithAi((s) => s.ai.config.currentSessionId);
   const deleteSession = useStoreWithAi((s) => s.ai.deleteSession);
 
   const [sessionToDeleteId, setSessionToDeleteId] = useState<string | null>(

--- a/packages/ai/src/components/session/SessionDropdown.tsx
+++ b/packages/ai/src/components/session/SessionDropdown.tsx
@@ -29,8 +29,8 @@ export interface SessionDropdownProps {
 export const SessionDropdown: React.FC<SessionDropdownProps> = ({
   className,
 }) => {
-  const sessions = useStoreWithAi((s) => s.config.ai.sessions);
-  const currentSessionId = useStoreWithAi((s) => s.config.ai.currentSessionId);
+  const sessions = useStoreWithAi((s) => s.ai.config.sessions);
+  const currentSessionId = useStoreWithAi((s) => s.ai.config.currentSessionId);
   const switchSession = useStoreWithAi((s) => s.ai.switchSession);
   const createSession = useStoreWithAi((s) => s.ai.createSession);
 

--- a/packages/canvas/README.md
+++ b/packages/canvas/README.md
@@ -2,5 +2,5 @@
 
 ReactFlow-based canvas for building and editing DAGs of SQL and Vega nodes, with a Zustand slice for persistence in SQLRooms apps.
 
-- CanvasSlice stores nodes and edges under `config.canvas`
+- CanvasSlice stores nodes and edges under `canvas.config`
 - Canvas component renders and edits the graph

--- a/packages/canvas/src/Canvas.tsx
+++ b/packages/canvas/src/Canvas.tsx
@@ -25,13 +25,13 @@ const nodeTypes = {
 
 export const Canvas: React.FC = () => {
   const nodes = useStoreWithCanvas(
-    (s) => s.config.canvas.nodes,
+    (s) => s.canvas.config.nodes,
   ) as unknown as Node<CanvasNodeData>[];
-  const edges = useStoreWithCanvas((s) => s.config.canvas.edges) as Edge[];
+  const edges = useStoreWithCanvas((s) => s.canvas.config.edges) as Edge[];
   const addEdge = useStoreWithCanvas((s) => s.canvas.addEdge);
   const applyNodeChanges = useStoreWithCanvas((s) => s.canvas.applyNodeChanges);
   const applyEdgeChanges = useStoreWithCanvas((s) => s.canvas.applyEdgeChanges);
-  const viewport = useStoreWithCanvas((s) => s.config.canvas.viewport);
+  const viewport = useStoreWithCanvas((s) => s.canvas.config.viewport);
   const setViewport = useStoreWithCanvas((s) => s.canvas.setViewport);
   const addNode = useStoreWithCanvas((s) => s.canvas.addNode);
 

--- a/packages/canvas/src/CanvasSlice.ts
+++ b/packages/canvas/src/CanvasSlice.ts
@@ -1,10 +1,5 @@
 import {createId} from '@paralleldrive/cuid2';
-import {
-  AiSliceConfig,
-  AiSliceState,
-  createAiSlice,
-  createDefaultAiConfig,
-} from '@sqlrooms/ai';
+import {AiSliceState, createAiSlice} from '@sqlrooms/ai';
 import {escapeId} from '@sqlrooms/duckdb';
 import {
   BaseRoomConfig,
@@ -92,19 +87,17 @@ export type SqlNodeQueryResult =
   | {status: 'error'; error: string}
   | {status: 'success'; tableName: string; lastQueryStatement: string};
 
-export const CanvasSliceConfig = z
-  .object({
-    canvas: z.object({
-      viewport: z.object({
-        x: z.number(),
-        y: z.number(),
-        zoom: z.number(),
-      }),
-      nodes: z.array(CanvasNodeSchema).default([]),
-      edges: z.array(CanvasEdgeSchema).default([]),
+export const CanvasSliceConfig = z.object({
+  canvas: z.object({
+    viewport: z.object({
+      x: z.number(),
+      y: z.number(),
+      zoom: z.number(),
     }),
-  })
-  .merge(AiSliceConfig);
+    nodes: z.array(CanvasNodeSchema).default([]),
+    edges: z.array(CanvasEdgeSchema).default([]),
+  }),
+});
 export type CanvasSliceConfig = z.infer<typeof CanvasSliceConfig>;
 
 export type CanvasSliceState = AiSliceState & {
@@ -146,7 +139,6 @@ export function createDefaultCanvasConfig(
       edges: [],
       ...props,
     },
-    ...createDefaultAiConfig({}),
   };
 }
 

--- a/packages/canvas/src/nodes/CanvasNodeContainer.tsx
+++ b/packages/canvas/src/nodes/CanvasNodeContainer.tsx
@@ -34,7 +34,7 @@ export const CanvasNodeContainer: FC<
 > = ({id, className, headerRight, children}) => {
   const renameNode = useStoreWithCanvas((s) => s.canvas.renameNode);
   const node = useStoreWithCanvas((s) =>
-    s.config.canvas.nodes.find((n) => n.id === id),
+    s.canvas.config.nodes.find((n) => n.id === id),
   );
   const title = node?.data.title;
   const onTitleChange = useCallback(

--- a/packages/room-shell/src/RoomShellStore.ts
+++ b/packages/room-shell/src/RoomShellStore.ts
@@ -147,12 +147,13 @@ export type RoomShellSliceStateActions<PC extends BaseRoomConfig> =
     ) => Promise<void>;
   };
 
-export type RoomShellSliceState<PC extends BaseRoomConfig> = RoomState<PC> & {
-  initialize?: () => Promise<void>;
-  config: PC;
-  room: RoomShellSliceStateProps<PC> & RoomShellSliceStateActions<PC>;
-} & DuckDbSliceState &
-  LayoutSliceState;
+export type RoomShellSliceState<PC extends BaseRoomConfig = BaseRoomConfig> =
+  RoomState<PC> & {
+    initialize?: () => Promise<void>;
+    config: PC;
+    room: RoomShellSliceStateProps<PC> & RoomShellSliceStateActions<PC>;
+  } & DuckDbSliceState &
+    LayoutSliceState;
 
 /**
  * 	This type takes a union type U (for example, A | B) and transforms it into an intersection type (A & B). This is useful because if you pass in, say, two slices of type { a: number } and { b: string }, the union of the slice types would be { a: number } | { b: string }, but you really want an object that has both properties—i.e. { a: number } & { b: string }.
@@ -169,9 +170,9 @@ const DOWNLOAD_DATA_SOURCES_TASK = 'download-data-sources';
 const INIT_DB_TASK = 'init-db';
 const INIT_ROOM_TASK = 'init-room';
 
-export function createRoomShellSlice<PC extends BaseRoomConfig>(
-  props: InitialState<PC>,
-): StateCreator<RoomShellSliceState<PC>> {
+export function createRoomShellSlice<
+  PC extends BaseRoomConfig = BaseRoomConfig,
+>(props: InitialState<PC>): StateCreator<RoomShellSliceState<PC>> {
   const slice: StateCreator<RoomShellSliceState<PC>> = (set, get, store) => {
     const {
       connector,


### PR DESCRIPTION
- AiSliceConfig separated from RoomConfig to make it easier to persist separately and to simplify typing (`state.ai.config` instead of `state.config.ai`)

- CanvasSliceConfig separated from RoomConfig to make it easier to persist separately and to simplify typing (`state.canvas.config` instead of `state.config.canvas`)
