### PR TITLE
feat: improve explain query output in sqleditor

### DIFF
--- a/packages/sql-editor/src/components/QueryResultPanel.tsx
+++ b/packages/sql-editor/src/components/QueryResultPanel.tsx
@@ -94,10 +94,6 @@ export const QueryResultPanel: React.FC<QueryResultPanelProps> = ({
     (s) => s.sqlEditor.queryResultLimitOptions,
   );
 
-  // EXPLAIN returns a result table, but it’s really “text output” (a plan) and
-  // rendering it as a normal data table tends to truncate it to a single cell.
-  // We special-case EXPLAIN: render the full plan as text, and only use the
-  // DataTable renderer for real tabular results (SELECT/PRAGMA).
   const tableForDataTable =
     isQueryWithResult(queryResult) && queryResult.type !== 'explain'
       ? queryResult.result


### PR DESCRIPTION
Show explain schema as a full height content in the QueryResultsPanel instead as a table row

Screenrecording:
- show regular table dataset, and explain schema
![explain](https://github.com/user-attachments/assets/11cc0779-5d78-4330-a76b-6b0cfba1bb19)
