### PR TITLE
fix: AI textarea not being scrollable if code is pasted

### DIFF
--- a/packages/ui/src/components/textarea.tsx
+++ b/packages/ui/src/components/textarea.tsx
@@ -17,11 +17,23 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       () => localRef.current as HTMLTextAreaElement,
     );
 
+    const [hasOverflow, setHasOverflow] = React.useState(false);
+
     const resizeToFitContent = React.useCallback(() => {
       const el = localRef.current;
       if (!el || !autoResize) return;
       el.style.height = 'auto';
       el.style.height = `${el.scrollHeight}px`;
+
+      // Check if content exceeds the max-height constraint
+      const computedStyle = window.getComputedStyle(el);
+      const maxHeight = computedStyle.maxHeight;
+      if (maxHeight && maxHeight !== 'none') {
+        const maxHeightValue = parseFloat(maxHeight);
+        setHasOverflow(el.scrollHeight > maxHeightValue);
+      } else {
+        setHasOverflow(false);
+      }
     }, [autoResize]);
 
     React.useEffect(() => {
@@ -38,7 +50,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       <textarea
         className={cn(
           'border-input placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-[60px] w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-sm focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
-          autoResize ? 'overflow-y-hidden' : undefined,
+          autoResize ? (hasOverflow ? 'overflow-y-auto' : 'overflow-y-hidden') : undefined,
           className,
         )}
         ref={localRef}


### PR DESCRIPTION
- Fix AI textbox` scroll not being activated when large amount of code are pasted using the AI help button.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved textarea overflow handling to properly display scrollbars when content exceeds the maximum height constraint, enhancing content visibility and user experience.
  * Enhanced automatic resize-to-fit functionality with better overflow detection and responsiveness to content changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->