### PR TITLE
feat: add markdown MonacoEditor

### DIFF
--- a/packages/monaco-editor/src/components/MarkdownMonacoEditor.tsx
+++ b/packages/monaco-editor/src/components/MarkdownMonacoEditor.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import {MonacoEditor, MonacoEditorProps} from './MonacoEditor';
+
+export type MarkdownMonacoEditorProps = Omit<MonacoEditorProps, 'language'>;
+
+/**
+ * A Monaco editor configured for editing Markdown files with
+ * readable dark/light theme colors for headings, links, lists, and code.
+ */
+export const MarkdownMonacoEditor: React.FC<MarkdownMonacoEditorProps> = ({
+  options: userOptions,
+  ...props
+}) => {
+  return (
+    <MonacoEditor
+      language="markdown"
+      options={{
+        wordWrap: 'on',
+        ...userOptions,
+      }}
+      {...props}
+    />
+  );
+};

--- a/packages/monaco-editor/src/components/MonacoEditor.tsx
+++ b/packages/monaco-editor/src/components/MonacoEditor.tsx
@@ -1,8 +1,12 @@
 import {Editor, EditorProps, OnChange, OnMount} from '@monaco-editor/react';
-import {Spinner, cn, getTheme} from '@sqlrooms/ui';
+import {Spinner, cn, getResolvedTheme, useTheme} from '@sqlrooms/ui';
 import type {Theme} from '@sqlrooms/ui';
 import React, {useEffect, useMemo, useRef} from 'react';
-import {getJsonEditorTheme, getMenuColors} from '../utils/color-utils';
+import {
+  getJsonEditorTheme,
+  getMarkdownEditorTheme,
+  getMenuColors,
+} from '../utils/color-utils';
 import type * as Monaco from 'monaco-editor';
 import {getCssColor, getMonospaceFont} from '@sqlrooms/utils';
 
@@ -78,9 +82,6 @@ export interface MonacoEditorProps extends Omit<EditorProps, 'onMount'> {
   options?: Monaco.editor.IStandaloneEditorConstructionOptions;
 }
 
-// Module-level singleton to track theme state
-let lastDefinedForDarkMode: boolean | null = null;
-
 function defineMonacoThemes(
   monaco: typeof Monaco,
   isDark: boolean,
@@ -88,11 +89,6 @@ function defineMonacoThemes(
 ) {
   suppressMonacoTextareaFlash();
 
-  // Only redefine if the theme mode has changed or themes haven't been defined yet
-  if (lastDefinedForDarkMode === isDark) return;
-  lastDefinedForDarkMode = isDark;
-
-  // Define both light and dark themes with current CSS variable values
   // Light theme
   monaco.editor.defineTheme('sqlrooms-light', {
     base: 'vs',
@@ -113,6 +109,10 @@ function defineMonacoThemes(
   });
 
   monaco.editor.defineTheme('sqlrooms-json-light', getJsonEditorTheme(false));
+  monaco.editor.defineTheme(
+    'sqlrooms-markdown-light',
+    getMarkdownEditorTheme(false),
+  );
 
   // Dark theme
   monaco.editor.defineTheme('sqlrooms-dark', {
@@ -134,6 +134,10 @@ function defineMonacoThemes(
   });
 
   monaco.editor.defineTheme('sqlrooms-json-dark', getJsonEditorTheme(true));
+  monaco.editor.defineTheme(
+    'sqlrooms-markdown-dark',
+    getMarkdownEditorTheme(true),
+  );
 
   // Apply the correct theme variant (respects JSON-specific themes)
   monaco.editor.setTheme(currentTheme);
@@ -166,16 +170,21 @@ export const MonacoEditor: React.FC<MonacoEditorProps> = ({
   beforeMount,
   ...props
 }) => {
-  const isDark = getTheme() === 'dark';
+  const {theme} = useTheme();
+  const isDark = getResolvedTheme(theme) === 'dark';
 
   const monacoTheme =
     language === 'json'
       ? isDark
         ? 'sqlrooms-json-dark'
         : 'sqlrooms-json-light'
-      : isDark
-        ? 'sqlrooms-dark'
-        : 'sqlrooms-light';
+      : language === 'markdown'
+        ? isDark
+          ? 'sqlrooms-markdown-dark'
+          : 'sqlrooms-markdown-light'
+        : isDark
+          ? 'sqlrooms-dark'
+          : 'sqlrooms-light';
 
   const editorRef = useRef<any>(null);
   const monacoRef = useRef<typeof Monaco | null>(null);

--- a/packages/monaco-editor/src/index.ts
+++ b/packages/monaco-editor/src/index.ts
@@ -17,3 +17,6 @@ export {
 
 export {JsonMonacoEditor} from './components/JsonMonacoEditor';
 export type {JsonMonacoEditorProps} from './components/JsonMonacoEditor';
+
+export {MarkdownMonacoEditor} from './components/MarkdownMonacoEditor';
+export type {MarkdownMonacoEditorProps} from './components/MarkdownMonacoEditor';

--- a/packages/monaco-editor/src/utils/color-utils.ts
+++ b/packages/monaco-editor/src/utils/color-utils.ts
@@ -168,6 +168,117 @@ export function getMenuColors(isDarkTheme: boolean): Record<string, string> {
 }
 
 /**
+ * Generates a Monaco editor theme for Markdown editing with Tailwind colors.
+ * Provides syntax-aware highlighting for headings, code blocks, links,
+ * bold/italic, lists, block quotes, and inline HTML.
+ * @param isDarkTheme Whether the current theme is dark or light
+ * @returns A complete Monaco editor theme data object for Markdown editing
+ */
+export function getMarkdownEditorTheme(isDarkTheme: boolean): any {
+  const background = getCssColor(
+    '--background',
+    isDarkTheme ? '#0b1220' : '#ffffff',
+  );
+  const foreground = getCssColor(
+    '--foreground',
+    isDarkTheme ? '#e0e6ed' : '#24292f',
+  );
+  const lineHighlight = getCssColor(
+    '--muted',
+    isDarkTheme ? '#111a2b' : '#f5f5f5',
+  );
+  const cursor = getCssColor('--primary', isDarkTheme ? '#ffffff' : '#000000');
+  const selection = getCssColor(
+    '--accent',
+    isDarkTheme ? '#23436b' : '#e3e3e3',
+  );
+  const lineNumbers = getCssColor(
+    '--muted-foreground',
+    isDarkTheme ? '#8b97ab' : '#888888',
+  );
+
+  const heading = getCssColor(
+    '--editor-heading',
+    isDarkTheme ? '#78AEFF' : '#0550AE',
+  );
+  const bold = isDarkTheme ? '#E0E6ED' : '#24292F';
+  const italic = isDarkTheme ? '#C987E8' : '#8250DF';
+  const link = getCssColor(
+    '--editor-link',
+    isDarkTheme ? '#58A6FF' : '#0969DA',
+  );
+  const codeInline = isDarkTheme ? '#FFAD85' : '#DB745C';
+  const codeContent = isDarkTheme ? '#8BD5CA' : '#2B6F63';
+  const codeFence = isDarkTheme ? '#525C6A' : '#A0A8B4';
+  const listMarker = isDarkTheme ? '#F0883E' : '#CF5309';
+  const quote = isDarkTheme ? '#8b97ab' : '#6E7781';
+  const separator = isDarkTheme ? '#3D444D' : '#D0D7DE';
+  const htmlTag = isDarkTheme ? '#7CD992' : '#116329';
+
+  const fg = (hex: string) => hex.slice(1);
+
+  return {
+    base: isDarkTheme ? 'vs-dark' : 'vs',
+    inherit: true,
+    rules: [
+      // Headings (# to ######)
+      {token: 'keyword.md', foreground: fg(heading), fontStyle: 'bold'},
+      {token: 'keyword.table.header.md', foreground: fg(heading)},
+
+      // Bold **text**
+      {token: 'strong.md', foreground: fg(bold), fontStyle: 'bold'},
+
+      // Italic *text*
+      {token: 'emphasis.md', foreground: fg(italic), fontStyle: 'italic'},
+
+      // Strikethrough ~~text~~
+      {token: 'strikethrough.md', fontStyle: 'strikethrough'},
+
+      // Links [text](url)
+      {token: 'string.link.md', foreground: fg(link)},
+      {token: 'type.header.md', foreground: fg(link), fontStyle: 'underline'},
+
+      // Inline code `code`
+      {token: 'variable.md', foreground: fg(codeInline)},
+
+      // Fenced code block fence markers (``` lines)
+      {token: 'variable.source.md', foreground: fg(codeFence)},
+
+      // Fenced code block content
+      {token: 'string.md', foreground: fg(codeContent)},
+
+      // List markers (-, *, 1.)
+      {token: 'keyword.list.md', foreground: fg(listMarker)},
+
+      // Block quotes >
+      {token: 'comment.md', foreground: fg(quote), fontStyle: 'italic'},
+      {token: 'quote.md', foreground: fg(quote), fontStyle: 'italic'},
+
+      // Horizontal rules --- / ***
+      {token: 'keyword.hr.md', foreground: fg(separator)},
+
+      // HTML tags in markdown
+      {token: 'tag.md', foreground: fg(htmlTag)},
+      {token: 'tag', foreground: fg(htmlTag)},
+      {token: 'attribute.name.md', foreground: fg(heading)},
+      {token: 'attribute.value.md', foreground: fg(codeInline)},
+
+      // Fallback
+      {token: '', foreground: fg(foreground)},
+    ],
+    colors: {
+      'editor.background': background,
+      'editor.foreground': foreground,
+      'editor.lineHighlightBackground': lineHighlight,
+      'editorCursor.foreground': cursor,
+      'editor.selectionBackground': selection,
+      'editorLineNumber.foreground': lineNumbers,
+      ...getMenuColors(isDarkTheme),
+    },
+  };
+}
+
+/**
  * Generates a Monaco editor theme specifically for JSON editing with Tailwind colors
  * @param isDarkTheme Whether the current theme is dark or light
  * @returns A complete Monaco editor theme data object for JSON editing


### PR DESCRIPTION
<img width="784" height="714" alt="Screenshot 2026-04-16 at 10 47 44 AM" src="https://github.com/user-attachments/assets/73ad872f-6ef6-4608-99d6-aa543a1ca342" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a dedicated Markdown editor component for optimized markdown editing experience
  * Added markdown-specific light and dark themes with improved syntax highlighting and visual consistency
  * Enhanced theme detection system for better automatic light/dark mode support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->