### PR TITLE
fix: Avoid deckgl v8 type errors

### DIFF
--- a/packages/kepler/tsconfig.json
+++ b/packages/kepler/tsconfig.json
@@ -1,7 +1,15 @@
 {
   "extends": "@sqlrooms/preset-typescript/react-library.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "baseUrl": ".",
+    "paths": {
+      "@deck.gl/core/src/*": [
+        "../../node_modules/@deck.gl/core/typed/*",
+        "../../../node_modules/@deck.gl/core/typed/*",
+        "../../../../node_modules/@deck.gl/core/typed/*"
+      ]
+    }
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
Should prevent type errors in dev/build caused by having two versions of deck.gl in the monorepo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced TypeScript module resolution configuration with path aliasing support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
