### PR TITLE
fix: Improve copy message placement in AI assistant

### DIFF
--- a/packages/ai-core/src/components/AnalysisResult.tsx
+++ b/packages/ai-core/src/components/AnalysisResult.tsx
@@ -134,7 +134,7 @@ export const AnalysisResult: React.FC<AnalysisResultProps> = ({
           <div className="flex justify-start">
             <CopyButton
               text={allTextContent}
-              tooltipLabel="Copy entire response"
+              tooltipLabel="Copy message"
               className="border-muted border"
             />
           </div>


### PR DESCRIPTION
Rollback copy button in the ai assistant
and I would suggest we decrease the gap of the messages to 2 instead of 4

Here are the screenshots showing gap-2
<img width="407" height="660" alt="Screenshot 2026-02-26 at 13 48 23" src="https://github.com/user-attachments/assets/ae15452d-ac16-47bf-956e-28dbe52fa65a" />
<img width="394" height="627" alt="Screenshot 2026-02-26 at 13 48 00" src="https://github.com/user-attachments/assets/ebf670d1-4686-4ca9-b704-22d89d2ff02f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Copy button to analysis results to copy the aggregated textual response with one click (tooltip: "Copy message"); shown only when textual content exists.
* **UI Improvements**
  * Reduced spacing for a tighter, more compact result display; Copy button has a subtle border and is positioned after the message/error content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->