### PR TITLE
fix: fix tab reordering

### DIFF
--- a/packages/sql-editor/src/components/QueryEditorPanel.tsx
+++ b/packages/sql-editor/src/components/QueryEditorPanel.tsx
@@ -6,6 +6,7 @@ import {QueryEditorPanelEditor} from './QueryEditorPanelEditor';
 import {QueryEditorPanelTabsList} from './QueryEditorPanelTabsList';
 
 export interface QueryEditorPanelProps {
+  /** Custom class name for styling */
   className?: string;
 }
 
@@ -19,37 +20,25 @@ export const QueryEditorPanel: React.FC<QueryEditorPanelProps> = ({
 
   const isSelectedOpen = openTabs.includes(selectedQueryId);
 
-  // Keep all editors mounted, but hide inactive ones
   return (
-    <div className={cn('flex h-full flex-col overflow-visible', className)}>
+    <div
+      className={cn(
+        'flex h-full flex-col',
+        // this is for Monaco's completion menu to not being cut off
+        'overflow-visible',
+        className,
+      )}
+    >
       <div className="border-border flex items-center gap-4 border-b px-2 pt-1">
         <QueryEditorPanelTabsList />
         <div className="flex-1" />
         <QueryEditorPanelActions />
       </div>
-
       {isSelectedOpen ? (
         <div className="bg-background h-full w-full py-1">
           <div className="relative h-full flex-grow">
             <div className="absolute inset-0">
-              {openTabs.map((queryId) => {
-                const isSelected = queryId === selectedQueryId;
-                return (
-                  <div
-                    key={queryId}
-                    className={cn(
-                      'absolute inset-0 transition-opacity duration-100',
-                      isSelected
-                        ? 'opacity-100'
-                        : 'pointer-events-none opacity-0',
-                    )}
-                    aria-hidden={!isSelected}
-                    {...(!isSelected ? {inert: true} : null)}
-                  >
-                    <QueryEditorPanelEditor queryId={queryId} />
-                  </div>
-                );
-              })}
+              <QueryEditorPanelEditor queryId={selectedQueryId} />
             </div>
           </div>
         </div>


### PR DESCRIPTION
Remove editor virtualization to fix the issue when tab reordering crashes the app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined the query editor panel by removing virtualization logic and simplifying to render only the currently selected editor, reducing code complexity while maintaining functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->