### PR TITLE
fix: add copy to ai assistant prompt

### DIFF
--- a/packages/ai-core/src/components/AnalysisResult.tsx
+++ b/packages/ai-core/src/components/AnalysisResult.tsx
@@ -108,7 +108,7 @@ export const AnalysisResult: React.FC<AnalysisResultProps> = ({
           <div className="opacity-0 transition-opacity group-focus-within/prompt:opacity-100 group-hover/prompt:opacity-100">
             <CopyButton
               text={analysisResult.prompt}
-              tooltipLabel="Copy question"
+              tooltipLabel="Copy prompt"
               className="h-6 w-6"
             />
           </div>


### PR DESCRIPTION
Add back copy button to the user prompt when user hover mouse over the prompt

<img width="350" height="362" alt="Screenshot 2026-03-03 at 12 46 09" src="https://github.com/user-attachments/assets/bba6dfd7-5fea-4aee-80b0-c7c57adc0886" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a copy button for analysis questions so users can quickly copy and reuse prompts.

* **Style**
  * Button now appears on hover or focus for clearer discoverability and improved accessibility (with a descriptive tooltip).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->