### PR TITLE
fix: Styles of schema tree node and mosaic layout (main)

### DIFF
--- a/packages/schema-tree/src/nodes/TableTreeNode.tsx
+++ b/packages/schema-tree/src/nodes/TableTreeNode.tsx
@@ -102,18 +102,16 @@ export const TableTreeNode: FC<{
   return (
     <>
       <BaseTreeNode asChild className={className} nodeObject={nodeObject}>
-        <div className="relative flex w-full min-w-0 items-center space-x-2 pr-5">
+        <div className="relative flex w-full items-center space-x-2">
           {isView ? (
             <ViewIcon size="16px" className="shrink-0 text-blue-500" />
           ) : (
             <TableIcon size="16px" className="shrink-0 text-blue-500" />
           )}
-          <div className="flex w-full min-w-0 items-center justify-between gap-1">
-            <span className="min-w-0 flex-1 truncate" title={name}>
-              {name}
-            </span>
+          <div className="flex w-full items-center justify-between gap-2">
+            <span>{name}</span>
             {rowCount !== undefined && (
-              <span className="text-muted-foreground/50 shrink-0 whitespace-nowrap text-xs">
+              <span className="text-muted-foreground/50 ml-1 whitespace-nowrap pr-8 text-xs">
                 {formatCount(rowCount)} {rowCount === 1 ? 'row' : 'rows'}
               </span>
             )}

--- a/packages/schema-tree/src/nodes/TreeNodeActionsMenu.tsx
+++ b/packages/schema-tree/src/nodes/TreeNodeActionsMenu.tsx
@@ -36,7 +36,7 @@ export const TreeNodeActionsMenu: FC<TreeNodeActionsMenuProps> = (props) => {
     <div className="absolute right-0 top-[1px] opacity-0 outline-none group-hover:opacity-100">
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <div className="hover:bg-foreground/10 flex h-5 w-4 items-center justify-center p-0 outline-none transition-colors">
+          <div className="hover:bg-foreground/10 flex h-5 w-7 items-center justify-center p-0 outline-none transition-colors">
             <EllipsisVerticalIcon size="16px" />
           </div>
         </DropdownMenuTrigger>

--- a/packages/sql-editor/src/components/QueryEditorPanel.tsx
+++ b/packages/sql-editor/src/components/QueryEditorPanel.tsx
@@ -34,9 +34,10 @@ export const QueryEditorPanel: React.FC<QueryEditorPanelProps> = ({
         className,
       )}
     >
-      <div className="border-border flex items-center border-b p-1">
-        <QueryEditorPanelActions />
+      <div className="border-border flex items-center gap-4 border-b px-2 pt-1">
         <QueryEditorPanelTabsList />
+        <div className="flex-1" />
+        <QueryEditorPanelActions />
       </div>
       {queries.map((q) => (
         <TabsContent


### PR DESCRIPTION
Same as https://github.com/sqlrooms/sqlrooms/pull/180

- Add truncate for schema tree node
<img width="300" height="219" alt="Screenshot 2025-11-06 at 2 44 07 PM" src="https://github.com/user-attachments/assets/e9120e10-aae2-47df-9155-b344c6312fcd" />


- Remove margin (3-4px) of each mosaic components
<img width="139" height="604" alt="Screenshot 2025-11-06 at 11 01 18 AM" src="https://github.com/user-attachments/assets/ab7d018e-7782-4ef9-b80c-7b879cdcbd5f" />