### PR TITLE
feat: add duplicate kepler map

### DIFF
--- a/packages/kepler/src/KeplerSlice.ts
+++ b/packages/kepler/src/KeplerSlice.ts
@@ -113,10 +113,10 @@ function createKeplerCommands(): RoomCommand<
 >[] {
   const DUPLICATE_MAP_COMMAND_ID = 'kepler.duplicate-tab';
 
-  // Error codes for internal tracking/logging
+  // Error codes for internal tracking/logging (kebab-case for consistency)
   const ERROR_CODES = {
-    MAP_NOT_FOUND: 'MAP_NOT_FOUND',
-    MAP_STATE_NOT_INITIALIZED: 'MAP_STATE_NOT_INITIALIZED',
+    MAP_NOT_FOUND: 'map-not-found',
+    MAP_STATE_NOT_INITIALIZED: 'map-state-not-initialized',
   };
 
   return [
@@ -576,7 +576,7 @@ export function createKeplerSlice({
             return {
               success: false,
               message: 'Unable to duplicate map: source map or state not found',
-              code: 'SOURCE_MAP_NOT_FOUND',
+              code: 'source-map-not-found',
             };
           }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Map tab duplication: create a new tab that copies styling, configuration, layers, and datasets from the current map.
  * Duplicate via room commands: trigger map duplication quickly from the room command interface.

* **Bug Fixes / Stability**
  * Cleaner shutdown: registered room commands are removed on unload to free resources and avoid stale handlers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->