### PR TITLE
fix: add onExportStart event

### DIFF
--- a/packages/kepler/src/components/KeplerImageExport.tsx
+++ b/packages/kepler/src/components/KeplerImageExport.tsx
@@ -29,6 +29,7 @@ export interface KeplerImageExportProps {
   cleanupExportImage: () => void;
   exportImageSettings: ExportImage;
   fileName?: string;
+  onExportStart?: () => void;
 }
 
 export const KeplerImageExport: React.FC<KeplerImageExportProps> = ({
@@ -36,6 +37,7 @@ export const KeplerImageExport: React.FC<KeplerImageExportProps> = ({
   cleanupExportImage,
   exportImageSettings,
   fileName,
+  onExportStart,
 }) => {
   const {legend, ratio, resolution, processing, imageDataUri} =
     exportImageSettings;
@@ -49,10 +51,11 @@ export const KeplerImageExport: React.FC<KeplerImageExportProps> = ({
 
   const handleExportImage = useCallback(() => {
     if (!processing && imageDataUri) {
+      onExportStart?.();
       const file = dataURItoBlob(imageDataUri);
       downloadFile(file, `${fileName || 'Untitled'}.png`);
     }
-  }, [processing, imageDataUri, fileName]);
+  }, [processing, imageDataUri, fileName, onExportStart]);
 
   return (
     <div className="flex flex-col gap-6 px-[5px] pb-5 pt-1">


### PR DESCRIPTION
Add a on export start event to KeplerImageExport

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image export now supports optional start callbacks, enabling applications to perform custom actions when the export process initiates. This feature allows for enhanced user feedback through loading indicators, progress notifications, status messages, or activity tracking, giving users clear visibility into the export operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->