### PR TITLE
fix: chart tool text color

### DIFF
--- a/packages/ai-core/src/components/GroupedMessageParts.tsx
+++ b/packages/ai-core/src/components/GroupedMessageParts.tsx
@@ -78,6 +78,7 @@ export const GroupedMessageParts: React.FC<GroupedMessagePartsProps> = ({
                       key={`tool-call-${groupIndex}-${partIndex}`}
                       part={part}
                       toolCallId={part.toolCallId}
+                      isExcludedFromGrouping={true}
                     />
                   ) : null,
                 )}

--- a/packages/ai-core/src/components/ToolCallInfo.tsx
+++ b/packages/ai-core/src/components/ToolCallInfo.tsx
@@ -19,6 +19,7 @@ type ToolCallInfoProps = {
     | 'input-available'
     | 'output-available'
     | 'output-error';
+  isExcludedFromGrouping?: boolean;
 };
 
 /**
@@ -32,6 +33,7 @@ type ToolCallInfoProps = {
  * @param props.input - Input arguments passed to the tool
  * @param props.isCompleted - Whether the tool call has completed
  * @param props.state - Current state of the tool call
+ * @param props.isExcludedFromGrouping - Whether this tool is excluded from grouping (uses text-foreground instead of gray)
  * @returns A React component displaying the tool call details
  */
 export const ToolCallInfo: React.FC<ToolCallInfoProps> = ({
@@ -39,17 +41,39 @@ export const ToolCallInfo: React.FC<ToolCallInfoProps> = ({
   input,
   isCompleted,
   state,
+  isExcludedFromGrouping = false,
 }) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
   return (
     <div className="flex flex-col gap-1">
-      <div className="flex items-center gap-2 pl-2 text-xs text-gray-700 dark:text-gray-300">
+      <div
+        className={cn(
+          'flex items-center gap-2 pl-2 text-xs',
+          isExcludedFromGrouping
+            ? 'text-foreground'
+            : 'text-gray-700 dark:text-gray-300',
+        )}
+      >
         {/* Loading/Completed Indicator */}
         {state !== 'output-available' && state !== 'output-error' ? (
-          <Loader2 className="h-4 w-4 shrink-0 animate-spin text-gray-400 dark:text-gray-500" />
+          <Loader2
+            className={cn(
+              'h-4 w-4 shrink-0 animate-spin',
+              isExcludedFromGrouping
+                ? 'text-foreground'
+                : 'text-gray-400 dark:text-gray-500',
+            )}
+          />
         ) : (
-          <CircleArrowRightIcon className="h-4 w-4 shrink-0 text-gray-400 dark:text-gray-500" />
+          <CircleArrowRightIcon
+            className={cn(
+              'h-4 w-4 shrink-0',
+              isExcludedFromGrouping
+                ? 'text-foreground'
+                : 'text-gray-400 dark:text-gray-500',
+            )}
+          />
         )}
 
         {/* Clickable Tool Name */}
@@ -57,7 +81,7 @@ export const ToolCallInfo: React.FC<ToolCallInfoProps> = ({
           onClick={() => setIsExpanded(!isExpanded)}
           className={cn(
             'flex items-center gap-1 rounded px-1 py-0.5 font-medium transition-colors',
-            'text-gray-700',
+            isExcludedFromGrouping ? 'text-foreground' : 'text-gray-700',
           )}
         >
           {isExpanded ? (

--- a/packages/ai-core/src/components/ToolPartRenderer.tsx
+++ b/packages/ai-core/src/components/ToolPartRenderer.tsx
@@ -229,14 +229,17 @@ const AgentProgressSection: React.FC<{
  * @component
  * @param props - Component props
  * @param props.part - The UI message part to render
+ * @param props.isExcludedFromGrouping - Whether this tool is excluded from being grouped in the GroupedMessageParts component
  * @returns A React component displaying the tool part, or null if not a tool part
  */
 export const ToolPartRenderer = ({
   part,
   toolCallId,
+  isExcludedFromGrouping = false,
 }: {
   part: UIMessagePart;
   toolCallId: string;
+  isExcludedFromGrouping?: boolean;
 }) => {
   const tools = useStoreWithAi((s) => s.ai.tools);
   const toolRenderers = useStoreWithAi((s) => s.ai.toolRenderers);
@@ -290,6 +293,7 @@ export const ToolPartRenderer = ({
           input={input}
           isCompleted={isCompleted}
           state={state}
+          isExcludedFromGrouping={isExcludedFromGrouping}
         />
         <div data-tool-call-id={toolCallId}>
           {isAgentTool ? (
@@ -308,6 +312,7 @@ export const ToolPartRenderer = ({
               input={input}
               state={state}
               errorText={state === 'output-error' ? errorText : undefined}
+              isExcludedFromGrouping={isExcludedFromGrouping}
             />
           )}
         </div>

--- a/packages/ai-core/src/components/tools/ToolResult.tsx
+++ b/packages/ai-core/src/components/tools/ToolResult.tsx
@@ -1,5 +1,6 @@
 import type {FC} from 'react';
 import {useEffect} from 'react';
+import {cn} from '@sqlrooms/ui';
 import {useStoreWithAi} from '../../AiSlice';
 import {MessageContainer} from '../MessageContainer';
 import {ToolCallErrorBoundary} from './ToolResultErrorBoundary';
@@ -16,6 +17,7 @@ type ToolResultProps = {
     | 'output-available'
     | 'output-error';
   errorText?: string;
+  isExcludedFromGrouping?: boolean;
 };
 
 export const ToolResult: FC<ToolResultProps> = ({
@@ -25,6 +27,7 @@ export const ToolResult: FC<ToolResultProps> = ({
   input,
   state,
   errorText,
+  isExcludedFromGrouping = false,
 }) => {
   const toolRenderers = useStoreWithAi((s) => s.ai.toolRenderers);
   // Look up directly from the registry object (stable reference) to avoid
@@ -64,7 +67,14 @@ export const ToolResult: FC<ToolResultProps> = ({
   }, [isCompleted, isSuccess, toolName, ToolComponent]);
 
   return !isCompleted ? (
-    <div className="text-sm text-gray-500">{reason ?? ''}</div>
+    <div
+      className={cn(
+        'text-sm',
+        isExcludedFromGrouping ? 'text-foreground' : 'text-gray-500',
+      )}
+    >
+      {reason ?? ''}
+    </div>
   ) : (
     <MessageContainer
       isSuccess={isSuccess}
@@ -76,7 +86,12 @@ export const ToolResult: FC<ToolResultProps> = ({
         isCompleted,
       }}
     >
-      <div className="text-sm text-gray-500">
+      <div
+        className={cn(
+          'text-sm',
+          isExcludedFromGrouping ? 'text-foreground' : 'text-gray-500',
+        )}
+      >
         {reason && <span>{reason}</span>}
         {isCompleted && (errorText || !isSuccess) && (
           <ToolErrorMessage

--- a/packages/data-table/src/DataTableModal.tsx
+++ b/packages/data-table/src/DataTableModal.tsx
@@ -72,7 +72,6 @@ const DataTableModal: FC<DataTableModalProps> = (props) => {
       >
         <DialogHeader>
           <DialogTitle>{title ?? ''}</DialogTitle>
-          <DialogDescription className="hidden">{title}</DialogDescription>
         </DialogHeader>
         <div className="bg-muted flex-1 overflow-hidden">
           {tableModal.isOpen && (

--- a/packages/data-table/src/DataTableModal.tsx
+++ b/packages/data-table/src/DataTableModal.tsx
@@ -72,6 +72,7 @@ const DataTableModal: FC<DataTableModalProps> = (props) => {
       >
         <DialogHeader>
           <DialogTitle>{title ?? ''}</DialogTitle>
+          <DialogDescription className="hidden">{title}</DialogDescription>
         </DialogHeader>
         <div className="bg-muted flex-1 overflow-hidden">
           {tableModal.isOpen && (


### PR DESCRIPTION
Text color content in the ai assistant chat is looking inconsistent.
Reason is cause some tools that are excluded from grouping are by default uncolpased and  darker gray color. 


Before
<img width="360" height="635" alt="Screenshot 2026-04-09 at 12 03 17" src="https://github.com/user-attachments/assets/af36c7ba-e7b9-437b-a6ed-a923a5a6eb62" />

After
<img width="354" height="633" alt="Screenshot 2026-04-09 at 12 02 48" src="https://github.com/user-attachments/assets/84ddfc11-6a8d-4e77-9946-66e4e2b656a6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visual styling and contrast for tools displayed outside grouped sections
  * Refined data table modal header presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->