### PR TITLE
fix: Prevent horizontal scrolling in TabStrip.SearchDropdown

### DIFF
--- a/packages/ui/src/components/tab-strip.tsx
+++ b/packages/ui/src/components/tab-strip.tsx
@@ -594,7 +594,10 @@ function TabStripSearchDropdown({
       <DropdownMenuContent
         align="start"
         onCloseAutoFocus={(event) => event.preventDefault()}
-        className={cn('flex max-h-[400px] max-w-[240px] flex-col', className)}
+        className={cn(
+          'flex max-h-[400px] max-w-[240px] flex-col overflow-x-hidden',
+          className,
+        )}
       >
         <div className="flex flex-shrink-0 items-center gap-1 px-2">
           <SearchIcon className="text-muted-foreground" size={14} />
@@ -623,7 +626,7 @@ function TabStripSearchDropdown({
         </div>
         <DropdownMenuSeparator className="flex-shrink-0" />
 
-        <div className="overflow-y-auto">
+        <div className="overflow-y-auto overflow-x-hidden">
           {isSearching ? (
             filteredTabs.length === 0 ? (
               <DropdownTabItems


### PR DESCRIPTION
Prevents this:

<img width="253" height="253" alt="image" src="https://github.com/user-attachments/assets/07f1c431-a7cd-494b-a98e-7be634461b91" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed horizontal scrolling behavior in dropdown menus and content panels, preventing unwanted overflow in search results and dropdown areas for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->