### PR TITLE
feat: enhance ErrorMessage with customizable Markdown component

### DIFF
--- a/packages/ai-core/src/components/ErrorMessage.tsx
+++ b/packages/ai-core/src/components/ErrorMessage.tsx
@@ -1,16 +1,20 @@
 import Markdown from 'react-markdown';
+import {Components} from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import {MessageContainer} from './MessageContainer';
 
 export type ErrorMessageComponentProps = {
   errorMessage: string;
+  components?: Partial<Components>;
 };
 
 export function ErrorMessage(props: ErrorMessageComponentProps) {
   return (
     <MessageContainer isSuccess={false} type="error" content={props}>
       <div className="prose dark:prose-invert max-w-none text-sm">
-        <Markdown remarkPlugins={[remarkGfm]}>{props.errorMessage}</Markdown>
+        <Markdown remarkPlugins={[remarkGfm]} components={props.components}>
+          {props.errorMessage}
+        </Markdown>
       </div>
     </MessageContainer>
   );


### PR DESCRIPTION
 enhance ErrorMessage with customizable Markdown component, we we can use e.g. hyperlink (like [contact us](url)) in customized ErrorMessage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ErrorMessage component now supports custom rendering for Markdown content, enabling developers to customize how error messages are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->