### PR TITLE
feat: customizable tool render behavior in ai-core

### DIFF
--- a/packages/ai-core/src/agents/AgentUtils.ts
+++ b/packages/ai-core/src/agents/AgentUtils.ts
@@ -406,6 +406,17 @@ export async function streamSubAgent<TOOLS extends ToolSet = ToolSet>(
       }
     } catch (err) {
       if (abortSignal?.aborted) {
+        const now = Date.now();
+        for (const [id, tc] of toolCallMap) {
+          if (tc.state === 'pending' || tc.state === 'approval-requested') {
+            toolCallMap.set(id, {
+              ...tc,
+              state: 'error',
+              errorText: TOOL_CALL_CANCELLED,
+              completedAt: now,
+            });
+          }
+        }
         const snapshot = buildAbortSnapshot(
           parentToolCallId,
           toolCallMap,
@@ -506,6 +517,20 @@ export async function streamSubAgent<TOOLS extends ToolSet = ToolSet>(
   // AgentProgressSection can render nested tool calls from the store instead
   // of relying on agentToolCalls embedded in the tool output (which would
   // bloat the main orchestrator's message context).
+  if (abortSignal?.aborted) {
+    const now = Date.now();
+    for (const [id, tc] of toolCallMap) {
+      if (tc.state === 'pending' || tc.state === 'approval-requested') {
+        toolCallMap.set(id, {
+          ...tc,
+          state: 'error',
+          errorText: TOOL_CALL_CANCELLED,
+          completedAt: now,
+        });
+      }
+    }
+  }
+
   pushProgress();
 
   if (abortSignal?.aborted) {

--- a/packages/ai-core/src/agents/AgentUtils.ts
+++ b/packages/ai-core/src/agents/AgentUtils.ts
@@ -121,6 +121,28 @@ function summarizeOutput(output: unknown): unknown {
 }
 
 /**
+ * Transition any tool calls still in `pending` or `approval-requested` state
+ * to `error` with the cancellation message. Clears `approvalId` on the
+ * approval-requested path so downstream consumers don't act on a stale id.
+ */
+function markPendingToolCallsAsCancelled(
+  toolCallMap: Map<string, AgentToolCall>,
+): void {
+  const now = Date.now();
+  for (const [id, tc] of toolCallMap) {
+    if (tc.state === 'pending' || tc.state === 'approval-requested') {
+      toolCallMap.set(id, {
+        ...tc,
+        state: 'error',
+        errorText: TOOL_CALL_CANCELLED,
+        completedAt: now,
+        approvalId: undefined,
+      });
+    }
+  }
+}
+
+/**
  * Build an `AgentProgressSnapshot` from the current `toolCallMap` state.
  * For any entry whose `toolName` starts with `agent-`, reads the child's
  * abort snapshot from the store (written by the child's `streamSubAgent`
@@ -406,17 +428,7 @@ export async function streamSubAgent<TOOLS extends ToolSet = ToolSet>(
       }
     } catch (err) {
       if (abortSignal?.aborted) {
-        const now = Date.now();
-        for (const [id, tc] of toolCallMap) {
-          if (tc.state === 'pending' || tc.state === 'approval-requested') {
-            toolCallMap.set(id, {
-              ...tc,
-              state: 'error',
-              errorText: TOOL_CALL_CANCELLED,
-              completedAt: now,
-            });
-          }
-        }
+        markPendingToolCallsAsCancelled(toolCallMap);
         const snapshot = buildAbortSnapshot(
           parentToolCallId,
           toolCallMap,
@@ -518,17 +530,7 @@ export async function streamSubAgent<TOOLS extends ToolSet = ToolSet>(
   // of relying on agentToolCalls embedded in the tool output (which would
   // bloat the main orchestrator's message context).
   if (abortSignal?.aborted) {
-    const now = Date.now();
-    for (const [id, tc] of toolCallMap) {
-      if (tc.state === 'pending' || tc.state === 'approval-requested') {
-        toolCallMap.set(id, {
-          ...tc,
-          state: 'error',
-          errorText: TOOL_CALL_CANCELLED,
-          completedAt: now,
-        });
-      }
-    }
+    markPendingToolCallsAsCancelled(toolCallMap);
   }
 
   pushProgress();

--- a/packages/ai-core/src/components/Chat.tsx
+++ b/packages/ai-core/src/components/Chat.tsx
@@ -1,5 +1,9 @@
 import type {FC, PropsWithChildren} from 'react';
 import {AnalysisResultsContainer} from './AnalysisResultsContainer';
+import {
+  type ToolRenderBehavior,
+  ToolRenderBehaviorProvider,
+} from './FlatAgentRenderer';
 import {InlineApiKeyInput} from './InlineApiKeyInput';
 import {ModelSelector} from './ModelSelector';
 import {PromptSuggestions} from './PromptSuggestions';
@@ -7,8 +11,12 @@ import {QueryControls} from './QueryControls';
 import {SessionChatManager} from './SessionChatManager';
 import {SessionControls} from './SessionControls';
 
-type ChatComponent = FC<PropsWithChildren> & {
-  Root: FC<PropsWithChildren>;
+type RootProps = PropsWithChildren<{
+  toolRenderBehavior?: ToolRenderBehavior;
+}>;
+
+type ChatComponent = FC<RootProps> & {
+  Root: FC<RootProps>;
   Sessions: typeof SessionControls;
   Messages: typeof AnalysisResultsContainer;
   Composer: typeof QueryControls;
@@ -24,11 +32,11 @@ type ChatComponent = FC<PropsWithChildren> & {
  * Local compound component wrapper to reduce the number of @sqlrooms/ai imports
  * and provide a single "root" place to mount SessionChatManager.
  */
-const Root: FC<PropsWithChildren> = ({children}) => (
-  <>
+const Root: FC<RootProps> = ({children, toolRenderBehavior = {}}) => (
+  <ToolRenderBehaviorProvider value={toolRenderBehavior}>
     <SessionChatManager />
     {children}
-  </>
+  </ToolRenderBehaviorProvider>
 );
 
 const PromptSuggestionsCompound = Object.assign(PromptSuggestions.Container, {

--- a/packages/ai-core/src/components/Chat.tsx
+++ b/packages/ai-core/src/components/Chat.tsx
@@ -28,12 +28,14 @@ type ChatComponent = FC<RootProps> & {
   ModelSelector: typeof ModelSelector;
 };
 
+const EMPTY_BEHAVIOR: ToolRenderBehavior = {};
+
 /**
  * Local compound component wrapper to reduce the number of @sqlrooms/ai imports
  * and provide a single "root" place to mount SessionChatManager.
  */
-const Root: FC<RootProps> = ({children, toolRenderBehavior = {}}) => (
-  <ToolRenderBehaviorProvider value={toolRenderBehavior}>
+const Root: FC<RootProps> = ({children, toolRenderBehavior}) => (
+  <ToolRenderBehaviorProvider value={toolRenderBehavior ?? EMPTY_BEHAVIOR}>
     <SessionChatManager />
     {children}
   </ToolRenderBehaviorProvider>

--- a/packages/ai-core/src/components/FlatAgentRenderer.tsx
+++ b/packages/ai-core/src/components/FlatAgentRenderer.tsx
@@ -46,8 +46,10 @@ export type ToolStructureBehavior = {
  * - `getToolDisplayName`: label for agent summary lines (ParentSummaryLine).
  *   Falls back to the raw tool name.
  * - `getActivityLabel`: label for leaf activity log lines (ActivityLogLine,
- *   OrchestratorLogLineInner). Falls back to `reasoning` input field, then
- *   "Thinking..." while pending, then the raw tool name.
+ *   OrchestratorLogLineInner). Used only when the tool call has no
+ *   `reasoning` input field — a present `reasoning` always wins so that
+ *   model-provided thoughts are never hidden. Falls back to "Thinking..."
+ *   while pending, then to the raw tool name.
  */
 export type ToolDisplayBehavior = {
   getToolDisplayName?: (toolCall: AgentToolCall) => string | undefined;

--- a/packages/ai-core/src/components/FlatAgentRenderer.tsx
+++ b/packages/ai-core/src/components/FlatAgentRenderer.tsx
@@ -6,7 +6,7 @@ import type {UIMessagePart} from '@sqlrooms/ai-config';
 import {useStoreWithAi} from '../AiSlice';
 import type {AgentToolCall} from '../types';
 import {useElapsedTime} from '../hooks/useElapsedTime';
-import {humanizeToolName, isDynamicToolPart, isToolPart} from '../utils';
+import {isDynamicToolPart, isToolPart} from '../utils';
 import {useHoistedRenderers} from './HoistedRenderersContext';
 import {ActivityBox} from './ActivityBox';
 import {type HoistableToolCall} from './collectHoistableRenderers';
@@ -22,6 +22,47 @@ export const ShowToolCallDetailsProvider = ShowToolCallDetailsContext.Provider;
 
 function useShowToolCallDetails() {
   return useContext(ShowToolCallDetailsContext);
+}
+
+// ---------------------------------------------------------------------------
+// Context for host-app-provided tool rendering behavior
+// ---------------------------------------------------------------------------
+
+/**
+ * Controls the segment-tree structure: which tool calls are treated as
+ * transparent wrappers whose children are promoted to the caller's level.
+ *
+ * - `isPassthroughTool`: when true, no summary line is rendered and nested
+ *   calls are flattened into the parent's segment list.
+ */
+export type ToolStructureBehavior = {
+  isPassthroughTool?: (toolCall: AgentToolCall) => boolean;
+};
+
+/**
+ * Controls how tool calls are labeled in the UI. All callbacks return
+ * `undefined` to fall back to the renderer's default.
+ *
+ * - `getToolDisplayName`: label for agent summary lines (ParentSummaryLine).
+ *   Falls back to the raw tool name.
+ * - `getActivityLabel`: label for leaf activity log lines (ActivityLogLine,
+ *   OrchestratorLogLineInner). Falls back to `reasoning` input field, then
+ *   "Thinking..." while pending, then the raw tool name.
+ */
+export type ToolDisplayBehavior = {
+  getToolDisplayName?: (toolCall: AgentToolCall) => string | undefined;
+  getActivityLabel?: (toolCall: AgentToolCall) => string | undefined;
+};
+
+/** Combined structural + display customization passed via Chat.Root. */
+export type ToolRenderBehavior = ToolStructureBehavior & ToolDisplayBehavior;
+
+const ToolRenderBehaviorContext = createContext<ToolRenderBehavior>({});
+
+export const ToolRenderBehaviorProvider = ToolRenderBehaviorContext.Provider;
+
+function useToolRenderBehavior(): ToolRenderBehavior {
+  return useContext(ToolRenderBehaviorContext);
 }
 
 // ---------------------------------------------------------------------------
@@ -49,6 +90,7 @@ const ActivityLogLine: React.FC<{
   toolCall: AgentToolCall;
 }> = ({toolCall}) => {
   const showDetails = useShowToolCallDetails();
+  const {getActivityLabel} = useToolRenderBehavior();
   const isSuccess = toolCall.state === 'success';
   const isError = toolCall.state === 'error';
   const isPending = toolCall.state === 'pending';
@@ -59,7 +101,10 @@ const ActivityLogLine: React.FC<{
       : undefined;
   const reasoning = inputObj?.reasoning as string | undefined;
 
-  const label = reasoning || toolCall.toolName;
+  const label =
+    reasoning ??
+    (getActivityLabel ? getActivityLabel(toolCall) : undefined) ??
+    (isPending ? 'Thinking...' : toolCall.toolName);
 
   return (
     <div
@@ -80,7 +125,12 @@ const ActivityLogLine: React.FC<{
         )}
         {isError && <CircleXIcon className="h-3 w-3" />}
       </span>
-      <span className="min-w-0 leading-4 break-all whitespace-normal">
+      <span
+        className={cn(
+          'min-w-0 leading-4 break-all whitespace-normal',
+          reasoning && 'italic',
+        )}
+      >
         {label}
       </span>
       {toolCall.startedAt != null ? (
@@ -124,21 +174,13 @@ const LogLineElapsed: React.FC<{
 const ParentSummaryLine: React.FC<{
   toolCallId: string;
   toolName: string;
-  reasoning?: string;
   isComplete: boolean;
   startedAt?: number;
   completedAt?: number;
   toolCall?: AgentToolCall;
-}> = ({
-  toolCallId,
-  toolName,
-  reasoning,
-  isComplete,
-  startedAt,
-  completedAt,
-  toolCall,
-}) => {
+}> = ({toolCallId, toolName, isComplete, startedAt, completedAt, toolCall}) => {
   const showDetails = useShowToolCallDetails();
+  const {getToolDisplayName} = useToolRenderBehavior();
   const timing = useStoreWithAi((s) => s.ai.toolTimings[toolCallId]);
   const effectiveStartedAt = timing?.startedAt ?? startedAt;
   const effectiveCompletedAt = timing?.completedAt ?? completedAt;
@@ -147,7 +189,10 @@ const ParentSummaryLine: React.FC<{
     effectiveStartedAt,
     effectiveCompletedAt,
   );
-  const displayName = humanizeToolName(toolName);
+  const displayName =
+    (toolCall && getToolDisplayName
+      ? getToolDisplayName(toolCall)
+      : undefined) ?? toolName;
 
   return (
     <div
@@ -165,22 +210,7 @@ const ParentSummaryLine: React.FC<{
           <CircleIcon className="text-muted-foreground/30 h-2 w-2 fill-current" />
         )}
       </span>
-      <span className="flex min-w-0 items-baseline leading-4">
-        <span className="shrink-0 font-medium">{displayName}</span>
-        {reasoning && (
-          <span
-            className="text-muted-foreground/50 relative ml-1.5 overflow-hidden font-normal whitespace-nowrap italic"
-            style={{
-              maskImage:
-                'linear-gradient(to right, black 80%, transparent 100%)',
-              WebkitMaskImage:
-                'linear-gradient(to right, black 80%, transparent 100%)',
-            }}
-          >
-            {reasoning}
-          </span>
-        )}
-      </span>
+      <span className="min-w-0 leading-4 font-medium">{displayName}</span>
       {elapsed ? (
         <span className="text-muted-foreground/50 shrink-0 text-[11px] tabular-nums">
           {elapsed}
@@ -317,23 +347,18 @@ function getNestedCalls(
   return agentProgress[tc.toolCallId] ?? tc.agentToolCalls ?? [];
 }
 
-function getReasoning(tc: AgentToolCall): string | undefined {
-  const inputObj =
-    tc.input && typeof tc.input === 'object'
-      ? (tc.input as Record<string, unknown>)
-      : undefined;
-  return inputObj?.reasoning as string | undefined;
-}
-
 // ---------------------------------------------------------------------------
 // buildFlatSegments — partition a list of tool calls into segments:
 //   consecutive non-agent tools => ToolGroupSegment
 //   agent calls => AgentSegment (recursed at render time)
+// Tools flagged as passthrough by the host app are collapsed: their children
+// are flattened into the caller's segment list so no summary line is emitted.
 // ---------------------------------------------------------------------------
 
 function buildFlatSegments(
   calls: AgentToolCall[],
   agentProgress: Record<string, AgentToolCall[]>,
+  isPassthroughTool?: (tc: AgentToolCall) => boolean,
 ): FlatSegment[] {
   const segments: FlatSegment[] = [];
   let pendingTools: AgentToolCall[] = [];
@@ -346,6 +371,24 @@ function buildFlatSegments(
   };
 
   for (const tc of calls) {
+    if (isPassthroughTool?.(tc)) {
+      const nested = getNestedCalls(tc, agentProgress);
+      const nestedSegments = buildFlatSegments(
+        nested,
+        agentProgress,
+        isPassthroughTool,
+      );
+      for (const seg of nestedSegments) {
+        if (seg.kind === 'tool-group') {
+          pendingTools.push(...seg.tools);
+        } else {
+          flushTools();
+          segments.push(seg);
+        }
+      }
+      continue;
+    }
+
     if (isAgentCall(tc, agentProgress)) {
       flushTools();
       segments.push({
@@ -371,7 +414,14 @@ const FlatSegmentList: React.FC<{
   agentProgress: Record<string, AgentToolCall[]>;
   hoistableSet: ReadonlySet<string>;
   toolRenderers: Record<string, unknown>;
-}> = ({segments, agentProgress, hoistableSet, toolRenderers}) => {
+  isPassthroughTool?: (tc: AgentToolCall) => boolean;
+}> = ({
+  segments,
+  agentProgress,
+  hoistableSet,
+  toolRenderers,
+  isPassthroughTool,
+}) => {
   return (
     <>
       {segments.map((seg, idx) => {
@@ -436,18 +486,20 @@ const FlatSegmentList: React.FC<{
 
         // Agent segment: render summary line, then recurse into sub-segments
         const {toolCall, nestedCalls} = seg;
-        const reasoning = getReasoning(toolCall);
         const isComplete =
           toolCall.state === 'success' || toolCall.state === 'error';
 
-        const childSegments = buildFlatSegments(nestedCalls, agentProgress);
+        const childSegments = buildFlatSegments(
+          nestedCalls,
+          agentProgress,
+          isPassthroughTool,
+        );
 
         return (
           <React.Fragment key={toolCall.toolCallId}>
             <ParentSummaryLine
               toolCallId={toolCall.toolCallId}
               toolName={toolCall.toolName}
-              reasoning={reasoning}
               isComplete={isComplete}
               startedAt={toolCall.startedAt}
               completedAt={toolCall.completedAt}
@@ -458,6 +510,7 @@ const FlatSegmentList: React.FC<{
               agentProgress={agentProgress}
               hoistableSet={hoistableSet}
               toolRenderers={toolRenderers}
+              isPassthroughTool={isPassthroughTool}
             />
           </React.Fragment>
         );
@@ -487,13 +540,6 @@ export const OrchestratorToolLogLine: React.FC<{
   const isError = state === 'output-error' || state === 'output-denied';
   const isPending = !isSuccess && !isError;
 
-  const inputObj =
-    part.input && typeof part.input === 'object'
-      ? (part.input as Record<string, unknown>)
-      : undefined;
-  const reasoning = inputObj?.reasoning as string | undefined;
-  const label = reasoning || toolName;
-
   const toolCall: AgentToolCall = {
     toolCallId,
     toolName,
@@ -505,7 +551,6 @@ export const OrchestratorToolLogLine: React.FC<{
   return (
     <OrchestratorLogLineInner
       toolCallId={toolCallId}
-      label={label}
       isPending={isPending}
       isSuccess={isSuccess}
       isError={isError}
@@ -516,19 +561,30 @@ export const OrchestratorToolLogLine: React.FC<{
 
 const OrchestratorLogLineInner: React.FC<{
   toolCallId: string;
-  label: string;
   isPending: boolean;
   isSuccess: boolean;
   isError: boolean;
   toolCall: AgentToolCall;
-}> = ({toolCallId, label, isPending, isSuccess, isError, toolCall}) => {
+}> = ({toolCallId, isPending, isSuccess, isError, toolCall}) => {
   const showDetails = useShowToolCallDetails();
+  const {getActivityLabel} = useToolRenderBehavior();
   const timing = useStoreWithAi((s) => s.ai.toolTimings[toolCallId]);
   const elapsed = useElapsedTime(
     isPending,
     timing?.startedAt,
     timing?.completedAt,
   );
+
+  const inputObj =
+    toolCall.input && typeof toolCall.input === 'object'
+      ? (toolCall.input as Record<string, unknown>)
+      : undefined;
+  const reasoning = inputObj?.reasoning as string | undefined;
+
+  const label =
+    reasoning ??
+    (getActivityLabel ? getActivityLabel(toolCall) : undefined) ??
+    (isPending ? 'Thinking...' : toolCall.toolName);
 
   return (
     <div
@@ -549,7 +605,12 @@ const OrchestratorLogLineInner: React.FC<{
         )}
         {isError && <CircleXIcon className="h-3 w-3" />}
       </span>
-      <span className="min-w-0 leading-4 break-all whitespace-normal">
+      <span
+        className={cn(
+          'min-w-0 leading-4 break-all whitespace-normal',
+          reasoning && 'italic',
+        )}
+      >
         {label}
       </span>
       {elapsed ? (
@@ -589,6 +650,7 @@ export const FlatAgentRenderer: React.FC<{
   const toolRenderers = useStoreWithAi((s) => s.ai.toolRenderers);
   const agentProgress = useStoreWithAi((s) => s.ai.agentProgress);
   const hoistedRendererNames = useHoistedRenderers();
+  const {isPassthroughTool} = useToolRenderBehavior();
 
   const displayCalls = agentProgress[toolCallId] ?? agentToolCalls;
 
@@ -598,15 +660,9 @@ export const FlatAgentRenderer: React.FC<{
   );
 
   const segments = useMemo(
-    () => buildFlatSegments(displayCalls, agentProgress),
-    [displayCalls, agentProgress],
+    () => buildFlatSegments(displayCalls, agentProgress, isPassthroughTool),
+    [displayCalls, agentProgress, isPassthroughTool],
   );
-
-  const parentInputObj =
-    parentInput && typeof parentInput === 'object'
-      ? (parentInput as Record<string, unknown>)
-      : undefined;
-  const parentReasoning = parentInputObj?.reasoning as string | undefined;
 
   const parentToolCall = useMemo(
     (): AgentToolCall | undefined =>
@@ -621,13 +677,18 @@ export const FlatAgentRenderer: React.FC<{
     [toolCallId, parentToolName, parentInput, isComplete],
   );
 
+  const hideParentSummary = !!(
+    parentToolCall &&
+    isPassthroughTool &&
+    isPassthroughTool(parentToolCall)
+  );
+
   return (
     <div className="mt-1 flex w-full min-w-0 flex-col gap-1.5 overflow-hidden text-[0.9em]">
-      {parentToolName && (
+      {parentToolName && !hideParentSummary && (
         <ParentSummaryLine
           toolCallId={toolCallId}
           toolName={parentToolName}
-          reasoning={parentReasoning}
           isComplete={!!isComplete}
           toolCall={parentToolCall}
         />
@@ -638,6 +699,7 @@ export const FlatAgentRenderer: React.FC<{
         agentProgress={agentProgress}
         hoistableSet={hoistableSet}
         toolRenderers={toolRenderers}
+        isPassthroughTool={isPassthroughTool}
       />
     </div>
   );

--- a/packages/ai-core/src/index.ts
+++ b/packages/ai-core/src/index.ts
@@ -35,7 +35,6 @@ export {
   ToolAbortError,
   extractModelsFromSettings,
   shouldEndAnalysis,
-  humanizeToolName,
 } from './utils';
 export type {
   AddToolApprovalResponse,
@@ -70,6 +69,11 @@ export {
   FlatAgentRenderer,
   OrchestratorToolLogLine,
   ShowToolCallDetailsProvider,
+} from './components/FlatAgentRenderer';
+export type {
+  ToolRenderBehavior,
+  ToolStructureBehavior,
+  ToolDisplayBehavior,
 } from './components/FlatAgentRenderer';
 export {collectHoistableRenderers} from './components/collectHoistableRenderers';
 export type {HoistableToolCall} from './components/collectHoistableRenderers';

--- a/packages/ai-core/src/utils.ts
+++ b/packages/ai-core/src/utils.ts
@@ -512,26 +512,3 @@ export function fixIncompleteToolCalls(messages: UIMessage[]): UIMessage[] {
     };
   });
 }
-
-// ---------------------------------------------------------------------------
-// Tool name helpers
-// ---------------------------------------------------------------------------
-
-const KNOWN_ACRONYMS = new Set(['fsq', 'h3', 'api', 'sql', 'ui', 'csv', 'db']);
-
-/**
- * Humanize a tool name like "agent-fsq-visits-chart" → "FSQ Visits Chart".
- * Strips common prefixes (agent-, skill-) and title-cases each word,
- * auto-uppercasing known acronyms.
- */
-export function humanizeToolName(toolName: string): string {
-  const stripped = toolName.replace(/^agent-/, '').replace(/^skill-/, '');
-  return stripped
-    .split(/[-_]+/)
-    .map((w) =>
-      KNOWN_ACRONYMS.has(w.toLowerCase())
-        ? w.toUpperCase()
-        : w.charAt(0).toUpperCase() + w.slice(1),
-    )
-    .join(' ');
-}

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -81,6 +81,11 @@ export type {SessionType} from '@sqlrooms/ai-core';
 export {ToolErrorMessage} from '@sqlrooms/ai-core';
 export {ToolCallInfo} from '@sqlrooms/ai-core';
 export {ShowToolCallDetailsProvider} from '@sqlrooms/ai-core';
+export type {
+  ToolRenderBehavior,
+  ToolStructureBehavior,
+  ToolDisplayBehavior,
+} from '@sqlrooms/ai-core';
 export {Chat} from '@sqlrooms/ai-core';
 
 // From @sqlrooms/ai-config


### PR DESCRIPTION
## Summary

Adds a `ToolRenderBehavior` API on `Chat.Root` so host apps can customize how tool calls are rendered in `FlatAgentRenderer`, and fixes a bug where pending tool calls were left in a stuck state when a stream was aborted.

## Motivation

`FlatAgentRenderer` previously hardcoded tool-call presentation: every agent tool call produced a summary line, leaf calls were labeled with their raw tool name (or a `reasoning` input field, if present), and display names were passed through a built-in `humanizeToolName` helper with a fixed acronym list.

This works for generic cases but becomes limiting when host apps introduce higher-level tool-call concepts — for example, an orchestrator tool whose only job is to dispatch work to another agent, where rendering a wrapper summary line adds noise without adding information. Host apps also typically have richer context for producing human-readable labels (domain vocabulary, dynamic inputs) than any generic helper baked into the library.

## Changes

### `ai-core` — `ToolRenderBehavior` API

`Chat.Root` now accepts an optional `toolRenderBehavior` prop, made available to `FlatAgentRenderer` via `ToolRenderBehaviorContext`. The API is split into two concerns:

- **Structural** — `isPassthroughTool(toolCall)`: when true, the tool call renders no summary line and its nested calls are flattened into the caller's segment list. Applied recursively in `buildFlatSegments` and also respected at the top-level parent-summary in `FlatAgentRenderer`.
- **Display** — `getToolDisplayName(toolCall)` overrides `ParentSummaryLine` labels; `getActivityLabel(toolCall)` overrides leaf log-line labels in `ActivityLogLine` and `OrchestratorLogLineInner`. Both return `undefined` to fall back to the default.

All three callbacks are optional; the default behavior is unchanged when `toolRenderBehavior` is omitted.

### Removed `humanizeToolName`

With host apps now able to provide display names directly, the built-in `humanizeToolName` helper (and its hardcoded acronym list) is no longer needed and has been removed from the public exports. The default fallback is simply the raw tool name, and the pending state shows "Thinking..." to avoid flashing the raw name before `reasoning` input is available. Leaf labels that come from a `reasoning` input field are now rendered in italic to distinguish them from tool names.

### Dropped `reasoning` tail from `ParentSummaryLine`

Previously parent summary lines appended a masked, italicized `reasoning` tail next to the tool name. This has been removed in favor of a clean, single-label line — host apps that want richer labels can compose them via `getToolDisplayName`.

### Bug fix — abort leaves tool calls stuck

`streamSubAgent` now marks any tool calls still in `pending` or `approval-requested` state as `error` with a cancellation message when the abort signal fires. This happens both inside the stream error path and after the main loop. Previously those calls could remain indefinitely in their pre-abort state in the progress snapshot.

## Public API additions

Exported from `@sqlrooms/ai-core` (and re-exported from `@sqlrooms/ai`):

- `ToolRenderBehavior`
- `ToolStructureBehavior`
- `ToolDisplayBehavior`

## Removed exports

- `humanizeToolName`

## Test plan

- [ ] Existing `FlatAgentRenderer` usage renders identically when no `toolRenderBehavior` is passed
- [ ] Passthrough tools flatten nested calls and render no summary line
- [ ] `getToolDisplayName` / `getActivityLabel` overrides apply; `undefined` returns fall back to defaults
- [ ] Aborting a streaming sub-agent leaves no tool calls in `pending` state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat component accepts a toolRenderBehavior prop to customize tool labels and structure.
  * New configurable rendering behavior lets hosts control tool display and passthrough handling.

* **Bug Fixes**
  * In-flight tool calls are now consistently marked errored and cleaned up when aborted.

* **Refactor**
  * Tool rendering system reorganized to support the new configurable behaviors.

* **Chores**
  * Cleaned up legacy tool-name helper from public exports; new types re-exported for config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->