### PR TITLE
fix: improve sql error display in vega charts

### DIFF
--- a/packages/vega/src/editor/VegaChartDisplay.tsx
+++ b/packages/vega/src/editor/VegaChartDisplay.tsx
@@ -77,13 +77,15 @@ export const VegaChartDisplay: React.FC<VegaChartDisplayProps> = ({
   // Show error state
   if (sqlQuery && !arrowTable && sqlResult.error) {
     return (
-      <ToolErrorMessage
-        error={sqlResult.error}
-        triggerLabel="SQL query failed"
-        title="Query error"
-        align="start"
-        details={sqlQuery}
-      />
+      <div className={className}>
+        <ToolErrorMessage
+          error={sqlResult.error}
+          triggerLabel="SQL query failed"
+          title="Query error"
+          align="start"
+          details={sqlQuery}
+        />
+      </div>
     );
   }
 


### PR DESCRIPTION
Use ToolErrorMessage component for SQL query errors in VegaChartDisplay to provide consistent, expandable error details with the query that failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Chart visualization error display updated: SQL query errors now show a consistent, styled error panel with a clear title, trigger label, alignment, and details of the failed query for easier diagnosis. Loading behavior is unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->