### PR TITLE
feat: add split map functionality and related context to Kepler

### DIFF
--- a/packages/kepler/src/KeplerSlice.ts
+++ b/packages/kepler/src/KeplerSlice.ts
@@ -11,6 +11,7 @@ import {
   setFilter as setFilterAction,
   setFilterAnimationTime as setFilterAnimationTimeAction,
   setFilterAnimationWindow as setFilterAnimationWindowAction,
+  setFilterView as setFilterViewAction,
   toggleLayerForMap as toggleLayerForMapAction,
   toggleSplitMap as toggleSplitMapAction,
   wrapTo,
@@ -298,6 +299,11 @@ export type KeplerSliceState = {
       filterId: string,
       animationWindow: string,
     ) => void;
+    setFilterView: (
+      mapId: string,
+      filterIdx: number,
+      view: 'side' | 'enlarged' | 'minified',
+    ) => void;
     updateTooltipFields: (
       mapId: string,
       datasetId: string,
@@ -546,6 +552,14 @@ export function createKeplerSlice({
           get().kepler.dispatchAction(
             mapId,
             setFilterAnimationWindowAction({id: filterId, animationWindow}),
+          );
+        },
+
+        setFilterView: (mapId, filterIdx, view) => {
+          get().kepler.registerKeplerMapIfNotExists(mapId);
+          get().kepler.dispatchAction(
+            mapId,
+            setFilterViewAction(filterIdx, view),
           );
         },
 

--- a/packages/kepler/src/KeplerSlice.ts
+++ b/packages/kepler/src/KeplerSlice.ts
@@ -11,6 +11,8 @@ import {
   setFilter as setFilterAction,
   setFilterAnimationTime as setFilterAnimationTimeAction,
   setFilterAnimationWindow as setFilterAnimationWindowAction,
+  toggleLayerForMap as toggleLayerForMapAction,
+  toggleSplitMap as toggleSplitMapAction,
   wrapTo,
 } from '@kepler.gl/actions';
 import {ALL_FIELD_TYPES, VectorTileDatasetMetadata} from '@kepler.gl/constants';
@@ -123,6 +125,10 @@ function createDefaultMapKeplerState(
       currentModal: null,
       mapControls: {
         visibleLayers: INITIAL_UI_STATE.mapControls.visibleLayers,
+        splitMap: {
+          show: true,
+          active: false,
+        },
         mapLegend: {
           show: true,
           active: false,
@@ -296,6 +302,12 @@ export type KeplerSliceState = {
       mapId: string,
       datasetId: string,
       fieldNames: string[],
+    ) => void;
+    toggleSplitMap: (mapId: string, index?: number) => void;
+    toggleLayerForMap: (
+      mapId: string,
+      mapIndex: number,
+      layerId: string,
     ) => void;
     addTableToMap: (
       mapId: string,
@@ -577,6 +589,22 @@ export function createKeplerSlice({
                 },
               },
             }),
+          );
+        },
+
+        toggleSplitMap: (mapId, index) => {
+          get().kepler.registerKeplerMapIfNotExists(mapId);
+          get().kepler.dispatchAction(
+            mapId,
+            toggleSplitMapAction(index as number),
+          );
+        },
+
+        toggleLayerForMap: (mapId, mapIndex, layerId) => {
+          get().kepler.registerKeplerMapIfNotExists(mapId);
+          get().kepler.dispatchAction(
+            mapId,
+            toggleLayerForMapAction(mapIndex, layerId),
           );
         },
 

--- a/packages/kepler/src/components/CustomMapLegend.tsx
+++ b/packages/kepler/src/components/CustomMapLegend.tsx
@@ -28,7 +28,7 @@ import {
   useState,
 } from 'react';
 import {useStoreWithKepler} from '../KeplerSlice';
-import {SplitMapIndexContext} from './KeplerMapContainer';
+import {SplitMapIndexContext} from './SplitMapIndexContext';
 
 const defaultActionIcons = {
   expanded: ArrowDown,

--- a/packages/kepler/src/components/CustomMapLegend.tsx
+++ b/packages/kepler/src/components/CustomMapLegend.tsx
@@ -28,6 +28,7 @@ import {
   useState,
 } from 'react';
 import {useStoreWithKepler} from '../KeplerSlice';
+import {SplitMapIndexContext} from './KeplerMapContainer';
 
 const defaultActionIcons = {
   expanded: ArrowDown,
@@ -43,21 +44,36 @@ export function CustomMapLegendFactory(
   LayerLegendHeader: ReturnType<typeof LayerLegendHeaderFactory>,
   LayerLegendContent: ReturnType<typeof LayerLegendContentFactory>,
 ) {
-  const MapLegend: React.FC<MapLegendProps> = ({
+  const MapLegend: React.FC<MapLegendProps & {mapIndex?: number}> = ({
     layers = [],
     width,
     isExport,
+    mapIndex: mapIndexProp,
     ...restProps
   }) => {
     const containerW = width || DIMENSIONS.mapControl.width;
     const mapId = useContext(KeplerGlContext).id;
+    const splitMapIndex = useContext(SplitMapIndexContext);
+    const mapIndex = mapIndexProp ?? splitMapIndex;
     const dispatchAction = useStoreWithKepler(
       (state) => state.kepler.dispatchAction,
+    );
+    const splitMaps = useStoreWithKepler(
+      (state) => state.kepler.map[mapId]?.visState?.splitMaps,
     );
     const handleClose = (evt: React.MouseEvent<HTMLButtonElement>) => {
       evt.stopPropagation();
       dispatchAction(mapId, toggleMapControl('mapLegend', 0));
     };
+
+    const isSplit = splitMaps && splitMaps.length > 1;
+    const panelLayers =
+      isSplit && mapIndex != null ? splitMaps[mapIndex]?.layers : undefined;
+
+    const visibleLayers = layers.filter(
+      (layer) =>
+        layer.config.isVisible && (!panelLayers || panelLayers[layer.id]),
+    );
 
     return (
       <div
@@ -79,19 +95,17 @@ export function CustomMapLegendFactory(
             </div>
           )}
           <div className="flex w-full flex-1 flex-col items-center">
-            {layers
-              .filter((layer) => layer.config.isVisible)
-              .map((layer, index) => {
-                return (
-                  <LayerLegendItem
-                    key={index}
-                    layer={layer}
-                    containerW={containerW}
-                    isExport={isExport}
-                    {...restProps}
-                  />
-                );
-              })}
+            {visibleLayers.map((layer, index) => {
+              return (
+                <LayerLegendItem
+                  key={index}
+                  layer={layer}
+                  containerW={containerW}
+                  isExport={isExport}
+                  {...restProps}
+                />
+              );
+            })}
           </div>
         </div>
       </div>

--- a/packages/kepler/src/components/CustomMapLegendPanel.tsx
+++ b/packages/kepler/src/components/CustomMapLegendPanel.tsx
@@ -9,7 +9,9 @@ export function CustomMapLegendPanelFactory(
   ...deps: Parameters<typeof MapLegendPanelFactory>
 ): ReturnType<typeof MapLegendPanelFactory> {
   const MapLegendPanel = MapLegendPanelFactory(...deps);
-  const CustomMapLegendPanel = (props: MapLegendPanelProps) => {
+  const CustomMapLegendPanel = (
+    props: MapLegendPanelProps & {mapIndex?: number},
+  ) => {
     return (
       <>
         <style>{`.draggable-legend .map-control__panel-header { display: none !important; }`}</style>

--- a/packages/kepler/src/components/KeplerMapContainer.tsx
+++ b/packages/kepler/src/components/KeplerMapContainer.tsx
@@ -1,4 +1,4 @@
-import {FC, useMemo, useRef, useEffect, useState} from 'react';
+import {FC, createContext, useMemo, useRef, useEffect, useState} from 'react';
 
 import {
   MapContainerFactory,
@@ -25,6 +25,10 @@ const BottomWidget = getKeplerFactory(BottomWidgetFactory);
 const GeoCoderPanel = getKeplerFactory(GeocoderPanelFactory);
 const ModalContainer = getKeplerFactory(ModalContainerFactory);
 
+export const SplitMapIndexContext = createContext<number | undefined>(
+  undefined,
+);
+
 const DEFAULT_DIMENSIONS = {
   width: 0,
   height: 0,
@@ -49,6 +53,13 @@ const CustomWidgetcontainer = styled.div`
   .bottom-widget--container .animation-control-container {
     margin-top: 0 !important;
   }
+`;
+
+const SplitMapsContainer = styled.div`
+  display: flex;
+  width: 100%;
+  height: 100%;
+  position: relative;
 `;
 
 type KeplerGLProps = Parameters<typeof geoCoderPanelSelector>[0];
@@ -97,9 +108,22 @@ const KeplerGl: FC<{
         size || DEFAULT_DIMENSIONS,
       )
     : null;
+
+  const splitMaps = keplerState?.visState?.splitMaps;
+  const isSplit = splitMaps && splitMaps.length > 1;
+
   const mapFields = useMemo(
     () => (keplerState?.visState ? mapFieldsSelector(mergedKeplerProps) : null),
     [keplerState, mergedKeplerProps],
+  );
+  const mapFieldsSplit = useMemo(
+    () =>
+      isSplit && keplerState?.visState
+        ? splitMaps.map((_, index) =>
+            mapFieldsSelector(mergedKeplerProps, index),
+          )
+        : null,
+    [keplerState, mergedKeplerProps, isSplit, splitMaps],
   );
 
   // Check if there are filters or animatable layers (e.g., Trip layers)
@@ -127,7 +151,30 @@ const KeplerGl: FC<{
         ref={containerRef}
         className="kepler-gl relative flex h-full w-full flex-col justify-between"
       >
-        {mapFields?.mapState ? (
+        {isSplit && mapFieldsSplit ? (
+          <SplitMapsContainer>
+            <MapViewStateContextProvider
+              mapState={
+                (mapFieldsSplit[0]?.mapState ??
+                  mapFields?.mapState) as NonNullable<
+                  typeof mapFields
+                >['mapState']
+              }
+            >
+              {mapFieldsSplit.map((fields, index) => (
+                <SplitMapIndexContext.Provider key={index} value={index}>
+                  <MapContainer
+                    index={index}
+                    primary={index === 1}
+                    containerId={index}
+                    {...fields}
+                    mapboxApiAccessToken={mapboxApiAccessToken || ''}
+                  />
+                </SplitMapIndexContext.Provider>
+              ))}
+            </MapViewStateContextProvider>
+          </SplitMapsContainer>
+        ) : mapFields?.mapState ? (
           <MapViewStateContextProvider mapState={mapFields.mapState}>
             <MapContainer
               primary={true}

--- a/packages/kepler/src/components/KeplerMapContainer.tsx
+++ b/packages/kepler/src/components/KeplerMapContainer.tsx
@@ -1,4 +1,4 @@
-import {FC, createContext, useMemo, useRef, useEffect, useState} from 'react';
+import {FC, useMemo, useRef, useEffect, useState} from 'react';
 
 import {
   MapContainerFactory,
@@ -19,15 +19,12 @@ import {getKeplerFactory} from './KeplerInjector';
 import {KeplerProvider} from './KeplerProvider';
 import {useKeplerStateActions} from '../hooks/useKeplerStateActions';
 import {useStoreWithKepler} from '../KeplerSlice';
+import {SplitMapIndexContext} from './SplitMapIndexContext';
 
 const MapContainer = getKeplerFactory(MapContainerFactory);
 const BottomWidget = getKeplerFactory(BottomWidgetFactory);
 const GeoCoderPanel = getKeplerFactory(GeocoderPanelFactory);
 const ModalContainer = getKeplerFactory(ModalContainerFactory);
-
-export const SplitMapIndexContext = createContext<number | undefined>(
-  undefined,
-);
 
 const DEFAULT_DIMENSIONS = {
   width: 0,

--- a/packages/kepler/src/components/SplitMapIndexContext.ts
+++ b/packages/kepler/src/components/SplitMapIndexContext.ts
@@ -1,0 +1,5 @@
+import {createContext} from 'react';
+
+export const SplitMapIndexContext = createContext<number | undefined>(
+  undefined,
+);

--- a/packages/kepler/src/index.ts
+++ b/packages/kepler/src/index.ts
@@ -34,10 +34,8 @@ export type {
   KeplerFactoryRecipe,
   KeplerFactoryRecipeMode,
 } from './components/KeplerInjector';
-export {
-  KeplerMapContainer,
-  SplitMapIndexContext,
-} from './components/KeplerMapContainer';
+export {KeplerMapContainer} from './components/KeplerMapContainer';
+export {SplitMapIndexContext} from './components/SplitMapIndexContext';
 export {KeplerPlotContainer} from './components/KeplerPlotContainer';
 export {KeplerProvider} from './components/KeplerProvider';
 export {KeplerS3Browser} from './components/KeplerS3Browser';

--- a/packages/kepler/src/index.ts
+++ b/packages/kepler/src/index.ts
@@ -34,7 +34,10 @@ export type {
   KeplerFactoryRecipe,
   KeplerFactoryRecipeMode,
 } from './components/KeplerInjector';
-export {KeplerMapContainer} from './components/KeplerMapContainer';
+export {
+  KeplerMapContainer,
+  SplitMapIndexContext,
+} from './components/KeplerMapContainer';
 export {KeplerPlotContainer} from './components/KeplerPlotContainer';
 export {KeplerProvider} from './components/KeplerProvider';
 export {KeplerS3Browser} from './components/KeplerS3Browser';


### PR DESCRIPTION
- add support for split map functionality in the Kepler map components
- enable the display and control of multiple map panels side-by-side
- update the legend and map container components to handle split map state


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added split-map mode allowing multiple map panels to be displayed and controlled simultaneously.
  * Map controls for toggling split view and per-panel layer visibility exposed to the UI.
  * Legends now show only the layers relevant to the active split panel.
  * Split-map control is enabled by default in the per-map UI state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->