### PR TITLE
fix: update custom map legend panel when exporting image

### DIFF
--- a/packages/kepler/src/components/CustomMapLegend.tsx
+++ b/packages/kepler/src/components/CustomMapLegend.tsx
@@ -67,7 +67,7 @@ export function CustomMapLegendFactory(
         <div className="relative flex flex-col">
           {!isExport && (
             <div className="border-muted bg-background sticky top-0 flex w-full items-center justify-between border-b p-2">
-              <div className="text-xs font-medium">Map Layers</div>
+              <div className="text-xs font-medium">Legend</div>
               <Button
                 variant="ghost"
                 size="xs"


### PR DESCRIPTION
Related to this slack thread:
https://foursquare.slack.com/archives/C08ANNK76FM/p1771564223125299?thread_ts=1771543581.796869&cid=C08ANNK76FM

tasks:
- Change panel header to show Legend instead of Map Layers
- Remove eye icon from the legend panel
- Show only visible lanes in the legend panel
- When exporting image fix the issue with double header title showing

Screenshot of the UI and exported image:
<img width="963" height="583" alt="Screenshot 2026-02-20 at 14 14 36" src="https://github.com/user-attachments/assets/c2bbf1a3-977d-45c7-a5b2-1b0bbf876d08" />
<img width="679" height="576" alt="Untitled Map" src="https://github.com/user-attachments/assets/05bb1589-a4ef-4a48-ab3e-84dd17920f7c" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export mode cleans up map legend: header and panel actions are hidden, visibility toggle controls are concealed, and only layers currently set visible are included in exports for a clearer, more professional output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->