### PR TITLE
feat: Ai model persistence migration

### DIFF
--- a/examples/ai/src/store.ts
+++ b/examples/ai/src/store.ts
@@ -5,9 +5,10 @@ import {
   AiSliceState,
   createAiSettingsSlice,
   createAiSlice,
+  createDefaultAiInstructions,
+  createDefaultAiSettingsConfig,
   createDefaultAiTools,
   createDefaultAiToolRenderers,
-  createDefaultAiInstructions,
 } from '@sqlrooms/ai';
 import {
   BaseRoomConfig,
@@ -51,9 +52,30 @@ export type RoomState = RoomShellSliceState &
  * Create a customized room store
  */
 export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
-  persistSliceConfigs(
+  persistSliceConfigs<RoomState>(
     {
       name: 'ai-example-app-state-storage',
+      version: 1,
+      migrate: ((persistedState: unknown) => {
+        if (
+          typeof persistedState !== 'object' ||
+          persistedState === null ||
+          !('aiSettings' in persistedState)
+        ) {
+          return persistedState;
+        }
+
+        const defaults = createDefaultAiSettingsConfig(AI_SETTINGS);
+        const state = persistedState as Record<string, unknown>;
+
+        return {
+          ...state,
+          aiSettings: AiSettingsSliceConfig.parse({
+            defaults,
+            persisted: state.aiSettings,
+          }),
+        };
+      }) as any,
       sliceConfigSchemas: {
         room: BaseRoomConfig,
         layout: LayoutConfig,

--- a/examples/ai/src/store.ts
+++ b/examples/ai/src/store.ts
@@ -56,13 +56,14 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
     {
       name: 'ai-example-app-state-storage',
       version: 1,
-      migrate: ((persistedState: unknown) => {
+      migrate: (persistedState: unknown, version: number): RoomState => {
+        if (version >= 1) return persistedState as RoomState;
         if (
           typeof persistedState !== 'object' ||
           persistedState === null ||
           !('aiSettings' in persistedState)
         ) {
-          return persistedState;
+          return persistedState as RoomState;
         }
 
         const defaults = createDefaultAiSettingsConfig(AI_SETTINGS);
@@ -74,8 +75,8 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
             defaults,
             persisted: state.aiSettings,
           }),
-        };
-      }) as any,
+        } as unknown as RoomState;
+      },
       sliceConfigSchemas: {
         room: BaseRoomConfig,
         layout: LayoutConfig,

--- a/packages/ai-config/__tests__/AiSettingsSliceConfig.test.ts
+++ b/packages/ai-config/__tests__/AiSettingsSliceConfig.test.ts
@@ -1,0 +1,79 @@
+import {describe, expect, it} from '@jest/globals';
+import {AiSettingsSliceConfig} from '../src/AiSettingsSliceConfig';
+
+const defaults = {
+  providers: {
+    openai: {
+      baseUrl: 'https://api.openai.com/v1',
+      apiKey: '',
+      models: [{modelName: 'gpt-5'}, {modelName: 'gpt-4.1'}],
+    },
+    anthropic: {
+      baseUrl: 'https://api.anthropic.com/v1',
+      apiKey: '',
+      models: [{modelName: 'claude-3-5-sonnet'}],
+    },
+  },
+  customModels: [],
+  modelParameters: {
+    maxSteps: 50,
+    additionalInstruction: '',
+  },
+};
+
+describe('AiSettingsSliceConfig', () => {
+  it('strictly prunes removed providers/models while preserving mutable provider fields', () => {
+    const merged = AiSettingsSliceConfig.parse({
+      defaults,
+      persisted: {
+        providers: {
+          openai: {
+            baseUrl: 'https://custom-openai.example/v1',
+            apiKey: 'sk-test',
+            models: [{modelName: 'gpt-5'}, {modelName: 'legacy-model'}],
+          },
+          removedProvider: {
+            baseUrl: 'https://removed.example',
+            apiKey: 'removed-key',
+            models: [{modelName: 'removed-model'}],
+          },
+        },
+        customModels: [
+          {
+            baseUrl: 'http://localhost:11434/v1',
+            apiKey: '',
+            modelName: 'qwen3',
+          },
+        ],
+        modelParameters: {
+          maxSteps: 12,
+          additionalInstruction: 'Always return JSON.',
+        },
+      },
+    });
+
+    expect(Object.keys(merged.providers)).toEqual(['openai', 'anthropic']);
+    expect(merged.providers.openai.baseUrl).toBe(
+      'https://custom-openai.example/v1',
+    );
+    expect(merged.providers.openai.apiKey).toBe('sk-test');
+    expect(merged.providers.openai.models.map((m) => m.modelName)).toEqual([
+      'gpt-5',
+      'gpt-4.1',
+    ]);
+    expect(merged.providers.anthropic.models.map((m) => m.modelName)).toEqual([
+      'claude-3-5-sonnet',
+    ]);
+    expect(merged.customModels.map((m) => m.modelName)).toEqual(['qwen3']);
+    expect(merged.modelParameters.maxSteps).toBe(12);
+  });
+
+  it('falls back to defaults when persisted settings are missing', () => {
+    const merged = AiSettingsSliceConfig.parse({
+      defaults,
+      persisted: undefined,
+    });
+
+    expect(merged).toEqual(defaults);
+  });
+});

--- a/packages/ai-config/__tests__/AiSettingsSliceConfig.test.ts
+++ b/packages/ai-config/__tests__/AiSettingsSliceConfig.test.ts
@@ -22,7 +22,7 @@ const defaults = {
 };
 
 describe('AiSettingsSliceConfig', () => {
-  it('strictly prunes removed providers/models while preserving mutable provider fields', () => {
+  it('adds code defaults while preserving persisted provider fields and user additions', () => {
     const merged = AiSettingsSliceConfig.parse({
       defaults,
       persisted: {
@@ -32,10 +32,10 @@ describe('AiSettingsSliceConfig', () => {
             apiKey: 'sk-test',
             models: [{modelName: 'gpt-5'}, {modelName: 'legacy-model'}],
           },
-          removedProvider: {
-            baseUrl: 'https://removed.example',
-            apiKey: 'removed-key',
-            models: [{modelName: 'removed-model'}],
+          customProvider: {
+            baseUrl: 'https://custom.example',
+            apiKey: 'custom-key',
+            models: [{modelName: 'custom-provider-model'}],
           },
         },
         customModels: [
@@ -52,7 +52,11 @@ describe('AiSettingsSliceConfig', () => {
       },
     });
 
-    expect(Object.keys(merged.providers)).toEqual(['openai', 'anthropic']);
+    expect(Object.keys(merged.providers)).toEqual([
+      'openai',
+      'anthropic',
+      'customProvider',
+    ]);
     expect(merged.providers.openai.baseUrl).toBe(
       'https://custom-openai.example/v1',
     );
@@ -60,10 +64,14 @@ describe('AiSettingsSliceConfig', () => {
     expect(merged.providers.openai.models.map((m) => m.modelName)).toEqual([
       'gpt-5',
       'gpt-4.1',
+      'legacy-model',
     ]);
     expect(merged.providers.anthropic.models.map((m) => m.modelName)).toEqual([
       'claude-3-5-sonnet',
     ]);
+    expect(
+      merged.providers.customProvider.models.map((m) => m.modelName),
+    ).toEqual(['custom-provider-model']);
     expect(merged.customModels.map((m) => m.modelName)).toEqual(['qwen3']);
     expect(merged.modelParameters.maxSteps).toBe(12);
   });

--- a/packages/ai-config/jest.config.js
+++ b/packages/ai-config/jest.config.js
@@ -1,0 +1,6 @@
+import nodeConfig from '@sqlrooms/preset-jest/node.js';
+
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+export default {
+  ...nodeConfig,
+};

--- a/packages/ai-config/package.json
+++ b/packages/ai-config/package.json
@@ -26,6 +26,13 @@
     "@paralleldrive/cuid2": "^3.0.0",
     "zod": "^4.1.8"
   },
+  "devDependencies": {
+    "@jest/globals": "^30.2.0",
+    "@sqlrooms/preset-jest": "workspace:*",
+    "@types/jest": "^30.0.0",
+    "jest": "^30.1.3",
+    "ts-jest": "^29.4.4"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/ai-config/package.json
+++ b/packages/ai-config/package.json
@@ -19,6 +19,7 @@
     "build": "tsc",
     "dev": "tsc -w",
     "lint": "eslint .",
+    "test": "jest",
     "typecheck": "tsc --noEmit",
     "typedoc": "typedoc"
   },

--- a/packages/ai-config/src/AiSettingsSliceConfig.ts
+++ b/packages/ai-config/src/AiSettingsSliceConfig.ts
@@ -1,5 +1,13 @@
 import {z} from 'zod';
 
+/**
+ * Shared symbol contract with `@sqlrooms/room-store`'s `createPersistHelpers`.
+ *
+ * `Symbol.for(...)` keeps this package aligned with `room-store` at runtime
+ * without introducing a direct runtime dependency.
+ */
+const PersistMergeInputSymbol = Symbol.for('sqlrooms.persist.mergeInput');
+
 const AiProviderModelSchema = z.object({
   modelName: z.string(),
 });
@@ -147,3 +155,22 @@ export const AiSettingsSliceConfig = z.preprocess((data) => {
 
   return data;
 }, AiSettingsSliceConfigSchema);
+
+Object.assign(AiSettingsSliceConfig, {
+  /**
+   * Opt this schema into defaults-aware rehydrate input.
+   *
+   * `createPersistHelpers.merge` reads this marker and passes the returned
+   * object into this schema's `preprocess`, which handles the merge.
+   */
+  [PersistMergeInputSymbol]: ({
+    defaults,
+    persisted,
+  }: {
+    defaults: unknown;
+    persisted: unknown;
+  }) => ({
+    defaults,
+    persisted,
+  }),
+});

--- a/packages/ai-config/src/AiSettingsSliceConfig.ts
+++ b/packages/ai-config/src/AiSettingsSliceConfig.ts
@@ -43,7 +43,7 @@ type AiSettingsProviderConfig = z.infer<typeof AiProviderSchema>;
 export type AiSettingsSliceConfig = z.infer<typeof AiSettingsSliceConfigSchema>;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function mergeProviderModels(

--- a/packages/ai-config/src/AiSettingsSliceConfig.ts
+++ b/packages/ai-config/src/AiSettingsSliceConfig.ts
@@ -1,30 +1,149 @@
 import {z} from 'zod';
 
-export const AiSettingsSliceConfig = z.object({
-  providers: z.record(
-    z.string(), // provider name
-    z.object({
-      baseUrl: z.string(),
-      apiKey: z.string(),
-      models: z.array(
-        z.object({
-          modelName: z.string(),
-        }),
-      ),
-    }),
-  ),
-  // custom models using provider 'custom'
-  customModels: z.array(
-    z.object({
-      baseUrl: z.string(),
-      apiKey: z.string(),
-      modelName: z.string(),
-    }),
-  ),
-  modelParameters: z.object({
-    maxSteps: z.number(),
-    additionalInstruction: z.string(),
-  }),
+const AiProviderModelSchema = z.object({
+  modelName: z.string(),
 });
 
-export type AiSettingsSliceConfig = z.infer<typeof AiSettingsSliceConfig>;
+const AiProviderSchema = z.object({
+  baseUrl: z.string(),
+  apiKey: z.string(),
+  models: z.array(AiProviderModelSchema),
+});
+
+const AiCustomModelSchema = z.object({
+  baseUrl: z.string(),
+  apiKey: z.string(),
+  modelName: z.string(),
+});
+
+const AiModelParametersSchema = z.object({
+  maxSteps: z.number(),
+  additionalInstruction: z.string(),
+});
+
+const AiSettingsSliceConfigSchema = z.object({
+  providers: z.record(
+    z.string(), // provider name
+    AiProviderSchema,
+  ),
+  // custom models using provider 'custom'
+  customModels: z.array(AiCustomModelSchema),
+  modelParameters: AiModelParametersSchema,
+});
+
+type AiSettingsProviderConfig = z.infer<typeof AiProviderSchema>;
+export type AiSettingsSliceConfig = z.infer<typeof AiSettingsSliceConfigSchema>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function mergeProviderModels(
+  defaultProvider: AiSettingsProviderConfig,
+  persistedProvider: unknown,
+) {
+  if (
+    !isRecord(persistedProvider) ||
+    !Array.isArray(persistedProvider.models)
+  ) {
+    return defaultProvider.models;
+  }
+
+  const persistedByModelName = new Map<string, Record<string, unknown>>();
+  for (const model of persistedProvider.models) {
+    if (!isRecord(model) || typeof model.modelName !== 'string') {
+      continue;
+    }
+    persistedByModelName.set(model.modelName, model);
+  }
+
+  // Strict prune: only keep models present in code defaults.
+  return defaultProvider.models.map((defaultModel) => {
+    const persistedModel = persistedByModelName.get(defaultModel.modelName);
+    if (!persistedModel) return defaultModel;
+    return {
+      ...defaultModel,
+      ...persistedModel,
+      modelName: defaultModel.modelName,
+    };
+  });
+}
+
+export function mergeAiSettingsWithDefaults(
+  defaults: AiSettingsSliceConfig,
+  persisted: unknown,
+): AiSettingsSliceConfig {
+  if (!isRecord(persisted)) {
+    return defaults;
+  }
+
+  const persistedProviders = isRecord(persisted.providers)
+    ? persisted.providers
+    : undefined;
+
+  const providers = Object.fromEntries(
+    Object.entries(defaults.providers).map(
+      ([providerName, defaultProvider]) => {
+        const persistedProvider =
+          persistedProviders && isRecord(persistedProviders[providerName])
+            ? persistedProviders[providerName]
+            : undefined;
+
+        return [
+          providerName,
+          {
+            ...defaultProvider,
+            baseUrl:
+              persistedProvider && typeof persistedProvider.baseUrl === 'string'
+                ? persistedProvider.baseUrl
+                : defaultProvider.baseUrl,
+            apiKey:
+              persistedProvider && typeof persistedProvider.apiKey === 'string'
+                ? persistedProvider.apiKey
+                : defaultProvider.apiKey,
+            models: mergeProviderModels(defaultProvider, persistedProvider),
+          },
+        ];
+      },
+    ),
+  );
+
+  const customModels = AiSettingsSliceConfigSchema.shape.customModels.safeParse(
+    persisted.customModels,
+  );
+
+  const modelParameters = AiSettingsSliceConfigSchema.shape.modelParameters
+    .partial()
+    .safeParse(persisted.modelParameters);
+
+  return AiSettingsSliceConfigSchema.parse({
+    ...defaults,
+    providers,
+    customModels: customModels.success
+      ? customModels.data
+      : defaults.customModels,
+    modelParameters: {
+      ...defaults.modelParameters,
+      ...(modelParameters.success ? modelParameters.data : {}),
+    },
+  });
+}
+
+const MergeAiSettingsInputSchema = z.object({
+  defaults: AiSettingsSliceConfigSchema,
+  persisted: z.unknown(),
+});
+
+export const AiSettingsSliceConfig = z.preprocess((data) => {
+  if (isRecord(data)) {
+    const mergeInput = MergeAiSettingsInputSchema.safeParse(data);
+    if (mergeInput.success) {
+      return mergeAiSettingsWithDefaults(
+        mergeInput.data.defaults,
+        mergeInput.data.persisted,
+      );
+    }
+  }
+
+  return data;
+}, AiSettingsSliceConfigSchema);

--- a/packages/ai-config/src/AiSettingsSliceConfig.ts
+++ b/packages/ai-config/src/AiSettingsSliceConfig.ts
@@ -58,23 +58,33 @@ function mergeProviderModels(
   }
 
   const persistedByModelName = new Map<string, Record<string, unknown>>();
+  const persistedModels: Record<string, unknown>[] = [];
   for (const model of persistedProvider.models) {
     if (!isRecord(model) || typeof model.modelName !== 'string') {
       continue;
     }
+    persistedModels.push(model);
     persistedByModelName.set(model.modelName, model);
   }
 
-  // Strict prune: only keep models present in code defaults.
-  return defaultProvider.models.map((defaultModel) => {
-    const persistedModel = persistedByModelName.get(defaultModel.modelName);
-    if (!persistedModel) return defaultModel;
-    return {
-      ...defaultModel,
-      ...persistedModel,
-      modelName: defaultModel.modelName,
-    };
-  });
+  const defaultModelNames = new Set(
+    defaultProvider.models.map((model) => model.modelName),
+  );
+
+  return [
+    ...defaultProvider.models.map((defaultModel) => {
+      const persistedModel = persistedByModelName.get(defaultModel.modelName);
+      if (!persistedModel) return defaultModel;
+      return {
+        ...defaultModel,
+        ...persistedModel,
+        modelName: defaultModel.modelName,
+      };
+    }),
+    ...persistedModels
+      .filter((model) => !defaultModelNames.has(model.modelName as string))
+      .map((model) => AiProviderModelSchema.parse(model)),
+  ];
 }
 
 export function mergeAiSettingsWithDefaults(
@@ -89,8 +99,8 @@ export function mergeAiSettingsWithDefaults(
     ? persisted.providers
     : undefined;
 
-  const providers = Object.fromEntries(
-    Object.entries(defaults.providers).map(
+  const providers = Object.fromEntries([
+    ...Object.entries(defaults.providers).map(
       ([providerName, defaultProvider]) => {
         const persistedProvider =
           persistedProviders && isRecord(persistedProviders[providerName])
@@ -114,7 +124,13 @@ export function mergeAiSettingsWithDefaults(
         ];
       },
     ),
-  );
+    ...Object.entries(persistedProviders ?? {})
+      .filter(([providerName]) => !(providerName in defaults.providers))
+      .flatMap(([providerName, persistedProvider]) => {
+        const parsed = AiProviderSchema.safeParse(persistedProvider);
+        return parsed.success ? [[providerName, parsed.data] as const] : [];
+      }),
+  ]);
 
   const customModels = AiSettingsSliceConfigSchema.shape.customModels.safeParse(
     persisted.customModels,

--- a/packages/room-store/__tests__/CommandSlice.test.ts
+++ b/packages/room-store/__tests__/CommandSlice.test.ts
@@ -1,3 +1,4 @@
+import {jest} from '@jest/globals';
 import {createStore} from 'zustand';
 import {z} from 'zod';
 import {createBaseRoomSlice, BaseRoomStoreState} from '../src/BaseRoomStore';

--- a/packages/room-store/__tests__/createPersistHelpers.test.ts
+++ b/packages/room-store/__tests__/createPersistHelpers.test.ts
@@ -1,0 +1,87 @@
+import {describe, expect, it} from '@jest/globals';
+import {z} from 'zod';
+import {AiSettingsSliceConfig} from '../../ai-config/src/AiSettingsSliceConfig';
+import {createPersistHelpers} from '../src/createPersistHelpers';
+
+const defaults = {
+  providers: {
+    openai: {
+      baseUrl: 'https://api.openai.com/v1',
+      apiKey: '',
+      models: [{modelName: 'gpt-5'}, {modelName: 'gpt-4.1'}],
+    },
+    anthropic: {
+      baseUrl: 'https://api.anthropic.com/v1',
+      apiKey: '',
+      models: [{modelName: 'claude-3-5-sonnet'}],
+    },
+  },
+  customModels: [],
+  modelParameters: {
+    maxSteps: 50,
+    additionalInstruction: '',
+  },
+};
+
+describe('createPersistHelpers.merge', () => {
+  it('keeps current state when persisted slice is missing', () => {
+    const helpers = createPersistHelpers({
+      room: z.object({title: z.string()}),
+      aiSettings: AiSettingsSliceConfig,
+    });
+
+    const currentState = {
+      room: {config: {title: 'Demo room'}},
+      aiSettings: {config: defaults},
+    };
+
+    const merged = helpers.merge(undefined, currentState);
+
+    expect(merged).toEqual(currentState);
+  });
+
+  it('applies strict-prune aiSettings merge on rehydrate', () => {
+    const helpers = createPersistHelpers({
+      aiSettings: AiSettingsSliceConfig,
+    });
+
+    const currentState = {
+      aiSettings: {
+        config: defaults,
+      },
+    };
+
+    const merged = helpers.merge(
+      {
+        aiSettings: {
+          providers: {
+            openai: {
+              baseUrl: 'https://custom-openai.example/v1',
+              apiKey: 'sk-test',
+              models: [{modelName: 'gpt-5'}, {modelName: 'legacy-model'}],
+            },
+            removedProvider: {
+              baseUrl: 'https://removed.example/v1',
+              apiKey: 'removed-key',
+              models: [{modelName: 'removed-model'}],
+            },
+          },
+          customModels: [],
+          modelParameters: {maxSteps: 20, additionalInstruction: ''},
+        },
+      },
+      currentState,
+    );
+
+    expect(Object.keys(merged.aiSettings.config.providers)).toEqual([
+      'openai',
+      'anthropic',
+    ]);
+    expect(
+      merged.aiSettings.config.providers.openai.models.map((m) => m.modelName),
+    ).toEqual(['gpt-5', 'gpt-4.1']);
+    expect(merged.aiSettings.config.providers.openai.baseUrl).toBe(
+      'https://custom-openai.example/v1',
+    );
+  });
+});

--- a/packages/room-store/__tests__/createPersistHelpers.test.ts
+++ b/packages/room-store/__tests__/createPersistHelpers.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from '@jest/globals';
+import {AiSettingsSliceConfig} from '@sqlrooms/ai-config';
 import {z} from 'zod';
-import {AiSettingsSliceConfig} from '../../ai-config/src/AiSettingsSliceConfig';
 import {createPersistHelpers} from '../src/createPersistHelpers';
 
 const defaults = {

--- a/packages/room-store/__tests__/createPersistHelpers.test.ts
+++ b/packages/room-store/__tests__/createPersistHelpers.test.ts
@@ -1,10 +1,9 @@
 import {describe, expect, it} from '@jest/globals';
 import {AiSettingsSliceConfig} from '@sqlrooms/ai-config';
 import {z} from 'zod';
-import {
-  createPersistHelpers,
-  PersistMergeInputSymbol,
-} from '../src/createPersistHelpers';
+import {createPersistHelpers} from '../src/createPersistHelpers';
+
+const PersistMergeInputSymbol = Symbol.for('sqlrooms.persist.mergeInput');
 
 const defaults = {
   providers: {
@@ -43,7 +42,7 @@ describe('createPersistHelpers.merge', () => {
     expect(merged).toEqual(currentState);
   });
 
-  it('applies strict-prune aiSettings merge on rehydrate', () => {
+  it('applies defaults-aware aiSettings merge on rehydrate', () => {
     const helpers = createPersistHelpers({
       aiSettings: AiSettingsSliceConfig,
     });
@@ -63,10 +62,10 @@ describe('createPersistHelpers.merge', () => {
               apiKey: 'sk-test',
               models: [{modelName: 'gpt-5'}, {modelName: 'legacy-model'}],
             },
-            removedProvider: {
-              baseUrl: 'https://removed.example/v1',
-              apiKey: 'removed-key',
-              models: [{modelName: 'removed-model'}],
+            customProvider: {
+              baseUrl: 'https://custom.example/v1',
+              apiKey: 'custom-key',
+              models: [{modelName: 'custom-provider-model'}],
             },
           },
           customModels: [],
@@ -79,12 +78,18 @@ describe('createPersistHelpers.merge', () => {
     expect(Object.keys(merged.aiSettings.config.providers)).toEqual([
       'openai',
       'anthropic',
+      'customProvider',
     ]);
     expect(
       merged.aiSettings.config.providers.openai.models.map(
         (m: {modelName: string}) => m.modelName,
       ),
-    ).toEqual(['gpt-5', 'gpt-4.1']);
+    ).toEqual(['gpt-5', 'gpt-4.1', 'legacy-model']);
+    expect(
+      merged.aiSettings.config.providers.customProvider.models.map(
+        (m: {modelName: string}) => m.modelName,
+      ),
+    ).toEqual(['custom-provider-model']);
     expect(merged.aiSettings.config.providers.openai.baseUrl).toBe(
       'https://custom-openai.example/v1',
     );

--- a/packages/room-store/package.json
+++ b/packages/room-store/package.json
@@ -31,7 +31,10 @@
     "zustand": "^5.0.8"
   },
   "devDependencies": {
+    "@jest/globals": "^30.2.0",
     "@sqlrooms/preset-jest": "workspace:*",
+    "@types/jest": "^30.0.0",
+    "jest": "^30.1.3",
     "ts-jest": "^29.4.4"
   },
   "peerDependencies": {

--- a/packages/room-store/package.json
+++ b/packages/room-store/package.json
@@ -31,6 +31,7 @@
     "zustand": "^5.0.8"
   },
   "devDependencies": {
+    "@sqlrooms/ai-config": "workspace:*",
     "@jest/globals": "^30.2.0",
     "@sqlrooms/preset-jest": "workspace:*",
     "@types/jest": "^30.0.0",

--- a/packages/room-store/package.json
+++ b/packages/room-store/package.json
@@ -19,8 +19,8 @@
     "build": "tsc",
     "dev": "tsc -w",
     "lint": "eslint .",
-    "test": "jest",
-    "test:watch": "jest --watch",
+    "test": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest",
+    "test:watch": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest --watch",
     "typecheck": "tsc --noEmit",
     "typedoc": "typedoc"
   },

--- a/packages/room-store/src/createPersistHelpers.ts
+++ b/packages/room-store/src/createPersistHelpers.ts
@@ -77,10 +77,24 @@ export function createPersistHelpers<T extends Record<string, z.ZodType>>(
     merge: (persistedState: any, currentState: any) => {
       const merged = {...currentState};
       for (const [key, schema] of Object.entries(sliceConfigs)) {
+        const persistedConfig = persistedState?.[key];
+
+        if (persistedConfig === undefined || persistedConfig === null) {
+          continue;
+        }
+
         try {
+          const config =
+            key === 'aiSettings'
+              ? schema.parse({
+                  defaults: currentState[key]?.config,
+                  persisted: persistedConfig,
+                })
+              : schema.parse(persistedConfig);
+
           merged[key] = {
             ...currentState[key],
-            config: schema.parse(persistedState[key]),
+            config,
           };
         } catch (error) {
           throw new Error(`Error parsing config key "${key}"`, {

--- a/packages/room-store/src/createPersistHelpers.ts
+++ b/packages/room-store/src/createPersistHelpers.ts
@@ -1,5 +1,5 @@
-import {persist, PersistOptions} from 'zustand/middleware';
 import z from 'zod';
+import {persist, PersistOptions} from 'zustand/middleware';
 import {StateCreator} from './BaseRoomStore';
 
 /**
@@ -30,11 +30,52 @@ function createSafeStorage<S>(
 }
 
 /**
+ * Symbol-based extension point for schema-specific rehydrate merge input.
+ *
+ * If a Zod schema sets a function under this symbol, `createPersistHelpers().merge`
+ * will call it with `{defaults, persisted}` and parse the returned value instead of
+ * parsing `persisted` directly.
+ *
+ * This allows slices to opt into defaults-aware merging without hard-coding slice keys.
+ */
+export const PersistMergeInputSymbol = Symbol.for(
+  'sqlrooms.persist.mergeInput',
+);
+
+/**
+ * Builds the value passed to `schema.parse(...)` during rehydrate merge.
+ */
+type PersistMergeInputBuilder = (params: {
+  persisted: unknown;
+  defaults: unknown;
+}) => unknown;
+
+function getPersistMergeInputBuilder(
+  schema: z.ZodType,
+): PersistMergeInputBuilder | undefined {
+  // Schemas can optionally expose a merge-input builder under this symbol.
+  // This lets slices define custom rehydrate behavior without key-based branching.
+  const marker = (
+    schema as z.ZodType & {
+      [PersistMergeInputSymbol]?: PersistMergeInputBuilder;
+    }
+  )[PersistMergeInputSymbol];
+
+  return typeof marker === 'function' ? marker : undefined;
+}
+
+/**
  * Creates partialize and merge functions for Zustand persist middleware.
  * Automatically handles extracting and merging slice configs.
  *
  * @param sliceConfigs - Map of slice names to their Zod config schemas
  * @returns Object with partialize and merge functions
+ *   - `partialize`: serializes `state[slice].config` for each configured slice
+ *   - `merge`: rehydrates each slice config from persisted storage
+ *
+ * `merge` supports schema-level customization via `PersistMergeInputSymbol`.
+ * When present on a schema, the marker function receives the current defaults and
+ * persisted value and can return custom parse input for `schema.parse(...)`.
  *
  * @example
  * ```ts
@@ -84,13 +125,17 @@ export function createPersistHelpers<T extends Record<string, z.ZodType>>(
         }
 
         try {
-          const config =
-            key === 'aiSettings'
-              ? schema.parse({
-                  defaults: currentState[key]?.config,
-                  persisted: persistedConfig,
-                })
-              : schema.parse(persistedConfig);
+          // Default behavior parses persisted config as-is.
+          // If a schema declares a merge-input builder, we pass both persisted
+          // and current defaults so that schema can merge before validation.
+          const parseMergeInput = getPersistMergeInputBuilder(schema);
+          const mergeInput = parseMergeInput
+            ? parseMergeInput({
+                defaults: currentState[key]?.config,
+                persisted: persistedConfig,
+              })
+            : persistedConfig;
+          const config = schema.parse(mergeInput);
 
           merged[key] = {
             ...currentState[key],

--- a/packages/room-store/src/createPersistHelpers.ts
+++ b/packages/room-store/src/createPersistHelpers.ts
@@ -30,7 +30,7 @@ function createSafeStorage<S>(
 }
 
 /**
- * Symbol-based extension point for schema-specific rehydrate merge input.
+ * Internal symbol-based hook for schema-specific rehydrate merge input.
  *
  * If a Zod schema sets a function under this symbol, `createPersistHelpers().merge`
  * will call it with `{defaults, persisted}` and parse the returned value instead of
@@ -38,9 +38,7 @@ function createSafeStorage<S>(
  *
  * This allows slices to opt into defaults-aware merging without hard-coding slice keys.
  */
-export const PersistMergeInputSymbol = Symbol.for(
-  'sqlrooms.persist.mergeInput',
-);
+const PersistMergeInputSymbol = Symbol.for('sqlrooms.persist.mergeInput');
 
 /**
  * Builds the value passed to `schema.parse(...)` during rehydrate merge.
@@ -73,7 +71,7 @@ function getPersistMergeInputBuilder(
  *   - `partialize`: serializes `state[slice].config` for each configured slice
  *   - `merge`: rehydrates each slice config from persisted storage
  *
- * `merge` supports schema-level customization via `PersistMergeInputSymbol`.
+ * `merge` supports schema-level customization via an internal symbol marker.
  * When present on a schema, the marker function receives the current defaults and
  * persisted value and can return custom parse input for `schema.parse(...)`.
  *

--- a/packages/room-store/src/index.ts
+++ b/packages/room-store/src/index.ts
@@ -31,7 +31,6 @@ export type {
 
 export type {StateCreator, StoreApi} from 'zustand';
 export {
-  PersistMergeInputSymbol,
   createPersistHelpers,
   persistSliceConfigs,
 } from './createPersistHelpers';

--- a/packages/room-store/src/index.ts
+++ b/packages/room-store/src/index.ts
@@ -31,6 +31,7 @@ export type {
 
 export type {StateCreator, StoreApi} from 'zustand';
 export {
+  PersistMergeInputSymbol,
   createPersistHelpers,
   persistSliceConfigs,
 } from './createPersistHelpers';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3879,6 +3879,9 @@ importers:
       '@jest/globals':
         specifier: ^30.2.0
         version: 30.4.1
+      '@sqlrooms/ai-config':
+        specifier: workspace:*
+        version: link:../ai-config
       '@sqlrooms/preset-jest':
         specifier: workspace:*
         version: link:../preset-jest

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2400,6 +2400,22 @@ importers:
       zod:
         specifier: ^4.1.8
         version: 4.1.13
+    devDependencies:
+      '@jest/globals':
+        specifier: ^30.2.0
+        version: 30.4.1
+      '@sqlrooms/preset-jest':
+        specifier: workspace:*
+        version: link:../preset-jest
+      '@types/jest':
+        specifier: ^30.0.0
+        version: 30.0.0
+      jest:
+        specifier: ^30.1.3
+        version: 30.4.2(@types/node@24.12.4)
+      ts-jest:
+        specifier: ^29.4.4
+        version: 29.4.9(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(jest-util@30.4.1)(jest@30.4.2(@types/node@24.12.4))(typescript@5.9.3)
 
   packages/ai-core:
     dependencies:
@@ -3860,9 +3876,18 @@ importers:
         specifier: ^5.0.8
         version: 5.0.13(@types/react@19.2.7)(immer@11.1.8)(react@19.2.1)(use-sync-external-store@1.6.0(react@19.2.1))
     devDependencies:
+      '@jest/globals':
+        specifier: ^30.2.0
+        version: 30.4.1
       '@sqlrooms/preset-jest':
         specifier: workspace:*
         version: link:../preset-jest
+      '@types/jest':
+        specifier: ^30.0.0
+        version: 30.0.0
+      jest:
+        specifier: ^30.1.3
+        version: 30.4.2(@types/node@24.12.4)
       ts-jest:
         specifier: ^29.4.4
         version: 29.4.9(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(jest-util@30.4.1)(jest@30.4.2(@types/node@24.12.4))(typescript@5.9.3)


### PR DESCRIPTION
fixes #311


Ensure model additions/removals in code are reflected for existing users with persisted local storage, with strict prune behavior and implementation centered in schema preprocessing + migration.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persisted AI settings now migrate on load: merged with defaults, normalized, and strictly prune removed providers/models while preserving validated fields.

* **Tests**
  * Added unit tests covering AI settings parsing, defaults-aware merges, and rehydration/strict-prune behavior.

* **Chores**
  * Added test configuration and test scripts/dev-dependencies to enable running the new test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->