### PR TITLE
Circular dependencies and canvas

### DIFF
--- a/examples/canvas/src/store.ts
+++ b/examples/canvas/src/store.ts
@@ -94,12 +94,7 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
         cellRegistry: createDefaultCellRegistry(),
       })(set, get, store),
 
-      ...createCanvasSlice({
-        ai: {
-          getApiKey: () => get().app.config.apiKey,
-          defaultModel: 'gpt-4.1-mini',
-        },
-      })(set, get, store),
+      ...createCanvasSlice({})(set, get, store),
 
       // App slice with config
       app: {

--- a/packages/cells/src/execution.ts
+++ b/packages/cells/src/execution.ts
@@ -1,7 +1,6 @@
 import {escapeId, makeQualifiedTableName} from '@sqlrooms/duckdb';
 import {convertToValidColumnOrTableName} from '@sqlrooms/utils';
 import {produce} from 'immer';
-import type {CellsRootState} from './cellsSlice';
 import {findSheetIdForCell, resolveSheetSchemaName} from './helpers';
 import {
   findSqlDependencies,
@@ -12,6 +11,7 @@ import {
   isInputCell,
   isSqlCell,
   type CellResultData,
+  type CellsRootState,
   type SqlCellData,
   type SqlCellStatus,
 } from './types';


### PR DESCRIPTION
Fixes a circular dependency in the `cells` package and a TypeScript error in the `canvas-example` build.

The circular dependency `cellsSlice.ts > defaultCellRegistry.tsx > execution.ts` was broken by changing `execution.ts` to import `CellsRootState` directly from `types.ts`. The `canvas-example` build error was due to an outdated `ai` option being passed to `createCanvasSlice`, which no longer exists in its type definition.

---
<p><a href="https://cursor.com/agents?id=bc-f44c0e71-ab9a-499a-809a-623e94b671f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f44c0e71-ab9a-499a-809a-623e94b671f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

