### PR TITLE
fix: AI settings changes are only applied in new sessions

### DIFF
--- a/packages/ai-core/src/AiSlice.ts
+++ b/packages/ai-core/src/AiSlice.ts
@@ -1077,13 +1077,10 @@ export function createAiSlice(
         chatHeaders,
 
         getLocalChatTransport: (sessionId: string) => {
-          const state = get();
           return createLocalChatTransportFactory({
             store,
             defaultProvider: defaultProvider,
             defaultModel: defaultModel,
-            apiKey: state.ai.getApiKeyFromSettings(),
-            baseUrl: state.ai.getBaseUrlFromSettings(),
             getInstructions: () => store.getState().ai.getFullInstructions(),
             getCustomModel,
             sessionId,

--- a/packages/ai-core/src/chatTransport.ts
+++ b/packages/ai-core/src/chatTransport.ts
@@ -37,8 +37,6 @@ export type ChatTransportConfig = {
   store: StoreApi<AiSliceStateForTransport>;
   defaultProvider: string;
   defaultModel: string;
-  apiKey: string;
-  baseUrl?: string;
   headers?: Record<string, string>;
   getInstructions: () => string;
   /**
@@ -131,8 +129,6 @@ export function createLocalChatTransportFactory({
   store,
   defaultProvider,
   defaultModel,
-  apiKey,
-  baseUrl,
   headers,
   getInstructions,
   getCustomModel,
@@ -149,11 +145,15 @@ export function createLocalChatTransportFactory({
       }
       const parsedObj = (parsed as {messages?: unknown}) || {};
 
-      // Resolve provider/model and client at call time to pick up latest settings.
+      // Resolve provider/model/apiKey/baseUrl at call time to pick up latest settings.
       const state = store.getState();
       const sessionFromBody = getSessionById(store, sessionId);
       const provider = sessionFromBody?.modelProvider || defaultProvider;
       const modelId = sessionFromBody?.model || defaultModel;
+
+      // Fetch API key and base URL dynamically to pick up settings changes
+      const apiKey = state.ai.getApiKeyFromSettings();
+      const baseUrl = state.ai.getBaseUrlFromSettings();
 
       // Prefer a user-supplied model if available
       let model: LanguageModel | undefined = getCustomModel?.();

--- a/packages/ai-core/src/types.ts
+++ b/packages/ai-core/src/types.ts
@@ -56,7 +56,10 @@ export interface AiStateForTransport {
   setSessionUiMessages: (sessionId: string, uiMessages: UIMessage[]) => void;
   findToolComponent: (toolName: string) => React.ComponentType | undefined;
   /** Map toolCallId -> sessionId for long-running tool streams (e.g. agents) */
-  setToolCallSession: (toolCallId: string, sessionId: string | undefined) => void;
+  setToolCallSession: (
+    toolCallId: string,
+    sessionId: string | undefined,
+  ) => void;
   getToolCallSession: (toolCallId: string) => string | undefined;
   waitForToolResult: (
     sessionId: string,
@@ -64,6 +67,10 @@ export interface AiStateForTransport {
     abortSignal?: AbortSignal,
   ) => Promise<void>;
   getFullInstructions: () => string;
+  /** Get API key from settings for the current session's provider */
+  getApiKeyFromSettings: () => string;
+  /** Get base URL from settings for the current session's provider */
+  getBaseUrlFromSettings: () => string | undefined;
 }
 
 /**


### PR DESCRIPTION
fixes https://github.com/sqlrooms/sqlrooms/issues/310


## Summary

The issue was that AI settings changes (like API keys) were only applied in new sessions because the API key and base URL were captured at transport creation time, not fetched dynamically when making requests.

### Root Cause

In `chatTransport.ts`, the `createLocalChatTransportFactory` function received `apiKey` and `baseUrl` as parameters and captured them in a closure. These values were only read once when the transport was created, not when each request was made.

### Changes Made

1. **`packages/ai-core/src/chatTransport.ts`**:
   - Removed `apiKey` and `baseUrl` from `ChatTransportConfig` type (lines 35-49)
   - Modified `createLocalChatTransportFactory` to fetch `apiKey` and `baseUrl` dynamically from the store at request time using `state.ai.getApiKeyFromSettings()` and `state.ai.getBaseUrlFromSettings()` (lines 154-156)

2. **`packages/ai-core/src/AiSlice.ts`**:
   - Removed the `apiKey` and `baseUrl` parameters from the `createLocalChatTransportFactory` call in `getLocalChatTransport` (lines 1079-1087)

3. **`packages/ai-core/src/types.ts`**:
   - Added `getApiKeyFromSettings` and `getBaseUrlFromSettings` methods to the `AiStateForTransport` interface so they can be called from the transport (lines 68-71)

### How It Works Now

When a chat request is made, the transport now:
1. Gets the current state from the store
2. Fetches the API key using `state.ai.getApiKeyFromSettings()` which reads from the latest settings
3. Fetches the base URL using `state.ai.getBaseUrlFromSettings()` which reads from the latest settings
4. Creates the OpenAI-compatible client with the fresh credentials

This means that if a user adds or changes their API key in settings, the next chat message in any existing session will use the updated credentials without needing to create a new session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced API credential management in chat transport operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->