### PR TITLE
fix: Vector tiles creating layers

### DIFF
--- a/packages/kepler/src/KeplerSlice.ts
+++ b/packages/kepler/src/KeplerSlice.ts
@@ -528,7 +528,7 @@ export function createKeplerSlice({
             addDataToMap({
               datasets: dataset,
               options: {
-                autoCreateLayers: autoCreateLayers,
+                autoCreateLayers,
                 centerMap: true,
               },
             }),


### PR DESCRIPTION
Issue: When creating vector tile using function Add as tiles to map, the vector tile is shown on every map, instead of that it should be added as layer only on active tab