### PR TITLE
hide popover for binary column by default

### DIFF
--- a/packages/data-table/src/useArrowDataTable.tsx
+++ b/packages/data-table/src/useArrowDataTable.tsx
@@ -240,7 +240,7 @@ export default function useArrowDataTable(
                 </PopoverContent>
               </Popover>
             ) : (
-              shorten(valueStr, MAX_VALUE_LENGTH)
+              valueStr
             );
           },
           header: shorten(field.name, MAX_VALUE_LENGTH),


### PR DESCRIPTION
Hide the popover by default when clicking on binary column in the arrow table