### PR TITLE
feat: update Vercel AI SDK to v6

### DIFF
--- a/examples/ai-agent/package.json
+++ b/examples/ai-agent/package.json
@@ -11,13 +11,13 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ai-sdk/openai-compatible": "^1.0.22",
+    "@ai-sdk/openai-compatible": "^2.0.4",
     "@sqlrooms/ai-config": "workspace:*",
     "@sqlrooms/ai-core": "workspace:*",
     "@sqlrooms/ai-settings": "workspace:*",
     "@sqlrooms/room-store": "workspace:*",
     "@sqlrooms/ui": "workspace:*",
-    "ai": "^5.0.44",
+    "ai": "^6.0.18",
     "lucide-react": "^0.555.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/examples/ai-nextjs/package.json
+++ b/examples/ai-nextjs/package.json
@@ -9,13 +9,13 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@ai-sdk/openai-compatible": "^1.0.18",
+    "@ai-sdk/openai-compatible": "^2.0.4",
     "@openassistant/utils": "1.0.0-alpha.0",
     "@sqlrooms/ai-core": "workspace:*",
     "@sqlrooms/ai-settings": "workspace:*",
     "@sqlrooms/room-store": "workspace:*",
     "@sqlrooms/ui": "workspace:*",
-    "ai": "^5.0.44",
+    "ai": "^6.0.18",
     "lucide-react": "^0.555.0",
     "next": "15.5.9",
     "react": "^19.2.0",

--- a/examples/ai-rag/package.json
+++ b/examples/ai-rag/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ai-sdk/openai": "^2.0.32",
+    "@ai-sdk/openai": "^2.0.38",
     "@sqlrooms/ai": "workspace:*",
     "@sqlrooms/dropzone": "workspace:*",
     "@sqlrooms/ai-rag": "workspace:*",

--- a/packages/ai-config/__tests__/UIMessageSchema.v5-compat.test.ts
+++ b/packages/ai-config/__tests__/UIMessageSchema.v5-compat.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Tests for backwards compatibility with AI SDK v5 data format.
+ * These tests ensure that persisted v5 UIMessage data can be loaded
+ * and validated with the v6 schema.
+ */
+
+import {
+  UIMessageSchema,
+  UIMessagePartSchema,
+} from '../src/schema/UIMessageSchema';
+
+describe('UIMessageSchema v5 compatibility', () => {
+  describe('ToolUIPart states', () => {
+    it('should validate v5 input-streaming state', () => {
+      const v5ToolPart = {
+        type: 'tool-myTool',
+        toolCallId: 'call-123',
+        state: 'input-streaming',
+        input: {query: 'test'},
+      };
+
+      const result = UIMessagePartSchema.safeParse(v5ToolPart);
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate v5 input-available state', () => {
+      const v5ToolPart = {
+        type: 'tool-myTool',
+        toolCallId: 'call-123',
+        state: 'input-available',
+        input: {query: 'test'},
+      };
+
+      const result = UIMessagePartSchema.safeParse(v5ToolPart);
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate v5 output-available state', () => {
+      const v5ToolPart = {
+        type: 'tool-myTool',
+        toolCallId: 'call-123',
+        state: 'output-available',
+        input: {query: 'test'},
+        output: {result: 'success'},
+      };
+
+      const result = UIMessagePartSchema.safeParse(v5ToolPart);
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate v5 output-error state', () => {
+      const v5ToolPart = {
+        type: 'tool-myTool',
+        toolCallId: 'call-123',
+        state: 'output-error',
+        input: {query: 'test'},
+        errorText: 'Something went wrong',
+      };
+
+      const result = UIMessagePartSchema.safeParse(v5ToolPart);
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate v5 tool part with providerExecuted field', () => {
+      const v5ToolPart = {
+        type: 'tool-myTool',
+        toolCallId: 'call-123',
+        state: 'output-available',
+        input: {query: 'test'},
+        output: {result: 'success'},
+        providerExecuted: true,
+      };
+
+      const result = UIMessagePartSchema.safeParse(v5ToolPart);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('DynamicToolUIPart states', () => {
+    it('should validate v5 dynamic-tool input-streaming state', () => {
+      const v5DynamicToolPart = {
+        type: 'dynamic-tool',
+        toolName: 'dynamicTool',
+        toolCallId: 'call-456',
+        state: 'input-streaming',
+      };
+
+      const result = UIMessagePartSchema.safeParse(v5DynamicToolPart);
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate v5 dynamic-tool output-available state', () => {
+      const v5DynamicToolPart = {
+        type: 'dynamic-tool',
+        toolName: 'dynamicTool',
+        toolCallId: 'call-456',
+        state: 'output-available',
+        input: {param: 'value'},
+        output: {data: 'result'},
+      };
+
+      const result = UIMessagePartSchema.safeParse(v5DynamicToolPart);
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate v5 dynamic-tool output-error state', () => {
+      const v5DynamicToolPart = {
+        type: 'dynamic-tool',
+        toolName: 'dynamicTool',
+        toolCallId: 'call-456',
+        state: 'output-error',
+        input: {param: 'value'},
+        errorText: 'Tool execution failed',
+      };
+
+      const result = UIMessagePartSchema.safeParse(v5DynamicToolPart);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('Full UIMessage v5 format', () => {
+    it('should validate a complete v5 assistant message with tool calls', () => {
+      const v5Message = {
+        id: 'msg-123',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'text',
+            text: 'I will help you with that.',
+          },
+          {
+            type: 'tool-analyzeSql',
+            toolCallId: 'call-789',
+            state: 'output-available',
+            input: {sql: 'SELECT * FROM users'},
+            output: {rowCount: 100},
+          },
+          {
+            type: 'text',
+            text: 'The query returned 100 rows.',
+          },
+        ],
+      };
+
+      const result = UIMessageSchema.safeParse(v5Message);
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate a v5 user message', () => {
+      const v5Message = {
+        id: 'msg-user-123',
+        role: 'user',
+        parts: [
+          {
+            type: 'text',
+            text: 'Analyze this SQL query',
+          },
+        ],
+      };
+
+      const result = UIMessageSchema.safeParse(v5Message);
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate v5 message with reasoning part', () => {
+      const v5Message = {
+        id: 'msg-456',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'reasoning',
+            text: 'Thinking about the query...',
+          },
+          {
+            type: 'text',
+            text: 'Here is my analysis.',
+          },
+        ],
+      };
+
+      const result = UIMessageSchema.safeParse(v5Message);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('v6 new states', () => {
+    it('should validate v6 approval-requested state', () => {
+      const v6ToolPart = {
+        type: 'tool-dangerousAction',
+        toolCallId: 'call-999',
+        state: 'approval-requested',
+        input: {action: 'delete'},
+        approval: {
+          state: 'requested',
+        },
+      };
+
+      const result = UIMessagePartSchema.safeParse(v6ToolPart);
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate v6 approval-responded state', () => {
+      const v6ToolPart = {
+        type: 'tool-dangerousAction',
+        toolCallId: 'call-999',
+        state: 'approval-responded',
+        input: {action: 'delete'},
+        approval: {
+          state: 'approved',
+          reason: 'User confirmed action',
+        },
+      };
+
+      const result = UIMessagePartSchema.safeParse(v6ToolPart);
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate v6 output-denied state', () => {
+      const v6ToolPart = {
+        type: 'tool-dangerousAction',
+        toolCallId: 'call-999',
+        state: 'output-denied',
+        input: {action: 'delete'},
+        approval: {
+          state: 'denied',
+          reason: 'User rejected action',
+        },
+      };
+
+      const result = UIMessagePartSchema.safeParse(v6ToolPart);
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/packages/ai-config/__tests__/UIMessageSchema.v5-compat.test.ts
+++ b/packages/ai-config/__tests__/UIMessageSchema.v5-compat.test.ts
@@ -1,234 +1,66 @@
 /**
  * Tests for backwards compatibility with AI SDK v5 data format.
- * These tests ensure that persisted v5 UIMessage data can be loaded
- * and validated with the v6 schema.
  */
-
 import {
   UIMessageSchema,
   UIMessagePartSchema,
 } from '../src/schema/UIMessageSchema';
 
 describe('UIMessageSchema v5 compatibility', () => {
-  describe('ToolUIPart states', () => {
-    it('should validate v5 input-streaming state', () => {
-      const v5ToolPart = {
-        type: 'tool-myTool',
-        toolCallId: 'call-123',
-        state: 'input-streaming',
-        input: {query: 'test'},
-      };
+  it('should validate all v5 tool states', () => {
+    const v5States = [
+      {state: 'input-streaming', input: {q: 'test'}},
+      {state: 'input-available', input: {q: 'test'}},
+      {state: 'output-available', input: {q: 'test'}, output: {r: 1}},
+      {state: 'output-error', input: {q: 'test'}, errorText: 'err'},
+    ];
 
-      const result = UIMessagePartSchema.safeParse(v5ToolPart);
-      expect(result.success).toBe(true);
-    });
-
-    it('should validate v5 input-available state', () => {
-      const v5ToolPart = {
-        type: 'tool-myTool',
-        toolCallId: 'call-123',
-        state: 'input-available',
-        input: {query: 'test'},
-      };
-
-      const result = UIMessagePartSchema.safeParse(v5ToolPart);
-      expect(result.success).toBe(true);
-    });
-
-    it('should validate v5 output-available state', () => {
-      const v5ToolPart = {
-        type: 'tool-myTool',
-        toolCallId: 'call-123',
-        state: 'output-available',
-        input: {query: 'test'},
-        output: {result: 'success'},
-      };
-
-      const result = UIMessagePartSchema.safeParse(v5ToolPart);
-      expect(result.success).toBe(true);
-    });
-
-    it('should validate v5 output-error state', () => {
-      const v5ToolPart = {
-        type: 'tool-myTool',
-        toolCallId: 'call-123',
-        state: 'output-error',
-        input: {query: 'test'},
-        errorText: 'Something went wrong',
-      };
-
-      const result = UIMessagePartSchema.safeParse(v5ToolPart);
-      expect(result.success).toBe(true);
-    });
-
-    it('should validate v5 tool part with providerExecuted field', () => {
-      const v5ToolPart = {
-        type: 'tool-myTool',
-        toolCallId: 'call-123',
-        state: 'output-available',
-        input: {query: 'test'},
-        output: {result: 'success'},
-        providerExecuted: true,
-      };
-
-      const result = UIMessagePartSchema.safeParse(v5ToolPart);
-      expect(result.success).toBe(true);
-    });
+    for (const s of v5States) {
+      const part = {type: 'tool-myTool', toolCallId: 'c1', ...s};
+      expect(UIMessagePartSchema.safeParse(part).success).toBe(true);
+    }
   });
 
-  describe('DynamicToolUIPart states', () => {
-    it('should validate v5 dynamic-tool input-streaming state', () => {
-      const v5DynamicToolPart = {
-        type: 'dynamic-tool',
-        toolName: 'dynamicTool',
-        toolCallId: 'call-456',
-        state: 'input-streaming',
-      };
-
-      const result = UIMessagePartSchema.safeParse(v5DynamicToolPart);
-      expect(result.success).toBe(true);
-    });
-
-    it('should validate v5 dynamic-tool output-available state', () => {
-      const v5DynamicToolPart = {
-        type: 'dynamic-tool',
-        toolName: 'dynamicTool',
-        toolCallId: 'call-456',
-        state: 'output-available',
-        input: {param: 'value'},
-        output: {data: 'result'},
-      };
-
-      const result = UIMessagePartSchema.safeParse(v5DynamicToolPart);
-      expect(result.success).toBe(true);
-    });
-
-    it('should validate v5 dynamic-tool output-error state', () => {
-      const v5DynamicToolPart = {
-        type: 'dynamic-tool',
-        toolName: 'dynamicTool',
-        toolCallId: 'call-456',
-        state: 'output-error',
-        input: {param: 'value'},
-        errorText: 'Tool execution failed',
-      };
-
-      const result = UIMessagePartSchema.safeParse(v5DynamicToolPart);
-      expect(result.success).toBe(true);
-    });
+  it('should validate v5 dynamic-tool states', () => {
+    const part = {
+      type: 'dynamic-tool',
+      toolName: 'dyn',
+      toolCallId: 'c1',
+      state: 'output-available',
+      input: {},
+      output: {},
+    };
+    expect(UIMessagePartSchema.safeParse(part).success).toBe(true);
   });
 
-  describe('Full UIMessage v5 format', () => {
-    it('should validate a complete v5 assistant message with tool calls', () => {
-      const v5Message = {
-        id: 'msg-123',
-        role: 'assistant',
-        parts: [
-          {
-            type: 'text',
-            text: 'I will help you with that.',
-          },
-          {
-            type: 'tool-analyzeSql',
-            toolCallId: 'call-789',
-            state: 'output-available',
-            input: {sql: 'SELECT * FROM users'},
-            output: {rowCount: 100},
-          },
-          {
-            type: 'text',
-            text: 'The query returned 100 rows.',
-          },
-        ],
-      };
-
-      const result = UIMessageSchema.safeParse(v5Message);
-      expect(result.success).toBe(true);
-    });
-
-    it('should validate a v5 user message', () => {
-      const v5Message = {
-        id: 'msg-user-123',
-        role: 'user',
-        parts: [
-          {
-            type: 'text',
-            text: 'Analyze this SQL query',
-          },
-        ],
-      };
-
-      const result = UIMessageSchema.safeParse(v5Message);
-      expect(result.success).toBe(true);
-    });
-
-    it('should validate v5 message with reasoning part', () => {
-      const v5Message = {
-        id: 'msg-456',
-        role: 'assistant',
-        parts: [
-          {
-            type: 'reasoning',
-            text: 'Thinking about the query...',
-          },
-          {
-            type: 'text',
-            text: 'Here is my analysis.',
-          },
-        ],
-      };
-
-      const result = UIMessageSchema.safeParse(v5Message);
-      expect(result.success).toBe(true);
-    });
+  it('should validate complete v5 assistant message', () => {
+    const msg = {
+      id: 'm1',
+      role: 'assistant',
+      parts: [
+        {type: 'text', text: 'Hello'},
+        {
+          type: 'tool-sql',
+          toolCallId: 'c1',
+          state: 'output-available',
+          input: {},
+          output: {},
+        },
+      ],
+    };
+    expect(UIMessageSchema.safeParse(msg).success).toBe(true);
   });
 
-  describe('v6 new states', () => {
-    it('should validate v6 approval-requested state', () => {
-      const v6ToolPart = {
-        type: 'tool-dangerousAction',
-        toolCallId: 'call-999',
-        state: 'approval-requested',
-        input: {action: 'delete'},
-        approval: {
-          state: 'requested',
-        },
-      };
+  it('should validate v6 new states (additive compatibility)', () => {
+    const v6States = [
+      {state: 'approval-requested', approval: {state: 'requested'}},
+      {state: 'approval-responded', approval: {state: 'approved'}},
+      {state: 'output-denied', approval: {state: 'denied'}},
+    ];
 
-      const result = UIMessagePartSchema.safeParse(v6ToolPart);
-      expect(result.success).toBe(true);
-    });
-
-    it('should validate v6 approval-responded state', () => {
-      const v6ToolPart = {
-        type: 'tool-dangerousAction',
-        toolCallId: 'call-999',
-        state: 'approval-responded',
-        input: {action: 'delete'},
-        approval: {
-          state: 'approved',
-          reason: 'User confirmed action',
-        },
-      };
-
-      const result = UIMessagePartSchema.safeParse(v6ToolPart);
-      expect(result.success).toBe(true);
-    });
-
-    it('should validate v6 output-denied state', () => {
-      const v6ToolPart = {
-        type: 'tool-dangerousAction',
-        toolCallId: 'call-999',
-        state: 'output-denied',
-        input: {action: 'delete'},
-        approval: {
-          state: 'denied',
-          reason: 'User rejected action',
-        },
-      };
-
-      const result = UIMessagePartSchema.safeParse(v6ToolPart);
-      expect(result.success).toBe(true);
-    });
+    for (const s of v6States) {
+      const part = {type: 'tool-action', toolCallId: 'c1', input: {}, ...s};
+      expect(UIMessagePartSchema.safeParse(part).success).toBe(true);
+    }
   });
 });

--- a/packages/ai-config/jest.config.js
+++ b/packages/ai-config/jest.config.js
@@ -1,0 +1,6 @@
+import nodeConfig from '@sqlrooms/preset-jest/node.js';
+
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+export default {
+  ...nodeConfig,
+};

--- a/packages/ai-config/package.json
+++ b/packages/ai-config/package.json
@@ -22,9 +22,13 @@
     "@paralleldrive/cuid2": "^3.0.0",
     "zod": "^4.1.8"
   },
+  "devDependencies": {
+    "ts-jest": "^29.4.4"
+  },
   "scripts": {
     "dev": "tsc -w",
     "build": "tsc",
+    "test": "jest",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "typedoc": "typedoc"

--- a/packages/ai-core/README.md
+++ b/packages/ai-core/README.md
@@ -368,7 +368,7 @@ AI SDK v5 supports message annotations, but these are still part of the message 
 
 ## Agent Framework
 
-The agent framework enables building autonomous AI agents that can use tools and make multi-step decisions. Built on top of AI SDK v5's `Experimental_Agent` class, it provides utilities for integrating agents as tools within the main chat interface.
+The agent framework enables building autonomous AI agents that can use tools and make multi-step decisions. Built on top of the Vercel AI SDK v6's `ToolLoopAgent` class, it provides utilities for integrating agents as tools within the main chat interface.
 
 ### What are Agents?
 
@@ -383,7 +383,7 @@ Agents differ from regular tools in that they:
 Agent tools follow the same OpenAssistantTool pattern but use the `processAgentStream` utility to handle streaming and progress tracking:
 
 ```typescript
-import {Experimental_Agent as Agent, tool} from 'ai';
+import {ToolLoopAgent, tool} from 'ai';
 import {processAgentStream} from '@sqlrooms/ai';
 import {z} from 'zod';
 
@@ -399,12 +399,13 @@ export function weatherAgentTool(store: StoreApi<RoomState>) {
       const currentSession = state.ai.getCurrentSession();
 
       // Create the agent with its own set of tools
-      const weatherAgent = new Agent({
+      const weatherAgent = new ToolLoopAgent({
         model: getModel(state),
+        instructions: 'You are a helpful weather assistant.',
         tools: {
           weather: tool({
             description: 'Get current weather in a location',
-            inputSchema: z.object({
+            parameters: z.object({
               location: z.string()
             }),
             execute: async ({location}) => ({
@@ -414,7 +415,7 @@ export function weatherAgentTool(store: StoreApi<RoomState>) {
           }),
           convertTemperature: tool({
             description: 'Convert temperature units',
-            inputSchema: z.object({
+            parameters: z.object({
               temperature: z.number(),
               from: z.enum(['F', 'C']),
               to: z.enum(['F', 'C'])
@@ -424,7 +425,7 @@ export function weatherAgentTool(store: StoreApi<RoomState>) {
             }
           })
         },
-        stopWhen: stepCountIs(10) // Limit agent steps
+        stopWhen: stepCountIs(10) // Limit agent steps (default is now 20)
       });
 
       // Stream the agent's execution

--- a/packages/ai-core/__tests__/chatTransport.v5-compat.test.ts
+++ b/packages/ai-core/__tests__/chatTransport.v5-compat.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Tests for backwards compatibility of chatTransport functions with AI SDK v5 data.
+ *
+ * This test file contains a copy of the completeIncompleteToolCalls function
+ * to avoid ESM/CommonJS module resolution issues with the full chatTransport module.
+ */
+
+// Simplified type for testing purposes
+type UIMessage = {
+  id: string;
+  role: 'user' | 'assistant' | 'system';
+  parts: Array<Record<string, unknown>>;
+};
+
+/**
+ * Copy of completeIncompleteToolCalls for isolated testing.
+ * This avoids importing the full chatTransport module which has many dependencies.
+ */
+function completeIncompleteToolCalls(messages: UIMessage[]): UIMessage[] {
+  return messages.map((message) => {
+    if (message.role !== 'assistant' || !message.parts) {
+      return message;
+    }
+
+    type ToolPart = {
+      type: string;
+      toolCallId: string;
+      toolName?: string;
+      input?: unknown;
+      state?: string;
+    };
+
+    const isToolPart = (part: unknown): part is ToolPart => {
+      if (typeof part !== 'object' || part === null) return false;
+      const p = part as Record<string, unknown> & {type?: unknown};
+      const typeVal =
+        typeof p.type === 'string' ? (p.type as string) : undefined;
+      return (
+        !!typeVal &&
+        'toolCallId' in p &&
+        (typeVal === 'dynamic-tool' || typeVal.startsWith('tool-'))
+      );
+    };
+
+    const updatedParts = [...message.parts];
+    let sawAnyTool = false;
+    for (let i = updatedParts.length - 1; i >= 0; i--) {
+      const current = updatedParts[i] as unknown;
+      if (!isToolPart(current)) {
+        if (sawAnyTool) break;
+        continue;
+      }
+      sawAnyTool = true;
+      const toolPart = current as ToolPart;
+      const hasOutput = toolPart.state?.startsWith('output');
+      if (hasOutput) {
+        continue;
+      }
+
+      const base = {
+        toolCallId: toolPart.toolCallId,
+        state: 'output-error' as const,
+        input: toolPart.input ?? {},
+        errorText: 'Operation cancelled by user',
+        providerExecuted: false,
+      };
+
+      const syntheticPart =
+        toolPart.type === 'dynamic-tool'
+          ? {
+              type: 'dynamic-tool' as const,
+              toolName: toolPart.toolName || 'unknown',
+              ...base,
+            }
+          : {type: toolPart.type as string, ...base};
+
+      updatedParts[i] =
+        syntheticPart as unknown as (typeof message.parts)[number];
+    }
+
+    return {...message, parts: updatedParts};
+  });
+}
+
+describe('completeIncompleteToolCalls v5 compatibility', () => {
+  describe('v5 tool states', () => {
+    it('should not modify completed v5 output-available tool calls', () => {
+      const messages: UIMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-myTool',
+              toolCallId: 'call-1',
+              state: 'output-available',
+              input: {query: 'test'},
+              output: {result: 'success'},
+            },
+          ],
+        },
+      ];
+
+      const result = completeIncompleteToolCalls(messages);
+      expect(result[0].parts[0]).toMatchObject({
+        state: 'output-available',
+        output: {result: 'success'},
+      });
+    });
+
+    it('should not modify completed v5 output-error tool calls', () => {
+      const messages: UIMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-myTool',
+              toolCallId: 'call-1',
+              state: 'output-error',
+              input: {query: 'test'},
+              errorText: 'Original error',
+            },
+          ],
+        },
+      ];
+
+      const result = completeIncompleteToolCalls(messages);
+      expect(result[0].parts[0]).toMatchObject({
+        state: 'output-error',
+        errorText: 'Original error',
+      });
+    });
+
+    it('should complete v5 input-streaming tool calls with output-error', () => {
+      const messages: UIMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-myTool',
+              toolCallId: 'call-1',
+              state: 'input-streaming',
+              input: {query: 'test'},
+            },
+          ],
+        },
+      ];
+
+      const result = completeIncompleteToolCalls(messages);
+      expect(result[0].parts[0]).toMatchObject({
+        state: 'output-error',
+        errorText: 'Operation cancelled by user',
+      });
+    });
+
+    it('should complete v5 input-available tool calls with output-error', () => {
+      const messages: UIMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-myTool',
+              toolCallId: 'call-1',
+              state: 'input-available',
+              input: {query: 'test'},
+            },
+          ],
+        },
+      ];
+
+      const result = completeIncompleteToolCalls(messages);
+      expect(result[0].parts[0]).toMatchObject({
+        state: 'output-error',
+        errorText: 'Operation cancelled by user',
+      });
+    });
+  });
+
+  describe('v5 dynamic-tool states', () => {
+    it('should not modify completed v5 dynamic-tool output-available', () => {
+      const messages: UIMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'dynamic-tool',
+              toolName: 'dynamicTool',
+              toolCallId: 'call-1',
+              state: 'output-available',
+              input: {param: 'value'},
+              output: {data: 'result'},
+            },
+          ],
+        },
+      ];
+
+      const result = completeIncompleteToolCalls(messages);
+      expect(result[0].parts[0]).toMatchObject({
+        type: 'dynamic-tool',
+        state: 'output-available',
+      });
+    });
+
+    it('should complete v5 dynamic-tool input-available with output-error', () => {
+      const messages: UIMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'dynamic-tool',
+              toolName: 'dynamicTool',
+              toolCallId: 'call-1',
+              state: 'input-available',
+              input: {param: 'value'},
+            },
+          ],
+        },
+      ];
+
+      const result = completeIncompleteToolCalls(messages);
+      expect(result[0].parts[0]).toMatchObject({
+        type: 'dynamic-tool',
+        toolName: 'dynamicTool',
+        state: 'output-error',
+        errorText: 'Operation cancelled by user',
+      });
+    });
+  });
+
+  describe('v6 new states', () => {
+    it('should not modify completed v6 output-denied tool calls', () => {
+      const messages: UIMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-dangerousAction',
+              toolCallId: 'call-1',
+              state: 'output-denied',
+              input: {action: 'delete'},
+              approval: {state: 'denied'},
+            },
+          ],
+        },
+      ];
+
+      const result = completeIncompleteToolCalls(messages);
+      // output-denied starts with 'output', so should not be modified
+      expect(result[0].parts[0]).toMatchObject({
+        state: 'output-denied',
+      });
+    });
+
+    it('should complete v6 approval-requested tool calls with output-error', () => {
+      const messages: UIMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-dangerousAction',
+              toolCallId: 'call-1',
+              state: 'approval-requested',
+              input: {action: 'delete'},
+              approval: {state: 'requested'},
+            },
+          ],
+        },
+      ];
+
+      const result = completeIncompleteToolCalls(messages);
+      // approval-requested doesn't start with 'output', so should be completed
+      expect(result[0].parts[0]).toMatchObject({
+        state: 'output-error',
+        errorText: 'Operation cancelled by user',
+      });
+    });
+
+    it('should complete v6 approval-responded tool calls with output-error', () => {
+      const messages: UIMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-dangerousAction',
+              toolCallId: 'call-1',
+              state: 'approval-responded',
+              input: {action: 'delete'},
+              approval: {state: 'approved'},
+            },
+          ],
+        },
+      ];
+
+      const result = completeIncompleteToolCalls(messages);
+      // approval-responded doesn't start with 'output', so should be completed
+      expect(result[0].parts[0]).toMatchObject({
+        state: 'output-error',
+        errorText: 'Operation cancelled by user',
+      });
+    });
+  });
+
+  describe('mixed messages', () => {
+    it('should handle v5 messages with text and tool parts', () => {
+      const messages: UIMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          parts: [
+            {type: 'text', text: 'Let me analyze that.'},
+            {
+              type: 'tool-analyze',
+              toolCallId: 'call-1',
+              state: 'output-available',
+              input: {sql: 'SELECT *'},
+              output: {rows: 100},
+            },
+            {type: 'text', text: 'Found 100 rows.'},
+          ],
+        },
+      ];
+
+      const result = completeIncompleteToolCalls(messages);
+      expect(result[0].parts).toHaveLength(3);
+      expect(result[0].parts[0]).toMatchObject({type: 'text'});
+      expect(result[0].parts[1]).toMatchObject({state: 'output-available'});
+      expect(result[0].parts[2]).toMatchObject({type: 'text'});
+    });
+
+    it('should not modify user messages', () => {
+      const messages: UIMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'user',
+          parts: [{type: 'text', text: 'Hello'}],
+        },
+      ];
+
+      const result = completeIncompleteToolCalls(messages);
+      expect(result).toEqual(messages);
+    });
+  });
+});

--- a/packages/ai-core/__tests__/utils.v5-compat.test.ts
+++ b/packages/ai-core/__tests__/utils.v5-compat.test.ts
@@ -1,7 +1,6 @@
 /**
  * Tests for backwards compatibility of utility functions with AI SDK v5 data.
  */
-
 import {
   isToolPart,
   isDynamicToolPart,
@@ -11,191 +10,67 @@ import {
 import type {UIMessagePart} from '@sqlrooms/ai-config';
 
 describe('Type guards v5 compatibility', () => {
-  describe('isToolPart', () => {
-    it('should return true for v5 tool-* parts', () => {
-      const v5ToolPart = {
-        type: 'tool-myTool',
-        toolCallId: 'call-1',
-        state: 'output-available',
+  it('isToolPart works with v5 and v6 states', () => {
+    const states = [
+      'input-streaming',
+      'input-available',
+      'output-available',
+      'output-error',
+      'approval-requested',
+    ];
+    for (const state of states) {
+      const part = {
+        type: 'tool-x',
+        toolCallId: 'c1',
+        state,
         input: {},
-        output: {},
       } as UIMessagePart;
-
-      expect(isToolPart(v5ToolPart)).toBe(true);
-    });
-
-    it('should return true for v5 tool parts with any state', () => {
-      const states = [
-        'input-streaming',
-        'input-available',
-        'output-available',
-        'output-error',
-      ];
-
-      for (const state of states) {
-        const part = {
-          type: 'tool-analyze',
-          toolCallId: 'call-1',
-          state,
-          input: {},
-        } as UIMessagePart;
-
-        expect(isToolPart(part)).toBe(true);
-      }
-    });
-
-    it('should return true for v6 tool parts with new states', () => {
-      const v6States = [
-        'approval-requested',
-        'approval-responded',
-        'output-denied',
-      ];
-
-      for (const state of v6States) {
-        const part = {
-          type: 'tool-action',
-          toolCallId: 'call-1',
-          state,
-          input: {},
-          approval: {state: 'requested'},
-        } as UIMessagePart;
-
-        expect(isToolPart(part)).toBe(true);
-      }
-    });
-
-    it('should return false for dynamic-tool parts', () => {
-      const dynamicToolPart = {
+      expect(isToolPart(part)).toBe(true);
+    }
+    expect(isToolPart({type: 'text', text: 'hi'} as UIMessagePart)).toBe(false);
+    expect(
+      isToolPart({
         type: 'dynamic-tool',
-        toolName: 'myTool',
-        toolCallId: 'call-1',
+        toolName: 'x',
+        toolCallId: 'c1',
         state: 'output-available',
         input: {},
         output: {},
-      } as UIMessagePart;
-
-      expect(isToolPart(dynamicToolPart)).toBe(false);
-    });
-
-    it('should return false for text parts', () => {
-      const textPart = {
-        type: 'text',
-        text: 'Hello',
-      } as UIMessagePart;
-
-      expect(isToolPart(textPart)).toBe(false);
-    });
+      } as UIMessagePart),
+    ).toBe(false);
   });
 
-  describe('isDynamicToolPart', () => {
-    it('should return true for v5 dynamic-tool parts', () => {
-      const v5DynamicToolPart = {
-        type: 'dynamic-tool',
-        toolName: 'myDynamicTool',
-        toolCallId: 'call-1',
+  it('isDynamicToolPart works with v5 format', () => {
+    const part = {
+      type: 'dynamic-tool',
+      toolName: 'dyn',
+      toolCallId: 'c1',
+      state: 'output-available',
+      input: {},
+      output: {},
+    } as UIMessagePart;
+    expect(isDynamicToolPart(part)).toBe(true);
+    expect(
+      isDynamicToolPart({
+        type: 'tool-x',
+        toolCallId: 'c1',
         state: 'output-available',
         input: {},
         output: {},
-      } as UIMessagePart;
-
-      expect(isDynamicToolPart(v5DynamicToolPart)).toBe(true);
-    });
-
-    it('should return true for v6 dynamic-tool parts with new states', () => {
-      const v6DynamicToolPart = {
-        type: 'dynamic-tool',
-        toolName: 'myDynamicTool',
-        toolCallId: 'call-1',
-        state: 'approval-requested',
-        input: {},
-        approval: {state: 'requested'},
-      } as UIMessagePart;
-
-      expect(isDynamicToolPart(v6DynamicToolPart)).toBe(true);
-    });
-
-    it('should return false for tool-* parts', () => {
-      const toolPart = {
-        type: 'tool-myTool',
-        toolCallId: 'call-1',
-        state: 'output-available',
-        input: {},
-        output: {},
-      } as UIMessagePart;
-
-      expect(isDynamicToolPart(toolPart)).toBe(false);
-    });
-
-    it('should return false for text parts', () => {
-      const textPart = {
-        type: 'text',
-        text: 'Hello',
-      } as UIMessagePart;
-
-      expect(isDynamicToolPart(textPart)).toBe(false);
-    });
+      } as UIMessagePart),
+    ).toBe(false);
   });
 
-  describe('isTextPart', () => {
-    it('should return true for text parts', () => {
-      const textPart = {
-        type: 'text',
-        text: 'Hello world',
-      } as UIMessagePart;
-
-      expect(isTextPart(textPart)).toBe(true);
-    });
-
-    it('should return true for text parts with optional state', () => {
-      const textPart = {
-        type: 'text',
-        text: 'Hello world',
-        state: 'done',
-      } as UIMessagePart;
-
-      expect(isTextPart(textPart)).toBe(true);
-    });
-
-    it('should return false for tool parts', () => {
-      const toolPart = {
-        type: 'tool-myTool',
-        toolCallId: 'call-1',
-        state: 'output-available',
-        input: {},
-        output: {},
-      } as UIMessagePart;
-
-      expect(isTextPart(toolPart)).toBe(false);
-    });
-  });
-
-  describe('isReasoningPart', () => {
-    it('should return true for reasoning parts', () => {
-      const reasoningPart = {
-        type: 'reasoning',
-        text: 'Thinking about the problem...',
-      } as UIMessagePart;
-
-      expect(isReasoningPart(reasoningPart)).toBe(true);
-    });
-
-    it('should return true for reasoning parts with state', () => {
-      const reasoningPart = {
-        type: 'reasoning',
-        text: 'Analyzing...',
-        state: 'streaming',
-      } as UIMessagePart;
-
-      expect(isReasoningPart(reasoningPart)).toBe(true);
-    });
-
-    it('should return false for text parts', () => {
-      const textPart = {
-        type: 'text',
-        text: 'Hello',
-      } as UIMessagePart;
-
-      expect(isReasoningPart(textPart)).toBe(false);
-    });
+  it('isTextPart and isReasoningPart work with v5 format', () => {
+    expect(isTextPart({type: 'text', text: 'hi'} as UIMessagePart)).toBe(true);
+    expect(
+      isReasoningPart({type: 'reasoning', text: 'think'} as UIMessagePart),
+    ).toBe(true);
+    expect(isTextPart({type: 'reasoning', text: 'x'} as UIMessagePart)).toBe(
+      false,
+    );
+    expect(isReasoningPart({type: 'text', text: 'x'} as UIMessagePart)).toBe(
+      false,
+    );
   });
 });

--- a/packages/ai-core/__tests__/utils.v5-compat.test.ts
+++ b/packages/ai-core/__tests__/utils.v5-compat.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for backwards compatibility of utility functions with AI SDK v5 data.
+ */
+
+import {
+  isToolPart,
+  isDynamicToolPart,
+  isTextPart,
+  isReasoningPart,
+} from '../src/utils';
+import type {UIMessagePart} from '@sqlrooms/ai-config';
+
+describe('Type guards v5 compatibility', () => {
+  describe('isToolPart', () => {
+    it('should return true for v5 tool-* parts', () => {
+      const v5ToolPart = {
+        type: 'tool-myTool',
+        toolCallId: 'call-1',
+        state: 'output-available',
+        input: {},
+        output: {},
+      } as UIMessagePart;
+
+      expect(isToolPart(v5ToolPart)).toBe(true);
+    });
+
+    it('should return true for v5 tool parts with any state', () => {
+      const states = [
+        'input-streaming',
+        'input-available',
+        'output-available',
+        'output-error',
+      ];
+
+      for (const state of states) {
+        const part = {
+          type: 'tool-analyze',
+          toolCallId: 'call-1',
+          state,
+          input: {},
+        } as UIMessagePart;
+
+        expect(isToolPart(part)).toBe(true);
+      }
+    });
+
+    it('should return true for v6 tool parts with new states', () => {
+      const v6States = [
+        'approval-requested',
+        'approval-responded',
+        'output-denied',
+      ];
+
+      for (const state of v6States) {
+        const part = {
+          type: 'tool-action',
+          toolCallId: 'call-1',
+          state,
+          input: {},
+          approval: {state: 'requested'},
+        } as UIMessagePart;
+
+        expect(isToolPart(part)).toBe(true);
+      }
+    });
+
+    it('should return false for dynamic-tool parts', () => {
+      const dynamicToolPart = {
+        type: 'dynamic-tool',
+        toolName: 'myTool',
+        toolCallId: 'call-1',
+        state: 'output-available',
+        input: {},
+        output: {},
+      } as UIMessagePart;
+
+      expect(isToolPart(dynamicToolPart)).toBe(false);
+    });
+
+    it('should return false for text parts', () => {
+      const textPart = {
+        type: 'text',
+        text: 'Hello',
+      } as UIMessagePart;
+
+      expect(isToolPart(textPart)).toBe(false);
+    });
+  });
+
+  describe('isDynamicToolPart', () => {
+    it('should return true for v5 dynamic-tool parts', () => {
+      const v5DynamicToolPart = {
+        type: 'dynamic-tool',
+        toolName: 'myDynamicTool',
+        toolCallId: 'call-1',
+        state: 'output-available',
+        input: {},
+        output: {},
+      } as UIMessagePart;
+
+      expect(isDynamicToolPart(v5DynamicToolPart)).toBe(true);
+    });
+
+    it('should return true for v6 dynamic-tool parts with new states', () => {
+      const v6DynamicToolPart = {
+        type: 'dynamic-tool',
+        toolName: 'myDynamicTool',
+        toolCallId: 'call-1',
+        state: 'approval-requested',
+        input: {},
+        approval: {state: 'requested'},
+      } as UIMessagePart;
+
+      expect(isDynamicToolPart(v6DynamicToolPart)).toBe(true);
+    });
+
+    it('should return false for tool-* parts', () => {
+      const toolPart = {
+        type: 'tool-myTool',
+        toolCallId: 'call-1',
+        state: 'output-available',
+        input: {},
+        output: {},
+      } as UIMessagePart;
+
+      expect(isDynamicToolPart(toolPart)).toBe(false);
+    });
+
+    it('should return false for text parts', () => {
+      const textPart = {
+        type: 'text',
+        text: 'Hello',
+      } as UIMessagePart;
+
+      expect(isDynamicToolPart(textPart)).toBe(false);
+    });
+  });
+
+  describe('isTextPart', () => {
+    it('should return true for text parts', () => {
+      const textPart = {
+        type: 'text',
+        text: 'Hello world',
+      } as UIMessagePart;
+
+      expect(isTextPart(textPart)).toBe(true);
+    });
+
+    it('should return true for text parts with optional state', () => {
+      const textPart = {
+        type: 'text',
+        text: 'Hello world',
+        state: 'done',
+      } as UIMessagePart;
+
+      expect(isTextPart(textPart)).toBe(true);
+    });
+
+    it('should return false for tool parts', () => {
+      const toolPart = {
+        type: 'tool-myTool',
+        toolCallId: 'call-1',
+        state: 'output-available',
+        input: {},
+        output: {},
+      } as UIMessagePart;
+
+      expect(isTextPart(toolPart)).toBe(false);
+    });
+  });
+
+  describe('isReasoningPart', () => {
+    it('should return true for reasoning parts', () => {
+      const reasoningPart = {
+        type: 'reasoning',
+        text: 'Thinking about the problem...',
+      } as UIMessagePart;
+
+      expect(isReasoningPart(reasoningPart)).toBe(true);
+    });
+
+    it('should return true for reasoning parts with state', () => {
+      const reasoningPart = {
+        type: 'reasoning',
+        text: 'Analyzing...',
+        state: 'streaming',
+      } as UIMessagePart;
+
+      expect(isReasoningPart(reasoningPart)).toBe(true);
+    });
+
+    it('should return false for text parts', () => {
+      const textPart = {
+        type: 'text',
+        text: 'Hello',
+      } as UIMessagePart;
+
+      expect(isReasoningPart(textPart)).toBe(false);
+    });
+  });
+});

--- a/packages/ai-core/jest.config.js
+++ b/packages/ai-core/jest.config.js
@@ -1,0 +1,6 @@
+import nodeConfig from '@sqlrooms/preset-jest/node.js';
+
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+export default {
+  ...nodeConfig,
+};

--- a/packages/ai-core/package.json
+++ b/packages/ai-core/package.json
@@ -40,9 +40,13 @@
     "react": ">=18",
     "react-dom": ">=18"
   },
+  "devDependencies": {
+    "ts-jest": "^29.4.4"
+  },
   "scripts": {
     "dev": "tsc -w",
     "build": "tsc",
+    "test": "jest",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "typedoc": "typedoc"

--- a/packages/ai-core/package.json
+++ b/packages/ai-core/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@ai-sdk/openai-compatible": "^1.0.18",
-    "@ai-sdk/react": "^2.0.44",
+    "@ai-sdk/openai-compatible": "^2.0.4",
+    "@ai-sdk/react": "^3.0.18",
     "@openassistant/utils": "1.0.0-alpha.0",
     "@paralleldrive/cuid2": "^3.0.0",
     "@sqlrooms/ai-config": "workspace:*",
@@ -28,7 +28,7 @@
     "@sqlrooms/room-store": "workspace:*",
     "@sqlrooms/ui": "workspace:*",
     "@sqlrooms/utils": "workspace:*",
-    "ai": "^5.0.44",
+    "ai": "^6.0.18",
     "immer": "^11.0.1",
     "lucide-react": "^0.556.0",
     "react-markdown": "^10.1.0",

--- a/packages/ai-core/src/chatTransport.ts
+++ b/packages/ai-core/src/chatTransport.ts
@@ -231,7 +231,7 @@ export function createLocalChatTransportFactory({
 
       const result = streamText({
         model,
-        messages: convertToModelMessages(messagesCopy),
+        messages: await convertToModelMessages(messagesCopy),
         tools,
         system: systemInstructions,
         abortSignal: state.ai.analysisAbortController?.signal,
@@ -338,9 +338,10 @@ export function createChatHandlers({
           // Always provide a defined messages array to the tool runtime
           const sessionMessages = (state.ai.getCurrentSession()?.uiMessages ??
             []) as UIMessage[];
+          const modelMessages = await convertToModelMessages(sessionMessages);
           const llmResult = await tool.execute(input, {
             toolCallId,
-            messages: convertToModelMessages(sessionMessages),
+            messages: modelMessages,
             abortSignal: state.ai.analysisAbortController?.signal,
           });
 

--- a/packages/ai-core/src/components/ToolCallInfo.tsx
+++ b/packages/ai-core/src/components/ToolCallInfo.tsx
@@ -17,8 +17,12 @@ type ToolCallInfoProps = {
   state:
     | 'input-streaming'
     | 'input-available'
+    | 'approval-requested'
+    | 'approval-responded'
     | 'output-available'
-    | 'output-error';
+    | 'output-error'
+    | 'output-denied'
+    | string; // Allow any string to support future states
 };
 
 /**
@@ -72,7 +76,7 @@ export const ToolCallInfo: React.FC<ToolCallInfoProps> = ({
       {/* Expanded Arguments */}
       {isExpanded && (
         <div className="px-5 py-2">
-          <pre className="text-muted-foreground bg-muted m-0 max-h-24 overflow-auto whitespace-pre-wrap break-words rounded-md p-2 font-mono text-xs">
+          <pre className="text-muted-foreground bg-muted m-0 max-h-24 overflow-auto rounded-md p-2 font-mono text-xs break-words whitespace-pre-wrap">
             {JSON.stringify(input, null, 2)}
           </pre>
         </div>

--- a/packages/ai-core/src/components/ToolPartRenderer.tsx
+++ b/packages/ai-core/src/components/ToolPartRenderer.tsx
@@ -56,7 +56,7 @@ const AgentProgressRenderer: React.FC<{
               </div>
 
               {isSuccess && hasComponent && hasObjectOutput ? (
-                <div className="ml-6 mt-1">
+                <div className="mt-1 ml-6">
                   <ToolComponent
                     {...(toolCall.output as Record<string, unknown>)}
                   />
@@ -92,14 +92,24 @@ export const ToolPartRenderer = ({part}: {part: UIMessagePart}) => {
 
   if (!isToolPart(part) && !isDynamicToolPart(part)) return null;
 
-  const {type, toolCallId, state, input} = part;
+  // Cast to any to access union type properties uniformly
+  const toolPart = part as {
+    type: string;
+    toolCallId: string;
+    state: string;
+    input?: unknown;
+    output?: unknown;
+    errorText?: string;
+    toolName?: string;
+  };
+  const {type, toolCallId, state, input} = toolPart;
   const toolName =
     type === 'dynamic-tool'
-      ? part.toolName || 'unknown'
+      ? toolPart.toolName || 'unknown'
       : type.replace(/^tool-/, '') || 'unknown';
 
-  const output = state === 'output-available' ? part.output : undefined;
-  const errorText = state === 'output-error' ? part.errorText : undefined;
+  const output = state === 'output-available' ? toolPart.output : undefined;
+  const errorText = state === 'output-error' ? toolPart.errorText : undefined;
   const isCompleted = state === 'output-available' || state === 'output-error';
   const additionalData = toolAdditionalData[toolCallId];
 

--- a/packages/ai-core/src/components/tools/ToolResult.tsx
+++ b/packages/ai-core/src/components/tools/ToolResult.tsx
@@ -17,8 +17,11 @@ type ToolData = {
     | 'partial-call'
     | 'input-streaming'
     | 'input-available'
+    | 'approval-requested'
+    | 'approval-responded'
     | 'output-available'
-    | 'output-error';
+    | 'output-error'
+    | 'output-denied';
   result?: any;
   output?: any;
   errorText?: string;

--- a/packages/ai-core/src/hooks/useAssistantMessageParts.ts
+++ b/packages/ai-core/src/hooks/useAssistantMessageParts.ts
@@ -40,7 +40,8 @@ export function useAssistantMessageParts(
     for (let i = userMessageIndex + 1; i < uiMessages.length; i++) {
       const msg = uiMessages[i];
       if (msg?.role === 'assistant') {
-        return msg.parts;
+        // Cast to UIMessagePart[] since the types are structurally compatible
+        return msg.parts as unknown as UIMessagePart[];
       }
       if (msg?.role === 'user') {
         // Hit next user message without finding assistant response

--- a/packages/ai-core/src/utils.ts
+++ b/packages/ai-core/src/utils.ts
@@ -7,8 +7,9 @@ import {
   AnalysisResultSchema,
   AnalysisSessionSchema,
   UIMessagePart,
+  ToolUIPart,
 } from '@sqlrooms/ai-config';
-import {DynamicToolUIPart, TextUIPart, ToolUIPart} from 'ai';
+import {TextUIPart} from 'ai';
 
 /**
  * Custom error class for operation abort errors.
@@ -117,9 +118,14 @@ export function isToolPart(part: UIMessagePart): part is ToolUIPart {
   return typeof part.type === 'string' && part.type.startsWith('tool-');
 }
 
+/**
+ * Type guard to check if a UIMessagePart is a dynamic tool part
+ * @param part - The message part to check
+ * @returns True if the part is a dynamic tool part
+ */
 export function isDynamicToolPart(
   part: UIMessagePart,
-): part is DynamicToolUIPart {
+): part is UIMessagePart & {type: 'dynamic-tool'} {
   return part.type === 'dynamic-tool';
 }
 

--- a/packages/ai-rag/docs/EMBEDDING_PROVIDERS.md
+++ b/packages/ai-rag/docs/EMBEDDING_PROVIDERS.md
@@ -101,7 +101,7 @@ import {createAiEmbeddingProvider, type AiProvider} from '@sqlrooms/ai-rag';
 
 // Custom provider that implements the interface
 const myProvider: AiProvider = {
-  textEmbeddingModel(modelId: string, settings?: {dimensions?: number}) {
+  embedding(modelId: string, settings?: {dimensions?: number}) {
     return {
       // Your custom implementation
       // Must be compatible with Vercel AI SDK's embed() function

--- a/packages/ai-rag/package.json
+++ b/packages/ai-rag/package.json
@@ -24,7 +24,7 @@
     "@sqlrooms/duckdb": "workspace:*",
     "@sqlrooms/room-store": "workspace:*",
     "@sqlrooms/ui": "workspace:*",
-    "ai": "^5.0.44",
+    "ai": "^6.0.18",
     "zod": "^4.1.8"
   },
   "peerDependencies": {

--- a/packages/ai-rag/src/createAiEmbeddingProvider.ts
+++ b/packages/ai-rag/src/createAiEmbeddingProvider.ts
@@ -62,8 +62,8 @@ export type AiProviderFactory = (apiKey?: string) => AiProvider;
  * );
  * ```
  *
- * @note Requires AI SDK 5+ which uses v2 embedding specification.
- * The provider must support the `embedding()` method that returns a v2 model.
+ * @note Requires AI SDK v6 which uses the `embedding()` method.
+ * The provider must support the `embedding()` method that returns an embedding model.
  */
 export function createAiEmbeddingProvider(
   providerOrFactory: AiProvider | AiProviderFactory,
@@ -82,7 +82,7 @@ export function createAiEmbeddingProvider(
           ? providerOrFactory(apiKey)
           : providerOrFactory;
 
-      // Use v2 embedding API (required for AI SDK 5+)
+      // Use embedding API (AI SDK v6)
       const embeddingModel = provider.embedding(modelId, {
         dimensions,
       });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,8 +282,8 @@ importers:
   examples/ai-agent:
     dependencies:
       '@ai-sdk/openai-compatible':
-        specifier: ^1.0.22
-        version: 1.0.28(zod@4.1.13)
+        specifier: ^2.0.4
+        version: 2.0.4(zod@4.1.13)
       '@sqlrooms/ai-config':
         specifier: workspace:*
         version: link:../../packages/ai-config
@@ -300,8 +300,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui
       ai:
-        specifier: ^5.0.44
-        version: 5.0.108(zod@4.1.13)
+        specifier: ^6.0.18
+        version: 6.0.18(zod@4.1.13)
       lucide-react:
         specifier: ^0.555.0
         version: 0.555.0(react@19.2.1)
@@ -434,8 +434,8 @@ importers:
   examples/ai-nextjs:
     dependencies:
       '@ai-sdk/openai-compatible':
-        specifier: ^1.0.18
-        version: 1.0.28(zod@4.1.13)
+        specifier: ^2.0.4
+        version: 2.0.4(zod@4.1.13)
       '@openassistant/utils':
         specifier: 1.0.0-alpha.0
         version: 1.0.0-alpha.0
@@ -452,8 +452,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui
       ai:
-        specifier: ^5.0.44
-        version: 5.0.108(zod@4.1.13)
+        specifier: ^6.0.18
+        version: 6.0.18(zod@4.1.13)
       lucide-react:
         specifier: ^0.555.0
         version: 0.555.0(react@19.2.1)
@@ -498,7 +498,7 @@ importers:
   examples/ai-rag:
     dependencies:
       '@ai-sdk/openai':
-        specifier: ^2.0.32
+        specifier: ^2.0.38
         version: 2.0.65(zod@4.1.13)
       '@sqlrooms/ai':
         specifier: workspace:*
@@ -1966,11 +1966,11 @@ importers:
   packages/ai-core:
     dependencies:
       '@ai-sdk/openai-compatible':
-        specifier: ^1.0.18
-        version: 1.0.28(zod@4.1.13)
+        specifier: ^2.0.4
+        version: 2.0.4(zod@4.1.13)
       '@ai-sdk/react':
-        specifier: ^2.0.44
-        version: 2.0.109(react@19.2.1)(zod@4.1.13)
+        specifier: ^3.0.18
+        version: 3.0.18(react@19.2.1)(zod@4.1.13)
       '@openassistant/utils':
         specifier: 1.0.0-alpha.0
         version: 1.0.0-alpha.0
@@ -1993,8 +1993,8 @@ importers:
         specifier: workspace:*
         version: link:../utils
       ai:
-        specifier: ^5.0.44
-        version: 5.0.108(zod@4.1.13)
+        specifier: ^6.0.18
+        version: 6.0.18(zod@4.1.13)
       immer:
         specifier: ^11.0.1
         version: 11.0.1
@@ -2038,8 +2038,8 @@ importers:
         specifier: workspace:*
         version: link:../ui
       ai:
-        specifier: ^5.0.44
-        version: 5.0.108(zod@4.1.13)
+        specifier: ^6.0.18
+        version: 6.0.18(zod@4.1.13)
       apache-arrow:
         specifier: 17.0.0
         version: 17.0.0
@@ -2373,7 +2373,7 @@ importers:
         version: 3.2.4(@deck.gl/aggregation-layers@9.2.2(@deck.gl/core@9.2.2)(@deck.gl/layers@9.2.2(@deck.gl/core@9.2.2)(@loaders.gl/core@4.3.4)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))))(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))))(@loaders.gl/core@4.3.4)(@loaders.gl/images@4.3.4(@loaders.gl/core@4.3.4))(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/gltools@8.5.21)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))(@luma.gl/webgl@9.2.4(@luma.gl/core@9.2.4))(@math.gl/core@4.1.0)(@math.gl/web-mercator@4.1.0)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(enzyme-adapter-utils@1.14.2(react@19.2.1))(enzyme@3.11.0)(gl-matrix@3.4.4)(react-dom@19.2.1(react@19.2.1))(react-test-renderer@16.14.0(react@19.2.1))(react@19.2.1)(typescript@5.9.3)
       '@kepler.gl/components':
         specifier: 3.2.4
-        version: 3.2.4(694d0a6aa1a9ec8d9ea1645f12e2555a)
+        version: 3.2.4(645386686b0cd22c6f0600a17cd688ca)
       '@kepler.gl/constants':
         specifier: 3.2.4
         version: 3.2.4
@@ -2391,7 +2391,7 @@ importers:
         version: 3.2.4(@deck.gl/aggregation-layers@9.2.2(@deck.gl/core@9.2.2)(@deck.gl/layers@9.2.2(@deck.gl/core@9.2.2)(@loaders.gl/core@4.3.4)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))))(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))))(@loaders.gl/images@4.3.4(@loaders.gl/core@4.3.4))(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/gltools@8.5.21)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))(@luma.gl/webgl@9.2.4(@luma.gl/core@9.2.4))(@math.gl/core@4.1.0)(@math.gl/web-mercator@4.1.0)(enzyme-adapter-utils@1.14.2(react@19.2.1))(enzyme@3.11.0)(gl-matrix@3.4.4)(react-dom@19.2.1(react@19.2.1))(react-test-renderer@16.14.0(react@19.2.1))(react@19.2.1)(typescript@5.9.3)
       '@kepler.gl/reducers':
         specifier: 3.2.4
-        version: 3.2.4(b4ca8b638769c58faff91485a405d8a9)
+        version: 3.2.4(ea64a3dede37dbc3bc035957020fc314)
       '@kepler.gl/schemas':
         specifier: 3.2.4
         version: 3.2.4(@deck.gl/aggregation-layers@9.2.2(@deck.gl/core@9.2.2)(@deck.gl/layers@9.2.2(@deck.gl/core@9.2.2)(@loaders.gl/core@4.3.4)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))))(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))))(@loaders.gl/core@4.3.4)(@loaders.gl/images@4.3.4(@loaders.gl/core@4.3.4))(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/gltools@8.5.21)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))(@luma.gl/webgl@9.2.4(@luma.gl/core@9.2.4))(@math.gl/core@4.1.0)(@math.gl/web-mercator@4.1.0)(enzyme-adapter-utils@1.14.2(react@19.2.1))(enzyme@3.11.0)(gl-matrix@3.4.4)(react-dom@19.2.1(react@19.2.1))(react-test-renderer@16.14.0(react@19.2.1))(react@19.2.1)(typescript@5.9.3)
@@ -3121,14 +3121,14 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
-  '@ai-sdk/gateway@2.0.18':
-    resolution: {integrity: sha512-sDQcW+6ck2m0pTIHW6BPHD7S125WD3qNkx/B8sEzJp/hurocmJ5Cni0ybExg6sQMGo+fr/GWOwpHF1cmCdg5rQ==}
+  '@ai-sdk/gateway@3.0.9':
+    resolution: {integrity: sha512-EA5dZIukimwoJ9HIPuuREotAqaTItpdc/yImzVF0XGNg7B0YRJmYI8Uq3aCMr87vjr1YB1cWUfnrTt6OJ9eHiQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: 4.1.13
 
-  '@ai-sdk/openai-compatible@1.0.28':
-    resolution: {integrity: sha512-yKubDxLYtXyGUzkr9lNStf/lE/I+Okc8tmotvyABhsQHHieLKk6oV5fJeRJxhr67Ejhg+FRnwUOxAmjRoFM4dA==}
+  '@ai-sdk/openai-compatible@2.0.4':
+    resolution: {integrity: sha512-kzsXyybJKM3wtUtGZkNbvmpDwqpsvg/hTjlPZe3s/bCx3enVdAlRtXD853nnj6mZjteNCDLoR2OgVLuDpyRN5Q==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: 4.1.13
@@ -3145,8 +3145,8 @@ packages:
     peerDependencies:
       zod: 4.1.13
 
-  '@ai-sdk/provider-utils@3.0.18':
-    resolution: {integrity: sha512-ypv1xXMsgGcNKUP+hglKqtdDuMg68nWHucPPAhIENrbFAI+xCHiqPVN8Zllxyv1TNZwGWUghPxJXU+Mqps0YRQ==}
+  '@ai-sdk/provider-utils@4.0.4':
+    resolution: {integrity: sha512-VxhX0B/dWGbpNHxrKCWUAJKXIXV015J4e7qYjdIU9lLWeptk0KMLGcqkB4wFxff5Njqur8dt8wRi1MN9lZtDqg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: 4.1.13
@@ -3155,15 +3155,15 @@ packages:
     resolution: {integrity: sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==}
     engines: {node: '>=18'}
 
-  '@ai-sdk/react@2.0.109':
-    resolution: {integrity: sha512-5qM8KuN7bv7E+g6BXkSAYLFjwIfMSTKOA1prjg1zEShJXJyLSc+Yqkd3EfGibm75b7nJAqJNShurDmR/IlQqFQ==}
+  '@ai-sdk/provider@3.0.2':
+    resolution: {integrity: sha512-HrEmNt/BH/hkQ7zpi2o6N3k1ZR1QTb7z85WYhYygiTxOQuaml4CMtHCWRbric5WPU+RNsYI7r1EpyVQMKO1pYw==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/react@3.0.18':
+    resolution: {integrity: sha512-0er68pgMoYZkRPV8k5y8TSr//s3FuGWH6maovi4DtEtE1iZ29txTyqpxlMyzz+9HiyGDDxJhYXwX4rUGHsJdGg==}
     engines: {node: '>=18'}
     peerDependencies:
       react: 19.2.1
-      zod: 4.1.13
-    peerDependenciesMeta:
-      zod:
-        optional: true
 
   '@algolia/abtesting@1.9.0':
     resolution: {integrity: sha512-4q9QCxFPiDIx1n5w41A1JMkrXI8p0ugCQnCGFtCKZPmWtwgWCqwVRncIbp++81xSELFZVQUfiB7Kbsla1tIBSw==}
@@ -7161,6 +7161,9 @@ packages:
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
@@ -8141,8 +8144,8 @@ packages:
     resolution: {integrity: sha512-8r4TNknD7OJQADe3VygeofFR7UNAXZ2/jjBFP5dgI8+2uMfnuGYgbuHivasKr9WSQ64sPej6m8rDoM1uSllXjQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  '@vercel/oidc@3.0.5':
-    resolution: {integrity: sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw==}
+  '@vercel/oidc@3.1.0':
+    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
 
   '@vis.gl/react-mapbox@8.1.0':
@@ -8324,8 +8327,8 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  ai@5.0.108:
-    resolution: {integrity: sha512-Jex3Lb7V41NNpuqJHKgrwoU6BCLHdI1Pg4qb4GJH4jRIDRXUBySJErHjyN4oTCwbiYCeb/8II9EnqSRPq9EifA==}
+  ai@6.0.18:
+    resolution: {integrity: sha512-WyscdyO+79MH46xDOPfT+CWEzzMl8MMJqVSw9y3VKjQB1hvO6pSO3YibHO3pqHZLsUjANyHGmyIhx72pDH9+qA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: 4.1.13
@@ -14704,17 +14707,17 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@ai-sdk/gateway@2.0.18(zod@4.1.13)':
+  '@ai-sdk/gateway@3.0.9(zod@4.1.13)':
     dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.18(zod@4.1.13)
-      '@vercel/oidc': 3.0.5
+      '@ai-sdk/provider': 3.0.2
+      '@ai-sdk/provider-utils': 4.0.4(zod@4.1.13)
+      '@vercel/oidc': 3.1.0
       zod: 4.1.13
 
-  '@ai-sdk/openai-compatible@1.0.28(zod@4.1.13)':
+  '@ai-sdk/openai-compatible@2.0.4(zod@4.1.13)':
     dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.18(zod@4.1.13)
+      '@ai-sdk/provider': 3.0.2
+      '@ai-sdk/provider-utils': 4.0.4(zod@4.1.13)
       zod: 4.1.13
 
   '@ai-sdk/openai@2.0.65(zod@4.1.13)':
@@ -14730,10 +14733,10 @@ snapshots:
       eventsource-parser: 3.0.6
       zod: 4.1.13
 
-  '@ai-sdk/provider-utils@3.0.18(zod@4.1.13)':
+  '@ai-sdk/provider-utils@4.0.4(zod@4.1.13)':
     dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@standard-schema/spec': 1.0.0
+      '@ai-sdk/provider': 3.0.2
+      '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
       zod: 4.1.13
 
@@ -14741,15 +14744,19 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@2.0.109(react@19.2.1)(zod@4.1.13)':
+  '@ai-sdk/provider@3.0.2':
     dependencies:
-      '@ai-sdk/provider-utils': 3.0.18(zod@4.1.13)
-      ai: 5.0.108(zod@4.1.13)
+      json-schema: 0.4.0
+
+  '@ai-sdk/react@3.0.18(react@19.2.1)(zod@4.1.13)':
+    dependencies:
+      '@ai-sdk/provider-utils': 4.0.4(zod@4.1.13)
+      ai: 6.0.18(zod@4.1.13)
       react: 19.2.1
       swr: 2.3.7(react@19.2.1)
       throttleit: 2.1.0
-    optionalDependencies:
-      zod: 4.1.13
+    transitivePeerDependencies:
+      - zod
 
   '@algolia/abtesting@1.9.0':
     dependencies:
@@ -16386,6 +16393,39 @@ snapshots:
       '@luma.gl/shadertools': 9.2.4(@luma.gl/core@9.2.4)
       '@math.gl/core': 4.1.0
 
+  '@deck.gl/geo-layers@8.9.36(835cb881bfc488415e6cd31b7bd1b08e)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@deck.gl/core': 8.9.27
+      '@deck.gl/extensions': 9.2.2(@deck.gl/core@9.2.2)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))
+      '@deck.gl/layers': 8.9.36(@deck.gl/core@8.9.27)(@loaders.gl/core@4.3.4)(@luma.gl/core@8.5.21)
+      '@deck.gl/mesh-layers': 9.2.2(@deck.gl/core@9.2.2)(@loaders.gl/core@4.3.4)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/gltf@9.2.4(@luma.gl/constants@8.5.21)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))
+      '@loaders.gl/3d-tiles': 3.4.15(@loaders.gl/core@4.3.4)
+      '@loaders.gl/core': 4.3.4
+      '@loaders.gl/gis': 3.4.15
+      '@loaders.gl/loader-utils': 3.4.15
+      '@loaders.gl/mvt': 3.4.15
+      '@loaders.gl/schema': 3.4.15
+      '@loaders.gl/terrain': 3.4.15
+      '@loaders.gl/tiles': 3.4.15(@loaders.gl/core@4.3.4)
+      '@loaders.gl/wms': 3.4.15
+      '@luma.gl/constants': 8.5.21
+      '@luma.gl/core': 8.5.21
+      '@luma.gl/experimental': 8.5.21(@loaders.gl/gltf@4.3.4(@loaders.gl/core@4.3.4))(@loaders.gl/images@4.3.4(@loaders.gl/core@4.3.4))(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/gltools@8.5.21)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))(@luma.gl/webgl@9.2.4(@luma.gl/core@9.2.4))
+      '@math.gl/core': 3.6.3
+      '@math.gl/culling': 3.6.3
+      '@math.gl/web-mercator': 3.6.3
+      '@types/geojson': 7946.0.16
+      h3-js: 3.7.2
+      long: 3.2.0
+    transitivePeerDependencies:
+      - '@loaders.gl/gltf'
+      - '@loaders.gl/images'
+      - '@luma.gl/engine'
+      - '@luma.gl/gltools'
+      - '@luma.gl/shadertools'
+      - '@luma.gl/webgl'
+
   '@deck.gl/geo-layers@8.9.36(@deck.gl/core@8.9.27)(@deck.gl/extensions@8.9.36(@deck.gl/core@8.9.27)(@luma.gl/constants@8.5.21)(@luma.gl/core@9.2.4)(@math.gl/core@4.1.0)(@math.gl/web-mercator@3.6.3)(gl-matrix@3.4.4))(@deck.gl/layers@8.9.36(@deck.gl/core@8.9.27)(@loaders.gl/core@4.3.4)(@luma.gl/core@9.2.4))(@deck.gl/mesh-layers@8.9.36(@deck.gl/core@8.9.27)(@loaders.gl/images@4.3.4(@loaders.gl/core@4.3.4))(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/gltools@8.5.21)(@luma.gl/webgl@9.2.4(@luma.gl/core@9.2.4)))(@loaders.gl/core@4.3.4)(@loaders.gl/gltf@4.3.4(@loaders.gl/core@4.3.4))(@loaders.gl/images@4.3.4(@loaders.gl/core@4.3.4))(@luma.gl/core@8.5.21)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/gltools@8.5.21)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))(@luma.gl/webgl@9.2.4(@luma.gl/core@9.2.4))':
     dependencies:
       '@babel/runtime': 7.28.4
@@ -16504,39 +16544,6 @@ snapshots:
       '@luma.gl/constants': 8.5.21
       '@luma.gl/core': 9.2.4
       '@luma.gl/experimental': 8.5.21(@loaders.gl/gltf@4.3.4(@loaders.gl/core@4.3.4))(@loaders.gl/images@4.3.4(@loaders.gl/core@4.3.4))(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/gltools@8.5.21)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))(@luma.gl/webgl@9.2.4(@luma.gl/core@9.2.4))
-      '@math.gl/core': 3.6.3
-      '@math.gl/culling': 3.6.3
-      '@math.gl/web-mercator': 3.6.3
-      '@types/geojson': 7946.0.16
-      h3-js: 3.7.2
-      long: 3.2.0
-    transitivePeerDependencies:
-      - '@loaders.gl/gltf'
-      - '@loaders.gl/images'
-      - '@luma.gl/engine'
-      - '@luma.gl/gltools'
-      - '@luma.gl/shadertools'
-      - '@luma.gl/webgl'
-
-  '@deck.gl/geo-layers@8.9.36(a3b58aae3a4df3ea6da6b9ac1a6f404a)':
-    dependencies:
-      '@babel/runtime': 7.28.4
-      '@deck.gl/core': 8.9.27
-      '@deck.gl/extensions': 9.2.2(@deck.gl/core@9.2.2)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))
-      '@deck.gl/layers': 8.9.36(@deck.gl/core@8.9.27)(@loaders.gl/core@4.3.4)(@luma.gl/core@8.5.21)
-      '@deck.gl/mesh-layers': 9.2.2(@deck.gl/core@9.2.2)(@loaders.gl/core@4.3.4)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/gltf@9.2.4(@luma.gl/constants@8.5.21)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))
-      '@loaders.gl/3d-tiles': 3.4.15(@loaders.gl/core@4.3.4)
-      '@loaders.gl/core': 4.3.4
-      '@loaders.gl/gis': 3.4.15
-      '@loaders.gl/loader-utils': 3.4.15
-      '@loaders.gl/mvt': 3.4.15
-      '@loaders.gl/schema': 3.4.15
-      '@loaders.gl/terrain': 3.4.15
-      '@loaders.gl/tiles': 3.4.15(@loaders.gl/core@4.3.4)
-      '@loaders.gl/wms': 3.4.15
-      '@luma.gl/constants': 8.5.21
-      '@luma.gl/core': 8.5.21
-      '@luma.gl/experimental': 8.5.21(@loaders.gl/gltf@3.4.15)(@loaders.gl/images@4.3.4(@loaders.gl/core@4.3.4))(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/gltools@8.5.21)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))(@luma.gl/webgl@9.2.4(@luma.gl/core@9.2.4))
       '@math.gl/core': 3.6.3
       '@math.gl/culling': 3.6.3
       '@math.gl/web-mercator': 3.6.3
@@ -17754,7 +17761,7 @@ snapshots:
       h3-js: 3.7.2
       type-analyzer: 0.4.0
 
-  '@kepler.gl/components@3.2.4(694d0a6aa1a9ec8d9ea1645f12e2555a)':
+  '@kepler.gl/components@3.2.4(645386686b0cd22c6f0600a17cd688ca)':
     dependencies:
       '@deck.gl/core': 8.9.27
       '@deck.gl/react': 8.9.36(@deck.gl/core@8.9.27)(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -17772,7 +17779,7 @@ snapshots:
       '@kepler.gl/layers': 3.2.4(@deck.gl/aggregation-layers@9.2.2(@deck.gl/core@9.2.2)(@deck.gl/layers@9.2.2(@deck.gl/core@9.2.2)(@loaders.gl/core@4.3.4)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))))(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))))(@loaders.gl/images@4.3.4(@loaders.gl/core@4.3.4))(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/gltools@8.5.21)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))(@luma.gl/webgl@9.2.4(@luma.gl/core@9.2.4))(@math.gl/core@4.1.0)(@math.gl/web-mercator@4.1.0)(enzyme-adapter-utils@1.14.2(react@19.2.1))(enzyme@3.11.0)(gl-matrix@3.4.4)(react-dom@19.2.1(react@19.2.1))(react-test-renderer@16.14.0(react@19.2.1))(typescript@5.9.3)
       '@kepler.gl/localization': 3.2.4(typescript@5.9.3)
       '@kepler.gl/processors': 3.2.4(@deck.gl/aggregation-layers@9.2.2(@deck.gl/core@9.2.2)(@deck.gl/layers@9.2.2(@deck.gl/core@9.2.2)(@loaders.gl/core@4.3.4)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))))(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))))(@loaders.gl/images@4.3.4(@loaders.gl/core@4.3.4))(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/gltools@8.5.21)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))(@luma.gl/webgl@9.2.4(@luma.gl/core@9.2.4))(@math.gl/core@4.1.0)(@math.gl/web-mercator@4.1.0)(enzyme-adapter-utils@1.14.2(react@19.2.1))(enzyme@3.11.0)(gl-matrix@3.4.4)(react-dom@19.2.1(react@19.2.1))(react-test-renderer@16.14.0(react@19.2.1))(react@19.2.1)(typescript@5.9.3)
-      '@kepler.gl/reducers': 3.2.4(b5efb7b9d777f5fe9c42f57803bf052d)
+      '@kepler.gl/reducers': 3.2.4(4cc2f82ec7aab0c593a15289aa7a3af3)
       '@kepler.gl/schemas': 3.2.4(@deck.gl/aggregation-layers@9.2.2(@deck.gl/core@9.2.2)(@deck.gl/layers@9.2.2(@deck.gl/core@9.2.2)(@loaders.gl/core@4.3.4)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))))(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))))(@loaders.gl/core@4.3.4)(@loaders.gl/images@4.3.4(@loaders.gl/core@4.3.4))(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/gltools@8.5.21)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))(@luma.gl/webgl@9.2.4(@luma.gl/core@9.2.4))(@math.gl/core@4.1.0)(@math.gl/web-mercator@4.1.0)(enzyme-adapter-utils@1.14.2(react@19.2.1))(enzyme@3.11.0)(gl-matrix@3.4.4)(react-dom@19.2.1(react@19.2.1))(react-test-renderer@16.14.0(react@19.2.1))(react@19.2.1)(typescript@5.9.3)
       '@kepler.gl/styles': 3.2.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@kepler.gl/table': 3.2.4(@loaders.gl/core@4.3.4)(enzyme-adapter-utils@1.14.2(react@19.2.1))(enzyme@3.11.0)(react-dom@19.2.1(react@19.2.1))(react-test-renderer@16.14.0(react@19.2.1))(react@19.2.1)
@@ -18035,12 +18042,12 @@ snapshots:
       - '@luma.gl/webgl'
       - react-dom
 
-  '@kepler.gl/deckgl-layers@3.2.4(@deck.gl/extensions@9.2.2(@deck.gl/core@9.2.2)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))))(@deck.gl/mesh-layers@9.2.2(@deck.gl/core@9.2.2)(@loaders.gl/core@4.3.4)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/gltf@9.2.4(@luma.gl/constants@8.5.21)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@loaders.gl/core@4.3.4)(@loaders.gl/gltf@3.4.15)(@loaders.gl/images@4.3.4(@loaders.gl/core@4.3.4))(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/gltools@8.5.21)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))(@luma.gl/webgl@9.2.4(@luma.gl/core@9.2.4))(react-dom@19.2.1(react@19.2.1))':
+  '@kepler.gl/deckgl-layers@3.2.4(@deck.gl/extensions@9.2.2(@deck.gl/core@9.2.2)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))))(@deck.gl/mesh-layers@9.2.2(@deck.gl/core@9.2.2)(@loaders.gl/core@4.3.4)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/gltf@9.2.4(@luma.gl/constants@8.5.21)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@loaders.gl/core@4.3.4)(@loaders.gl/gltf@4.3.4(@loaders.gl/core@4.3.4))(@loaders.gl/images@4.3.4(@loaders.gl/core@4.3.4))(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/gltools@8.5.21)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))(@luma.gl/webgl@9.2.4(@luma.gl/core@9.2.4))(react-dom@19.2.1(react@19.2.1))':
     dependencies:
       '@danmarshall/deckgl-typings': 4.9.22
       '@deck.gl/aggregation-layers': 8.9.36(@deck.gl/core@8.9.27)(@deck.gl/layers@8.9.36(@deck.gl/core@8.9.27)(@loaders.gl/core@4.3.4)(@luma.gl/core@8.5.21))(@luma.gl/core@8.5.21)
       '@deck.gl/core': 8.9.27
-      '@deck.gl/geo-layers': 8.9.36(a3b58aae3a4df3ea6da6b9ac1a6f404a)
+      '@deck.gl/geo-layers': 8.9.36(835cb881bfc488415e6cd31b7bd1b08e)
       '@deck.gl/layers': 8.9.36(@deck.gl/core@8.9.27)(@loaders.gl/core@4.3.4)(@luma.gl/core@8.5.21)
       '@kepler.gl/constants': 3.2.4
       '@kepler.gl/types': 3.2.4
@@ -18372,14 +18379,14 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@kepler.gl/reducers@3.2.4(b4ca8b638769c58faff91485a405d8a9)':
+  '@kepler.gl/reducers@3.2.4(4cc2f82ec7aab0c593a15289aa7a3af3)':
     dependencies:
       '@kepler.gl/actions': 3.2.4(@deck.gl/aggregation-layers@9.2.2(@deck.gl/core@9.2.2)(@deck.gl/layers@9.2.2(@deck.gl/core@9.2.2)(@loaders.gl/core@4.3.4)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))))(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))))(@loaders.gl/core@4.3.4)(@loaders.gl/images@4.3.4(@loaders.gl/core@4.3.4))(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/gltools@8.5.21)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))(@luma.gl/webgl@9.2.4(@luma.gl/core@9.2.4))(@math.gl/core@4.1.0)(@math.gl/web-mercator@3.6.3)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(enzyme-adapter-utils@1.14.2(react@19.2.1))(enzyme@3.11.0)(gl-matrix@3.4.4)(react-dom@19.2.1(react@19.2.1))(react-test-renderer@16.14.0(react@19.2.1))(react@19.2.1)(typescript@5.9.3)
       '@kepler.gl/cloud-providers': 3.2.4
       '@kepler.gl/common-utils': 3.2.4
       '@kepler.gl/constants': 3.2.4
-      '@kepler.gl/deckgl-arrow-layers': 3.2.4(1400addcacd6ffcbd56896f766730719)
-      '@kepler.gl/deckgl-layers': 3.2.4(@deck.gl/extensions@9.2.2(@deck.gl/core@9.2.2)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))))(@deck.gl/mesh-layers@9.2.2(@deck.gl/core@9.2.2)(@loaders.gl/core@4.3.4)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/gltf@9.2.4(@luma.gl/constants@8.5.21)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@loaders.gl/core@4.3.4)(@loaders.gl/gltf@3.4.15)(@loaders.gl/images@4.3.4(@loaders.gl/core@4.3.4))(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/gltools@8.5.21)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))(@luma.gl/webgl@9.2.4(@luma.gl/core@9.2.4))(react-dom@19.2.1(react@19.2.1))
+      '@kepler.gl/deckgl-arrow-layers': 3.2.4(54f696f2a01b6a1607825ba222cd90e8)
+      '@kepler.gl/deckgl-layers': 3.2.4(@deck.gl/extensions@9.2.2(@deck.gl/core@9.2.2)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))))(@deck.gl/mesh-layers@9.2.2(@deck.gl/core@9.2.2)(@loaders.gl/core@4.3.4)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/gltf@9.2.4(@luma.gl/constants@8.5.21)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@loaders.gl/core@4.3.4)(@loaders.gl/gltf@4.3.4(@loaders.gl/core@4.3.4))(@loaders.gl/images@4.3.4(@loaders.gl/core@4.3.4))(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/gltools@8.5.21)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))(@luma.gl/webgl@9.2.4(@luma.gl/core@9.2.4))(react-dom@19.2.1(react@19.2.1))
       '@kepler.gl/effects': 3.2.4(@loaders.gl/core@4.3.4)(react-dom@19.2.1(react@19.2.1))
       '@kepler.gl/layers': 3.2.4(@deck.gl/aggregation-layers@9.2.2(@deck.gl/core@9.2.2)(@deck.gl/layers@9.2.2(@deck.gl/core@9.2.2)(@loaders.gl/core@4.3.4)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))))(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))))(@loaders.gl/images@4.3.4(@loaders.gl/core@4.3.4))(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/gltools@8.5.21)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))(@luma.gl/webgl@9.2.4(@luma.gl/core@9.2.4))(@math.gl/core@4.1.0)(@math.gl/web-mercator@3.6.3)(enzyme-adapter-utils@1.14.2(react@19.2.1))(enzyme@3.11.0)(gl-matrix@3.4.4)(react-dom@19.2.1(react@19.2.1))(react-test-renderer@16.14.0(react@19.2.1))(typescript@5.9.3)
       '@kepler.gl/localization': 3.2.4(typescript@5.9.3)
@@ -18437,14 +18444,14 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@kepler.gl/reducers@3.2.4(b5efb7b9d777f5fe9c42f57803bf052d)':
+  '@kepler.gl/reducers@3.2.4(ea64a3dede37dbc3bc035957020fc314)':
     dependencies:
       '@kepler.gl/actions': 3.2.4(@deck.gl/aggregation-layers@9.2.2(@deck.gl/core@9.2.2)(@deck.gl/layers@9.2.2(@deck.gl/core@9.2.2)(@loaders.gl/core@4.3.4)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))))(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))))(@loaders.gl/core@4.3.4)(@loaders.gl/images@4.3.4(@loaders.gl/core@4.3.4))(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/gltools@8.5.21)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))(@luma.gl/webgl@9.2.4(@luma.gl/core@9.2.4))(@math.gl/core@4.1.0)(@math.gl/web-mercator@3.6.3)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(enzyme-adapter-utils@1.14.2(react@19.2.1))(enzyme@3.11.0)(gl-matrix@3.4.4)(react-dom@19.2.1(react@19.2.1))(react-test-renderer@16.14.0(react@19.2.1))(react@19.2.1)(typescript@5.9.3)
       '@kepler.gl/cloud-providers': 3.2.4
       '@kepler.gl/common-utils': 3.2.4
       '@kepler.gl/constants': 3.2.4
-      '@kepler.gl/deckgl-arrow-layers': 3.2.4(54f696f2a01b6a1607825ba222cd90e8)
-      '@kepler.gl/deckgl-layers': 3.2.4(@deck.gl/extensions@9.2.2(@deck.gl/core@9.2.2)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))))(@deck.gl/mesh-layers@9.2.2(@deck.gl/core@9.2.2)(@loaders.gl/core@4.3.4)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/gltf@9.2.4(@luma.gl/constants@8.5.21)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@loaders.gl/core@4.3.4)(@loaders.gl/gltf@3.4.15)(@loaders.gl/images@4.3.4(@loaders.gl/core@4.3.4))(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/gltools@8.5.21)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))(@luma.gl/webgl@9.2.4(@luma.gl/core@9.2.4))(react-dom@19.2.1(react@19.2.1))
+      '@kepler.gl/deckgl-arrow-layers': 3.2.4(1400addcacd6ffcbd56896f766730719)
+      '@kepler.gl/deckgl-layers': 3.2.4(@deck.gl/extensions@9.2.2(@deck.gl/core@9.2.2)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))))(@deck.gl/mesh-layers@9.2.2(@deck.gl/core@9.2.2)(@loaders.gl/core@4.3.4)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/gltf@9.2.4(@luma.gl/constants@8.5.21)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@loaders.gl/core@4.3.4)(@loaders.gl/gltf@4.3.4(@loaders.gl/core@4.3.4))(@loaders.gl/images@4.3.4(@loaders.gl/core@4.3.4))(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/gltools@8.5.21)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))(@luma.gl/webgl@9.2.4(@luma.gl/core@9.2.4))(react-dom@19.2.1(react@19.2.1))
       '@kepler.gl/effects': 3.2.4(@loaders.gl/core@4.3.4)(react-dom@19.2.1(react@19.2.1))
       '@kepler.gl/layers': 3.2.4(@deck.gl/aggregation-layers@9.2.2(@deck.gl/core@9.2.2)(@deck.gl/layers@9.2.2(@deck.gl/core@9.2.2)(@loaders.gl/core@4.3.4)(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))))(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))))(@loaders.gl/images@4.3.4(@loaders.gl/core@4.3.4))(@luma.gl/core@9.2.4)(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/gltools@8.5.21)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))(@luma.gl/webgl@9.2.4(@luma.gl/core@9.2.4))(@math.gl/core@4.1.0)(@math.gl/web-mercator@3.6.3)(enzyme-adapter-utils@1.14.2(react@19.2.1))(enzyme@3.11.0)(gl-matrix@3.4.4)(react-dom@19.2.1(react@19.2.1))(react-test-renderer@16.14.0(react@19.2.1))(typescript@5.9.3)
       '@kepler.gl/localization': 3.2.4(typescript@5.9.3)
@@ -19279,18 +19286,6 @@ snapshots:
       '@luma.gl/engine': 9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))
       '@luma.gl/gltools': 8.5.21
       '@luma.gl/shadertools': 8.5.21
-      '@luma.gl/webgl': 9.2.4(@luma.gl/core@9.2.4)
-      '@math.gl/core': 3.6.3
-      earcut: 2.2.4
-
-  '@luma.gl/experimental@8.5.21(@loaders.gl/gltf@3.4.15)(@loaders.gl/images@4.3.4(@loaders.gl/core@4.3.4))(@luma.gl/engine@9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4)))(@luma.gl/gltools@8.5.21)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))(@luma.gl/webgl@9.2.4(@luma.gl/core@9.2.4))':
-    dependencies:
-      '@loaders.gl/gltf': 3.4.15
-      '@loaders.gl/images': 4.3.4(@loaders.gl/core@4.3.4)
-      '@luma.gl/constants': 8.5.21
-      '@luma.gl/engine': 9.2.4(@luma.gl/core@9.2.4)(@luma.gl/shadertools@9.2.4(@luma.gl/core@9.2.4))
-      '@luma.gl/gltools': 8.5.21
-      '@luma.gl/shadertools': 9.2.4(@luma.gl/core@9.2.4)
       '@luma.gl/webgl': 9.2.4(@luma.gl/core@9.2.4)
       '@math.gl/core': 3.6.3
       earcut: 2.2.4
@@ -21299,6 +21294,8 @@ snapshots:
 
   '@standard-schema/spec@1.0.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@standard-schema/utils@0.3.0': {}
 
   '@surma/rollup-plugin-off-main-thread@2.2.3':
@@ -22557,7 +22554,7 @@ snapshots:
     dependencies:
       '@vaadin/vaadin-development-mode-detector': 2.0.7
 
-  '@vercel/oidc@3.0.5': {}
+  '@vercel/oidc@3.1.0': {}
 
   '@vis.gl/react-mapbox@8.1.0(mapbox-gl@3.17.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
@@ -22786,11 +22783,11 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ai@5.0.108(zod@4.1.13):
+  ai@6.0.18(zod@4.1.13):
     dependencies:
-      '@ai-sdk/gateway': 2.0.18(zod@4.1.13)
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.18(zod@4.1.13)
+      '@ai-sdk/gateway': 3.0.9(zod@4.1.13)
+      '@ai-sdk/provider': 3.0.2
+      '@ai-sdk/provider-utils': 4.0.4(zod@4.1.13)
       '@opentelemetry/api': 1.9.0
       zod: 4.1.13
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1962,6 +1962,10 @@ importers:
       zod:
         specifier: 4.1.13
         version: 4.1.13
+    devDependencies:
+      ts-jest:
+        specifier: ^29.4.4
+        version: 29.4.6(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@30.2.0(@types/node@24.10.2))(typescript@5.9.3)
 
   packages/ai-core:
     dependencies:
@@ -2019,6 +2023,10 @@ importers:
       zod:
         specifier: 4.1.13
         version: 4.1.13
+    devDependencies:
+      ts-jest:
+        specifier: ^29.4.4
+        version: 29.4.6(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@30.2.0(@types/node@24.10.2))(typescript@5.9.3)
 
   packages/ai-rag:
     dependencies:


### PR DESCRIPTION
Update packages/ai-core and related packages to use the latest Vercel AI SDK:
- ai: 5.0.44 → 6.0.18
- @ai-sdk/react: 2.0.44 → 3.0.18
- @ai-sdk/openai-compatible: 1.0.18 → 2.0.4
- @ai-sdk/openai: 2.0.32 → 2.0.38

Breaking changes addressed:
- convertToModelMessages is now async, updated all call sites to await
- Added new tool states: approval-requested, approval-responded, output-denied
- Updated UIMessageSchema with approval workflow support
- Fixed type guards and component props for new tool states