### PR TITLE
feat: make View Instructions optional

### DIFF
--- a/packages/ai-settings/src/components/AiModelParameters.tsx
+++ b/packages/ai-settings/src/components/AiModelParameters.tsx
@@ -14,7 +14,13 @@ import {
 } from '@sqlrooms/ui';
 import {useStoreWithAiSettings} from '../AiSettingsSlice';
 
-export const AiModelParameters: FC = () => {
+export interface AiModelParametersProps {
+  showViewInstructions?: boolean;
+}
+
+export const AiModelParameters: FC<AiModelParametersProps> = ({
+  showViewInstructions = false,
+}) => {
   const maxSteps = useStoreWithAiSettings(
     (s) => s.aiSettings.config.modelParameters.maxSteps,
   );
@@ -109,6 +115,10 @@ export const AiModelParameters: FC = () => {
     fileInputRef.current?.click();
   };
 
+  const handleViewFullInstructions = () => {
+    onOpen();
+  };
+
   return (
     <div className="space-y-2">
       <label className="text-md flex items-center gap-2 pb-6 font-medium">
@@ -160,6 +170,17 @@ export const AiModelParameters: FC = () => {
               <Upload className="h-4 w-4" />
               Upload File
             </Button>
+            {showViewInstructions && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleViewFullInstructions}
+                className="flex items-center gap-2"
+              >
+                <Eye className="h-4 w-4" />
+                View Instructions
+              </Button>
+            )}
           </div>
           <Input
             ref={fileInputRef}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * AI Model Parameters component now supports configurable visibility of the View Instructions button, providing greater flexibility in how the interface displays this option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->