### PR TITLE
feat: allow custom error component in AnalysisResult

### DIFF
--- a/packages/ai-core/src/components/AnalysisResult.tsx
+++ b/packages/ai-core/src/components/AnalysisResult.tsx
@@ -3,7 +3,7 @@ import {Button, CopyButton} from '@sqlrooms/ui';
 import {SquareTerminalIcon, TrashIcon} from 'lucide-react';
 import {useState, useRef, useEffect} from 'react';
 import {Components} from 'react-markdown';
-import {ErrorMessage} from './ErrorMessage';
+import {ErrorMessage, type ErrorMessageComponentProps} from './ErrorMessage';
 import {GroupedMessageParts} from './GroupedMessageParts';
 import {MessagePartsList} from './MessagePartsList';
 import {useStoreWithAi} from '../AiSlice';
@@ -24,10 +24,7 @@ type AnalysisResultProps = {
   enableReasoningBox?: boolean;
   customMarkdownComponents?: Partial<Components>;
   userTools?: string[];
-  ErrorMessageComponent?: React.ComponentType<{
-    errorMessage: string;
-    analysisResult?: AnalysisResultSchema;
-  }>;
+  ErrorMessageComponent?: React.ComponentType<ErrorMessageComponentProps>;
 };
 
 /**

--- a/packages/ai-core/src/components/AnalysisResultsContainer.tsx
+++ b/packages/ai-core/src/components/AnalysisResultsContainer.tsx
@@ -6,15 +6,14 @@ import {useStoreWithAi} from '../AiSlice';
 import {useScrollToBottom} from '../hooks/useScrollToBottom';
 import {AnalysisResult} from './AnalysisResult';
 import {AiThinkingDots} from './AiThinkingDots';
+import type {ErrorMessageComponentProps} from './ErrorMessage';
 
 export const AnalysisResultsContainer: React.FC<{
   className?: string;
   enableReasoningBox?: boolean;
   customMarkdownComponents?: Partial<Components>;
   userTools?: string[];
-  ErrorMessageComponent?: Parameters<
-    typeof AnalysisResult
-  >[0]['ErrorMessageComponent'];
+  ErrorMessageComponent?: React.ComponentType<ErrorMessageComponentProps>;
 }> = ({
   className,
   enableReasoningBox = false,

--- a/packages/ai-core/src/components/ErrorMessage.tsx
+++ b/packages/ai-core/src/components/ErrorMessage.tsx
@@ -2,7 +2,11 @@ import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import {MessageContainer} from './MessageContainer';
 
-export function ErrorMessage(props: {errorMessage: string}) {
+export type ErrorMessageComponentProps = {
+  errorMessage: string;
+};
+
+export function ErrorMessage(props: ErrorMessageComponentProps) {
   return (
     <MessageContainer isSuccess={false} type="error" content={props}>
       <div className="prose dark:prose-invert max-w-none text-sm">

--- a/packages/ai-core/src/index.ts
+++ b/packages/ai-core/src/index.ts
@@ -22,6 +22,7 @@ export {SessionDropdown} from './components/session/SessionDropdown';
 export {SessionTitle} from './components/session/SessionTitle';
 export type {SessionType} from './components/session/SessionType';
 export {ToolErrorMessage} from './components/tools/ToolErrorMessage';
+export type {ErrorMessageComponentProps} from './components/ErrorMessage';
 export {ToolCallInfo} from './components/ToolCallInfo';
 
 export {AiSliceConfig, createDefaultAiConfig} from '@sqlrooms/ai-config';

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -43,6 +43,7 @@ export type {
 export {AnalysisResultsContainer} from '@sqlrooms/ai-core';
 export {AnalysisResult} from '@sqlrooms/ai-core';
 export {ErrorMessage} from '@sqlrooms/ai-core';
+export type {ErrorMessageComponentProps} from '@sqlrooms/ai-core';
 export {PromptSuggestions} from '@sqlrooms/ai-core';
 export {ModelSelector} from '@sqlrooms/ai-core';
 export {SessionControls} from '@sqlrooms/ai-core';


### PR DESCRIPTION
- Added an optional `ErrorMessageComponent` prop to the `AnalysisResult` and `AnalysisResultsContainer` components, support to override the default error message UI