### PR TITLE
fix: only sync tables used by kepler

### DIFF
--- a/packages/kepler/src/KeplerSlice.ts
+++ b/packages/kepler/src/KeplerSlice.ts
@@ -432,8 +432,8 @@ export function createKeplerSlice({
           );
           updateMapReduxStates();
           updateForwardDispatch();
-          get().kepler.syncKeplerDatasets();
           updateMapConfigs();
+          get().kepler.syncKeplerDatasets();
         },
 
         async initialize() {
@@ -467,8 +467,8 @@ export function createKeplerSlice({
             },
           });
           updateForwardDispatch();
-          await get().kepler.syncKeplerDatasets();
           updateMapConfigs();
+          await get().kepler.syncKeplerDatasets();
           requestMapStyle(config.currentMapId);
 
           // Register Kepler commands

--- a/packages/kepler/src/KeplerSlice.ts
+++ b/packages/kepler/src/KeplerSlice.ts
@@ -432,8 +432,8 @@ export function createKeplerSlice({
           );
           updateMapReduxStates();
           updateForwardDispatch();
-          updateMapConfigs();
           get().kepler.syncKeplerDatasets();
+          updateMapConfigs();
         },
 
         async initialize() {
@@ -467,8 +467,8 @@ export function createKeplerSlice({
             },
           });
           updateForwardDispatch();
-          updateMapConfigs();
           await get().kepler.syncKeplerDatasets();
+          updateMapConfigs();
           requestMapStyle(config.currentMapId);
 
           // Register Kepler commands

--- a/packages/kepler/src/KeplerSlice.ts
+++ b/packages/kepler/src/KeplerSlice.ts
@@ -616,14 +616,35 @@ export function createKeplerSlice({
             do {
               pendingKeplerSync = false;
               for (const mapId of Object.keys(get().kepler.map)) {
-                const keplerDatasets =
-                  get().kepler.map[mapId]?.visState.datasets;
-                for (const {table} of get().db.tables) {
+                const mapState = get().kepler.map[mapId];
+                if (!mapState) continue;
+                const keplerDatasets = mapState.visState.datasets;
+
+                // Only sync tables that are referenced by existing layers or filters
+                const referencedDataIds = new Set<string>();
+                for (const layer of mapState.visState.layers ?? []) {
+                  if (layer.config.dataId) {
+                    referencedDataIds.add(layer.config.dataId);
+                  }
+                }
+                for (const filter of mapState.visState.filters ?? []) {
+                  for (const dataId of filter.dataId ?? []) {
+                    referencedDataIds.add(dataId);
+                  }
+                }
+
+                const availableTables = new Set(
+                  get()
+                    .db.tables.filter((t) => t.table.schema === 'main')
+                    .map((t) => t.table.table),
+                );
+
+                for (const dataId of referencedDataIds) {
                   if (
-                    table.schema === 'main' &&
-                    !keplerDatasets?.[table.table]
+                    !keplerDatasets?.[dataId] &&
+                    availableTables.has(dataId)
                   ) {
-                    await get().kepler.addTableToMap(mapId, table.table, {
+                    await get().kepler.addTableToMap(mapId, dataId, {
                       autoCreateLayers: false,
                       centerMap: false,
                     });

--- a/packages/kepler/src/components/CustomLayerManager.tsx
+++ b/packages/kepler/src/components/CustomLayerManager.tsx
@@ -125,14 +125,17 @@ const TableListItem: React.FC<{value: TableOption}> = ({value}) => (
 );
 
 /**
- * Dropdown button that lists DuckDB table names. When a table is selected,
- * it is synced to Kepler on demand and a new layer is created for it.
+ * Dropdown button that lists available datasets and DuckDB tables.
+ * When a table is selected, it is synced to Kepler on demand and a new
+ * layer is created for it.
  */
 const AddTableLayerButton: React.FC<{
-  onAdd: (tableName: string) => void;
+  onAdd: (tableName: string) => Promise<void>;
+  keplerDatasetIds: string[];
   disabled?: boolean;
-}> = ({onAdd, disabled}) => {
+}> = ({onAdd, keplerDatasetIds, disabled}) => {
   const [isOpen, setIsOpen] = useState(false);
+  const [isAdding, setIsAdding] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const [menuPos, setMenuPos] = useState<{top: number; right: number}>({
@@ -143,17 +146,30 @@ const AddTableLayerButton: React.FC<{
 
   const dbTables = useStoreWithKepler((state) => state.db.tables);
 
-  const options: TableOption[] = useMemo(
-    () =>
+  const options: TableOption[] = useMemo(() => {
+    const tableNames = new Set(
       dbTables
         .filter((t) => t.table.schema === 'main')
-        .map((t) => ({label: t.table.table, value: t.table.table})),
-    [dbTables],
-  );
+        .map((t) => t.table.table),
+    );
+    for (const id of keplerDatasetIds) {
+      tableNames.add(id);
+    }
+    return Array.from(tableNames)
+      .sort()
+      .map((name) => ({label: name, value: name}));
+  }, [dbTables, keplerDatasetIds]);
 
-  const handleClick = useCallback(() => {
+  const handleClick = useCallback(async () => {
     if (options.length === 1 && options[0]) {
-      onAdd(options[0].value);
+      setIsAdding(true);
+      try {
+        await onAdd(options[0].value);
+      } catch (e) {
+        console.error('Failed to add layer:', e);
+      } finally {
+        setIsAdding(false);
+      }
       return;
     }
     if (buttonRef.current) {
@@ -169,8 +185,11 @@ const AddTableLayerButton: React.FC<{
   const handleSelect = useCallback(
     (option: TableOption | null) => {
       if (!option) return;
-      onAdd(option.value);
-      setIsOpen(false);
+      setIsAdding(true);
+      onAdd(option.value)
+        .then(() => setIsOpen(false))
+        .catch((e) => console.error('Failed to add layer:', e))
+        .finally(() => setIsAdding(false));
     },
     [onAdd],
   );
@@ -194,10 +213,9 @@ const AddTableLayerButton: React.FC<{
     <DropdownWrapper ref={dropdownRef}>
       <Button
         ref={buttonRef}
-        tabIndex={-1}
         className="add-layer-button"
         onClick={handleClick}
-        disabled={!options.length || disabled}
+        disabled={!options.length || disabled || isAdding}
       >
         <Icons.Add height="12px" />
         {intl.formatMessage({id: 'layerManager.addLayer'})}
@@ -275,6 +293,11 @@ export const CustomLayerManager: React.FC<CustomLayerManagerProps> = ({
 
   const {addLayer} = keplerActions.visStateActions;
 
+  const keplerDatasetIds = useMemo(
+    () => Object.keys(keplerState?.visState.datasets ?? {}),
+    [keplerState?.visState.datasets],
+  );
+
   const onAddTableLayer = useCallback(
     async (tableName: string) => {
       const keplerDatasets = keplerState?.visState.datasets;
@@ -327,7 +350,10 @@ export const CustomLayerManager: React.FC<CustomLayerManagerProps> = ({
               id: layerPanelMetadata?.label || 'Layers',
             })}
           >
-            <AddTableLayerButton onAdd={onAddTableLayer} />
+            <AddTableLayerButton
+              onAdd={onAddTableLayer}
+              keplerDatasetIds={keplerDatasetIds}
+            />
           </PanelTitle>
         </SidePanelSection>
 

--- a/packages/kepler/src/components/CustomLayerManager.tsx
+++ b/packages/kepler/src/components/CustomLayerManager.tsx
@@ -73,6 +73,7 @@ const CustomLayerManagerContainer = styled.div`
 const DropdownWrapper = styled.div`
   position: relative;
   display: inline-block;
+  overflow: visible;
 `;
 
 const DropdownMenu = styled.div`
@@ -80,10 +81,8 @@ const DropdownMenu = styled.div`
   flex-direction: column;
   min-width: 240px;
   max-width: 240px;
-  position: absolute;
-  top: 100%;
-  right: 0;
-  z-index: 5;
+  position: fixed;
+  z-index: 100;
 
   .list-selector {
     border-top: 1px solid ${(props) => props.theme.secondaryInputBorderColor};
@@ -135,6 +134,11 @@ const AddTableLayerButton: React.FC<{
 }> = ({onAdd, disabled}) => {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const [menuPos, setMenuPos] = useState<{top: number; right: number}>({
+    top: 0,
+    right: 0,
+  });
   const intl = useIntl();
 
   const dbTables = useStoreWithKepler((state) => state.db.tables);
@@ -151,6 +155,13 @@ const AddTableLayerButton: React.FC<{
     if (options.length === 1 && options[0]) {
       onAdd(options[0].value);
       return;
+    }
+    if (buttonRef.current) {
+      const rect = buttonRef.current.getBoundingClientRect();
+      setMenuPos({
+        top: rect.bottom,
+        right: window.innerWidth - rect.right,
+      });
     }
     setIsOpen((prev) => !prev);
   }, [options, onAdd]);
@@ -182,6 +193,7 @@ const AddTableLayerButton: React.FC<{
   return (
     <DropdownWrapper ref={dropdownRef}>
       <Button
+        ref={buttonRef}
         tabIndex={-1}
         className="add-layer-button"
         onClick={handleClick}
@@ -191,7 +203,7 @@ const AddTableLayerButton: React.FC<{
         {intl.formatMessage({id: 'layerManager.addLayer'})}
       </Button>
       {isOpen && options.length > 1 && (
-        <DropdownMenu>
+        <DropdownMenu style={{top: menuPos.top, right: menuPos.right}}>
           <Typeahead
             className={TYPEAHEAD_CLASS}
             customClasses={{

--- a/packages/kepler/src/components/CustomLayerManager.tsx
+++ b/packages/kepler/src/components/CustomLayerManager.tsx
@@ -1,13 +1,16 @@
-import React, {useCallback, useMemo} from 'react';
+import React, {useCallback, useMemo, useRef, useState} from 'react';
 import {useIntl} from 'react-intl';
 import styled from 'styled-components';
 
 import {
+  Accessor,
+  Button,
+  Icons,
   LayerListFactory,
   DatasetLayerGroupFactory,
   PanelTitleFactory,
-  AddLayerButtonFactory,
   SidePanelSection,
+  Typeahead,
 } from '@kepler.gl/components';
 import {PANEL_VIEW_TOGGLES, SIDEBAR_PANELS} from '@kepler.gl/constants';
 import {LayerClassesType} from '@kepler.gl/layers';
@@ -18,29 +21,22 @@ import {
   KeplerActions,
   useKeplerStateActions,
 } from '../hooks/useKeplerStateActions';
+import {useStoreWithKepler} from '../KeplerSlice';
 import {RGBColor} from '@kepler.gl/types';
 
-// Get the kepler.gl components through the injector
 const LayerList = getKeplerFactory(LayerListFactory);
 const DatasetLayerGroup = getKeplerFactory(DatasetLayerGroupFactory);
 const PanelTitle = getKeplerFactory(PanelTitleFactory);
-const AddLayerButton = getKeplerFactory(AddLayerButtonFactory);
 
 const layerPanelMetadata = SIDEBAR_PANELS.find((p) => p.id === 'layer');
 
-// Custom styled components for your layer manager
 const CustomLayerManagerContainer = styled.div`
-  .layer-manager {
-    /* Add your custom styles here */
-  }
-  
   .layer-manager-title {
-    /* Custom title styling */
   }
 
   .add-layer-button {
     background-color: ${(props) => props.theme.sidePanelBg || props.theme.panelBackground};
-    color: #2563EB; 
+    color: #2563EB;
     border: 0px;
     height: 28px;
     font-weight: 500;
@@ -74,12 +70,157 @@ const CustomLayerManagerContainer = styled.div`
 }
 `;
 
+const DropdownWrapper = styled.div`
+  position: relative;
+  display: inline-block;
+`;
+
+const DropdownMenu = styled.div`
+  display: flex;
+  flex-direction: column;
+  min-width: 240px;
+  max-width: 240px;
+  position: absolute;
+  top: 100%;
+  right: 0;
+  z-index: 5;
+
+  .list-selector {
+    border-top: 1px solid ${(props) => props.theme.secondaryInputBorderColor};
+    width: 100%;
+    max-height: unset;
+  }
+  .list__item > div {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    line-height: 18px;
+    padding: 0;
+  }
+`;
+
+const ListItemWrapper = styled.div`
+  display: flex;
+  color: ${(props) => props.theme.textColor};
+  font-size: 11px;
+  letter-spacing: 0.2px;
+  overflow: auto;
+  .table-name {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+`;
+
+const TYPEAHEAD_CLASS = 'typeahead';
+const TYPEAHEAD_INPUT_CLASS = 'typeahead__input';
+
+type TableOption = {label: string; value: string};
+
+const TableListItem: React.FC<{value: TableOption}> = ({value}) => (
+  <ListItemWrapper>
+    <div className="table-name" title={value.label}>
+      {value.label}
+    </div>
+  </ListItemWrapper>
+);
+
+/**
+ * Dropdown button that lists DuckDB table names. When a table is selected,
+ * it is synced to Kepler on demand and a new layer is created for it.
+ */
+const AddTableLayerButton: React.FC<{
+  onAdd: (tableName: string) => void;
+  disabled?: boolean;
+}> = ({onAdd, disabled}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const intl = useIntl();
+
+  const dbTables = useStoreWithKepler((state) => state.db.tables);
+
+  const options: TableOption[] = useMemo(
+    () =>
+      dbTables
+        .filter((t) => t.table.schema === 'main')
+        .map((t) => ({label: t.table.table, value: t.table.table})),
+    [dbTables],
+  );
+
+  const handleClick = useCallback(() => {
+    if (options.length === 1 && options[0]) {
+      onAdd(options[0].value);
+      return;
+    }
+    setIsOpen((prev) => !prev);
+  }, [options, onAdd]);
+
+  const handleSelect = useCallback(
+    (option: TableOption | null) => {
+      if (!option) return;
+      onAdd(option.value);
+      setIsOpen(false);
+    },
+    [onAdd],
+  );
+
+  // Close dropdown on outside click
+  React.useEffect(() => {
+    if (!isOpen) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(e.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [isOpen]);
+
+  return (
+    <DropdownWrapper ref={dropdownRef}>
+      <Button
+        tabIndex={-1}
+        className="add-layer-button"
+        onClick={handleClick}
+        disabled={!options.length || disabled}
+      >
+        <Icons.Add height="12px" />
+        {intl.formatMessage({id: 'layerManager.addLayer'})}
+      </Button>
+      {isOpen && options.length > 1 && (
+        <DropdownMenu>
+          <Typeahead
+            className={TYPEAHEAD_CLASS}
+            customClasses={{
+              results: 'list-selector',
+              input: TYPEAHEAD_INPUT_CLASS,
+              listItem: 'list__item',
+            }}
+            placeholder={
+              intl ? intl.formatMessage({id: 'placeholder.search'}) : 'Search'
+            }
+            selectedItems={null}
+            options={options}
+            displayOption={Accessor.generateOptionToStringFor('label')}
+            filterOption={'label'}
+            searchable
+            onOptionSelected={handleSelect}
+            customListItemComponent={TableListItem}
+          />
+        </DropdownMenu>
+      )}
+    </DropdownWrapper>
+  );
+};
+
 type CustomLayerManagerProps = {
   mapId: string;
   showDeleteDataset?: boolean;
 };
 
-// Custom hook for side panel actions
 function useCustomSidePanelActions(keplerActions: KeplerActions) {
   const {openDeleteModal, toggleModal} = keplerActions.uiStateActions;
   const {updateTableColor} = keplerActions.visStateActions;
@@ -113,23 +254,33 @@ export const CustomLayerManager: React.FC<CustomLayerManagerProps> = ({
 }) => {
   const {keplerActions, keplerState} = useKeplerStateActions({mapId});
   const intl = useIntl();
+  const addTableToMap = useStoreWithKepler(
+    (state) => state.kepler.addTableToMap,
+  );
 
   const {onRemoveDataset, onUpdateTableColor} =
     useCustomSidePanelActions(keplerActions);
 
   const {addLayer} = keplerActions.visStateActions;
 
-  const onAddLayer = useCallback(
-    (dataset: string) => {
-      addLayer(undefined, dataset);
+  const onAddTableLayer = useCallback(
+    async (tableName: string) => {
+      const keplerDatasets = keplerState?.visState.datasets;
+      if (!keplerDatasets?.[tableName]) {
+        await addTableToMap(mapId, tableName, {
+          autoCreateLayers: true,
+          centerMap: true,
+        });
+      } else {
+        addLayer(undefined, tableName);
+      }
     },
-    [addLayer],
+    [addLayer, addTableToMap, keplerState?.visState.datasets, mapId],
   );
 
   const isSortByDatasetMode =
     keplerState?.uiState.layerPanelListView === PANEL_VIEW_TOGGLES.byDataset;
 
-  // Filter layer classes based on application config
   const enableRasterTileLayer = getApplicationConfig().enableRasterTileLayer;
   const enableWMSLayer = getApplicationConfig().enableWMSLayer;
 
@@ -164,10 +315,7 @@ export const CustomLayerManager: React.FC<CustomLayerManagerProps> = ({
               id: layerPanelMetadata?.label || 'Layers',
             })}
           >
-            <AddLayerButton
-              datasets={keplerState.visState.datasets}
-              onAdd={onAddLayer}
-            />
+            <AddTableLayerButton onAdd={onAddTableLayer} />
           </PanelTitle>
         </SidePanelSection>
 

--- a/packages/mosaic/package.json
+++ b/packages/mosaic/package.json
@@ -37,8 +37,8 @@
     "apache-arrow": "17.0.0",
     "immer": "^11.0.1",
     "lucide-react": "^0.556.0",
-    "zustand": "^5.0.8",
-    "zod": "^4.1.8"
+    "zod": "^4.1.8",
+    "zustand": "^5.0.8"
   },
   "peerDependencies": {
     "react": ">=18",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced the add-layer control with a local add-layer button and searchable dropdown to pick and add database tables; if only one option exists it adds immediately.

* **Performance**
  * Improved dataset synchronization to skip irrelevant tables and only load datasets actively referenced by each map, reducing map load work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->