### PR TITLE
feat: add updateTooltipFields to dispatch tooltip action in KeplerSlice

### DIFF
--- a/packages/kepler/src/KeplerSlice.ts
+++ b/packages/kepler/src/KeplerSlice.ts
@@ -473,13 +473,27 @@ export function createKeplerSlice({
           if (!tooltipConfig) return;
           const currentFieldsToShow = tooltipConfig.config?.fieldsToShow || {};
           const existingFields = currentFieldsToShow[datasetId] || [];
-          const existingNames = new Set(
-            existingFields.map((f: {name: string}) => f.name),
+          const existingByName = new Map(
+            existingFields.map(
+              (field: {name: string; format: string | null}) => [
+                field.name,
+                field,
+              ],
+            ),
           );
-          const newFields = fieldNames
-            .filter((name) => !existingNames.has(name))
-            .map((name) => ({name, format: null}));
-          if (newFields.length === 0) return;
+          const nextFields = Array.from(new Set(fieldNames)).map(
+            (name) => existingByName.get(name) ?? {name, format: null},
+          );
+          if (
+            nextFields.length === existingFields.length &&
+            nextFields.every(
+              (field, index) =>
+                field.name === existingFields[index]?.name &&
+                field.format === existingFields[index]?.format,
+            )
+          ) {
+            return;
+          }
           get().kepler.dispatchAction(
             mapId,
             interactionConfigChange({
@@ -488,7 +502,7 @@ export function createKeplerSlice({
                 ...tooltipConfig.config,
                 fieldsToShow: {
                   ...currentFieldsToShow,
-                  [datasetId]: [...existingFields, ...newFields],
+                  [datasetId]: nextFields,
                 },
               },
             }),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to dynamically update which dataset fields appear in map tooltips, letting users customize tooltip content for improved data exploration and visualization workflows.
  * Update is applied safely—if the tooltip configuration or requested fields are unchanged, no action is taken to avoid unnecessary updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->