### PR TITLE
fix: add markdown to thought bubble

### DIFF
--- a/packages/ai-core/src/components/ToolPartRenderer.tsx
+++ b/packages/ai-core/src/components/ToolPartRenderer.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import Markdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import type {UIMessagePart} from '@sqlrooms/ai-config';
 import {useStoreWithAi} from '../AiSlice';
 import {isDynamicToolPart, isToolPart} from '../utils';
@@ -24,7 +26,11 @@ const AgentProgressRenderer: React.FC<{
   return (
     <div className="mt-2 px-5 text-[0.9em]">
       {reasoning ? (
-        <div className="mb-2 text-sm text-gray-500">{reasoning}</div>
+        <div className="mb-2 text-sm text-gray-500 prose prose-sm dark:prose-invert max-w-none">
+          <Markdown remarkPlugins={[remarkGfm]}>
+            {reasoning}
+          </Markdown>
+        </div>
       ) : null}
       <div className="ml-3">
         {agentToolCalls.map((toolCall) => {
@@ -72,7 +78,11 @@ const AgentProgressRenderer: React.FC<{
       </div>
       {finalOutput && (
         <div className="mt-3 pt-2">
-          <div className="text-gray-600">{finalOutput}</div>
+          <div className="text-gray-600 prose prose-sm dark:prose-invert max-w-none">
+            <Markdown remarkPlugins={[remarkGfm]}>
+              {finalOutput}
+            </Markdown>
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
Markdown responses in Thought bubble was shown as plain text before.
In this PR text is wrapped with Markdown processing component
![Uploading Screenshot 2026-02-10 at 13.54.04.png…]()




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool output display has been enhanced with full Markdown rendering support. Reasoning explanations and final results now render with improved visual formatting including styled text, lists, code blocks, and other markdown conventions, providing clearer and more organized output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->