### PR TITLE
feat: Improved color scales + example app

### DIFF
--- a/examples/color-scales/README.md
+++ b/examples/color-scales/README.md
@@ -1,0 +1,20 @@
+# SQLRooms color scales example
+
+A Vite application showing `@sqlrooms/color-scales` legends for the SQLRooms
+cars dataset.
+
+The room store loads:
+
+```ts
+https://huggingface.co/datasets/sqlrooms/cars/resolve/main/cars.parquet
+```
+
+into DuckDB as the `cars` table, then renders sequential, diverging, quantile,
+quantize, threshold, and categorical legends for columns in the dataset.
+
+## Running locally
+
+```sh
+npm install
+npm run dev
+```

--- a/examples/color-scales/eslint.config.js
+++ b/examples/color-scales/eslint.config.js
@@ -1,0 +1,32 @@
+import js from '@eslint/js';
+import {defineConfig} from 'eslint/config';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+
+export default defineConfig(
+  {ignores: ['dist']},
+  {
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+      parserOptions: {
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    plugins: {
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh,
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      'react-refresh/only-export-components': [
+        'warn',
+        {allowConstantExport: true},
+      ],
+    },
+  },
+);

--- a/examples/color-scales/index.html
+++ b/examples/color-scales/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SQLRooms Color Scales Example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/color-scales/package.json
+++ b/examples/color-scales/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "color-scales-example",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "lint": "eslint .",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@sqlrooms/color-scales": "workspace:*",
+    "@sqlrooms/duckdb": "workspace:*",
+    "@sqlrooms/room-shell": "workspace:*",
+    "@sqlrooms/ui": "workspace:*",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.36.0",
+    "@tailwindcss/vite": "^4.1.18",
+    "@types/react": "^19.1.13",
+    "@types/react-dom": "^19.1.9",
+    "@vitejs/plugin-react": "^5.0.3",
+    "eslint": "^9.36.0",
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-refresh": "^0.4.21",
+    "globals": "^15.15.0",
+    "tailwindcss": "^4.1.18",
+    "typescript": "5.9.2",
+    "typescript-eslint": "^8.44.1",
+    "vite": "^7.1.9"
+  }
+}

--- a/examples/color-scales/src/index.css
+++ b/examples/color-scales/src/index.css
@@ -1,0 +1,68 @@
+@import 'tailwindcss';
+
+@import '@sqlrooms/ui/tailwind-preset.css';
+
+@source '../index.html';
+@source 'src/**/*.{ts,tsx}';
+@source '../../../packages/*/src/**/*.{ts,tsx}';
+@source '../node_modules/@sqlrooms/*/dist/';
+
+#root {
+  width: 100vw;
+  height: 100vh;
+}
+
+:root {
+  --background: 0 0% 100%;
+  --foreground: 222.2 84% 4.9%;
+  --card: 0 0% 100%;
+  --card-foreground: 222.2 84% 4.9%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 222.2 84% 4.9%;
+  --primary: 221.2 83.2% 53.3%;
+  --primary-foreground: 210 40% 98%;
+  --secondary: 210 40% 96.1%;
+  --secondary-foreground: 222.2 47.4% 11.2%;
+  --muted: 210 40% 96.1%;
+  --muted-foreground: 215.4 16.3% 46.9%;
+  --accent: 210 40% 96.1%;
+  --accent-foreground: 222.2 47.4% 11.2%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 210 40% 98%;
+  --border: 214.3 31.8% 91.4%;
+  --input: 214.3 31.8% 91.4%;
+  --ring: 221.2 83.2% 53.3%;
+  --radius: 0.5rem;
+  --chart-1: 12 76% 61%;
+  --chart-2: 173 58% 39%;
+  --chart-3: 197 37% 24%;
+  --chart-4: 43 74% 66%;
+  --chart-5: 27 87% 67%;
+}
+
+.dark {
+  --background: 222.2 84% 4.9%;
+  --foreground: 210 40% 98%;
+  --card: 222.2 84% 4.9%;
+  --card-foreground: 210 40% 98%;
+  --popover: 222.2 84% 4.9%;
+  --popover-foreground: 210 40% 98%;
+  --primary: 217.2 91.2% 59.8%;
+  --primary-foreground: 222.2 47.4% 11.2%;
+  --secondary: 217.2 32.6% 17.5%;
+  --secondary-foreground: 210 40% 98%;
+  --muted: 217.2 32.6% 17.5%;
+  --muted-foreground: 215 20.2% 65.1%;
+  --accent: 217.2 32.6% 17.5%;
+  --accent-foreground: 210 40% 98%;
+  --destructive: 0 62.8% 30.6%;
+  --destructive-foreground: 210 40% 98%;
+  --border: 217.2 32.6% 17.5%;
+  --input: 217.2 32.6% 17.5%;
+  --ring: 224.3 76.3% 48%;
+  --chart-1: 220 70% 50%;
+  --chart-2: 160 60% 45%;
+  --chart-3: 30 80% 55%;
+  --chart-4: 280 65% 60%;
+  --chart-5: 340 75% 55%;
+}

--- a/examples/color-scales/src/main.tsx
+++ b/examples/color-scales/src/main.tsx
@@ -1,0 +1,10 @@
+import {StrictMode} from 'react';
+import {createRoot} from 'react-dom/client';
+import {Room} from './room';
+import './index.css';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <Room />
+  </StrictMode>,
+);

--- a/examples/color-scales/src/room.tsx
+++ b/examples/color-scales/src/room.tsx
@@ -1,0 +1,279 @@
+import {
+  buildColorScaleLegend,
+  ColorScaleLegend,
+  createColorScaleMapper,
+  type ColorScaleConfig,
+  type ResolvedColorLegend,
+} from '@sqlrooms/color-scales';
+import {useSql} from '@sqlrooms/duckdb';
+import {
+  createRoomShellSlice,
+  createRoomStore,
+  RoomShell,
+  type RoomShellSliceState,
+} from '@sqlrooms/room-shell';
+import {Spinner, ThemeProvider, ThemeSwitch, cn} from '@sqlrooms/ui';
+import {useMemo} from 'react';
+
+type CarRow = {
+  Car: string;
+  MPG: number;
+  Cylinders: number;
+  Displacement: number;
+  Horsepower: number;
+  Weight: number;
+  Acceleration: number;
+  Model: number;
+  Origin: string;
+};
+
+type LegendExample = {
+  label: string;
+  description: string;
+  colorScale: ColorScaleConfig;
+};
+
+type LegendWithExample = LegendExample & {
+  legend: ResolvedColorLegend;
+};
+
+const legendExamples: LegendExample[] = [
+  {
+    label: 'Fuel Economy',
+    description: 'Sequential ramp over MPG',
+    colorScale: {
+      field: 'MPG',
+      type: 'sequential',
+      scheme: 'Viridis',
+      domain: 'auto',
+      legend: {title: 'MPG'},
+    },
+  },
+  {
+    label: 'Horsepower',
+    description: 'Quantile bins',
+    colorScale: {
+      field: 'Horsepower',
+      type: 'quantile',
+      scheme: 'YlOrRd',
+      bins: 5,
+      legend: {title: 'Horsepower'},
+    },
+  },
+  {
+    label: 'Vehicle Weight',
+    description: 'Equal-width bins',
+    colorScale: {
+      field: 'Weight',
+      type: 'quantize',
+      scheme: 'PuBuGn',
+      domain: 'auto',
+      bins: 6,
+      legend: {title: 'Weight'},
+    },
+  },
+  {
+    label: 'Acceleration',
+    description: 'Diverging around the fleet midpoint',
+    colorScale: {
+      field: 'Acceleration',
+      type: 'diverging',
+      scheme: 'RdBu',
+      domain: 'auto',
+      reverse: true,
+      legend: {title: 'Acceleration'},
+    },
+  },
+  {
+    label: 'Cylinders',
+    description: 'Explicit thresholds',
+    colorScale: {
+      field: 'Cylinders',
+      type: 'threshold',
+      scheme: 'Spectral',
+      thresholds: [4, 6, 8],
+      legend: {title: 'Cylinders'},
+    },
+  },
+  {
+    label: 'Origin',
+    description: 'Categorical swatches',
+    colorScale: {
+      field: 'Origin',
+      type: 'categorical',
+      scheme: 'Tableau10',
+      legend: {title: 'Origin'},
+    },
+  },
+];
+
+export type RoomState = RoomShellSliceState;
+
+const {roomStore, useRoomStore} = createRoomStore<RoomState>(
+  (set, get, store) => ({
+    ...createRoomShellSlice({
+      config: {
+        dataSources: [
+          {
+            type: 'url',
+            url: 'https://huggingface.co/datasets/sqlrooms/cars/resolve/main/cars.parquet',
+            tableName: 'cars',
+          },
+        ],
+      },
+    })(set, get, store),
+  }),
+);
+
+export const Room = () => (
+  <ThemeProvider defaultTheme="light" storageKey="sqlrooms-ui-theme">
+    <RoomShell className="bg-background h-screen" roomStore={roomStore}>
+      <div className="absolute top-4 right-4 z-10">
+        <ThemeSwitch />
+      </div>
+      <ColorScalesApp />
+    </RoomShell>
+  </ThemeProvider>
+);
+
+function getColumnValues(rows: CarRow[], field: string) {
+  return rows.map((row) => row[field as keyof CarRow]);
+}
+
+function buildLegends(rows: CarRow[]): LegendWithExample[] {
+  return legendExamples.flatMap((example) => {
+    const legend = buildColorScaleLegend({
+      colorScale: example.colorScale,
+      values: getColumnValues(rows, example.colorScale.field),
+    });
+
+    return legend ? [{...example, legend}] : [];
+  });
+}
+
+function SampleCars({
+  rows,
+  colorScale,
+}: {
+  rows: CarRow[];
+  colorScale: ColorScaleConfig;
+}) {
+  const mapper = useMemo(
+    () =>
+      createColorScaleMapper({
+        colorScale,
+        values: getColumnValues(rows, colorScale.field),
+      }),
+    [colorScale, rows],
+  );
+  const sampleRows = rows.slice(0, 10);
+
+  return (
+    <div className="mt-4 grid grid-cols-2 gap-x-3 gap-y-1.5">
+      {sampleRows.map((row) => {
+        const value = row[colorScale.field as keyof CarRow];
+        const color = mapper(value);
+        return (
+          <div
+            key={`${colorScale.field}-${row.Car}`}
+            className="flex min-w-0 items-center gap-2 text-xs"
+            title={`${row.Car}: ${String(value)}`}
+          >
+            <span
+              className="border-border h-2.5 w-2.5 shrink-0 rounded-[2px] border"
+              style={{
+                backgroundColor: `rgba(${color[0]}, ${color[1]}, ${color[2]}, ${
+                  color[3] / 255
+                })`,
+              }}
+            />
+            <span className="text-muted-foreground truncate">{row.Car}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function LegendCard({
+  example,
+  rows,
+}: {
+  example: LegendWithExample;
+  rows: CarRow[];
+}) {
+  return (
+    <section className="border-border bg-card rounded-lg border p-4 shadow-sm">
+      <div className="mb-4">
+        <h2 className="text-card-foreground text-sm font-semibold">
+          {example.label}
+        </h2>
+        <p className="text-muted-foreground mt-1 text-xs">
+          {example.description}
+        </p>
+      </div>
+      <ColorScaleLegend
+        legends={[example.legend]}
+        width={300}
+        swatchColumns={2}
+      />
+      <SampleCars rows={rows} colorScale={example.colorScale} />
+    </section>
+  );
+}
+
+function ColorScalesApp() {
+  const isTableReady = useRoomStore((state) =>
+    Boolean(state.db.findTableByName('cars')),
+  );
+  const queryResult = useSql<CarRow>({
+    query: `SELECT * FROM cars ORDER BY Model, Car`,
+    enabled: isTableReady,
+  });
+  const rows = useMemo(
+    () => queryResult.data?.toArray() ?? [],
+    [queryResult.data],
+  );
+  const legends = useMemo(() => buildLegends(rows), [rows]);
+
+  if (!isTableReady || queryResult.isLoading) {
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  return (
+    <main className="h-full overflow-auto">
+      <div className="mx-auto flex max-w-7xl flex-col gap-6 px-6 py-8">
+        <header className="max-w-3xl">
+          <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+            SQLRooms color scales
+          </p>
+          <h1 className="text-foreground mt-2 text-3xl font-semibold tracking-normal">
+            Cars legend gallery
+          </h1>
+          <p className="text-muted-foreground mt-3 text-sm leading-6">
+            {rows.length.toLocaleString()} rows from the cars parquet dataset,
+            rendered through shared color-scale configs.
+          </p>
+        </header>
+        <div
+          className={cn(
+            'grid gap-4',
+            'grid-cols-1 lg:grid-cols-2 xl:grid-cols-3',
+          )}
+        >
+          {legends.map((example) => (
+            <LegendCard
+              key={`${example.colorScale.field}-${example.colorScale.type}`}
+              example={example}
+              rows={rows}
+            />
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/examples/color-scales/src/vite-env.d.ts
+++ b/examples/color-scales/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/color-scales/tsconfig.app.json
+++ b/examples/color-scales/tsconfig.app.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src"]
+}

--- a/examples/color-scales/tsconfig.json
+++ b/examples/color-scales/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    {"path": "./tsconfig.app.json"},
+    {"path": "./tsconfig.node.json"}
+  ]
+}

--- a/examples/color-scales/tsconfig.node.json
+++ b/examples/color-scales/tsconfig.node.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/examples/color-scales/vite.config.ts
+++ b/examples/color-scales/vite.config.ts
@@ -1,0 +1,7 @@
+import tailwindcss from '@tailwindcss/vite';
+import react from '@vitejs/plugin-react';
+import {defineConfig} from 'vite';
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+});

--- a/packages/color-scales/README.md
+++ b/packages/color-scales/README.md
@@ -210,9 +210,10 @@ const legend = buildColorScaleLegend(colorScale, values);
 
 `buildColorScaleLegend(...)` returns a `ResolvedColorLegend`, which is one of:
 
-- `continuous`
-- `stepped`
-- `categorical`
+- `continuous`: a gradient ramp with positioned tick labels
+- `stepped`: discrete color blocks with range labels and boundary ticks when
+  available
+- `categorical`: swatches for distinct category values
 
 You can render one or more resolved legends with the generic React component:
 
@@ -222,9 +223,26 @@ import {ColorScaleLegend} from '@sqlrooms/color-scales';
 <ColorScaleLegend legends={[legend]} />;
 ```
 
-The current legend renderer is intentionally generic and runtime-neutral. It is
-meant to work in any React environment, while runtime-specific packages can
-choose to render the same config/model through other systems such as
+The React renderer follows the same visual vocabulary as D3's
+[color legend](https://observablehq.com/@d3/color-legend): continuous scales are
+drawn as horizontal ramps with aligned ticks, quantize/quantile/threshold scales
+are drawn as segmented ramps, and categorical scales are drawn as compact
+swatches.
+
+Optional presentation props let callers tune the layout without changing the
+shared legend model:
+
+```tsx
+<ColorScaleLegend
+  legends={[mpgLegend, originLegend]}
+  width={320}
+  swatchColumns={2}
+/>
+```
+
+The renderer is still intentionally generic and runtime-neutral. It works in any
+React environment, while runtime-specific packages can choose to render the same
+config/model through other systems such as
 [Mosaic/VGPlot legends](https://idl.uw.edu/mosaic/examples/legends.html).
 
 ### Using the Same Config With `MosaicColorLegend`

--- a/packages/color-scales/src/ColorScaleLegend.tsx
+++ b/packages/color-scales/src/ColorScaleLegend.tsx
@@ -1,13 +1,22 @@
 import {cn} from '@sqlrooms/ui';
 import type {ResolvedColorLegend} from './config';
+import {CategoricalLegend} from './legend/CategoricalLegend';
+import {ContinuousLegend} from './legend/ContinuousLegend';
+import {SteppedLegend} from './legend/SteppedLegend';
 
 type ColorScaleLegendProps = {
   legends: ResolvedColorLegend[];
   className?: string;
+  width?: number;
+  swatchColumns?: number;
 };
 
-/** TODO: implement nicer legends like in https://observablehq.com/@d3/color-legend */
-export function ColorScaleLegend({legends, className}: ColorScaleLegendProps) {
+export function ColorScaleLegend({
+  legends,
+  className,
+  width = 280,
+  swatchColumns = 1,
+}: ColorScaleLegendProps) {
   if (!legends.length) {
     return null;
   }
@@ -17,54 +26,22 @@ export function ColorScaleLegend({legends, className}: ColorScaleLegendProps) {
       {legends.map((legend) => (
         <div
           key={`${legend.title}-${legend.type}`}
-          className="bg-background/70 rounded-md px-3 py-2 shadow-sm backdrop-blur-sm"
+          className="border-border/70 bg-background/90 w-fit max-w-full rounded-md border px-3 py-2.5 shadow-sm backdrop-blur-sm"
         >
-          <div className="text-foreground mb-2 text-xs font-semibold">
+          <div className="text-foreground mb-2 text-xs leading-none font-semibold">
             {legend.title}
           </div>
-          {legend.type === 'continuous' ? (
-            <div>
-              <div
-                className="h-3 rounded-sm border"
-                style={{background: legend.gradient}}
-              />
-              <div className="text-muted-foreground relative mt-1 h-4 text-[0.6rem]">
-                {legend.ticks.map((tick) => (
-                  <span
-                    key={`${legend.title}-${tick.offset}-${tick.label}`}
-                    className="absolute"
-                    style={{
-                      left: `${tick.offset}%`,
-                      transform:
-                        tick.offset === 0
-                          ? 'none'
-                          : tick.offset === 100
-                            ? 'translateX(-100%)'
-                            : 'translateX(-50%)',
-                    }}
-                  >
-                    {tick.label}
-                  </span>
-                ))}
-              </div>
-            </div>
-          ) : (
-            <div className="space-y-1.5">
-              {legend.items.map((item) => (
-                <div
-                  key={`${legend.title}-${item.label}`}
-                  className="text-foreground flex items-center gap-2 text-xs"
-                >
-                  <span
-                    className="h-3 w-3 rounded-sm border"
-                    style={{
-                      backgroundColor: `rgba(${item.color[0]}, ${item.color[1]}, ${item.color[2]}, ${item.color[3] / 255})`,
-                    }}
-                  />
-                  <span className="truncate">{item.label}</span>
-                </div>
-              ))}
-            </div>
+          {legend.type === 'continuous' && (
+            <ContinuousLegend legend={legend} width={width} />
+          )}
+          {legend.type === 'stepped' && (
+            <SteppedLegend legend={legend} width={width} />
+          )}
+          {legend.type === 'categorical' && (
+            <CategoricalLegend
+              legend={legend}
+              columns={Math.max(1, Math.round(swatchColumns))}
+            />
           )}
         </div>
       ))}

--- a/packages/color-scales/src/config.ts
+++ b/packages/color-scales/src/config.ts
@@ -104,6 +104,7 @@ export type ResolvedColorLegend =
       type: 'stepped';
       title: string;
       items: Array<{label: string; color: ResolvedRGBA}>;
+      ticks?: Array<{label: string; offset: number}>;
     }
   | {
       type: 'categorical';

--- a/packages/color-scales/src/legend/CategoricalLegend.tsx
+++ b/packages/color-scales/src/legend/CategoricalLegend.tsx
@@ -1,0 +1,32 @@
+import type {ResolvedColorLegend} from '../config';
+import {rgba} from './utils';
+
+export function CategoricalLegend({
+  legend,
+  columns,
+}: {
+  legend: Extract<ResolvedColorLegend, {type: 'categorical'}>;
+  columns: number;
+}) {
+  return (
+    <div
+      className="grid gap-x-3 gap-y-1.5"
+      style={{gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`}}
+    >
+      {legend.items.map((item) => (
+        <div
+          key={`${legend.title}-${item.label}`}
+          className="text-foreground flex min-w-0 items-center gap-2 text-xs leading-tight"
+          title={item.label}
+        >
+          <span
+            aria-hidden="true"
+            className="border-border/70 h-3 w-3 shrink-0 rounded-[2px] border"
+            style={{backgroundColor: rgba(item.color)}}
+          />
+          <span className="truncate">{item.label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/color-scales/src/legend/ContinuousLegend.tsx
+++ b/packages/color-scales/src/legend/ContinuousLegend.tsx
@@ -1,0 +1,22 @@
+import type {ResolvedColorLegend} from '../config';
+import {LegendTicks} from './LegendTicks';
+import {getRampStyle} from './utils';
+
+export function ContinuousLegend({
+  legend,
+  width,
+}: {
+  legend: Extract<ResolvedColorLegend, {type: 'continuous'}>;
+  width: number;
+}) {
+  return (
+    <div className="min-w-0" style={getRampStyle(width)}>
+      <div
+        aria-hidden="true"
+        className="border-border/70 h-3 rounded-[2px] border shadow-[inset_0_0_0_1px_rgb(255_255_255_/_0.22)]"
+        style={{background: legend.gradient}}
+      />
+      <LegendTicks ticks={legend.ticks} width={width} />
+    </div>
+  );
+}

--- a/packages/color-scales/src/legend/LegendTicks.tsx
+++ b/packages/color-scales/src/legend/LegendTicks.tsx
@@ -1,4 +1,4 @@
-import type {LegendTick} from './utils';
+import {LEGEND_TICKS_HEIGHT_CLASS, type LegendTick} from './utils';
 
 function getTickTransform(offset: number) {
   if (offset <= 0) {
@@ -57,7 +57,7 @@ export function LegendTicks({
   width: number;
 }) {
   return (
-    <div className="relative h-8">
+    <div className={`relative ${LEGEND_TICKS_HEIGHT_CLASS}`}>
       {getVisibleTicks(ticks, width).map((tick) => (
         <div
           key={`${tick.offset}-${tick.label}`}

--- a/packages/color-scales/src/legend/LegendTicks.tsx
+++ b/packages/color-scales/src/legend/LegendTicks.tsx
@@ -1,0 +1,78 @@
+import type {LegendTick} from './utils';
+
+function getTickTransform(offset: number) {
+  if (offset <= 0) {
+    return 'none';
+  }
+
+  if (offset >= 100) {
+    return 'translateX(-100%)';
+  }
+
+  return 'translateX(-50%)';
+}
+
+function estimateTickLabelWidth(label: string) {
+  return label.length * 5.6 + 8;
+}
+
+function getTickBounds(tick: LegendTick, width: number) {
+  const x = (tick.offset / 100) * width;
+  const labelWidth = estimateTickLabelWidth(tick.label);
+
+  if (tick.offset <= 0) {
+    return [x, x + labelWidth] as const;
+  }
+
+  if (tick.offset >= 100) {
+    return [x - labelWidth, x] as const;
+  }
+
+  return [x - labelWidth / 2, x + labelWidth / 2] as const;
+}
+
+function getVisibleTicks(ticks: LegendTick[], width: number) {
+  const sortedTicks = [...ticks].sort(
+    (left, right) => left.offset - right.offset,
+  );
+  const visibleTicks: LegendTick[] = [];
+  let lastEnd = -Infinity;
+
+  for (const tick of sortedTicks) {
+    const [start, end] = getTickBounds(tick, width);
+    if (start >= lastEnd + 6) {
+      visibleTicks.push(tick);
+      lastEnd = end;
+    }
+  }
+
+  return visibleTicks;
+}
+
+export function LegendTicks({
+  ticks,
+  width,
+}: {
+  ticks: LegendTick[];
+  width: number;
+}) {
+  return (
+    <div className="relative h-8">
+      {getVisibleTicks(ticks, width).map((tick) => (
+        <div
+          key={`${tick.offset}-${tick.label}`}
+          className="absolute top-0 flex flex-col items-center"
+          style={{
+            left: `${tick.offset}%`,
+            transform: getTickTransform(tick.offset),
+          }}
+        >
+          <span className="border-border h-1.5 border-l" />
+          <span className="text-muted-foreground mt-1 text-[10px] leading-none whitespace-nowrap tabular-nums">
+            {tick.label}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/color-scales/src/legend/SteppedLegend.tsx
+++ b/packages/color-scales/src/legend/SteppedLegend.tsx
@@ -1,6 +1,6 @@
 import type {ResolvedColorLegend} from '../config';
 import {LegendTicks} from './LegendTicks';
-import {getRampStyle, rgba} from './utils';
+import {getRampStyle, LEGEND_TICKS_HEIGHT_CLASS, rgba} from './utils';
 
 export function SteppedLegend({
   legend,
@@ -25,7 +25,7 @@ export function SteppedLegend({
       {legend.ticks?.length ? (
         <LegendTicks ticks={legend.ticks} width={width} />
       ) : (
-        <div className="h-2" />
+        <div className={LEGEND_TICKS_HEIGHT_CLASS} />
       )}
       <div className="mt-1 grid gap-1">
         {legend.items.map((item) => (

--- a/packages/color-scales/src/legend/SteppedLegend.tsx
+++ b/packages/color-scales/src/legend/SteppedLegend.tsx
@@ -1,0 +1,43 @@
+import type {ResolvedColorLegend} from '../config';
+import {LegendTicks} from './LegendTicks';
+import {getRampStyle, rgba} from './utils';
+
+export function SteppedLegend({
+  legend,
+  width,
+}: {
+  legend: Extract<ResolvedColorLegend, {type: 'stepped'}>;
+  width: number;
+}) {
+  return (
+    <div className="min-w-0" style={getRampStyle(width)}>
+      <div className="border-border/70 flex h-3 overflow-hidden rounded-[2px] border">
+        {legend.items.map((item) => (
+          <span
+            key={`${legend.title}-${item.label}`}
+            aria-label={item.label}
+            className="border-background/70 min-w-0 flex-1 border-r last:border-r-0"
+            style={{backgroundColor: rgba(item.color)}}
+            title={item.label}
+          />
+        ))}
+      </div>
+      {legend.ticks?.length ? (
+        <LegendTicks ticks={legend.ticks} width={width} />
+      ) : (
+        <div className="h-2" />
+      )}
+      <div className="mt-1 grid gap-1">
+        {legend.items.map((item) => (
+          <div
+            key={`${legend.title}-${item.label}-range`}
+            className="text-muted-foreground truncate text-[10px] leading-tight"
+            title={item.label}
+          >
+            {item.label}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/color-scales/src/legend/utils.ts
+++ b/packages/color-scales/src/legend/utils.ts
@@ -1,0 +1,12 @@
+export type LegendTick = {label: string; offset: number};
+
+export function rgba(color: [number, number, number, number]) {
+  return `rgba(${color[0]}, ${color[1]}, ${color[2]}, ${color[3] / 255})`;
+}
+
+export function getRampStyle(width: number) {
+  return {
+    width,
+    maxWidth: '100%',
+  };
+}

--- a/packages/color-scales/src/legend/utils.ts
+++ b/packages/color-scales/src/legend/utils.ts
@@ -1,5 +1,7 @@
 export type LegendTick = {label: string; offset: number};
 
+export const LEGEND_TICKS_HEIGHT_CLASS = 'h-8';
+
 export function rgba(color: [number, number, number, number]) {
   return `rgba(${color[0]}, ${color[1]}, ${color[2]}, ${color[3] / 255})`;
 }

--- a/packages/color-scales/src/scale.ts
+++ b/packages/color-scales/src/scale.ts
@@ -258,6 +258,29 @@ function buildSteppedLegendItems(
   }));
 }
 
+function buildSteppedLegendTicks(
+  scale: DiscreteScaleWithInvertExtent,
+  range: string[],
+) {
+  if (range.length < 2) {
+    return [];
+  }
+
+  return range.slice(0, -1).flatMap((color, index) => {
+    const end = coerceFiniteNumber(scale.invertExtent(color)[1]);
+    if (end === undefined) {
+      return [];
+    }
+
+    return [
+      {
+        label: formatLegendNumber(end),
+        offset: ((index + 1) / range.length) * 100,
+      },
+    ];
+  });
+}
+
 function createNullColorAccessor(nullColor: ResolvedRGBA) {
   return () => nullColor;
 }
@@ -504,5 +527,6 @@ export function buildColorScaleLegend(options: {
     type: 'stepped',
     title: resolvedTitle,
     items: buildSteppedLegendItems(numericScale.scale, numericScale.range),
+    ticks: buildSteppedLegendTicks(numericScale.scale, numericScale.range),
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -963,6 +963,67 @@ importers:
         specifier: ^7.1.9
         version: 7.2.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(yaml@2.8.2)
 
+  examples/color-scales:
+    dependencies:
+      '@sqlrooms/color-scales':
+        specifier: workspace:*
+        version: link:../../packages/color-scales
+      '@sqlrooms/duckdb':
+        specifier: workspace:*
+        version: link:../../packages/duckdb
+      '@sqlrooms/room-shell':
+        specifier: workspace:*
+        version: link:../../packages/room-shell
+      '@sqlrooms/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
+      react:
+        specifier: 19.2.1
+        version: 19.2.1
+      react-dom:
+        specifier: 19.2.1
+        version: 19.2.1(react@19.2.1)
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.36.0
+        version: 9.39.1
+      '@tailwindcss/vite':
+        specifier: ^4.1.18
+        version: 4.1.18(vite@7.2.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(yaml@2.8.2))
+      '@types/react':
+        specifier: 19.2.7
+        version: 19.2.7
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.7)
+      '@vitejs/plugin-react':
+        specifier: ^5.0.3
+        version: 5.1.2(vite@7.2.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(yaml@2.8.2))
+      eslint:
+        specifier: ^9.36.0
+        version: 9.39.1(jiti@2.6.1)
+      eslint-plugin-react-hooks:
+        specifier: ^5.2.0
+        version: 5.2.0(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-react-refresh:
+        specifier: ^0.4.21
+        version: 0.4.24(eslint@9.39.1(jiti@2.6.1))
+      globals:
+        specifier: ^15.15.0
+        version: 15.15.0
+      tailwindcss:
+        specifier: ^4.1.18
+        version: 4.1.18
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.44.1
+        version: 8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      vite:
+        specifier: ^7.1.9
+        version: 7.2.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(yaml@2.8.2)
+
   examples/cosmos:
     dependencies:
       '@sqlrooms/cosmos':
@@ -2585,10 +2646,10 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.1.3
-        version: 30.3.0(@types/node@25.5.0)
+        version: 30.3.0(@types/node@24.12.0)
       ts-jest:
         specifier: ^29.4.4
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@24.12.0))(typescript@5.9.3)
 
   packages/cosmos:
     dependencies:
@@ -2713,10 +2774,10 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@24.12.0)
+        version: 30.3.0(@types/node@25.5.0)
       ts-jest:
         specifier: ^29.4.4
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@24.12.0))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0))(typescript@5.9.3)
       zustand:
         specifier: ^5.0.8
         version: 5.0.9(@types/react@19.2.7)(immer@11.0.1)(react@19.2.1)(use-sync-external-store@1.6.0(react@19.2.1))


### PR DESCRIPTION
<img width="1030" height="903" alt="image" src="https://github.com/user-attachments/assets/019a78f4-fc6f-4113-b1e5-e030d56d620e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new color-scales example application demonstrating multiple legend rendering styles: sequential, diverging, quantile, quantize, threshold, and categorical legends loaded from a sample dataset.
  * Enhanced color legend component with customizable width and swatch column options for flexible legend presentation and styling.

* **Documentation**
  * Updated color-scales package documentation with expanded legend model descriptions and detailed rendering specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->