### PR TITLE
fix: move copy button in the message container

### DIFF
--- a/packages/ai-core/src/components/AnalysisAnswer.tsx
+++ b/packages/ai-core/src/components/AnalysisAnswer.tsx
@@ -155,10 +155,11 @@ export const AnalysisAnswer = React.memo(function AnalysisAnswer(
     () => processContent(content),
     [content],
   );
-  const footerActions = hasTextContent ? (
+  const headerActions = hasTextContent ? (
     <CopyButton
       text={copyableText}
       tooltipLabel={isAnswer ? 'Copy response' : 'Copy message'}
+      className="border-muted border"
     />
   ) : null;
 
@@ -196,7 +197,7 @@ export const AnalysisAnswer = React.memo(function AnalysisAnswer(
       isSuccess={true}
       type={isAnswer ? 'answer' : 'thinking'}
       content={{content, isAnswer}}
-      footerActions={footerActions}
+      headerActions={headerActions}
     >
       <div className="prose dark:prose-invert max-w-none text-sm">
         <Markdown

--- a/packages/ai-core/src/components/MessageContainer.tsx
+++ b/packages/ai-core/src/components/MessageContainer.tsx
@@ -10,6 +10,8 @@ type MessageContainerProps = {
   children: React.ReactNode;
   footerActions?: React.ReactNode;
   footerActionsClassName?: string;
+  headerActions?: React.ReactNode;
+  headerActionsClassName?: string;
 };
 
 export const MessageContainer: React.FC<MessageContainerProps> = ({
@@ -20,6 +22,8 @@ export const MessageContainer: React.FC<MessageContainerProps> = ({
   children,
   footerActions,
   footerActionsClassName,
+  headerActions,
+  headerActionsClassName,
 }) => {
   return (
     <div
@@ -35,7 +39,7 @@ export const MessageContainer: React.FC<MessageContainerProps> = ({
         <Badge
           variant="secondary"
           className={cn(
-            'absolute left-2 top-[-12px] flex items-center gap-1 border text-xs',
+            'absolute top-[-12px] left-2 flex items-center gap-1 border text-xs',
             'border-destructive bg-background',
             // isSuccess ? borderColor : 'border-red-500',
           )}
@@ -50,6 +54,16 @@ export const MessageContainer: React.FC<MessageContainerProps> = ({
       )}
 
       <div className="flex flex-col gap-5">{children}</div>
+      {headerActions && (
+        <div
+          className={cn(
+            'absolute right-2 bottom-2 flex items-center justify-end gap-1 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100',
+            headerActionsClassName,
+          )}
+        >
+          {headerActions}
+        </div>
+      )}
       {footerActions && (
         <div
           className={cn(


### PR DESCRIPTION
Move the copy button in the message container of the AI assistant
So it appears on mouse hover

<img width="362" height="292" alt="Screenshot 2026-02-25 at 17 21 18" src="https://github.com/user-attachments/assets/dd34ef9d-3352-47a5-9400-58a933faeef6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Repositioned the copy button in answer displays to the header area, providing enhanced accessibility and improved visibility of essential user actions.
  * Refined styling and positioning of message container elements, including adjustments to badge placement, for a more cohesive and polished visual experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->