### PR TITLE
fix: temporary disable SQL linter and gutter markers in DuckDB SQL extension

### DIFF
--- a/packages/sql-editor/src/codemirror/extensions/duck-db/duckdb-sql-extension.ts
+++ b/packages/sql-editor/src/codemirror/extensions/duck-db/duckdb-sql-extension.ts
@@ -20,12 +20,12 @@ export function createDuckDbSqlExtension(
   });
 
   return sqlExtension({
-    enableLinting: true,
+    enableLinting: false,
     linterConfig: {
       parser: duckdbParser,
       delay: LINT_DELAY_DEFAULT,
     },
-    enableGutterMarkers: true,
+    enableGutterMarkers: false,
     gutterConfig: {
       parser: duckdbParser,
     },


### PR DESCRIPTION
Temporary disable SQL linter and gutter markers in DuckDB SQL extension whiles we are looking for better solution