### PR TITLE
fix: decrease height of suggestions

### DIFF
--- a/packages/ai-core/src/components/PromptSuggestions.tsx
+++ b/packages/ai-core/src/components/PromptSuggestions.tsx
@@ -62,7 +62,7 @@ const Container: React.FC<PromptSuggestionsContainerProps> = ({
                         'relative',
                         'flex items-center justify-center',
                         'px-4 py-2',
-                        'h-18 max-h-18 min-h-18 w-48 max-w-48 min-w-48',
+                        'h-18 max-h-14 min-h-14 w-48 max-w-48 min-w-48',
                       )}
                       type="button"
                     >
@@ -141,7 +141,7 @@ const Item: React.FC<PromptSuggestionsItemProps> = ({
               'text-left',
               'overflow-hidden',
               'py-2 pr-4 pl-8',
-              'h-18 max-h-18 min-h-18 w-48 max-w-48 min-w-48',
+              'h-18 max-h-14 min-h-14 w-48 max-w-48 min-w-48',
               className,
             )}
             type="button"


### PR DESCRIPTION
fixes https://github.com/sqlrooms/sqlrooms/issues/395

Decrease the prompt suggestion height

<img width="410" height="588" alt="Screenshot 2026-03-04 at 12 08 24" src="https://github.com/user-attachments/assets/54faab99-dc76-43f4-826c-c08e3f0ffba0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted height constraints for prompt suggestion items to provide a more compact layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->