### PR TITLE
fix: reasoning textbox converts text to lowercase

### DIFF
--- a/packages/ai-core/src/hooks/useToolGrouping.tsx
+++ b/packages/ai-core/src/hooks/useToolGrouping.tsx
@@ -292,8 +292,8 @@ function generateToolGroupTitle(
 
     const truncatedReasoning =
       reasoning && reasoning.length > maxReasoningLength
-        ? `${reasoning.substring(0, maxReasoningLength).toLowerCase()}...`
-        : reasoning?.toLowerCase();
+        ? `${reasoning.substring(0, maxReasoningLength)}...`
+        : reasoning;
 
     const titleText = truncatedReasoning
       ? `${baseTitle} ${truncatedReasoning}`


### PR DESCRIPTION
Thought bubble converts text to lowercase, 
This PR removes the text case conversion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tool group reasoning text display to preserve original capitalization instead of converting to lowercase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->