### PR TITLE
feat: fix height for prompt textarea box

### DIFF
--- a/packages/ai-core/src/components/QueryControls.tsx
+++ b/packages/ai-core/src/components/QueryControls.tsx
@@ -86,8 +86,7 @@ export const QueryControls: React.FC<QueryControlsProps> = ({
           <Textarea
             ref={textareaRef}
             disabled={isRunningAnalysis}
-            className="min-h-[30px] resize-none border-none p-2 text-sm outline-none focus-visible:ring-0"
-            autoResize
+            className="max-h-70 min-h-[30px] resize-none overflow-y-auto border-none p-2 text-sm outline-none focus-visible:ring-0"
             value={analysisPrompt}
             onChange={(e) => setAnalysisPrompt(e.target.value)}
             onKeyDown={handleKeyDown}


### PR DESCRIPTION
The height of prompt textarea will grow with the input text. This PR tries to make the prompt textarea with fix height. Not sure if "Get max-height constraint from CSS" is the right way to do it. @albatross97 can you help to take a look? Thanks!

