### PR TITLE
fix: using escapeVal for value-comparison in addTable

### DIFF
--- a/packages/duckdb/src/DuckDbSlice.ts
+++ b/packages/duckdb/src/DuckDbSlice.ts
@@ -465,7 +465,6 @@ export function createDuckDbSlice({
             ${
               schema || database || table
                 ? `WHERE ${[
-                    // These columns are string values (not identifiers), so use escapeVal (which includes quotes).
                     schema ? `schema = ${escapeVal(schema)}` : '',
                     database ? `database = ${escapeVal(database)}` : '',
                     table ? `name = ${escapeVal(table)}` : '',
@@ -474,7 +473,6 @@ export function createDuckDbSlice({
                     .join(' AND ')}`
                 : ''
             }`;
-            console.log(sql);
             const describeResults = await connector.query(sql);
 
             const newTables: DataTable[] = [];

--- a/packages/kepler/src/KeplerSlice.ts
+++ b/packages/kepler/src/KeplerSlice.ts
@@ -177,7 +177,6 @@ export type KeplerSliceState = {
 const SKIP_AUTO_SAVE_ACTIONS: string[] = [
   KeplerActionTypes.LAYER_HOVER,
   KeplerActionTypes.UPDATE_MAP,
-  // High-frequency interaction events that should not trigger persistence / autosave
   KeplerActionTypes.MOUSE_MOVE,
 ];
 


### PR DESCRIPTION
- Issue: addTable() using an identifier-escaper (escapeId) in a value-comparison
  - e.g. WHERE ... table = '"earthquake"'

- Add `MOUSE_MOVE` to SKIP_AUTO_SAVE_ACTIONS