### PR TITLE
fix: sanitize UIMessages before sending to LLM to prevent empty content errors

### DIFF
--- a/packages/ai-core/src/chatTransport.ts
+++ b/packages/ai-core/src/chatTransport.ts
@@ -22,6 +22,7 @@ import {AddToolResult} from './types';
 import {
   fixIncompleteToolCalls,
   mergeAbortSignals,
+  sanitizeMessagesForLLM,
   ToolAbortError,
 } from './utils';
 
@@ -200,7 +201,7 @@ export function createLocalChatTransportFactory({
 
       const result = streamText({
         model,
-        messages: convertToModelMessages(messagesCopy),
+        messages: convertToModelMessages(sanitizeMessagesForLLM(messagesCopy)),
         tools,
         system: systemInstructions,
         abortSignal,
@@ -319,7 +320,9 @@ export function createChatHandlers({
           const sessionMessages = (session?.uiMessages ?? []) as UIMessage[];
           const llmResult = await tool.execute(input, {
             toolCallId,
-            messages: convertToModelMessages(sessionMessages),
+            messages: convertToModelMessages(
+              sanitizeMessagesForLLM(sessionMessages),
+            ),
             abortSignal: abortController?.signal,
           });
 

--- a/packages/ai-core/src/utils.ts
+++ b/packages/ai-core/src/utils.ts
@@ -250,6 +250,56 @@ export function cleanupPendingAnalysisResults(
 }
 
 /**
+ * Sanitizes UIMessages before sending to LLM APIs to prevent errors from malformed content.
+ *
+ * This handles issues that can occur when conversations are interrupted mid-stream:
+ * - Empty text parts (causes Bedrock error: "text field in ContentBlock is blank")
+ * - Assistant messages with no meaningful content after cleanup
+ *
+ * @param messages - The messages to sanitize
+ * @returns Sanitized messages safe to send to LLM APIs
+ */
+export function sanitizeMessagesForLLM(messages: UIMessage[]): UIMessage[] {
+  return messages
+    .map((message) => {
+      if (!message.parts || message.parts.length === 0) {
+        return message;
+      }
+
+      // Filter out empty text parts and empty reasoning parts
+      const sanitizedParts = message.parts.filter((part) => {
+        if (part.type === 'text') {
+          const textPart = part as {type: 'text'; text: string};
+          return textPart.text && textPart.text.trim().length > 0;
+        }
+        if (part.type === 'reasoning') {
+          const reasoningPart = part as {type: 'reasoning'; text: string};
+          return reasoningPart.text && reasoningPart.text.trim().length > 0;
+        }
+        return true;
+      });
+
+      // If all parts were filtered out, add a placeholder for assistant messages
+      // to maintain conversation structure (user messages should always have content)
+      if (sanitizedParts.length === 0 && message.role === 'assistant') {
+        return {
+          ...message,
+          parts: [{type: 'text' as const, text: '[Response interrupted]'}],
+        };
+      }
+
+      return {
+        ...message,
+        parts: sanitizedParts,
+      };
+    })
+    .filter((message) => {
+      // Remove messages that have no parts (shouldn't happen after above logic, but safety check)
+      return message.parts && message.parts.length > 0;
+    });
+}
+
+/**
  * Validates and completes UIMessages to ensure all tool-call parts have corresponding tool-result parts.
  * This is important when canceling with AbortController, which may leave incomplete tool-calls.
  * Assumes sequential tool execution (only one tool runs at a time).


### PR DESCRIPTION
<img width="970" height="648" alt="556042702-66528610-37da-4c52-974e-da54974ac53a" src="https://github.com/user-attachments/assets/a30b40b4-7a4e-44c9-9a27-b51833b3ba66" />

## Problem
When conversations are interrupted mid-stream (e.g., user cancels a request), UIMessages can end up with empty text parts. When these messages are later sent to LLM APIs (particularly Bedrock), it causes errors like "text field in ContentBlock is blank".

## Summary
- Add `sanitizeMessagesForLLM` utility function to handle issues that occur when conversations are interrupted mid-stream
- Filter out empty text parts (prevents Bedrock error: "text field in ContentBlock is blank")
- Filter out empty reasoning parts
- Add placeholder for assistant messages that have no content after cleanup to maintain conversation structure






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat message processing by filtering empty content before sending to language models, ensuring cleaner data transmission.
  * Enhanced assistant message reliability by guaranteeing valid content is preserved during conversation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->