### PR TITLE
feat: update ai chat ui component

### DIFF
--- a/examples/ai/src/components/MainView.tsx
+++ b/examples/ai/src/components/MainView.tsx
@@ -92,6 +92,7 @@ export const MainView: React.FC = () => {
           {isDataAvailable ? (
             <Chat.Messages
               key={currentSessionId} // will prevent scrolling to bottom after changing current session
+              hoistedRenderers={['chart']}
             />
           ) : (
             <div className="flex h-full w-full flex-col items-center justify-center">

--- a/packages/ai-core/src/components/ActivityBox.tsx
+++ b/packages/ai-core/src/components/ActivityBox.tsx
@@ -148,7 +148,7 @@ export const ActivityBox: React.FC<ActivityBoxProps> = ({
         >
           <div
             ref={innerRef}
-            className="text-muted-foreground w-full min-w-0 overflow-hidden p-2.5 text-xs break-words"
+            className="text-muted-foreground w-full min-w-0 overflow-hidden p-2.5 text-xs break-words hyphens-auto"
           >
             {children}
           </div>

--- a/packages/ai-core/src/components/ActivityBox.tsx
+++ b/packages/ai-core/src/components/ActivityBox.tsx
@@ -80,7 +80,7 @@ export const ActivityBox: React.FC<ActivityBoxProps> = ({
       ro.disconnect();
       mo.disconnect();
     };
-  }, [measure, updateScrollFlags, visible]);
+  }, [measure, updateScrollFlags, visible, isRunning]);
 
   useEffect(() => {
     const el = scrollRef.current;
@@ -88,7 +88,7 @@ export const ActivityBox: React.FC<ActivityBoxProps> = ({
     const handler = () => updateScrollFlags();
     el.addEventListener('scroll', handler, {passive: true});
     return () => el.removeEventListener('scroll', handler);
-  }, [updateScrollFlags, visible]);
+  }, [updateScrollFlags, visible, isRunning]);
 
   // Auto-scroll to bottom when running and content changes
   useEffect(() => {

--- a/packages/ai-core/src/components/ActivityBox.tsx
+++ b/packages/ai-core/src/components/ActivityBox.tsx
@@ -1,5 +1,5 @@
 import {cn} from '@sqlrooms/ui';
-import {ChevronDown, ChevronsUp} from 'lucide-react';
+import {ChevronDown, ChevronRight, ChevronsUp} from 'lucide-react';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 const DEFAULT_MAX_HEIGHT = 100;
@@ -11,6 +11,13 @@ type ActivityBoxProps = {
   /** When true, the box auto-scrolls to the bottom as content changes. */
   isRunning?: boolean;
   className?: string;
+  /**
+   * When provided, the box can be fully hidden behind a single clickable
+   * summary line (e.g. "Worked with 4 tools"). Clicking the line toggles
+   * visibility of the full activity box. While `isRunning` is true the
+   * box is always shown regardless of this prop.
+   */
+  summaryLabel?: string;
 };
 
 /**
@@ -24,6 +31,7 @@ export const ActivityBox: React.FC<ActivityBoxProps> = ({
   maxCollapsedHeight = DEFAULT_MAX_HEIGHT,
   isRunning = false,
   className,
+  summaryLabel,
 }) => {
   const scrollRef = useRef<HTMLDivElement>(null);
   const innerRef = useRef<HTMLDivElement>(null);
@@ -31,6 +39,11 @@ export const ActivityBox: React.FC<ActivityBoxProps> = ({
   const [overflows, setOverflows] = useState(false);
   const [canScrollUp, setCanScrollUp] = useState(false);
   const [canScrollDown, setCanScrollDown] = useState(false);
+  // Tracks which summaryLabel the user explicitly expanded. When the label
+  // changes (e.g. tool count updates) the override resets, auto-collapsing again.
+  const [expandedForLabel, setExpandedForLabel] = useState<string | null>(null);
+
+  const visible = !summaryLabel || expandedForLabel === summaryLabel;
 
   const measure = useCallback(() => {
     const el = innerRef.current;
@@ -67,7 +80,7 @@ export const ActivityBox: React.FC<ActivityBoxProps> = ({
       ro.disconnect();
       mo.disconnect();
     };
-  }, [measure, updateScrollFlags]);
+  }, [measure, updateScrollFlags, visible]);
 
   useEffect(() => {
     const el = scrollRef.current;
@@ -75,7 +88,7 @@ export const ActivityBox: React.FC<ActivityBoxProps> = ({
     const handler = () => updateScrollFlags();
     el.addEventListener('scroll', handler, {passive: true});
     return () => el.removeEventListener('scroll', handler);
-  }, [updateScrollFlags]);
+  }, [updateScrollFlags, visible]);
 
   // Auto-scroll to bottom when running and content changes
   useEffect(() => {
@@ -92,6 +105,22 @@ export const ActivityBox: React.FC<ActivityBoxProps> = ({
   }, [expanded, overflows, updateScrollFlags]);
 
   const showOverlay = overflows && !expanded;
+  const showBox = isRunning || !summaryLabel || visible;
+
+  if (!showBox) {
+    return (
+      <button
+        onClick={() => setExpandedForLabel(summaryLabel ?? null)}
+        className={cn(
+          'text-muted-foreground hover:text-foreground ml-4 flex w-full cursor-pointer items-center gap-1 py-0.5 text-xs transition-colors',
+          className,
+        )}
+      >
+        <ChevronRight className="h-3 w-3 shrink-0" />
+        <span>{summaryLabel}</span>
+      </button>
+    );
+  }
 
   return (
     <div
@@ -100,6 +129,15 @@ export const ActivityBox: React.FC<ActivityBoxProps> = ({
         className,
       )}
     >
+      {summaryLabel && !isRunning && (
+        <button
+          onClick={() => setExpandedForLabel(null)}
+          className="text-muted-foreground hover:text-foreground flex w-full cursor-pointer items-center gap-1 px-1.5 pt-1 pb-0.5 text-xs transition-colors"
+        >
+          <ChevronDown className="h-3 w-3 shrink-0" />
+          <span>{summaryLabel}</span>
+        </button>
+      )}
       <div className="relative">
         <div
           ref={scrollRef}

--- a/packages/ai-core/src/components/AnalysisResult.tsx
+++ b/packages/ai-core/src/components/AnalysisResult.tsx
@@ -203,9 +203,18 @@ export const AnalysisResult: React.FC<AnalysisResultProps> = ({
                   s !== 'output-denied'
                 );
               });
+              const toolCount = seg.parts.length;
+              const allToolsDone = !anyPending && toolCount > 0;
+              const summaryLabel =
+                allToolsDone && analysisResult.isCompleted
+                  ? `Worked with ${toolCount} tool${toolCount === 1 ? '' : 's'}`
+                  : undefined;
               return (
                 <React.Fragment key={`tg-${segIdx}`}>
-                  <ActivityBox isRunning={anyPending}>
+                  <ActivityBox
+                    isRunning={anyPending}
+                    summaryLabel={summaryLabel}
+                  >
                     {seg.parts.map((p) => {
                       const toolName = getToolName(p.part);
                       const isHoisted =

--- a/packages/ai-core/src/components/FlatAgentRenderer.tsx
+++ b/packages/ai-core/src/components/FlatAgentRenderer.tsx
@@ -417,12 +417,14 @@ const FlatSegmentList: React.FC<{
   hoistableSet: ReadonlySet<string>;
   toolRenderers: Record<string, unknown>;
   isPassthroughTool?: (tc: AgentToolCall) => boolean;
+  isAgentComplete?: boolean;
 }> = ({
   segments,
   agentProgress,
   hoistableSet,
   toolRenderers,
   isPassthroughTool,
+  isAgentComplete,
 }) => {
   return (
     <>
@@ -432,9 +434,16 @@ const FlatSegmentList: React.FC<{
             (t) => t.state === 'pending' || t.state === 'approval-requested',
           );
 
+          const toolCount = seg.tools.length;
+          const allToolsDone = !anyPending && toolCount > 0;
+          const summaryLabel =
+            allToolsDone && isAgentComplete
+              ? `Worked with ${toolCount} tool${toolCount === 1 ? '' : 's'}`
+              : undefined;
+
           return (
             <React.Fragment key={`tg-${idx}`}>
-              <ActivityBox isRunning={anyPending}>
+              <ActivityBox isRunning={anyPending} summaryLabel={summaryLabel}>
                 {seg.tools.map((tc) => {
                   const isHoisted =
                     hoistableSet.has(tc.toolName) &&
@@ -513,6 +522,7 @@ const FlatSegmentList: React.FC<{
               hoistableSet={hoistableSet}
               toolRenderers={toolRenderers}
               isPassthroughTool={isPassthroughTool}
+              isAgentComplete={isComplete}
             />
           </React.Fragment>
         );
@@ -702,6 +712,7 @@ export const FlatAgentRenderer: React.FC<{
         hoistableSet={hoistableSet}
         toolRenderers={toolRenderers}
         isPassthroughTool={isPassthroughTool}
+        isAgentComplete={!!isComplete}
       />
     </div>
   );

--- a/packages/ai-core/src/components/FlatAgentRenderer.tsx
+++ b/packages/ai-core/src/components/FlatAgentRenderer.tsx
@@ -129,7 +129,7 @@ const ActivityLogLine: React.FC<{
       </span>
       <span
         className={cn(
-          'min-w-0 leading-4 break-all whitespace-normal',
+          'min-w-0 leading-4 break-words hyphens-auto whitespace-normal',
           reasoning && 'italic',
         )}
       >
@@ -619,7 +619,7 @@ const OrchestratorLogLineInner: React.FC<{
       </span>
       <span
         className={cn(
-          'min-w-0 leading-4 break-all whitespace-normal',
+          'min-w-0 leading-4 break-words hyphens-auto whitespace-normal',
           reasoning && 'italic',
         )}
       >

--- a/packages/mosaic/src/tableInterop.ts
+++ b/packages/mosaic/src/tableInterop.ts
@@ -93,10 +93,10 @@ export function createMosaicTableFromArrowTable(
   const arrowTableRef =
     typeof WeakRef === 'undefined' ? undefined : new WeakRef(arrowTable);
 
-  return attachTableInterop(decodeIPC(ipcBytes) as unknown as MosaicTable, {
+  return attachTableInterop(decodeIPC(ipcBytes), {
     ipcBytes,
     decodeArrowTable: (bytes) => arrowTableRef?.deref() ?? tableFromIPC(bytes),
-  });
+  }) as unknown as MosaicTable;
 }
 
 /**

--- a/packages/mosaic/src/tableInterop.ts
+++ b/packages/mosaic/src/tableInterop.ts
@@ -93,10 +93,10 @@ export function createMosaicTableFromArrowTable(
   const arrowTableRef =
     typeof WeakRef === 'undefined' ? undefined : new WeakRef(arrowTable);
 
-  return attachTableInterop(decodeIPC(ipcBytes), {
+  return attachTableInterop(decodeIPC(ipcBytes) as unknown as MosaicTable, {
     ipcBytes,
     decodeArrowTable: (bytes) => arrowTableRef?.deref() ?? tableFromIPC(bytes),
-  }) as MosaicTable;
+  });
 }
 
 /**

--- a/packages/vega/src/VegaChartToolResult.tsx
+++ b/packages/vega/src/VegaChartToolResult.tsx
@@ -32,6 +32,7 @@ export type VegaChartToolResultProps = ToolRendererProps<
  */
 export function VegaChartToolResult({
   className,
+  input,
   output,
   options,
   editorMode = 'both',
@@ -45,6 +46,11 @@ export function VegaChartToolResult({
 
   return (
     <div className={cn('flex max-w-full flex-col gap-2', className)}>
+      {input?.reasoning && (
+        <p className="text-tiny text-muted-foreground ml-4">
+          {input.reasoning}
+        </p>
+      )}
       <VegaChartContainer
         spec={vegaLiteSpec}
         sqlQuery={sqlQuery}


### PR DESCRIPTION

  * Activity boxes can be collapsed to a clickable summary row and expanded back; running activities stay visible.
  * Completed tool groups and agent activities show summary labels when collapsed (e.g., "Worked with N tool(s)").
  * Vega charts display optional reasoning text above the chart when provided.
  * Log and content text wrap better with improved hyphenation and word-breaking.
