### PR TITLE
fix: schema tree row count alignment

### DIFF
--- a/packages/schema-tree/src/nodes/TableTreeNode.tsx
+++ b/packages/schema-tree/src/nodes/TableTreeNode.tsx
@@ -109,11 +109,7 @@ export const TableTreeNode: FC<{
             <TableIcon size="16px" className="shrink-0 text-blue-500" />
           )}
           <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
-            <span
-              className="shrink-0 truncate"
-              style={{maxWidth: '70%'}}
-              title={name}
-            >
+            <span className="max-w-[70%] shrink-0 truncate" title={name}>
               {name}
             </span>
             {rowCount !== undefined && rowCount > 0 && (


### PR DESCRIPTION
Fix content alignment for the row count in the schema tree

Preview:
![sidebar](https://github.com/user-attachments/assets/8cd4e038-5446-4e92-ad18-3693edee7408)
