### PR TITLE
fix: WasmDuckDbConnector: worker not terminated on init failure

### DIFF
--- a/packages/duckdb/src/connectors/WasmDuckDbConnector.ts
+++ b/packages/duckdb/src/connectors/WasmDuckDbConnector.ts
@@ -99,6 +99,22 @@ export function createWasmDuckDbConnector(
 
         conn = await db.connect();
       } catch (err) {
+        if (conn) {
+          try {
+            await conn.close();
+          } catch {
+            /* best-effort */
+          }
+        }
+        if (db) {
+          try {
+            await db.terminate();
+          } catch {
+            /* best-effort */
+          }
+        } else if (worker) {
+          worker.terminate();
+        }
         db = null;
         conn = null;
         worker = null;


### PR DESCRIPTION
fixes https://github.com/sqlrooms/sqlrooms/issues/531

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added explicit cleanup procedures during initialization failures, including connection closure and resource termination before re-throwing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->