### PR TITLE
feat: Add chat prompt context

### DIFF
--- a/apps/sqlrooms-cli-ui/src/components/AssistantPanel.tsx
+++ b/apps/sqlrooms-cli-ui/src/components/AssistantPanel.tsx
@@ -1,4 +1,10 @@
-import {AiSettingsPanel, Chat} from '@sqlrooms/ai';
+import {
+  AiSettingsPanel,
+  CHAT_CONTEXT_SELECTOR_SLOT,
+  Chat,
+  getAiRunContextItems,
+  type ContextSelectorItem,
+} from '@sqlrooms/ai';
 import {RoomPanelHeader} from '@sqlrooms/room-shell';
 import {
   Button,
@@ -15,7 +21,8 @@ import {
   useDisclosure,
 } from '@sqlrooms/ui';
 import {Settings} from 'lucide-react';
-import React from 'react';
+import React, {useCallback, useEffect, useMemo} from 'react';
+import {CLI_ARTIFACT_TYPES} from '../artifactTypes';
 import {useRoomStore} from '../store';
 
 export const AssistantPanel: React.FC = () => {
@@ -25,6 +32,7 @@ export const AssistantPanel: React.FC = () => {
   const isDataAvailable = useRoomStore((state) => state.room.initialized);
   const updateProvider = useRoomStore((s) => s.aiSettings.updateProvider);
   const settingsPanelOpen = useDisclosure();
+  const contextDropTarget = useAssistantContextDropTarget();
 
   return (
     <div className="flex h-full flex-col p-2">
@@ -114,12 +122,16 @@ export const AssistantPanel: React.FC = () => {
             <Chat.PromptSuggestions.Item text="What are the key trends?" />
             <Chat.PromptSuggestions.Item text="Help me understand the data structure" />
           </Chat.PromptSuggestions>
-          <Chat.Composer placeholder="What would you like to learn about the data?">
+          <Chat.Composer
+            placeholder="What would you like to learn about the data?"
+            contextDropTarget={contextDropTarget}
+          >
             <Chat.InlineApiKeyInput
               onSaveApiKey={(provider, apiKey) => {
                 updateProvider(provider, {apiKey});
               }}
             />
+            <AssistantContextSelector />
             <div className="flex items-center justify-end gap-2">
               <Chat.PromptSuggestions.VisibilityToggle />
               <Chat.ModelSelector />
@@ -130,3 +142,183 @@ export const AssistantPanel: React.FC = () => {
     </div>
   );
 };
+
+const SUPPORTED_CONTEXT_ARTIFACT_TYPES = new Set<string>(CLI_ARTIFACT_TYPES);
+
+type ArtifactDragPayload = {
+  kind: 'artifact';
+  id: string;
+  type: string;
+  title?: string;
+};
+
+function isArtifactDragPayload(data: unknown): data is ArtifactDragPayload {
+  if (!data || typeof data !== 'object') return false;
+  const payload = data as Record<string, unknown>;
+  return (
+    payload.kind === 'artifact' &&
+    typeof payload.id === 'string' &&
+    typeof payload.type === 'string'
+  );
+}
+
+function isContextArtifactType(type: string) {
+  return SUPPORTED_CONTEXT_ARTIFACT_TYPES.has(type);
+}
+
+function useAssistantContextDropTarget() {
+  const artifactsById = useRoomStore((s) => s.artifacts.config.artifactsById);
+  const aiContextItemIds = useRoomStore((s) => s.aiContextItemIds);
+  const setAiContextItemIds = useRoomStore((s) => s.setAiContextItemIds);
+
+  return useMemo(
+    () => ({
+      id: 'assistant-context-drop-target',
+      canAccept: (data: unknown) => {
+        if (!isArtifactDragPayload(data)) return false;
+        const artifact = artifactsById[data.id];
+        return Boolean(artifact && isContextArtifactType(artifact.type));
+      },
+      onDrop: (data: unknown) => {
+        if (!isArtifactDragPayload(data)) return;
+        const artifact = artifactsById[data.id];
+        if (!artifact || !isContextArtifactType(artifact.type)) return;
+        const nextIds = aiContextItemIds.includes(data.id)
+          ? [data.id, ...aiContextItemIds.filter((id) => id !== data.id)]
+          : [...aiContextItemIds, data.id];
+        setAiContextItemIds(nextIds, 'manual');
+      },
+    }),
+    [aiContextItemIds, artifactsById, setAiContextItemIds],
+  );
+}
+
+function AssistantContextSelector() {
+  const sessionIsRunning = useRoomStore(
+    (s) => s.ai.getCurrentSession()?.isRunning ?? false,
+  );
+  const runContext = useRoomStore((s) => s.ai.getCurrentSession()?.runContext);
+  const currentPrompt = useRoomStore(
+    (s) => s.ai.getCurrentSession()?.prompt ?? '',
+  );
+  const sessionIsEmpty = useRoomStore((s) => {
+    const session = s.ai.getCurrentSession();
+    if (!session) return true;
+    const hasMessages = session.uiMessages.length > 0;
+    const hasCompletedResults = session.analysisResults.some(
+      (result) => result.id !== '__pending__',
+    );
+    return !hasMessages && !hasCompletedResults;
+  });
+  const currentArtifactId = useRoomStore(
+    (s) => s.artifacts.config.currentArtifactId,
+  );
+  const artifactOrder = useRoomStore((s) => s.artifacts.config.artifactOrder);
+  const artifactsById = useRoomStore((s) => s.artifacts.config.artifactsById);
+  const aiContextMode = useRoomStore((s) => s.aiContextMode);
+  const aiContextItemIds = useRoomStore((s) => s.aiContextItemIds);
+  const setAiContextItemIds = useRoomStore((s) => s.setAiContextItemIds);
+  const replaceAiContextWithArtifact = useRoomStore(
+    (s) => s.replaceAiContextWithArtifact,
+  );
+  const currentArtifact = currentArtifactId
+    ? artifactsById[currentArtifactId]
+    : undefined;
+  const artifacts = useMemo(
+    () =>
+      artifactOrder
+        .map((id) => artifactsById[id])
+        .filter(
+          (artifact): artifact is NonNullable<(typeof artifactsById)[string]> =>
+            Boolean(artifact) && isContextArtifactType(artifact.type),
+        ),
+    [artifactOrder, artifactsById],
+  );
+  const items = useMemo<ContextSelectorItem[]>(() => {
+    const artifactItems = artifacts.map((artifact) => ({
+      id: artifact.id,
+      kind: 'artifact',
+      title: artifact.title,
+      type: artifact.type,
+      keywords: [artifact.title, artifact.type],
+    }));
+    const missingRunningItems = getAiRunContextItems(runContext)
+      .filter(
+        (item) =>
+          item.kind === 'artifact' &&
+          !artifactsById[item.id] &&
+          item.type &&
+          isContextArtifactType(item.type),
+      )
+      .map((item) => ({
+        id: item.id,
+        kind: item.kind,
+        title: item.title,
+        type: item.type,
+        missing: true,
+        disabled: true,
+        subtitle: 'Deleted',
+        keywords: [item.title, item.type ?? ''],
+      }));
+    return [...artifactItems, ...missingRunningItems];
+  }, [artifacts, artifactsById, runContext]);
+
+  useEffect(() => {
+    if (
+      aiContextMode === 'auto' &&
+      sessionIsEmpty &&
+      currentPrompt.trim().length === 0 &&
+      currentArtifactId &&
+      currentArtifact &&
+      isContextArtifactType(currentArtifact.type)
+    ) {
+      replaceAiContextWithArtifact(currentArtifactId);
+    }
+  }, [
+    aiContextMode,
+    sessionIsEmpty,
+    currentPrompt,
+    currentArtifactId,
+    currentArtifact,
+    replaceAiContextWithArtifact,
+  ]);
+
+  const selectedIds = useMemo(() => {
+    return aiContextItemIds.filter((id) => {
+      const artifact = artifactsById[id];
+      return artifact && isContextArtifactType(artifact.type);
+    });
+  }, [aiContextItemIds, artifactsById]);
+
+  const runningContextIds = sessionIsRunning
+    ? getAiRunContextItems(runContext).map((item) => item.id)
+    : undefined;
+
+  const handleSelectedIdsChange = useCallback(
+    (nextIds: string[]) => {
+      setAiContextItemIds(nextIds, 'manual');
+    },
+    [setAiContextItemIds],
+  );
+
+  if (items.length === 0 && selectedIds.length === 0) return null;
+
+  return (
+    <Chat.ContextSelector
+      items={items}
+      selectedIds={selectedIds}
+      onSelectedIdsChange={handleSelectedIdsChange}
+      runningContextIds={runningContextIds}
+    >
+      <Chat.ContextSelector.Badge tooltip="Add context" />
+      <Chat.ContextSelector.SearchDropdown
+        searchPlaceholder="Search artifacts..."
+        emptyLabel="No artifact found."
+      />
+    </Chat.ContextSelector>
+  );
+}
+
+Object.assign(AssistantContextSelector, {
+  [CHAT_CONTEXT_SELECTOR_SLOT]: true,
+});

--- a/apps/sqlrooms-cli-ui/src/store-types.ts
+++ b/apps/sqlrooms-cli-ui/src/store-types.ts
@@ -44,6 +44,13 @@ export type RoomState = RoomShellSliceState &
   CanvasSliceState &
   WebContainerSliceState &
   DbSettingsSliceState & {
+    aiContextMode: 'auto' | 'manual';
+    aiContextItemIds: string[];
+    setAiContextItemIds: (
+      artifactIds: string[],
+      mode?: 'auto' | 'manual',
+    ) => void;
+    replaceAiContextWithArtifact: (artifactId: string) => void;
     appProject: {
       config: AppBuilderProjectConfig;
       upsertArtifactApp: (

--- a/apps/sqlrooms-cli-ui/src/store.ts
+++ b/apps/sqlrooms-cli-ui/src/store.ts
@@ -2,11 +2,14 @@ import {ArtifactsSliceConfig, createArtifactsSlice} from '@sqlrooms/artifacts';
 import {
   AiSettingsSliceConfig,
   AiSliceConfig,
+  getAiRunContextItems,
   createAiSettingsSlice,
   createAiSlice,
   createDefaultAiInstructions,
   createDefaultAiToolRenderers,
   createDefaultAiTools,
+  type AiRunContext,
+  type AiRunContextItem,
 } from '@sqlrooms/ai';
 import {CanvasSliceConfig, createCanvasSlice} from '@sqlrooms/canvas';
 import {
@@ -270,6 +273,14 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
         Object.values(get().artifacts.config.artifactsById).find(
           (artifact) => artifact.type === 'dashboard',
         )?.id;
+      const getRunContextDashboardArtifactId = () => {
+        const currentSession = get().ai.getCurrentSession();
+        const contextItems = getAiRunContextItems(currentSession?.runContext);
+        return contextItems.find((item) => {
+          const artifact = get().artifacts.config.artifactsById[item.id];
+          return artifact?.type === 'dashboard';
+        })?.id;
+      };
 
       const dashboardSlice: RoomState['dashboard'] = {
         initialize: async () => {
@@ -367,6 +378,10 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
               : undefined;
           })(),
         getCurrentDashboardArtifactId: () => {
+          const contextDashboardArtifactId = getRunContextDashboardArtifactId();
+          if (contextDashboardArtifactId) {
+            return contextDashboardArtifactId;
+          }
           const currentArtifactId = get().artifacts.config.currentArtifactId;
           const currentArtifact = currentArtifactId
             ? get().artifacts.config.artifactsById[currentArtifactId]
@@ -544,6 +559,45 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
             getBaseUrl: () => runtimeConfig.apiBaseUrl || '',
             getInstructions: () =>
               `${createDefaultAiInstructions(store)}\n\n${getDashboardAiInstructions(store)}`,
+            getRunContext: () => {
+              const state = store.getState();
+              const {artifactsById} = state.artifacts.config;
+              const items = Array.from(new Set(state.aiContextItemIds))
+                .map((artifactId): AiRunContextItem | undefined => {
+                  const artifact = artifactsById[artifactId];
+                  if (!artifact) return undefined;
+                  return {
+                    kind: 'artifact',
+                    id: artifact.id,
+                    type: artifact.type,
+                    title: artifact.title,
+                  };
+                })
+                .filter(Boolean) as AiRunContextItem[];
+              if (items.length === 0) return undefined;
+              return {
+                items,
+                capturedAt: Date.now(),
+              } satisfies AiRunContext;
+            },
+            formatRunContextInstructions: ({runContext}) => {
+              const artifactItems = getAiRunContextItems(runContext).filter(
+                (item) => item.kind === 'artifact',
+              );
+              if (artifactItems.length === 0) return '';
+              const [mainItem, ...additionalItems] = artifactItems;
+              if (!mainItem) return '';
+              const artifactType = mainItem.type ?? 'artifact';
+              return [
+                'Current artifact context:',
+                `- Main/default target: ${artifactType} "${mainItem.title}" (id: ${mainItem.id}). Tools use this artifact as the implicit target when the artifact type is supported.`,
+                ...additionalItems.map(
+                  (item) =>
+                    `- Additional reference context: ${item.type ?? 'artifact'} "${item.title}" (id: ${item.id}).`,
+                ),
+                '- Additional context items are reference-only by default; tools will not implicitly target them.',
+              ].join('\n');
+            },
             tools: {
               ...createDefaultAiTools(store, {query: {}}),
               ...createDashboardAiTools(store),
@@ -557,6 +611,17 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
             },
           })(set, get, store);
         })(),
+        aiContextMode: 'auto',
+        aiContextItemIds: [],
+        setAiContextItemIds: (artifactIds, mode) => {
+          set({
+            aiContextItemIds: Array.from(new Set(artifactIds)),
+            ...(mode ? {aiContextMode: mode} : {}),
+          });
+        },
+        replaceAiContextWithArtifact: (artifactId) => {
+          set({aiContextItemIds: [artifactId]});
+        },
       };
     },
   ),

--- a/apps/sqlrooms-cli-ui/src/workspace/ArtifactsContainerPanel.tsx
+++ b/apps/sqlrooms-cli-ui/src/workspace/ArtifactsContainerPanel.tsx
@@ -31,6 +31,8 @@ export const ArtifactsContainerPanel: RoomPanelComponent = () => {
       panelKey="artifact"
       closeable={true}
       preventCloseLastTab={false}
+      dndMode="shared"
+      dndScopeId="cli-artifact-tabs"
       renderTabMenu={(tab) => (
         <>
           <ArtifactTabs.MenuItem disabled>
@@ -74,10 +76,7 @@ function CliArtifactAddMenu() {
         <>
           <DropdownMenuItem
             onClick={() => {
-              const artifactId = createDashboardArtifact(
-                'Dashboard',
-                'grid',
-              );
+              const artifactId = createDashboardArtifact('Dashboard', 'grid');
               artifactTabs.selectArtifact(artifactId);
             }}
           >
@@ -85,10 +84,7 @@ function CliArtifactAddMenu() {
           </DropdownMenuItem>
           <DropdownMenuItem
             onClick={() => {
-              const artifactId = createDashboardArtifact(
-                'Dashboard',
-                'dock',
-              );
+              const artifactId = createDashboardArtifact('Dashboard', 'dock');
               artifactTabs.selectArtifact(artifactId);
             }}
           >
@@ -97,15 +93,15 @@ function CliArtifactAddMenu() {
           {CLI_ARTIFACT_TYPES.filter(
             (artifactType) => artifactType !== 'dashboard',
           ).map((artifactType) => {
-          const type = ARTIFACT_TYPES[artifactType];
-          return (
-            <DropdownMenuItem
-              key={artifactType}
-              onClick={() => artifactTabs.createArtifact(artifactType)}
-            >
-              <type.icon /> {`New ${type.label}`}
-            </DropdownMenuItem>
-          );
+            const type = ARTIFACT_TYPES[artifactType];
+            return (
+              <DropdownMenuItem
+                key={artifactType}
+                onClick={() => artifactTabs.createArtifact(artifactType)}
+              >
+                <type.icon /> {`New ${type.label}`}
+              </DropdownMenuItem>
+            );
           })}
         </>
       )}

--- a/packages/ai-config/src/index.ts
+++ b/packages/ai-config/src/index.ts
@@ -1,9 +1,16 @@
 export {AiSliceConfig, createDefaultAiConfig} from './AiSliceConfig';
 export {AiSettingsSliceConfig} from './AiSettingsSliceConfig';
 export {
+  AiRunContextItemSchema,
+  AiRunContextSchema,
   AnalysisSessionSchema,
   AnalysisResultSchema,
   ErrorMessageSchema,
+  getAiRunContextItems,
+} from './schema/AnalysisSessionSchema';
+export type {
+  AiRunContext,
+  AiRunContextItem,
 } from './schema/AnalysisSessionSchema';
 export type {
   DynamicToolUIPart,

--- a/packages/ai-config/src/schema/AnalysisSessionSchema.ts
+++ b/packages/ai-config/src/schema/AnalysisSessionSchema.ts
@@ -26,6 +26,67 @@ export const AnalysisResultSchema = z.object({
 });
 export type AnalysisResultSchema = z.infer<typeof AnalysisResultSchema>;
 
+export const AiRunContextItemSchema = z
+  .object({
+    kind: z.string(),
+    id: z.string(),
+    title: z.string(),
+    type: z.string().optional(),
+    subtitle: z.string().optional(),
+  })
+  .passthrough();
+export type AiRunContextItem = z.infer<typeof AiRunContextItemSchema>;
+
+const AiRunContextBaseSchema = z
+  .object({
+    items: z.array(AiRunContextItemSchema),
+    capturedAt: z.number(),
+  })
+  .passthrough();
+
+export const AiRunContextSchema = z.preprocess((data) => {
+  if (
+    data &&
+    typeof data === 'object' &&
+    !Array.isArray(data) &&
+    'kind' in data &&
+    'id' in data &&
+    'title' in data &&
+    !('items' in data)
+  ) {
+    const legacyContext = data as {
+      kind: unknown;
+      id: unknown;
+      title: unknown;
+      type?: unknown;
+      capturedAt?: unknown;
+    };
+    const {capturedAt, ...item} = legacyContext;
+    return {
+      items: [item],
+      capturedAt: typeof capturedAt === 'number' ? capturedAt : 0,
+    };
+  }
+  return data;
+}, AiRunContextBaseSchema);
+export type AiRunContext = z.infer<typeof AiRunContextSchema>;
+
+export function getAiRunContextItems(
+  runContext: AiRunContext | unknown,
+): AiRunContextItem[] {
+  if (!runContext || typeof runContext !== 'object') return [];
+
+  if ('items' in runContext && Array.isArray(runContext.items)) {
+    return runContext.items
+      .map((item) => AiRunContextItemSchema.safeParse(item))
+      .filter((result) => result.success)
+      .map((result) => result.data);
+  }
+
+  const legacyResult = AiRunContextItemSchema.safeParse(runContext);
+  return legacyResult.success ? [legacyResult.data] : [];
+}
+
 const AnalysisSessionBaseSchema = z.object({
   id: z.string(),
   name: z.string(),
@@ -44,6 +105,8 @@ const AnalysisSessionBaseSchema = z.object({
   isRunning: z.boolean().default(false),
   /** Last time the session was opened/selected (epoch ms) */
   lastOpenedAt: z.number().optional(),
+  /** Context captured when the current run started. */
+  runContext: AiRunContextSchema.optional(),
   /** Persisted sub-agent tool call trees, keyed by parent toolCallId */
   agentProgress: z.record(z.string(), z.array(z.unknown())).optional(),
 });

--- a/packages/ai-core/__tests__/AiSlice.modelSelection.test.ts
+++ b/packages/ai-core/__tests__/AiSlice.modelSelection.test.ts
@@ -1,4 +1,6 @@
 import {AiSettingsSliceConfig} from '@sqlrooms/ai-config';
+import type {AiRunContext} from '@sqlrooms/ai-config';
+import {jest} from '@jest/globals';
 import {createStore} from 'zustand';
 import {AiSliceState, createAiSlice} from '../src/AiSlice';
 
@@ -8,7 +10,9 @@ type TestStoreState = AiSliceState & {
   };
 };
 
-function createTestStore() {
+function createTestStore(options?: {
+  getRunContext?: () => AiRunContext | undefined;
+}) {
   const now = Date.now();
   const settingsConfig: AiSettingsSliceConfig = {
     providers: {
@@ -34,6 +38,13 @@ function createTestStore() {
     ...createAiSlice({
       tools: {} as any,
       getInstructions: () => 'test instructions',
+      getRunContext: options?.getRunContext,
+      formatRunContextInstructions: ({runContext}) => {
+        const mainItem = runContext.items[0];
+        return mainItem
+          ? `Context: ${mainItem.type} ${mainItem.title}`
+          : '';
+      },
       defaultProvider: 'openai',
       defaultModel: 'shared-model',
       config: {
@@ -102,5 +113,50 @@ describe('AiSlice model selection', () => {
     expect(currentSession?.id).not.toBe(previousSessionId);
     expect(currentSession?.modelProvider).toBe('anthropic');
     expect(currentSession?.model).toBe('shared-model');
+  });
+
+  it('captures run context once when starting analysis', async () => {
+    const contextA: AiRunContext = {
+      items: [
+        {
+          kind: 'artifact',
+          id: 'map-a',
+          type: 'map',
+          title: 'Map A',
+        },
+      ],
+      capturedAt: 1,
+    };
+    const contextB: AiRunContext = {
+      items: [
+        {
+          kind: 'artifact',
+          id: 'map-b',
+          type: 'map',
+          title: 'Map B',
+        },
+      ],
+      capturedAt: 2,
+    };
+    let activeContext = contextA;
+    const store = createTestStore({
+      getRunContext: () => activeContext,
+    });
+    const sendMessage = jest.fn();
+
+    store.getState().ai.setChatSendMessage('session-1', sendMessage);
+    store.getState().ai.setPrompt('session-1', 'hello');
+    await store.getState().ai.startAnalysis('session-1');
+    activeContext = contextB;
+
+    const session = store.getState().ai.config.sessions[0];
+    expect(session?.runContext).toEqual(contextA);
+    expect(store.getState().ai.getFullInstructions('session-1')).toContain(
+      'Map A',
+    );
+    expect(store.getState().ai.getFullInstructions('session-1')).not.toContain(
+      'Map B',
+    );
+    expect(sendMessage).toHaveBeenCalledWith({text: 'hello'});
   });
 });

--- a/packages/ai-core/__tests__/ContextSelector.test.ts
+++ b/packages/ai-core/__tests__/ContextSelector.test.ts
@@ -1,5 +1,6 @@
 import {
   promoteContextSelectorItem,
+  reorderContextSelectorItems,
   toggleContextSelectorItem,
 } from '../src/components/ContextSelector';
 
@@ -22,6 +23,19 @@ describe('ContextSelector selection helpers', () => {
       'c',
       'a',
       'b',
+    ]);
+  });
+
+  it('reorders selected ids', () => {
+    expect(reorderContextSelectorItems(['a', 'b', 'c'], 'c', 'a')).toEqual([
+      'c',
+      'a',
+      'b',
+    ]);
+    expect(reorderContextSelectorItems(['a', 'b', 'c'], 'x', 'a')).toEqual([
+      'a',
+      'b',
+      'c',
     ]);
   });
 });

--- a/packages/ai-core/__tests__/ContextSelector.test.ts
+++ b/packages/ai-core/__tests__/ContextSelector.test.ts
@@ -1,0 +1,27 @@
+import {
+  promoteContextSelectorItem,
+  toggleContextSelectorItem,
+} from '../src/components/ContextSelector';
+
+describe('ContextSelector selection helpers', () => {
+  it('adds and removes selected ids without changing order', () => {
+    expect(toggleContextSelectorItem(['a'], 'b')).toEqual(['a', 'b']);
+    expect(toggleContextSelectorItem(['a', 'b', 'c'], 'b')).toEqual([
+      'a',
+      'c',
+    ]);
+  });
+
+  it('promotes an item to main without duplicating it', () => {
+    expect(promoteContextSelectorItem(['a', 'b', 'c'], 'c')).toEqual([
+      'c',
+      'a',
+      'b',
+    ]);
+    expect(promoteContextSelectorItem(['a', 'b'], 'c')).toEqual([
+      'c',
+      'a',
+      'b',
+    ]);
+  });
+});

--- a/packages/ai-core/__tests__/migration.test.ts
+++ b/packages/ai-core/__tests__/migration.test.ts
@@ -82,5 +82,65 @@ describe('AnalysisSession migration', () => {
       expect(result.uiMessages).toHaveLength(1);
       expect(result.uiMessages[0]?.id).toBe('msg-2');
     });
+
+    it('migrates optional legacy artifact run context', () => {
+      const raw = {
+        ...baseFields,
+        uiMessages: [],
+        runContext: {
+          kind: 'artifact',
+          id: 'map-1',
+          type: 'map',
+          title: 'Map A',
+          capturedAt: 123,
+        },
+      };
+      const result = AnalysisSessionSchema.parse(raw);
+      expect(result.runContext).toEqual({
+        items: [
+          {
+            kind: 'artifact',
+            id: 'map-1',
+            type: 'map',
+            title: 'Map A',
+          },
+        ],
+        capturedAt: 123,
+      });
+    });
+
+    it('preserves ordered multi-item run context', () => {
+      const raw = {
+        ...baseFields,
+        uiMessages: [],
+        runContext: {
+          items: [
+            {
+              kind: 'artifact',
+              id: 'map-1',
+              type: 'map',
+              title: 'Map A',
+            },
+            {
+              kind: 'artifact',
+              id: 'dashboard-1',
+              type: 'dashboard',
+              title: 'Dashboard',
+            },
+          ],
+          capturedAt: 123,
+        },
+      };
+      const result = AnalysisSessionSchema.parse(raw);
+      expect(result.runContext).toEqual(raw.runContext);
+    });
+
+    it('keeps run context optional for old sessions', () => {
+      const result = AnalysisSessionSchema.parse({
+        ...baseFields,
+        uiMessages: [],
+      });
+      expect(result.runContext).toBeUndefined();
+    });
   });
 });

--- a/packages/ai-core/package.json
+++ b/packages/ai-core/package.json
@@ -21,6 +21,8 @@
   "dependencies": {
     "@ai-sdk/openai-compatible": "^1.0.18",
     "@ai-sdk/react": "^3.0.118",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "@paralleldrive/cuid2": "^3.0.0",
     "@sqlrooms/ai-config": "workspace:*",
     "@sqlrooms/codemirror": "workspace:*",

--- a/packages/ai-core/package.json
+++ b/packages/ai-core/package.json
@@ -49,6 +49,7 @@
     "typedoc": "typedoc"
   },
   "devDependencies": {
+    "@jest/globals": "^30.3.0",
     "@sqlrooms/preset-jest": "workspace:*",
     "ts-jest": "^29.4.4",
     "zustand": "^5.0.8"

--- a/packages/ai-core/src/AiSlice.ts
+++ b/packages/ai-core/src/AiSlice.ts
@@ -5,6 +5,7 @@ import {
   AnalysisSessionSchema,
   createDefaultAiConfig,
 } from '@sqlrooms/ai-config';
+import type {AiRunContext} from '@sqlrooms/ai-config';
 import {
   BaseRoomStoreState,
   createSlice,
@@ -176,7 +177,7 @@ export type AiSliceState = {
     getApiKeyFromSettings: () => string;
     getBaseUrlFromSettings: () => string | undefined;
     getMaxStepsFromSettings: () => number;
-    getFullInstructions: () => string;
+    getFullInstructions: (sessionId?: string) => string;
     getLocalChatTransport: (
       sessionId: string,
     ) => DefaultChatTransport<UIMessage>;
@@ -221,7 +222,15 @@ export interface AiSliceOptions<TTools extends ToolSet = ToolSet> {
   initialPrompt?: string;
   tools: TTools;
   toolRenderers?: ToolRenderers<TTools>;
-  getInstructions: () => string;
+  getInstructions: (args?: {
+    session?: AnalysisSessionSchema;
+    runContext?: AiRunContext;
+  }) => string;
+  getRunContext?: () => AiRunContext | undefined;
+  formatRunContextInstructions?: (args: {
+    runContext: AiRunContext;
+    session?: AnalysisSessionSchema;
+  }) => string;
   defaultProvider?: string;
   defaultModel?: string;
   /** Provide a pre-configured model client for a provider (e.g., Azure). */
@@ -252,6 +261,8 @@ export function createAiSlice<TTools extends ToolSet = ToolSet>(
     getProviderOptions,
     chatEndPoint = '',
     chatHeaders = {},
+    getRunContext,
+    formatRunContextInstructions,
   } = params;
 
   return createSlice<AiSliceState>((set, get, store) => {
@@ -937,10 +948,27 @@ export function createAiSlice<TTools extends ToolSet = ToolSet>(
           return 50;
         },
 
-        getFullInstructions: () => {
+        getFullInstructions: (sessionId?: string) => {
           const store = get();
+          const session = sessionId
+            ? store.ai.config.sessions.find(
+                (candidate: AnalysisSessionSchema) =>
+                  candidate.id === sessionId,
+              )
+            : getCurrentSessionFromState(store);
+          const runContext = session?.runContext;
 
-          let instructions = getInstructions();
+          let instructions = getInstructions({session, runContext});
+
+          if (runContext && formatRunContextInstructions) {
+            const contextInstructions = formatRunContextInstructions({
+              runContext,
+              session,
+            });
+            if (contextInstructions.trim().length > 0) {
+              instructions = `${instructions}\n\n${contextInstructions}`;
+            }
+          }
 
           // Fall back to settings
           if (hasAiSettingsConfig(store)) {
@@ -1002,7 +1030,9 @@ export function createAiSlice<TTools extends ToolSet = ToolSet>(
               model,
               temperature: AI_DEFAULT_TEMPERATURE,
               messages: [{role: 'user', content: prompt}],
-              system: systemInstructions || state.ai.getFullInstructions(),
+              system:
+                systemInstructions ||
+                state.ai.getFullInstructions(currentSession?.id),
               abortSignal: abortSignal,
               ...(useTools ? {tools: toolsWithoutExecute as ToolSet} : {}),
             });
@@ -1056,6 +1086,7 @@ export function createAiSlice<TTools extends ToolSet = ToolSet>(
               );
               if (draftSession) {
                 draftSession.isRunning = true;
+                draftSession.runContext = getRunContext?.();
                 draftSession.prompt = '';
                 draft.ai.promptSuggestionsVisible = false;
 
@@ -1233,7 +1264,8 @@ export function createAiSlice<TTools extends ToolSet = ToolSet>(
             store,
             defaultProvider: defaultProvider,
             defaultModel: defaultModel,
-            getInstructions: () => store.getState().ai.getFullInstructions(),
+            getInstructions: () =>
+              store.getState().ai.getFullInstructions(sessionId),
             getCustomModel,
             sessionId,
           })();
@@ -1249,7 +1281,8 @@ export function createAiSlice<TTools extends ToolSet = ToolSet>(
             defaultProvider,
             defaultModel,
             sessionId,
-            getInstructions: () => store.getState().ai.getFullInstructions(),
+            getInstructions: () =>
+              store.getState().ai.getFullInstructions(sessionId),
           })(endpoint, headers),
 
         ...createChatHandlers({store}),

--- a/packages/ai-core/src/chatTransport.ts
+++ b/packages/ai-core/src/chatTransport.ts
@@ -23,6 +23,7 @@ import {
 } from './constants';
 import type {
   AiSliceStateForTransport,
+  AiToolExecutionContext,
   ToolTimingEntry,
   AssistantMessageMetadata,
   MessageTokenUsage,
@@ -133,6 +134,49 @@ function getSessionById(
     .ai.config.sessions.find((s: AnalysisSessionSchema) => s.id === sessionId);
 }
 
+function withRunContextTools(
+  tools: ToolSet,
+  args: AiToolExecutionContext & {
+    state: AiSliceStateForTransport;
+  },
+): ToolSet {
+  return Object.fromEntries(
+    Object.entries(tools).map(([name, tool]) => {
+      if (!tool || typeof tool.execute !== 'function') {
+        return [name, tool];
+      }
+
+      const originalExecute = tool.execute;
+      return [
+        name,
+        {
+          ...tool,
+          execute: async (
+            input: unknown,
+            options?: Record<string, unknown>,
+          ) => {
+            const toolCallId =
+              typeof options?.toolCallId === 'string'
+                ? options.toolCallId
+                : undefined;
+            if (toolCallId && args.sessionId) {
+              args.state.ai.setToolCallSession(toolCallId, args.sessionId);
+            }
+            return originalExecute(
+              input as never,
+              {
+                ...options,
+                sessionId: args.sessionId,
+                aiRunContext: args.aiRunContext,
+              } as never,
+            );
+          },
+        },
+      ];
+    }),
+  ) as ToolSet;
+}
+
 /**
  * The AI SDK stream metadata is not reliably surfaced back onto `UIMessage.metadata`
  * for our local transport setup, so persist token usage per session and stamp it
@@ -221,6 +265,7 @@ export function createLocalChatTransportFactory({
       const sessionFromBody = getSessionById(store, sessionId);
       const provider = sessionFromBody?.modelProvider || defaultProvider;
       const modelId = sessionFromBody?.model || defaultModel;
+      const aiRunContext = sessionFromBody?.runContext;
 
       // Fetch API key and base URL dynamically to pick up settings changes
       const apiKey = state.ai.getApiKeyFromSettings();
@@ -248,7 +293,11 @@ export function createLocalChatTransportFactory({
       // full tool loop server-side. UI-approval tools (no execute) are paused
       // by the agent and resumed via addToolOutput from the client.
       // Cast: state.ai.tools holds real AI SDK tools behind StoredToolSet.
-      const tools = (state.ai.tools || {}) as ToolSet;
+      const tools = withRunContextTools((state.ai.tools || {}) as ToolSet, {
+        state,
+        sessionId,
+        aiRunContext,
+      });
 
       // get system instructions dynamically at request time to ensure fresh table schema
       const systemInstructions = getInstructions();

--- a/packages/ai-core/src/components/Chat.tsx
+++ b/packages/ai-core/src/components/Chat.tsx
@@ -1,5 +1,6 @@
 import type {FC, PropsWithChildren} from 'react';
 import {AnalysisResultsContainer} from './AnalysisResultsContainer';
+import {ContextSelector} from './ContextSelector';
 import {
   type ToolRenderBehavior,
   ToolRenderBehaviorProvider,
@@ -26,6 +27,7 @@ type ChatComponent = FC<RootProps> & {
     VisibilityToggle: typeof PromptSuggestions.VisibilityToggle;
   };
   ModelSelector: typeof ModelSelector;
+  ContextSelector: typeof ContextSelector;
 };
 
 const EMPTY_BEHAVIOR: ToolRenderBehavior = {};
@@ -54,4 +56,5 @@ export const Chat: ChatComponent = Object.assign(Root, {
   InlineApiKeyInput: InlineApiKeyInput,
   PromptSuggestions: PromptSuggestionsCompound,
   ModelSelector: ModelSelector,
+  ContextSelector: ContextSelector,
 }) as ChatComponent;

--- a/packages/ai-core/src/components/ContextSelector.tsx
+++ b/packages/ai-core/src/components/ContextSelector.tsx
@@ -1,0 +1,461 @@
+import {
+  Badge as UiBadge,
+  Button,
+  cn,
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@sqlrooms/ui';
+import {
+  BarChart3Icon,
+  BoxesIcon,
+  MapIcon,
+  PlusIcon,
+  XIcon,
+} from 'lucide-react';
+import {
+  createContext,
+  type FC,
+  type PropsWithChildren,
+  type ReactNode,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+
+export const CHAT_CONTEXT_SELECTOR_SLOT = Symbol.for(
+  'sqlrooms.ai.contextSelectorSlot',
+);
+
+export type ContextSelectorItem = {
+  id: string;
+  kind: string;
+  title: string;
+  type?: string;
+  subtitle?: string;
+  disabled?: boolean;
+  missing?: boolean;
+  keywords?: string[];
+};
+
+type RenderItemArgs = {
+  item: ContextSelectorItem;
+  selected: boolean;
+  main: boolean;
+  running: boolean;
+};
+
+export type ContextSelectorRootProps = PropsWithChildren<{
+  items: ContextSelectorItem[];
+  selectedIds: string[];
+  onSelectedIdsChange: (nextIds: string[]) => void;
+  runningContextIds?: string[];
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  className?: string;
+  renderIcon?: (item: ContextSelectorItem) => ReactNode;
+  renderItem?: (args: RenderItemArgs) => ReactNode;
+  renderBadgeLabel?: (args: {
+    mainItem: ContextSelectorItem | undefined;
+    selectedItems: ContextSelectorItem[];
+    runningItems: ContextSelectorItem[];
+  }) => ReactNode;
+}>;
+
+type ContextSelectorBadgeProps = {
+  className?: string;
+  tooltip?: ReactNode;
+  emptyLabel?: ReactNode;
+  addLabel?: string;
+};
+
+type ContextSelectorSearchDropdownProps = {
+  className?: string;
+  align?: 'start' | 'center' | 'end';
+  searchPlaceholder?: string;
+  emptyLabel?: ReactNode;
+};
+
+type ContextSelectorContextValue = Omit<
+  ContextSelectorRootProps,
+  'children' | 'open' | 'defaultOpen' | 'onOpenChange' | 'className'
+> & {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  selectedItems: ContextSelectorItem[];
+  runningItems: ContextSelectorItem[];
+  displayItems: ContextSelectorItem[];
+  toggleItem: (itemId: string) => void;
+  removeItem: (itemId: string) => void;
+  makeMain: (itemId: string) => void;
+};
+
+type ContextSelectorComponent = FC<ContextSelectorRootProps> & {
+  Badge: FC<ContextSelectorBadgeProps>;
+  SearchDropdown: FC<ContextSelectorSearchDropdownProps>;
+};
+
+const ContextSelectorContext = createContext<
+  ContextSelectorContextValue | undefined
+>(undefined);
+
+function useContextSelectorContext() {
+  const context = useContext(ContextSelectorContext);
+  if (!context) {
+    throw new Error(
+      'Chat.ContextSelector compound components must be rendered inside Chat.ContextSelector.',
+    );
+  }
+  return context;
+}
+
+function uniqueIds(ids: string[]) {
+  return Array.from(new Set(ids));
+}
+
+export function toggleContextSelectorItem(
+  selectedIds: string[],
+  itemId: string,
+) {
+  return selectedIds.includes(itemId)
+    ? selectedIds.filter((id) => id !== itemId)
+    : [...selectedIds, itemId];
+}
+
+export function promoteContextSelectorItem(
+  selectedIds: string[],
+  itemId: string,
+) {
+  return [itemId, ...selectedIds.filter((id) => id !== itemId)];
+}
+
+function getKnownItems(items: ContextSelectorItem[], ids: string[]) {
+  const itemsById = new Map(items.map((item) => [item.id, item]));
+  return ids
+    .map((id) => itemsById.get(id))
+    .filter(Boolean) as ContextSelectorItem[];
+}
+
+function getDefaultIcon(item: ContextSelectorItem) {
+  if (item.kind === 'artifact' && item.type === 'map') return MapIcon;
+  if (item.kind === 'artifact' && item.type === 'dashboard')
+    return BarChart3Icon;
+  return BoxesIcon;
+}
+
+function defaultTypeLabel(item: ContextSelectorItem) {
+  return item.type ?? item.kind;
+}
+
+const Root: FC<ContextSelectorRootProps> = ({
+  children,
+  items,
+  selectedIds,
+  onSelectedIdsChange,
+  runningContextIds,
+  open,
+  defaultOpen = false,
+  onOpenChange,
+  className,
+  renderIcon,
+  renderItem,
+  renderBadgeLabel,
+}) => {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen);
+  const isControlled = open !== undefined;
+  const actualOpen = isControlled ? open : uncontrolledOpen;
+  const setOpen = (nextOpen: boolean) => {
+    if (!isControlled) setUncontrolledOpen(nextOpen);
+    onOpenChange?.(nextOpen);
+  };
+  const normalizedSelectedIds = useMemo(
+    () => uniqueIds(selectedIds),
+    [selectedIds],
+  );
+  const normalizedRunningIds = useMemo(
+    () => uniqueIds(runningContextIds ?? []),
+    [runningContextIds],
+  );
+  const selectedItems = useMemo(
+    () => getKnownItems(items, normalizedSelectedIds),
+    [items, normalizedSelectedIds],
+  );
+  const runningItems = useMemo(
+    () => getKnownItems(items, normalizedRunningIds),
+    [items, normalizedRunningIds],
+  );
+  const displayItems = runningContextIds ? runningItems : selectedItems;
+
+  const value = useMemo<ContextSelectorContextValue>(
+    () => ({
+      items,
+      selectedIds: normalizedSelectedIds,
+      onSelectedIdsChange,
+      runningContextIds,
+      renderIcon,
+      renderItem,
+      renderBadgeLabel,
+      open: actualOpen,
+      setOpen,
+      selectedItems,
+      runningItems,
+      displayItems,
+      toggleItem: (itemId) => {
+        onSelectedIdsChange(
+          toggleContextSelectorItem(normalizedSelectedIds, itemId),
+        );
+      },
+      removeItem: (itemId) => {
+        onSelectedIdsChange(
+          normalizedSelectedIds.filter((id) => id !== itemId),
+        );
+      },
+      makeMain: (itemId) => {
+        onSelectedIdsChange(
+          promoteContextSelectorItem(normalizedSelectedIds, itemId),
+        );
+      },
+    }),
+    [
+      items,
+      normalizedSelectedIds,
+      onSelectedIdsChange,
+      runningContextIds,
+      renderIcon,
+      renderItem,
+      renderBadgeLabel,
+      actualOpen,
+      selectedItems,
+      runningItems,
+      displayItems,
+    ],
+  );
+
+  return (
+    <ContextSelectorContext.Provider value={value}>
+      <TooltipProvider delayDuration={250}>
+        <Popover open={actualOpen} onOpenChange={setOpen}>
+          <div className={cn('inline-flex max-w-full min-w-0', className)}>
+            {children}
+          </div>
+        </Popover>
+      </TooltipProvider>
+    </ContextSelectorContext.Provider>
+  );
+};
+
+const Badge: FC<ContextSelectorBadgeProps> = ({
+  className,
+  tooltip,
+  emptyLabel = 'Add context',
+  addLabel = 'Add context',
+}) => {
+  const {
+    selectedItems,
+    runningItems,
+    renderIcon,
+    renderBadgeLabel,
+    removeItem,
+    makeMain,
+  } = useContextSelectorContext();
+  const mainItem = selectedItems[0];
+  const label =
+    renderBadgeLabel?.({mainItem, selectedItems, runningItems}) ??
+    mainItem?.title ??
+    emptyLabel;
+  const tooltipContent =
+    tooltip ??
+    (runningItems.length > 0
+      ? 'Next request context'
+      : 'Add context');
+
+  return (
+    <div
+      className={cn(
+        'flex max-w-full min-w-0 flex-wrap items-center gap-1',
+        className,
+      )}
+    >
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              className="h-6 w-6 shrink-0"
+              aria-label={addLabel}
+            >
+              <PlusIcon className="h-3 w-3" />
+            </Button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="max-w-60 text-xs">
+          {tooltipContent}
+        </TooltipContent>
+      </Tooltip>
+      {selectedItems.length > 0 ? (
+        selectedItems.map((item, index) => {
+          const Icon = getDefaultIcon(item);
+          const main = index === 0;
+          return (
+            <UiBadge
+              key={item.id}
+              variant={main ? 'default' : 'secondary'}
+              className="h-6 max-w-36 min-w-0 gap-1 px-1.5 text-[11px]"
+            >
+              <button
+                type="button"
+                className="flex min-w-0 items-center gap-1"
+                onClick={() => makeMain(item.id)}
+                aria-label={`Make ${item.title} the main context item`}
+              >
+                <span className="shrink-0">
+                  {renderIcon ? (
+                    renderIcon(item)
+                  ) : (
+                    <Icon className="h-3 w-3" />
+                  )}
+                </span>
+                <span className="truncate">{item.title}</span>
+              </button>
+              <button
+                type="button"
+                className="ml-0.5 shrink-0 opacity-70 hover:opacity-100"
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  removeItem(item.id);
+                }}
+                aria-label={`Remove ${item.title} from context`}
+              >
+                <XIcon className="h-2.5 w-2.5" />
+              </button>
+            </UiBadge>
+          );
+        })
+      ) : (
+        <span className="text-muted-foreground truncate text-[11px]">
+          {label}
+        </span>
+      )}
+    </div>
+  );
+};
+
+const SearchDropdown: FC<ContextSelectorSearchDropdownProps> = ({
+  className,
+  align = 'end',
+  searchPlaceholder = 'Search context...',
+  emptyLabel = 'No context item found.',
+}) => {
+  const {
+    items,
+    selectedIds,
+    runningContextIds,
+    setOpen,
+    renderIcon,
+    renderItem,
+    toggleItem,
+  } = useContextSelectorContext();
+  const selectedIdSet = useMemo(() => new Set(selectedIds), [selectedIds]);
+  const runningIdSet = useMemo(
+    () => new Set(runningContextIds ?? []),
+    [runningContextIds],
+  );
+  const availableItems = useMemo(
+    () => items.filter((item) => !selectedIdSet.has(item.id)),
+    [items, selectedIdSet],
+  );
+
+  return (
+    <PopoverContent align={align} className={cn('w-72 p-0', className)}>
+      <Command>
+        <CommandInput placeholder={searchPlaceholder} />
+        <CommandList>
+          <CommandEmpty>{emptyLabel}</CommandEmpty>
+          <CommandGroup>
+            {availableItems.map((item) => {
+              const running = runningIdSet.has(item.id);
+              const Icon = getDefaultIcon(item);
+              const keywords = [
+                item.title,
+                item.kind,
+                item.type,
+                item.subtitle,
+                ...(item.keywords ?? []),
+              ].filter(Boolean) as string[];
+
+              return (
+                <CommandItem
+                  key={item.id}
+                  value={item.id}
+                  keywords={keywords}
+                  disabled={item.disabled}
+                  onSelect={() => {
+                    toggleItem(item.id);
+                    setOpen(false);
+                  }}
+                  className="flex items-center gap-2 text-xs"
+                >
+                  {renderItem ? (
+                    renderItem({item, selected: false, main: false, running})
+                  ) : (
+                    <>
+                      <span className="shrink-0">
+                        {renderIcon ? (
+                          renderIcon(item)
+                        ) : (
+                          <Icon className="h-3.5 w-3.5" />
+                        )}
+                      </span>
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate">{item.title}</span>
+                        {item.subtitle ? (
+                          <span className="text-muted-foreground block truncate text-xs">
+                            {item.subtitle}
+                          </span>
+                        ) : null}
+                      </span>
+                      <span className="text-muted-foreground text-xs capitalize">
+                        {defaultTypeLabel(item)}
+                      </span>
+                      {running ? (
+                        <UiBadge
+                          variant="secondary"
+                          className="h-5 px-1.5 text-[10px]"
+                        >
+                          Running
+                        </UiBadge>
+                      ) : null}
+                    </>
+                  )}
+                </CommandItem>
+              );
+            })}
+          </CommandGroup>
+        </CommandList>
+      </Command>
+    </PopoverContent>
+  );
+};
+
+export const ContextSelector: ContextSelectorComponent = Object.assign(Root, {
+  Badge,
+  SearchDropdown,
+}) as ContextSelectorComponent;
+
+Object.assign(ContextSelector, {
+  [CHAT_CONTEXT_SELECTOR_SLOT]: true,
+});

--- a/packages/ai-core/src/components/ContextSelector.tsx
+++ b/packages/ai-core/src/components/ContextSelector.tsx
@@ -179,11 +179,12 @@ function getKnownItems(items: ContextSelectorItem[], ids: string[]) {
     .filter(Boolean) as ContextSelectorItem[];
 }
 
-function getDefaultIcon(item: ContextSelectorItem) {
-  if (item.kind === 'artifact' && item.type === 'map') return MapIcon;
+function renderDefaultIcon(item: ContextSelectorItem, className: string) {
+  if (item.kind === 'artifact' && item.type === 'map')
+    return <MapIcon className={className} />;
   if (item.kind === 'artifact' && item.type === 'dashboard')
-    return BarChart3Icon;
-  return BoxesIcon;
+    return <BarChart3Icon className={className} />;
+  return <BoxesIcon className={className} />;
 }
 
 function defaultTypeLabel(item: ContextSelectorItem) {
@@ -405,7 +406,6 @@ const SortableContextChip: FC<{
     transition,
     isDragging,
   } = useSortable({id: item.id});
-  const Icon = getDefaultIcon(item);
   const transformStyle = transform
     ? `translate3d(${Math.round(transform.x)}px, ${Math.round(
         transform.y,
@@ -441,7 +441,7 @@ const SortableContextChip: FC<{
           aria-label={`Make ${item.title} the main context item`}
         >
           <span className="shrink-0">
-            {renderIcon ? renderIcon(item) : <Icon className="h-3 w-3" />}
+            {renderIcon ? renderIcon(item) : renderDefaultIcon(item, 'h-3 w-3')}
           </span>
           <span className="truncate">{item.title}</span>
         </button>
@@ -496,7 +496,6 @@ const SearchDropdown: FC<ContextSelectorSearchDropdownProps> = ({
           <CommandGroup>
             {availableItems.map((item) => {
               const running = runningIdSet.has(item.id);
-              const Icon = getDefaultIcon(item);
               const keywords = [
                 item.title,
                 item.kind,
@@ -522,11 +521,9 @@ const SearchDropdown: FC<ContextSelectorSearchDropdownProps> = ({
                   ) : (
                     <>
                       <span className="shrink-0">
-                        {renderIcon ? (
-                          renderIcon(item)
-                        ) : (
-                          <Icon className="h-3.5 w-3.5" />
-                        )}
+                        {renderIcon
+                          ? renderIcon(item)
+                          : renderDefaultIcon(item, 'h-3.5 w-3.5')}
                       </span>
                       <span className="min-w-0 flex-1">
                         <span className="block truncate">{item.title}</span>

--- a/packages/ai-core/src/components/ContextSelector.tsx
+++ b/packages/ai-core/src/components/ContextSelector.tsx
@@ -45,6 +45,7 @@ import {
   type FC,
   type PropsWithChildren,
   type ReactNode,
+  useCallback,
   useContext,
   useMemo,
   useState,
@@ -206,10 +207,13 @@ const Root: FC<ContextSelectorRootProps> = ({
   const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen);
   const isControlled = open !== undefined;
   const actualOpen = isControlled ? open : uncontrolledOpen;
-  const setOpen = (nextOpen: boolean) => {
-    if (!isControlled) setUncontrolledOpen(nextOpen);
-    onOpenChange?.(nextOpen);
-  };
+  const setOpen = useCallback(
+    (nextOpen: boolean) => {
+      if (!isControlled) setUncontrolledOpen(nextOpen);
+      onOpenChange?.(nextOpen);
+    },
+    [isControlled, onOpenChange],
+  );
   const normalizedSelectedIds = useMemo(
     () => uniqueIds(selectedIds),
     [selectedIds],
@@ -272,6 +276,7 @@ const Root: FC<ContextSelectorRootProps> = ({
       renderItem,
       renderBadgeLabel,
       actualOpen,
+      setOpen,
       selectedItems,
       runningItems,
       displayItems,
@@ -557,8 +562,5 @@ const SearchDropdown: FC<ContextSelectorSearchDropdownProps> = ({
 export const ContextSelector: ContextSelectorComponent = Object.assign(Root, {
   Badge,
   SearchDropdown,
-}) as ContextSelectorComponent;
-
-Object.assign(ContextSelector, {
   [CHAT_CONTEXT_SELECTOR_SLOT]: true,
-});
+}) as ContextSelectorComponent;

--- a/packages/ai-core/src/components/ContextSelector.tsx
+++ b/packages/ai-core/src/components/ContextSelector.tsx
@@ -1,4 +1,20 @@
 import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  horizontalListSortingStrategy,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+} from '@dnd-kit/sortable';
+import {
   Badge as UiBadge,
   Button,
   cn,
@@ -19,6 +35,7 @@ import {
 import {
   BarChart3Icon,
   BoxesIcon,
+  GripVerticalIcon,
   MapIcon,
   PlusIcon,
   XIcon,
@@ -99,6 +116,7 @@ type ContextSelectorContextValue = Omit<
   toggleItem: (itemId: string) => void;
   removeItem: (itemId: string) => void;
   makeMain: (itemId: string) => void;
+  reorderItems: (activeId: string, overId: string) => void;
 };
 
 type ContextSelectorComponent = FC<ContextSelectorRootProps> & {
@@ -138,6 +156,19 @@ export function promoteContextSelectorItem(
   itemId: string,
 ) {
   return [itemId, ...selectedIds.filter((id) => id !== itemId)];
+}
+
+export function reorderContextSelectorItems(
+  selectedIds: string[],
+  activeId: string,
+  overId: string,
+) {
+  const oldIndex = selectedIds.indexOf(activeId);
+  const newIndex = selectedIds.indexOf(overId);
+  if (oldIndex < 0 || newIndex < 0 || oldIndex === newIndex) {
+    return selectedIds;
+  }
+  return arrayMove(selectedIds, oldIndex, newIndex);
 }
 
 function getKnownItems(items: ContextSelectorItem[], ids: string[]) {
@@ -226,6 +257,11 @@ const Root: FC<ContextSelectorRootProps> = ({
           promoteContextSelectorItem(normalizedSelectedIds, itemId),
         );
       },
+      reorderItems: (activeId, overId) => {
+        onSelectedIdsChange(
+          reorderContextSelectorItems(normalizedSelectedIds, activeId, overId),
+        );
+      },
     }),
     [
       items,
@@ -268,7 +304,16 @@ const Badge: FC<ContextSelectorBadgeProps> = ({
     renderBadgeLabel,
     removeItem,
     makeMain,
+    reorderItems,
   } = useContextSelectorContext();
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {distance: 4},
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
   const mainItem = selectedItems[0];
   const label =
     renderBadgeLabel?.({mainItem, selectedItems, runningItems}) ??
@@ -306,51 +351,109 @@ const Badge: FC<ContextSelectorBadgeProps> = ({
         </TooltipContent>
       </Tooltip>
       {selectedItems.length > 0 ? (
-        selectedItems.map((item, index) => {
-          const Icon = getDefaultIcon(item);
-          const main = index === 0;
-          return (
-            <UiBadge
-              key={item.id}
-              variant={main ? 'default' : 'secondary'}
-              className="h-6 max-w-36 min-w-0 gap-1 px-1.5 text-[11px]"
-            >
-              <button
-                type="button"
-                className="flex min-w-0 items-center gap-1"
-                onClick={() => makeMain(item.id)}
-                aria-label={`Make ${item.title} the main context item`}
-              >
-                <span className="shrink-0">
-                  {renderIcon ? (
-                    renderIcon(item)
-                  ) : (
-                    <Icon className="h-3 w-3" />
-                  )}
-                </span>
-                <span className="truncate">{item.title}</span>
-              </button>
-              <button
-                type="button"
-                className="ml-0.5 shrink-0 opacity-70 hover:opacity-100"
-                onClick={(event) => {
-                  event.preventDefault();
-                  event.stopPropagation();
-                  removeItem(item.id);
-                }}
-                aria-label={`Remove ${item.title} from context`}
-              >
-                <XIcon className="h-2.5 w-2.5" />
-              </button>
-            </UiBadge>
-          );
-        })
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={(event: DragEndEvent) => {
+            const {active, over} = event;
+            if (!over || active.id === over.id) return;
+            reorderItems(String(active.id), String(over.id));
+          }}
+        >
+          <SortableContext
+            items={selectedItems.map((item) => item.id)}
+            strategy={horizontalListSortingStrategy}
+          >
+            {selectedItems.map((item, index) => (
+              <SortableContextChip
+                key={item.id}
+                item={item}
+                main={index === 0}
+                renderIcon={renderIcon}
+                onMakeMain={makeMain}
+                onRemove={removeItem}
+              />
+            ))}
+          </SortableContext>
+        </DndContext>
       ) : (
         <span className="text-muted-foreground truncate text-[11px]">
           {label}
         </span>
       )}
     </div>
+  );
+};
+
+const SortableContextChip: FC<{
+  item: ContextSelectorItem;
+  main: boolean;
+  renderIcon?: (item: ContextSelectorItem) => ReactNode;
+  onMakeMain: (itemId: string) => void;
+  onRemove: (itemId: string) => void;
+}> = ({item, main, renderIcon, onMakeMain, onRemove}) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({id: item.id});
+  const Icon = getDefaultIcon(item);
+  const transformStyle = transform
+    ? `translate3d(${Math.round(transform.x)}px, ${Math.round(
+        transform.y,
+      )}px, 0)`
+    : undefined;
+
+  return (
+    <span
+      ref={setNodeRef}
+      className={cn('inline-flex min-w-0', isDragging && 'opacity-70')}
+      style={{
+        transform: transformStyle,
+        transition,
+      }}
+    >
+      <UiBadge
+        variant={main ? 'default' : 'secondary'}
+        className="h-6 max-w-36 min-w-0 gap-1 px-1.5 text-[11px]"
+      >
+        <button
+          type="button"
+          className="text-muted-foreground/80 hover:text-foreground shrink-0 cursor-grab active:cursor-grabbing"
+          aria-label={`Drag ${item.title} to reorder context`}
+          {...attributes}
+          {...listeners}
+        >
+          <GripVerticalIcon className="h-2.5 w-2.5" />
+        </button>
+        <button
+          type="button"
+          className="flex min-w-0 items-center gap-1"
+          onClick={() => onMakeMain(item.id)}
+          aria-label={`Make ${item.title} the main context item`}
+        >
+          <span className="shrink-0">
+            {renderIcon ? renderIcon(item) : <Icon className="h-3 w-3" />}
+          </span>
+          <span className="truncate">{item.title}</span>
+        </button>
+        <button
+          type="button"
+          className="ml-0.5 shrink-0 opacity-70 hover:opacity-100"
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            onRemove(item.id);
+          }}
+          aria-label={`Remove ${item.title} from context`}
+        >
+          <XIcon className="h-2.5 w-2.5" />
+        </button>
+      </UiBadge>
+    </span>
   );
 };
 

--- a/packages/ai-core/src/components/QueryControls.tsx
+++ b/packages/ai-core/src/components/QueryControls.tsx
@@ -4,12 +4,13 @@ import {ArrowUpIcon, LoaderCircleIcon, OctagonXIcon} from 'lucide-react';
 import {
   PropsWithChildren,
   useCallback,
-  useRef,
   useEffect,
   useState,
   Children,
   isValidElement,
   ReactNode,
+  Ref,
+  useRef,
 } from 'react';
 import {useStoreWithAi} from '../AiSlice';
 import {CHAT_CONTEXT_SELECTOR_SLOT, ContextSelector} from './ContextSelector';
@@ -27,6 +28,15 @@ type QueryControlsProps = PropsWithChildren<{
     onDrop: (data: unknown) => void;
   };
 }>;
+
+type ContextDropTargetConfig = NonNullable<
+  QueryControlsProps['contextDropTarget']
+>;
+
+type ContextDropTargetRenderArgs = {
+  isAcceptedOver: boolean;
+  setNodeRef?: Ref<HTMLDivElement>;
+};
 
 /**
  * Checks if a child is an InlineApiKeyInput component
@@ -119,50 +129,6 @@ export const QueryControls: React.FC<QueryControlsProps> = ({
   const setPrompt = useStoreWithAi((s) => s.ai.setPrompt);
   const runAnalysis = useStoreWithAi((s) => s.ai.startAnalysis);
   const cancelAnalysis = useStoreWithAi((s) => s.ai.cancelAnalysis);
-  const {
-    active,
-    isOver: isContextDropOver,
-    setNodeRef: setContextDropTargetRef,
-  } = useDroppable({
-    id: contextDropTarget?.id ?? 'chat-composer-context-drop-target-disabled',
-    disabled: !contextDropTarget,
-    data: {roomDndPriority: 100},
-  });
-  const activeDropData = active?.data.current;
-  const canAcceptContextDrop = Boolean(
-    contextDropTarget &&
-    activeDropData &&
-    contextDropTarget.canAccept(activeDropData),
-  );
-  const isAcceptedContextDropOver = isContextDropOver && canAcceptContextDrop;
-
-  const isPointerWithinContextDropTarget = useCallback(
-    (event: DragEndEvent) =>
-      Boolean(
-        contextDropTarget &&
-        event.collisions?.some(
-          (collision) =>
-            collision.id === contextDropTarget.id &&
-            collision.data?.pointerWithin === true,
-        ),
-      ),
-    [contextDropTarget],
-  );
-
-  useDndMonitor({
-    onDragEnd: (event) => {
-      if (!contextDropTarget || event.over?.id !== contextDropTarget.id) {
-        return;
-      }
-      if (!isPointerWithinContextDropTarget(event)) {
-        return;
-      }
-      const data = event.active.data.current;
-      if (contextDropTarget.canAccept(data)) {
-        contextDropTarget.onDrop(data);
-      }
-    },
-  });
 
   useEffect(() => {
     if (showApiKeyInput) return;
@@ -246,61 +212,122 @@ export const QueryControls: React.FC<QueryControlsProps> = ({
           </span>
         </div>
       )}
-      <div
-        ref={setContextDropTargetRef}
-        className={cn(
-          'bg-muted/50 flex h-full w-full flex-row items-center gap-2 rounded-md border transition-all',
-          isAcceptedContextDropOver &&
-            'border-primary/70 bg-primary/10 ring-primary/35 shadow-primary/10 shadow-sm ring-2',
-        )}
-      >
-        <div className="flex w-full flex-col gap-1 overflow-hidden">
-          {contextSelectors.length > 0 ? (
-            <div className="flex w-full flex-wrap items-center gap-1 px-2 pt-2">
-              {contextSelectors}
-            </div>
-          ) : null}
-          <Textarea
-            ref={textareaRef}
-            className="max-h-[min(300px,40vh)] min-h-[30px] resize-none border-none p-2 text-sm outline-hidden focus-visible:ring-0"
-            autoResize
-            value={prompt}
-            disabled={isSummarizing}
-            onChange={(e) => {
-              if (sessionId) {
-                setPrompt(sessionId, e.target.value);
-              }
-            }}
-            onKeyDown={handleKeyDown}
-            placeholder={placeholder}
-            autoFocus
-          />
-          <div className="align-stretch flex w-full items-center gap-2 overflow-hidden">
-            <div className="flex h-full w-full min-w-0 items-center gap-2 overflow-hidden">
-              <div className="min-w-0 flex-1 overflow-hidden">
-                <div className="flex flex-nowrap items-center gap-2 overflow-x-auto py-1 pl-2">
-                  {otherChildren}
+      <OptionalContextDropTarget target={contextDropTarget}>
+        {({setNodeRef, isAcceptedOver}) => (
+          <div
+            ref={setNodeRef}
+            className={cn(
+              'bg-muted/50 flex h-full w-full flex-row items-center gap-2 rounded-md border transition-all',
+              isAcceptedOver &&
+                'border-primary/70 bg-primary/10 ring-primary/35 shadow-primary/10 shadow-sm ring-2',
+            )}
+          >
+            <div className="flex w-full flex-col gap-1 overflow-hidden">
+              {contextSelectors.length > 0 ? (
+                <div className="flex w-full flex-wrap items-center gap-1 px-2 pt-2">
+                  {contextSelectors}
                 </div>
-              </div>
-              <div className="ml-auto flex shrink-0 items-center gap-1 p-2">
-                <ContextUsageIndicator />
-                <Button
-                  className="h-8 w-8 rounded-full"
-                  variant="default"
-                  size="icon"
-                  onClick={handleClickRunOrCancel}
-                  disabled={isSummarizing || (!isRunning && !canStart)}
-                >
-                  {isRunning ? <OctagonXIcon /> : <ArrowUpIcon />}
-                </Button>
+              ) : null}
+              <Textarea
+                ref={textareaRef}
+                className="max-h-[min(300px,40vh)] min-h-[30px] resize-none border-none p-2 text-sm outline-hidden focus-visible:ring-0"
+                autoResize
+                value={prompt}
+                disabled={isSummarizing}
+                onChange={(e) => {
+                  if (sessionId) {
+                    setPrompt(sessionId, e.target.value);
+                  }
+                }}
+                onKeyDown={handleKeyDown}
+                placeholder={placeholder}
+                autoFocus
+              />
+              <div className="align-stretch flex w-full items-center gap-2 overflow-hidden">
+                <div className="flex h-full w-full min-w-0 items-center gap-2 overflow-hidden">
+                  <div className="min-w-0 flex-1 overflow-hidden">
+                    <div className="flex flex-nowrap items-center gap-2 overflow-x-auto py-1 pl-2">
+                      {otherChildren}
+                    </div>
+                  </div>
+                  <div className="ml-auto flex shrink-0 items-center gap-1 p-2">
+                    <ContextUsageIndicator />
+                    <Button
+                      className="h-8 w-8 rounded-full"
+                      variant="default"
+                      size="icon"
+                      onClick={handleClickRunOrCancel}
+                      disabled={isSummarizing || (!isRunning && !canStart)}
+                    >
+                      {isRunning ? <OctagonXIcon /> : <ArrowUpIcon />}
+                    </Button>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
-        </div>
-      </div>
+        )}
+      </OptionalContextDropTarget>
     </div>
   );
 };
+
+function OptionalContextDropTarget({
+  target,
+  children,
+}: {
+  target?: ContextDropTargetConfig;
+  children: (args: ContextDropTargetRenderArgs) => ReactNode;
+}) {
+  if (!target) {
+    return children({setNodeRef: undefined, isAcceptedOver: false});
+  }
+
+  return <ContextDropTarget target={target}>{children}</ContextDropTarget>;
+}
+
+function ContextDropTarget({
+  target,
+  children,
+}: {
+  target: ContextDropTargetConfig;
+  children: (args: ContextDropTargetRenderArgs) => ReactNode;
+}) {
+  const {active, isOver, setNodeRef} = useDroppable({
+    id: target.id,
+    data: {roomDndPriority: 100},
+  });
+  const activeDropData = active?.data.current;
+  const isAcceptedOver = Boolean(
+    isOver && activeDropData && target.canAccept(activeDropData),
+  );
+
+  const isPointerWithinTarget = useCallback(
+    (event: DragEndEvent) =>
+      Boolean(
+        event.collisions?.some(
+          (collision) =>
+            collision.id === target.id &&
+            collision.data?.pointerWithin === true,
+        ),
+      ),
+    [target.id],
+  );
+
+  useDndMonitor({
+    onDragEnd: (event) => {
+      if (event.over?.id !== target.id || !isPointerWithinTarget(event)) {
+        return;
+      }
+      const data = event.active.data.current;
+      if (target.canAccept(data)) {
+        target.onDrop(data);
+      }
+    },
+  });
+
+  return children({setNodeRef, isAcceptedOver});
+}
 
 /**
  * Internal component that renders the InlineApiKeyInput with proper layout

--- a/packages/ai-core/src/components/QueryControls.tsx
+++ b/packages/ai-core/src/components/QueryControls.tsx
@@ -1,3 +1,4 @@
+import {DragEndEvent, useDndMonitor, useDroppable} from '@dnd-kit/core';
 import {Button, cn, Textarea} from '@sqlrooms/ui';
 import {ArrowUpIcon, LoaderCircleIcon, OctagonXIcon} from 'lucide-react';
 import {
@@ -11,10 +12,7 @@ import {
   ReactNode,
 } from 'react';
 import {useStoreWithAi} from '../AiSlice';
-import {
-  CHAT_CONTEXT_SELECTOR_SLOT,
-  ContextSelector,
-} from './ContextSelector';
+import {CHAT_CONTEXT_SELECTOR_SLOT, ContextSelector} from './ContextSelector';
 import {ContextUsageIndicator} from './ContextUsageIndicator';
 import {InlineApiKeyInput, InlineApiKeyInputButton} from './InlineApiKeyInput';
 
@@ -23,6 +21,11 @@ type QueryControlsProps = PropsWithChildren<{
   placeholder?: string;
   onRun?: () => void;
   onCancel?: () => void;
+  contextDropTarget?: {
+    id: string;
+    canAccept: (data: unknown) => boolean;
+    onDrop: (data: unknown) => void;
+  };
 }>;
 
 /**
@@ -84,6 +87,7 @@ export const QueryControls: React.FC<QueryControlsProps> = ({
   children,
   onRun,
   onCancel,
+  contextDropTarget,
 }) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -115,6 +119,50 @@ export const QueryControls: React.FC<QueryControlsProps> = ({
   const setPrompt = useStoreWithAi((s) => s.ai.setPrompt);
   const runAnalysis = useStoreWithAi((s) => s.ai.startAnalysis);
   const cancelAnalysis = useStoreWithAi((s) => s.ai.cancelAnalysis);
+  const {
+    active,
+    isOver: isContextDropOver,
+    setNodeRef: setContextDropTargetRef,
+  } = useDroppable({
+    id: contextDropTarget?.id ?? 'chat-composer-context-drop-target-disabled',
+    disabled: !contextDropTarget,
+    data: {roomDndPriority: 100},
+  });
+  const activeDropData = active?.data.current;
+  const canAcceptContextDrop = Boolean(
+    contextDropTarget &&
+    activeDropData &&
+    contextDropTarget.canAccept(activeDropData),
+  );
+  const isAcceptedContextDropOver = isContextDropOver && canAcceptContextDrop;
+
+  const isPointerWithinContextDropTarget = useCallback(
+    (event: DragEndEvent) =>
+      Boolean(
+        contextDropTarget &&
+        event.collisions?.some(
+          (collision) =>
+            collision.id === contextDropTarget.id &&
+            collision.data?.pointerWithin === true,
+        ),
+      ),
+    [contextDropTarget],
+  );
+
+  useDndMonitor({
+    onDragEnd: (event) => {
+      if (!contextDropTarget || event.over?.id !== contextDropTarget.id) {
+        return;
+      }
+      if (!isPointerWithinContextDropTarget(event)) {
+        return;
+      }
+      const data = event.active.data.current;
+      if (contextDropTarget.canAccept(data)) {
+        contextDropTarget.onDrop(data);
+      }
+    },
+  });
 
   useEffect(() => {
     if (showApiKeyInput) return;
@@ -198,7 +246,14 @@ export const QueryControls: React.FC<QueryControlsProps> = ({
           </span>
         </div>
       )}
-      <div className="bg-muted/50 flex h-full w-full flex-row items-center gap-2 rounded-md border">
+      <div
+        ref={setContextDropTargetRef}
+        className={cn(
+          'bg-muted/50 flex h-full w-full flex-row items-center gap-2 rounded-md border transition-all',
+          isAcceptedContextDropOver &&
+            'border-primary/70 bg-primary/10 ring-primary/35 shadow-primary/10 shadow-sm ring-2',
+        )}
+      >
         <div className="flex w-full flex-col gap-1 overflow-hidden">
           {contextSelectors.length > 0 ? (
             <div className="flex w-full flex-wrap items-center gap-1 px-2 pt-2">

--- a/packages/ai-core/src/components/QueryControls.tsx
+++ b/packages/ai-core/src/components/QueryControls.tsx
@@ -11,6 +11,10 @@ import {
   ReactNode,
 } from 'react';
 import {useStoreWithAi} from '../AiSlice';
+import {
+  CHAT_CONTEXT_SELECTOR_SLOT,
+  ContextSelector,
+} from './ContextSelector';
 import {ContextUsageIndicator} from './ContextUsageIndicator';
 import {InlineApiKeyInput, InlineApiKeyInputButton} from './InlineApiKeyInput';
 
@@ -30,29 +34,48 @@ function isInlineApiKeyInput(
   return isValidElement(child) && child.type === InlineApiKeyInput;
 }
 
+function isContextSelector(
+  child: ReactNode,
+): child is React.ReactElement<React.ComponentProps<typeof ContextSelector>> {
+  if (!isValidElement(child)) return false;
+  if (child.type === ContextSelector) return true;
+  return (
+    typeof child.type !== 'string' &&
+    Boolean(
+      (child.type as {[CHAT_CONTEXT_SELECTOR_SLOT]?: boolean})[
+        CHAT_CONTEXT_SELECTOR_SLOT
+      ],
+    )
+  );
+}
+
 /**
- * Extracts InlineApiKeyInput from children and returns the rest
+ * Extracts special composer children and returns the rest.
  */
-function extractInlineApiKeyInput(children: ReactNode): {
+function extractComposerChildren(children: ReactNode): {
   inlineApiKeyInput: React.ReactElement<
     React.ComponentProps<typeof InlineApiKeyInput>
   > | null;
+  contextSelectors: ReactNode[];
   otherChildren: ReactNode[];
 } {
   let inlineApiKeyInput: React.ReactElement<
     React.ComponentProps<typeof InlineApiKeyInput>
   > | null = null;
+  const contextSelectors: ReactNode[] = [];
   const otherChildren: ReactNode[] = [];
 
   Children.forEach(children, (child) => {
     if (isInlineApiKeyInput(child)) {
       inlineApiKeyInput = child;
+    } else if (isContextSelector(child)) {
+      contextSelectors.push(child);
     } else {
       otherChildren.push(child);
     }
   });
 
-  return {inlineApiKeyInput, otherChildren};
+  return {inlineApiKeyInput, contextSelectors, otherChildren};
 }
 
 export const QueryControls: React.FC<QueryControlsProps> = ({
@@ -71,8 +94,9 @@ export const QueryControls: React.FC<QueryControlsProps> = ({
   const apiKey = useStoreWithAi((s) => s.ai.getApiKeyFromSettings());
   const hasApiKeyError = useStoreWithAi((s) => s.ai.hasApiKeyError());
 
-  // Extract InlineApiKeyInput from children
-  const {inlineApiKeyInput, otherChildren} = extractInlineApiKeyInput(children);
+  // Extract special composer controls from children
+  const {inlineApiKeyInput, contextSelectors, otherChildren} =
+    extractComposerChildren(children);
 
   // Show API key input if InlineApiKeyInput is provided and either:
   // - No API key is set, OR
@@ -176,6 +200,11 @@ export const QueryControls: React.FC<QueryControlsProps> = ({
       )}
       <div className="bg-muted/50 flex h-full w-full flex-row items-center gap-2 rounded-md border">
         <div className="flex w-full flex-col gap-1 overflow-hidden">
+          {contextSelectors.length > 0 ? (
+            <div className="flex w-full flex-wrap items-center gap-1 px-2 pt-2">
+              {contextSelectors}
+            </div>
+          ) : null}
           <Textarea
             ref={textareaRef}
             className="max-h-[min(300px,40vh)] min-h-[30px] resize-none border-none p-2 text-sm outline-hidden focus-visible:ring-0"

--- a/packages/ai-core/src/index.ts
+++ b/packages/ai-core/src/index.ts
@@ -14,6 +14,14 @@ export {useScrollToBottom} from './hooks/useScrollToBottom';
 export {useSessionChat} from './hooks/useSessionChat';
 export {useElapsedTime} from './hooks/useElapsedTime';
 export {Chat} from './components/Chat';
+export {
+  CHAT_CONTEXT_SELECTOR_SLOT,
+  ContextSelector,
+} from './components/ContextSelector';
+export type {
+  ContextSelectorItem,
+  ContextSelectorRootProps,
+} from './components/ContextSelector';
 
 export {PromptSuggestions} from './components/PromptSuggestions';
 export {ModelSelector} from './components/ModelSelector';
@@ -28,7 +36,14 @@ export {ToolErrorMessage} from './components/tools/ToolErrorMessage';
 export type {ErrorMessageComponentProps} from './components/ErrorMessage';
 export {ToolCallInfo} from './components/ToolCallInfo';
 
-export {AiSliceConfig, createDefaultAiConfig} from '@sqlrooms/ai-config';
+export {
+  AiRunContextItemSchema,
+  AiRunContextSchema,
+  AiSliceConfig,
+  createDefaultAiConfig,
+  getAiRunContextItems,
+} from '@sqlrooms/ai-config';
+export type {AiRunContext, AiRunContextItem} from '@sqlrooms/ai-config';
 export {AiThinkingDots} from './components/AiThinkingDots';
 export {
   cleanupPendingAnalysisResults,
@@ -39,6 +54,7 @@ export {
 export type {
   AddToolApprovalResponse,
   AddToolOutput,
+  AiToolExecutionContext,
   AgentProgressSnapshot,
   StoredTool,
   StoredToolSet,

--- a/packages/ai-core/src/types.ts
+++ b/packages/ai-core/src/types.ts
@@ -1,5 +1,9 @@
 import type {ComponentType} from 'react';
-import type {AiSliceConfig, AnalysisSessionSchema} from '@sqlrooms/ai-config';
+import type {
+  AiRunContext,
+  AiSliceConfig,
+  AnalysisSessionSchema,
+} from '@sqlrooms/ai-config';
 import type {
   UIMessage,
   ToolSet,
@@ -171,6 +175,11 @@ export type AddToolApprovalResponse = (options: {
 
 export type AiChatSendMessage = (message: {text: string}) => void;
 
+export type AiToolExecutionContext = {
+  sessionId?: string;
+  aiRunContext?: AiRunContext;
+};
+
 /**
  * Minimal interface for the AI state accessed by chat transport functions.
  * This allows chatTransport.ts to avoid importing from AiSlice.ts directly.
@@ -215,7 +224,7 @@ export interface AiStateForTransport {
   ) => void;
   readAbortSnapshot?: (toolCallId: string) => AgentProgressSnapshot | undefined;
   clearAbortSnapshots?: () => void;
-  getFullInstructions: () => string;
+  getFullInstructions: (sessionId?: string) => string;
   /** Get API key from settings for the current session's provider */
   getApiKeyFromSettings: () => string;
   /** Get base URL from settings for the current session's provider */

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -51,6 +51,7 @@ export {fixIncompleteToolCalls} from '@sqlrooms/ai-core';
 export {streamSubAgent, updateAgentToolCallData} from '@sqlrooms/ai-core';
 export type {
   AddToolOutput,
+  AiToolExecutionContext,
   AgentStreamOutput,
   AgentToolCall,
   AgentToolCallAdditionalData,
@@ -87,16 +88,25 @@ export type {
   ToolDisplayBehavior,
 } from '@sqlrooms/ai-core';
 export {Chat} from '@sqlrooms/ai-core';
+export {ContextSelector} from '@sqlrooms/ai-core';
+export type {ContextSelectorItem, ContextSelectorRootProps} from '@sqlrooms/ai-core';
+export const CHAT_CONTEXT_SELECTOR_SLOT = Symbol.for(
+  'sqlrooms.ai.contextSelectorSlot',
+);
 
 // From @sqlrooms/ai-config
 export {
+  AiRunContextItemSchema,
+  AiRunContextSchema,
   AiSliceConfig,
   createDefaultAiConfig,
   AiSettingsSliceConfig,
   AnalysisSessionSchema,
   AnalysisResultSchema,
   ErrorMessageSchema,
+  getAiRunContextItems,
 } from '@sqlrooms/ai-config';
+export type {AiRunContext, AiRunContextItem} from '@sqlrooms/ai-config';
 export type {ToolUIPart, UIMessagePart} from '@sqlrooms/ai-config';
 
 // From @sqlrooms/ai-settings - State/Logic

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -88,11 +88,8 @@ export type {
   ToolDisplayBehavior,
 } from '@sqlrooms/ai-core';
 export {Chat} from '@sqlrooms/ai-core';
-export {ContextSelector} from '@sqlrooms/ai-core';
+export {ContextSelector, CHAT_CONTEXT_SELECTOR_SLOT} from '@sqlrooms/ai-core';
 export type {ContextSelectorItem, ContextSelectorRootProps} from '@sqlrooms/ai-core';
-export const CHAT_CONTEXT_SELECTOR_SLOT = Symbol.for(
-  'sqlrooms.ai.contextSelectorSlot',
-);
 
 // From @sqlrooms/ai-config
 export {

--- a/packages/artifacts/src/artifactTabs.tsx
+++ b/packages/artifacts/src/artifactTabs.tsx
@@ -554,14 +554,17 @@ function ArtifactTabsRoot({
                 )
             : undefined
         }
-        getTabDragData={(tab) =>
-          getTabDragData?.(tab) ?? {
+        getTabDragData={(tab) => {
+          const artifactTab = tab as ArtifactTabDescriptor;
+          const userData = getTabDragData?.(artifactTab);
+          return {
             kind: 'artifact',
-            id: (tab as ArtifactTabDescriptor).artifact.id,
-            type: (tab as ArtifactTabDescriptor).artifact.type,
-            title: (tab as ArtifactTabDescriptor).artifact.title,
-          }
-        }
+            id: artifactTab.artifact.id,
+            type: artifactTab.artifact.type,
+            title: artifactTab.artifact.title,
+            ...userData,
+          };
+        }}
       >
         {children ?? (
           <>

--- a/packages/artifacts/src/artifactTabs.tsx
+++ b/packages/artifacts/src/artifactTabs.tsx
@@ -522,6 +522,7 @@ function ArtifactTabsRoot({
   overlay,
   closeable = true,
   preventCloseLastTab = false,
+  getTabDragData,
   ...props
 }: ArtifactTabsProps) {
   const artifactTabs = useArtifactTabs({types, tabsId, panelKey});
@@ -552,6 +553,14 @@ function ArtifactTabsRoot({
                   artifactTabs,
                 )
             : undefined
+        }
+        getTabDragData={(tab) =>
+          getTabDragData?.(tab) ?? {
+            kind: 'artifact',
+            id: (tab as ArtifactTabDescriptor).artifact.id,
+            type: (tab as ArtifactTabDescriptor).artifact.type,
+            title: (tab as ArtifactTabDescriptor).artifact.title,
+          }
         }
       >
         {children ?? (

--- a/packages/cells/__tests__/defaultCellRegistry.integration.test.tsx
+++ b/packages/cells/__tests__/defaultCellRegistry.integration.test.tsx
@@ -54,7 +54,7 @@ describe('default cell registry integration', () => {
     const deps = await registry.sql?.findDependencies({
       cell: target,
       cells,
-      sheetId: 'sheet-1',
+      artifactId: 'sheet-1',
       sqlSelectToJson: async () =>
         ({error: false, statements: [{node: {table_name: 'a1'}}]}) as any,
     });
@@ -74,7 +74,7 @@ describe('default cell registry integration', () => {
     const deps = await registry.sql?.findDependencies({
       cell: target,
       cells,
-      sheetId: 'sheet-1',
+      artifactId: 'sheet-1',
       sqlSelectToJson: async () =>
         ({error: false, statements: [{node: {table_name: 'flights'}}]}) as any,
     });
@@ -93,7 +93,7 @@ describe('default cell registry integration', () => {
     const deps = await registry.vega?.findDependencies({
       cell: vegaCell,
       cells: {},
-      sheetId: 'sheet-1',
+      artifactId: 'sheet-1',
       sqlSelectToJson: async () => ({error: false, statements: []}),
     });
 

--- a/packages/layout/src/LayoutRenderer.tsx
+++ b/packages/layout/src/LayoutRenderer.tsx
@@ -8,6 +8,7 @@ import {
 import {renderLayoutNode} from './node-renderers/renderLayoutNode';
 import {DockingProvider} from './docking/DockingProvider';
 import {RenderNodeProvider} from './node-renderers/RenderNodeContext';
+import {RoomDndProvider} from './dnd/RoomDndProvider';
 
 export type LayoutRendererProps = {
   rootLayout: LayoutNode;
@@ -21,18 +22,20 @@ export const LayoutRenderer: FC<LayoutRendererProps> = ({
   return (
     <LayoutRendererProvider {...contextValue}>
       <RenderNodeProvider renderNode={renderLayoutNode}>
-        <DockingProvider
-          rootLayout={contextValue.rootLayout}
-          onLayoutChange={contextValue.onLayoutChange}
-        >
-          <div className={cn('h-full min-h-0 min-w-0 flex-1', className)}>
-            {renderLayoutNode({
-              node: contextValue.rootLayout,
-              path: [],
-              containerType: 'root',
-            })}
-          </div>
-        </DockingProvider>
+        <RoomDndProvider>
+          <DockingProvider
+            rootLayout={contextValue.rootLayout}
+            onLayoutChange={contextValue.onLayoutChange}
+          >
+            <div className={cn('h-full min-h-0 min-w-0 flex-1', className)}>
+              {renderLayoutNode({
+                node: contextValue.rootLayout,
+                path: [],
+                containerType: 'root',
+              })}
+            </div>
+          </DockingProvider>
+        </RoomDndProvider>
       </RenderNodeProvider>
     </LayoutRendererProvider>
   );

--- a/packages/layout/src/dnd/RoomDndProvider.tsx
+++ b/packages/layout/src/dnd/RoomDndProvider.tsx
@@ -1,0 +1,76 @@
+import {
+  closestCenter,
+  Collision,
+  CollisionDetection,
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  pointerWithin,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {createContext, FC, PropsWithChildren, useContext} from 'react';
+
+const RoomDndContext = createContext(false);
+
+function markPointerWithinCollisions(collisions: Collision[]) {
+  return collisions.map((collision) => ({
+    ...collision,
+    data: {...collision.data, pointerWithin: true},
+  }));
+}
+
+function markFallbackCollisions(collisions: Collision[]) {
+  return collisions.map((collision) => ({
+    ...collision,
+    data: {...collision.data, pointerWithin: false},
+  }));
+}
+
+function getCollisionPriority(
+  collision: Collision,
+  args: Parameters<CollisionDetection>[0],
+) {
+  const priority = args.droppableContainers.find(
+    (container) => container.id === collision.id,
+  )?.data.current?.roomDndPriority;
+  return typeof priority === 'number' ? priority : 0;
+}
+
+const roomCollisionDetection: CollisionDetection = (args) => {
+  const pointerCollisions = markPointerWithinCollisions(pointerWithin(args));
+  const collisions =
+    pointerCollisions.length > 0
+      ? pointerCollisions
+      : markFallbackCollisions(closestCenter(args));
+
+  if (args.active.data.current?.kind !== 'artifact') {
+    return collisions;
+  }
+
+  return [...collisions].sort(
+    (a, b) => getCollisionPriority(b, args) - getCollisionPriority(a, args),
+  );
+};
+
+export const RoomDndProvider: FC<PropsWithChildren> = ({children}) => {
+  const hasParentRoomDndProvider = useContext(RoomDndContext);
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {distance: 6},
+    }),
+    useSensor(KeyboardSensor),
+  );
+
+  if (hasParentRoomDndProvider) {
+    return <>{children}</>;
+  }
+
+  return (
+    <RoomDndContext.Provider value>
+      <DndContext sensors={sensors} collisionDetection={roomCollisionDetection}>
+        {children}
+      </DndContext>
+    </RoomDndContext.Provider>
+  );
+};

--- a/packages/layout/src/docking/DockingProvider.tsx
+++ b/packages/layout/src/docking/DockingProvider.tsx
@@ -1,14 +1,10 @@
 import {FC, PropsWithChildren, useCallback, useMemo, useState} from 'react';
 import {
-  closestCenter,
-  DndContext,
   DragEndEvent,
   DragMoveEvent,
   DragOverlay,
   DragStartEvent,
-  PointerSensor,
-  useSensor,
-  useSensors,
+  useDndMonitor,
 } from '@dnd-kit/core';
 import {LayoutNode} from '@sqlrooms/layout-config';
 import {DockingContext} from './DockingContext';
@@ -18,6 +14,7 @@ import {movePanel} from './dock-layout';
 import {findNearestDockAncestor, findNodeById} from '../layout-tree';
 import {DockPreviewOverlay} from './DockPreviewOverlay';
 import {DockDragOverlay} from './DockDragOverlay';
+import {LAYOUT_PANEL_DND_KIND} from '../node-renderers/leaf-node-renderer/LeafLayoutPanel';
 
 interface DockingProviderProps {
   rootLayout: LayoutNode;
@@ -34,13 +31,6 @@ export const DockingProvider: FC<PropsWithChildren<DockingProviderProps>> = ({
   onLayoutChange,
   children,
 }) => {
-  const sensors = useSensors(
-    useSensor(PointerSensor, {
-      activationConstraint: {
-        distance: 6,
-      },
-    }),
-  );
   const [activePanelId, setActivePanelId] = useState<string | null>(null);
   const [preview, setPreview] = useState<DockPreview | null>(null);
   const [cursorPosition, setCursorPosition] = useState<CursorPosition | null>(
@@ -93,8 +83,13 @@ export const DockingProvider: FC<PropsWithChildren<DockingProviderProps>> = ({
     [rootLayout],
   );
 
+  const isLayoutPanelDrag = useCallback((event: DragStartEvent) => {
+    return event.active.data.current?.kind === LAYOUT_PANEL_DND_KIND;
+  }, []);
+
   const handleDragStart = useCallback(
     (event: DragStartEvent) => {
+      if (!isLayoutPanelDrag(event)) return;
       const panelId = String(event.active.id);
       setActivePanelId(panelId);
 
@@ -111,11 +106,12 @@ export const DockingProvider: FC<PropsWithChildren<DockingProviderProps>> = ({
       setCursorPosition(cursor);
       updatePreview(event, cursor);
     },
-    [updatePreview],
+    [isLayoutPanelDrag, updatePreview],
   );
 
   const handleDragMove = useCallback(
     (event: DragMoveEvent) => {
+      if (!activePanelId) return;
       // Use center of translated rect as cursor position
       const rect = event.active.rect.current.translated;
 
@@ -131,11 +127,12 @@ export const DockingProvider: FC<PropsWithChildren<DockingProviderProps>> = ({
       setCursorPosition(cursor);
       updatePreview(event, cursor);
     },
-    [updatePreview],
+    [activePanelId, updatePreview],
   );
 
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
+      if (!activePanelId) return;
       const sourceId = String(event.active.id);
       const over = event.over;
 
@@ -160,8 +157,15 @@ export const DockingProvider: FC<PropsWithChildren<DockingProviderProps>> = ({
         onLayoutChange(nextLayout);
       }
     },
-    [clearDragState, cursorPosition, onLayoutChange, rootLayout],
+    [activePanelId, clearDragState, cursorPosition, onLayoutChange, rootLayout],
   );
+
+  useDndMonitor({
+    onDragStart: handleDragStart,
+    onDragMove: handleDragMove,
+    onDragEnd: handleDragEnd,
+    onDragCancel: clearDragState,
+  });
 
   const value = useMemo(
     () => ({
@@ -174,25 +178,16 @@ export const DockingProvider: FC<PropsWithChildren<DockingProviderProps>> = ({
 
   return (
     <DockingContext.Provider value={value}>
-      <DndContext
-        sensors={sensors}
-        collisionDetection={closestCenter}
-        onDragStart={handleDragStart}
-        onDragMove={handleDragMove}
-        onDragEnd={handleDragEnd}
-        onDragCancel={clearDragState}
-      >
-        {children}
-        <DragOverlay dropAnimation={null}>
-          {activePanelId && activePanelNode && (
-            <DockDragOverlay
-              activePanelId={activePanelId}
-              activePanelNode={activePanelNode}
-            />
-          )}
-        </DragOverlay>
-        <DockPreviewOverlay preview={preview} />
-      </DndContext>
+      {children}
+      <DragOverlay dropAnimation={null}>
+        {activePanelId && activePanelNode && (
+          <DockDragOverlay
+            activePanelId={activePanelId}
+            activePanelNode={activePanelNode}
+          />
+        )}
+      </DragOverlay>
+      <DockPreviewOverlay preview={preview} />
     </DockingContext.Provider>
   );
 };

--- a/packages/layout/src/docking/DockingProvider.tsx
+++ b/packages/layout/src/docking/DockingProvider.tsx
@@ -26,6 +26,14 @@ type CursorPosition = {
   y: number;
 };
 
+/**
+ * Provides layout panel docking inside a dnd-kit `DndContext`.
+ *
+ * `LayoutRenderer` wraps `DockingProvider` with `RoomDndProvider` by default.
+ * Custom shells that render `DockingProvider` directly must provide their own
+ * `DndContext`/`RoomDndProvider`; dnd-kit's `useDndMonitor` surfaces the
+ * development-time error if this requirement is missed.
+ */
 export const DockingProvider: FC<PropsWithChildren<DockingProviderProps>> = ({
   rootLayout,
   onLayoutChange,

--- a/packages/layout/src/index.ts
+++ b/packages/layout/src/index.ts
@@ -46,6 +46,7 @@ export {
 // New LayoutRenderer component
 export {LayoutRenderer} from './LayoutRenderer';
 export type {LayoutRendererProps} from './LayoutRenderer';
+export {RoomDndProvider} from './dnd/RoomDndProvider';
 
 // New primary exports from @sqlrooms/layout-config
 export {

--- a/packages/layout/src/node-renderers/grid-node-renderer/GridLayout.tsx
+++ b/packages/layout/src/node-renderers/grid-node-renderer/GridLayout.tsx
@@ -502,6 +502,7 @@ const Root: FC<RootProps> = ({node, path, parentDirection}) => {
     childIds,
     layouts,
   );
+  const scrollContainerElementRef = scrollContainerRef as Ref<HTMLDivElement>;
   const resizePreviewStyle = resizePreviewItem
     ? getGridItemPreviewStyle(resizePreviewItem, rowHeight, gridMetrics)
     : undefined;
@@ -592,7 +593,7 @@ const Root: FC<RootProps> = ({node, path, parentDirection}) => {
         </div>
       )}
       <div
-        ref={scrollContainerRef}
+        ref={scrollContainerElementRef}
         className="min-h-0 flex-1 overflow-auto px-5 py-2"
       >
         <ResponsiveGridLayout

--- a/packages/layout/src/node-renderers/grid-node-renderer/useScrollNewGridChildIntoView.ts
+++ b/packages/layout/src/node-renderers/grid-node-renderer/useScrollNewGridChildIntoView.ts
@@ -43,8 +43,8 @@ export function useScrollNewGridChildIntoView(
   nodeId: string,
   childIds: string[],
   layoutVersion: unknown,
-): RefObject<HTMLDivElement> {
-  const scrollContainerRef = useRef<HTMLDivElement>(null!);
+): RefObject<HTMLDivElement | null> {
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     return () => {

--- a/packages/layout/src/node-renderers/grid-node-renderer/useScrollNewGridChildIntoView.ts
+++ b/packages/layout/src/node-renderers/grid-node-renderer/useScrollNewGridChildIntoView.ts
@@ -43,8 +43,8 @@ export function useScrollNewGridChildIntoView(
   nodeId: string,
   childIds: string[],
   layoutVersion: unknown,
-): RefObject<HTMLDivElement | null> {
-  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+): RefObject<HTMLDivElement> {
+  const scrollContainerRef = useRef<HTMLDivElement>(null!);
 
   useEffect(() => {
     return () => {

--- a/packages/layout/src/node-renderers/leaf-node-renderer/LeafLayoutPanel.tsx
+++ b/packages/layout/src/node-renderers/leaf-node-renderer/LeafLayoutPanel.tsx
@@ -6,6 +6,8 @@ import {cn} from '@sqlrooms/ui';
 import {LeafLayoutPanelDraggableProvider} from './LeafLayoutPanelDraggableContext';
 import {useIsDockablePanel} from './useIsDockable';
 
+export const LAYOUT_PANEL_DND_KIND = 'sqlrooms.layout.panel';
+
 export const LeafLayoutPanel: FC<PropsWithChildren> = ({children}) => {
   const {node} = useLayoutNodeContext();
 
@@ -21,11 +23,13 @@ export const LeafLayoutPanel: FC<PropsWithChildren> = ({children}) => {
   } = useDraggable({
     id: panelId,
     disabled: !isDockablePanel,
+    data: {kind: LAYOUT_PANEL_DND_KIND, panelId},
   });
 
   const {setNodeRef: setDroppableNodeRef} = useDroppable({
     id: panelId,
     disabled: !isDockablePanel || isDragging,
+    data: {kind: LAYOUT_PANEL_DND_KIND, panelId},
   });
 
   const setNodeRef = useCallback(

--- a/packages/room-shell/src/RoomShell.tsx
+++ b/packages/room-shell/src/RoomShell.tsx
@@ -1,4 +1,4 @@
-import {LayoutRenderer} from '@sqlrooms/layout';
+import {LayoutRenderer, RoomDndProvider} from '@sqlrooms/layout';
 import type {LayoutNode} from '@sqlrooms/layout-config';
 import {RoomStateProvider} from '@sqlrooms/room-store';
 import {
@@ -173,6 +173,7 @@ export const LoadingProgress: FC<{className?: string}> = ({className}) => {
 };
 
 export const RoomShell = Object.assign(RoomShellBase, {
+  DndProvider: RoomDndProvider,
   /**
    * @deprecated Use SidebarContainer instead
    */

--- a/packages/room-shell/src/index.ts
+++ b/packages/room-shell/src/index.ts
@@ -4,6 +4,7 @@
  */
 
 export {RoomShell} from './RoomShell';
+export {RoomDndProvider} from '@sqlrooms/layout';
 export {RoomShellCommandPalette} from './RoomShellCommandPalette';
 export type {
   RoomShellCommandPaletteButtonProps,

--- a/packages/ui/src/components/tab-strip.tsx
+++ b/packages/ui/src/components/tab-strip.tsx
@@ -1,8 +1,13 @@
 import {
   DndContext,
   DragEndEvent,
+  DragMoveEvent,
+  DragOverEvent,
+  DragStartEvent,
+  DragOverlay,
   PointerSensor,
   closestCenter,
+  useDndMonitor,
   useSensor,
   useSensors,
 } from '@dnd-kit/core';
@@ -28,6 +33,7 @@ import React, {
   useContext,
   useEffect,
   useLayoutEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -62,6 +68,10 @@ export interface TabDescriptor {
   [key: string]: unknown;
 }
 
+export type TabStripDndMode = 'internal' | 'shared';
+
+export type TabStripDragData = Record<string, unknown>;
+
 // -----------------------------------------------------------------------------
 // Context
 // -----------------------------------------------------------------------------
@@ -80,6 +90,9 @@ interface TabStripContextValue {
   preventCloseLastTab: boolean;
   closeable: boolean;
   getLastOpenedAt: (tabId: string) => number | undefined;
+  dndMode: TabStripDndMode;
+  dndScopeId: string;
+  getTabDragData?: (tab: TabDescriptor) => TabStripDragData | undefined;
 
   // Callbacks
   onOpenTabsChange?: (tabIds: string[]) => void;
@@ -121,6 +134,7 @@ interface TabStripTabsProps {
 
 interface SortableTabProps {
   tab: TabDescriptor;
+  sortableId: string;
   tabClassName?: string;
   editingTabId: string | null;
   closeable?: boolean;
@@ -131,7 +145,11 @@ interface SortableTabProps {
   renderTabTitle?: (tab: TabDescriptor) => React.ReactNode;
   renderTabMenu?: (tab: TabDescriptor) => React.ReactNode;
   renderTabLabel?: (tab: TabDescriptor) => React.ReactNode;
+  dndScopeId: string;
+  getTabDragData?: (tab: TabDescriptor) => TabStripDragData | undefined;
 }
+
+const DEFAULT_TAB_DRAG_KIND = 'sqlrooms.tab';
 
 const TAB_STRIP_BUTTON_CLASSNAMES = [
   'flex h-full min-w-0 min-h-7 items-center',
@@ -144,6 +162,7 @@ const TAB_STRIP_BUTTON_CLASSNAMES = [
  */
 function SortableTab({
   tab,
+  sortableId,
   tabClassName,
   editingTabId,
   closeable = true,
@@ -154,9 +173,19 @@ function SortableTab({
   renderTabTitle,
   renderTabMenu,
   renderTabLabel,
+  dndScopeId,
+  getTabDragData,
 }: SortableTabProps) {
   const {attributes, listeners, setNodeRef, transform, transition, isDragging} =
-    useSortable({id: tab.id});
+    useSortable({
+      id: sortableId,
+      data: {
+        kind: DEFAULT_TAB_DRAG_KIND,
+        ...getTabDragData?.(tab),
+        tabId: tab.id,
+        tabStripId: dndScopeId,
+      },
+    });
 
   const style: React.CSSProperties = {
     // Use Translate instead of Transform to avoid scale changes that squeeze the tab
@@ -369,6 +398,9 @@ function TabStripTabs({className, tabClassName}: TabStripTabsProps) {
     editingTabId,
     scrollContainerRef,
     onOpenTabsChange,
+    dndMode,
+    dndScopeId,
+    getTabDragData,
     renderTabTitle,
     renderTabMenu,
     renderTabLabel,
@@ -387,13 +419,53 @@ function TabStripTabs({className, tabClassName}: TabStripTabsProps) {
       },
     }),
   );
+  const [activeDraggedTabId, setActiveDraggedTabId] = useState<string | null>(
+    null,
+  );
+  const [hideSharedDragOverlay, setHideSharedDragOverlay] = useState(false);
+
+  const isDragInsideTabStrip = (
+    event: DragMoveEvent | DragOverEvent | DragStartEvent,
+  ) => {
+    const rect =
+      event.active.rect.current.translated ?? event.active.rect.current.initial;
+    const tabStripRect = scrollContainerRef.current?.getBoundingClientRect();
+    if (!rect || !tabStripRect) return false;
+
+    const centerX = rect.left + rect.width / 2;
+    const centerY = rect.top + rect.height / 2;
+
+    return (
+      centerX >= tabStripRect.left &&
+      centerX <= tabStripRect.right &&
+      centerY >= tabStripRect.top &&
+      centerY <= tabStripRect.bottom
+    );
+  };
 
   const handleDragEnd = (event: DragEndEvent) => {
     const {active, over} = event;
     if (!over || active.id === over.id || !onOpenTabsChange) return;
 
-    const oldIndex = openTabItems.findIndex((tab) => tab.id === active.id);
-    const newIndex = openTabItems.findIndex((tab) => tab.id === over.id);
+    const activeData = active.data.current;
+    const overData = over.data.current;
+    const activeTabId =
+      typeof activeData?.tabId === 'string'
+        ? activeData.tabId
+        : String(active.id);
+    const overTabId =
+      typeof overData?.tabId === 'string' ? overData.tabId : String(over.id);
+
+    if (
+      dndMode === 'shared' &&
+      (activeData?.tabStripId !== dndScopeId ||
+        overData?.tabStripId !== dndScopeId)
+    ) {
+      return;
+    }
+
+    const oldIndex = openTabItems.findIndex((tab) => tab.id === activeTabId);
+    const newIndex = openTabItems.findIndex((tab) => tab.id === overTabId);
 
     if (oldIndex !== -1 && newIndex !== -1) {
       const newOrder = arrayMove(
@@ -405,7 +477,113 @@ function TabStripTabs({className, tabClassName}: TabStripTabsProps) {
     }
   };
 
-  const tabIds = useMemo(() => openTabItems.map((t) => t.id), [openTabItems]);
+  useDndMonitor({
+    onDragStart: (event) => {
+      const activeData = event.active.data.current;
+      if (dndMode !== 'shared' || activeData?.tabStripId !== dndScopeId) {
+        return;
+      }
+      setActiveDraggedTabId(
+        typeof activeData.tabId === 'string' ? activeData.tabId : null,
+      );
+      setHideSharedDragOverlay(true);
+    },
+    onDragMove: (event) => {
+      if (dndMode !== 'shared') return;
+      if (isDragInsideTabStrip(event)) {
+        setHideSharedDragOverlay(true);
+      }
+    },
+    onDragOver: (event) => {
+      if (dndMode !== 'shared') return;
+      if (!event.over || isDragInsideTabStrip(event)) {
+        setHideSharedDragOverlay(true);
+        return;
+      }
+      setHideSharedDragOverlay(
+        event.over?.data.current?.tabStripId === dndScopeId,
+      );
+    },
+    onDragEnd: (event) => {
+      if (dndMode === 'shared') {
+        handleDragEnd(event);
+      }
+      setActiveDraggedTabId(null);
+      setHideSharedDragOverlay(false);
+    },
+    onDragCancel: () => {
+      setActiveDraggedTabId(null);
+      setHideSharedDragOverlay(false);
+    },
+  });
+
+  const getSortableId = (tabId: string) =>
+    dndMode === 'shared' ? `${dndScopeId}:${tabId}` : tabId;
+
+  const tabIds = useMemo(
+    () => openTabItems.map((t) => getSortableId(t.id)),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [openTabItems, dndMode, dndScopeId],
+  );
+
+  const content = (
+    <SortableContext items={tabIds} strategy={horizontalListSortingStrategy}>
+      <ScrollableRow
+        className="h-full min-w-0 shrink overflow-hidden"
+        scrollRef={scrollContainerRef}
+        scrollClassName={cn(
+          'flex h-full min-w-0 items-center gap-1 overflow-x-auto overflow-y-visible',
+          'pl-1 pr-1 scroll-pl-7 scroll-pr-7 [&::-webkit-scrollbar]:hidden',
+          className,
+        )}
+        arrowVisibility="always"
+        arrowClassName="w-7"
+        arrowIconClassName="h-4 w-4 opacity-60"
+      >
+        {openTabItems.map((tab) => (
+          <SortableTab
+            key={tab.id}
+            tab={tab}
+            sortableId={getSortableId(tab.id)}
+            tabClassName={tabClassName}
+            editingTabId={editingTabId}
+            closeable={
+              closeable && !(preventCloseLastTab && openTabItems.length === 1)
+            }
+            onClose={handleClose}
+            onStartEditing={handleStartEditing}
+            onStopEditing={handleStopEditing}
+            onInlineRename={handleInlineRename}
+            renderTabTitle={renderTabTitle}
+            renderTabMenu={renderTabMenu}
+            renderTabLabel={renderTabLabel}
+            dndScopeId={dndScopeId}
+            getTabDragData={getTabDragData}
+          />
+        ))}
+      </ScrollableRow>
+    </SortableContext>
+  );
+
+  if (dndMode === 'shared') {
+    const activeDraggedTab = activeDraggedTabId
+      ? openTabItems.find((tab) => tab.id === activeDraggedTabId)
+      : undefined;
+
+    return (
+      <>
+        {content}
+        <DragOverlay dropAnimation={null}>
+          {activeDraggedTab && !hideSharedDragOverlay ? (
+            <TabDragOverlay
+              tab={activeDraggedTab}
+              renderTabLabel={renderTabLabel}
+            />
+          ) : null}
+        </DragOverlay>
+      </>
+    );
+  }
 
   return (
     <DndContext
@@ -415,40 +593,30 @@ function TabStripTabs({className, tabClassName}: TabStripTabsProps) {
       autoScroll={true}
       onDragEnd={handleDragEnd}
     >
-      <SortableContext items={tabIds} strategy={horizontalListSortingStrategy}>
-        <ScrollableRow
-          className="h-full min-w-0 shrink overflow-hidden"
-          scrollRef={scrollContainerRef}
-          scrollClassName={cn(
-            'flex h-full min-w-0 items-center gap-1 overflow-x-auto overflow-y-visible',
-            'pl-1 pr-1 scroll-pl-7 scroll-pr-7 [&::-webkit-scrollbar]:hidden',
-            className,
-          )}
-          arrowVisibility="always"
-          arrowClassName="w-7"
-          arrowIconClassName="h-4 w-4 opacity-60"
-        >
-          {openTabItems.map((tab) => (
-            <SortableTab
-              key={tab.id}
-              tab={tab}
-              tabClassName={tabClassName}
-              editingTabId={editingTabId}
-              closeable={
-                closeable && !(preventCloseLastTab && openTabItems.length === 1)
-              }
-              onClose={handleClose}
-              onStartEditing={handleStartEditing}
-              onStopEditing={handleStopEditing}
-              onInlineRename={handleInlineRename}
-              renderTabTitle={renderTabTitle}
-              renderTabMenu={renderTabMenu}
-              renderTabLabel={renderTabLabel}
-            />
-          ))}
-        </ScrollableRow>
-      </SortableContext>
+      {content}
     </DndContext>
+  );
+}
+
+function TabDragOverlay({
+  tab,
+  renderTabLabel,
+}: {
+  tab: TabDescriptor;
+  renderTabLabel?: (tab: TabDescriptor) => React.ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        'bg-primary/15 text-foreground border-primary/50 flex h-7 max-w-[200px] min-w-[100px]',
+        'cursor-grabbing items-center justify-center gap-1 overflow-hidden rounded-md border px-6 py-1',
+        'text-sm shadow-lg',
+      )}
+    >
+      <div className="truncate text-center">
+        {renderTabLabel ? renderTabLabel(tab) : tab.name}
+      </div>
+    </div>
   );
 }
 
@@ -855,6 +1023,12 @@ export interface TabStripProps {
   renderSearchItemActions?: (tab: TabDescriptor) => React.ReactNode;
   /** Render function for custom tab content. Receives the tab and returns the content to display. */
   renderTabLabel?: (tab: TabDescriptor) => React.ReactNode;
+  /** Whether this tab strip owns its dnd context or participates in a shared parent context. */
+  dndMode?: TabStripDndMode;
+  /** Unique scope for shared dnd tab ids. Defaults to a generated component id. */
+  dndScopeId?: string;
+  /** Extra drag payload attached to tab drags. */
+  getTabDragData?: (tab: TabDescriptor) => TabStripDragData | undefined;
 }
 
 /**
@@ -896,7 +1070,12 @@ function TabStripRoot({
   renderTabMenu,
   renderSearchItemActions,
   renderTabLabel,
+  dndMode = 'internal',
+  dndScopeId,
+  getTabDragData,
 }: TabStripProps) {
+  const generatedDndScopeId = useId();
+  const actualDndScopeId = dndScopeId ?? generatedDndScopeId;
   const [search, setSearch] = useState('');
   const [editingTabId, setEditingTabId] = useState<string | null>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null!);
@@ -1069,6 +1248,9 @@ function TabStripRoot({
     preventCloseLastTab,
     closeable,
     getLastOpenedAt: (tabId) => lastOpenedAtRef.current.get(tabId),
+    dndMode,
+    dndScopeId: actualDndScopeId,
+    getTabDragData,
     onOpenTabsChange,
     onSelect,
     onCreate,

--- a/packages/ui/src/components/tab-strip.tsx
+++ b/packages/ui/src/components/tab-strip.tsx
@@ -759,20 +759,24 @@ function DropdownTabItems({
 /**
  * A general-purpose button for the tab strip.
  */
-function TabStripButton({className, ...props}: ButtonProps) {
-  return (
-    <Button
-      size="icon"
-      variant="ghost"
-      className={cn(
-        ...TAB_STRIP_BUTTON_CLASSNAMES,
-        'h-full shrink-0',
-        className,
-      )}
-      {...props}
-    />
-  );
-}
+const TabStripButton = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({className, ...props}, ref) => {
+    return (
+      <Button
+        ref={ref}
+        size="icon"
+        variant="ghost"
+        className={cn(
+          ...TAB_STRIP_BUTTON_CLASSNAMES,
+          'h-full shrink-0',
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+TabStripButton.displayName = 'TabStripButton';
 type TabStripNewButtonProps = ButtonProps & {
   /** Optional tooltip content for the button. */
   tooltip?: React.ReactNode;

--- a/packages/ui/src/components/tab-strip.tsx
+++ b/packages/ui/src/components/tab-strip.tsx
@@ -70,6 +70,11 @@ export interface TabDescriptor {
 
 export type TabStripDndMode = 'internal' | 'shared';
 
+/**
+ * Extra payload attached to tab drags. `TabStrip` always preserves `tabId` and
+ * `tabStripId`; callers may intentionally override `kind` for cross-component
+ * drags such as artifact tabs.
+ */
 export type TabStripDragData = Record<string, unknown>;
 
 // -----------------------------------------------------------------------------
@@ -176,12 +181,13 @@ function SortableTab({
   dndScopeId,
   getTabDragData,
 }: SortableTabProps) {
+  const tabDragData = getTabDragData?.(tab);
   const {attributes, listeners, setNodeRef, transform, transition, isDragging} =
     useSortable({
       id: sortableId,
       data: {
         kind: DEFAULT_TAB_DRAG_KIND,
-        ...getTabDragData?.(tab),
+        ...tabDragData,
         tabId: tab.id,
         tabStripId: dndScopeId,
       },
@@ -443,6 +449,18 @@ function TabStripTabs({className, tabClassName}: TabStripTabsProps) {
     );
   };
 
+  const shouldHideSharedDragOverlay = (
+    event: DragMoveEvent | DragOverEvent | DragStartEvent,
+  ) => {
+    if (isDragInsideTabStrip(event)) {
+      return true;
+    }
+    if ('over' in event) {
+      return event.over?.data.current?.tabStripId === dndScopeId;
+    }
+    return false;
+  };
+
   const handleDragEnd = (event: DragEndEvent) => {
     const {active, over} = event;
     if (!over || active.id === over.id || !onOpenTabsChange) return;
@@ -476,46 +494,6 @@ function TabStripTabs({className, tabClassName}: TabStripTabsProps) {
       onOpenTabsChange(newOrder);
     }
   };
-
-  useDndMonitor({
-    onDragStart: (event) => {
-      const activeData = event.active.data.current;
-      if (dndMode !== 'shared' || activeData?.tabStripId !== dndScopeId) {
-        return;
-      }
-      setActiveDraggedTabId(
-        typeof activeData.tabId === 'string' ? activeData.tabId : null,
-      );
-      setHideSharedDragOverlay(true);
-    },
-    onDragMove: (event) => {
-      if (dndMode !== 'shared') return;
-      if (isDragInsideTabStrip(event)) {
-        setHideSharedDragOverlay(true);
-      }
-    },
-    onDragOver: (event) => {
-      if (dndMode !== 'shared') return;
-      if (!event.over || isDragInsideTabStrip(event)) {
-        setHideSharedDragOverlay(true);
-        return;
-      }
-      setHideSharedDragOverlay(
-        event.over?.data.current?.tabStripId === dndScopeId,
-      );
-    },
-    onDragEnd: (event) => {
-      if (dndMode === 'shared') {
-        handleDragEnd(event);
-      }
-      setActiveDraggedTabId(null);
-      setHideSharedDragOverlay(false);
-    },
-    onDragCancel: () => {
-      setActiveDraggedTabId(null);
-      setHideSharedDragOverlay(false);
-    },
-  });
 
   const getSortableId = (tabId: string) =>
     dndMode === 'shared' ? `${dndScopeId}:${tabId}` : tabId;
@@ -572,6 +550,13 @@ function TabStripTabs({className, tabClassName}: TabStripTabsProps) {
 
     return (
       <>
+        <SharedTabStripDndMonitor
+          dndScopeId={dndScopeId}
+          handleDragEnd={handleDragEnd}
+          setActiveDraggedTabId={setActiveDraggedTabId}
+          setHideSharedDragOverlay={setHideSharedDragOverlay}
+          shouldHideSharedDragOverlay={shouldHideSharedDragOverlay}
+        />
         {content}
         <DragOverlay dropAnimation={null}>
           {activeDraggedTab && !hideSharedDragOverlay ? (
@@ -596,6 +581,59 @@ function TabStripTabs({className, tabClassName}: TabStripTabsProps) {
       {content}
     </DndContext>
   );
+}
+
+function SharedTabStripDndMonitor({
+  dndScopeId,
+  handleDragEnd,
+  setActiveDraggedTabId,
+  setHideSharedDragOverlay,
+  shouldHideSharedDragOverlay,
+}: {
+  dndScopeId: string;
+  handleDragEnd: (event: DragEndEvent) => void;
+  setActiveDraggedTabId: React.Dispatch<React.SetStateAction<string | null>>;
+  setHideSharedDragOverlay: React.Dispatch<React.SetStateAction<boolean>>;
+  shouldHideSharedDragOverlay: (
+    event: DragMoveEvent | DragOverEvent | DragStartEvent,
+  ) => boolean;
+}) {
+  const isOwnTabDrag = (
+    event: DragStartEvent | DragMoveEvent | DragOverEvent | DragEndEvent,
+  ) => event.active.data.current?.tabStripId === dndScopeId;
+
+  useDndMonitor({
+    onDragStart: (event) => {
+      const activeData = event.active.data.current;
+      if (!isOwnTabDrag(event)) {
+        return;
+      }
+      setActiveDraggedTabId(
+        typeof activeData?.tabId === 'string' ? activeData.tabId : null,
+      );
+      setHideSharedDragOverlay(true);
+    },
+    onDragMove: (event) => {
+      if (!isOwnTabDrag(event)) return;
+      setHideSharedDragOverlay(shouldHideSharedDragOverlay(event));
+    },
+    onDragOver: (event) => {
+      if (!isOwnTabDrag(event)) return;
+      setHideSharedDragOverlay(shouldHideSharedDragOverlay(event));
+    },
+    onDragEnd: (event) => {
+      if (!isOwnTabDrag(event)) return;
+      handleDragEnd(event);
+      setActiveDraggedTabId(null);
+      setHideSharedDragOverlay(false);
+    },
+    onDragCancel: () => {
+      setActiveDraggedTabId(null);
+      setHideSharedDragOverlay(false);
+    },
+  });
+
+  return null;
 }
 
 function TabDragOverlay({
@@ -1027,7 +1065,7 @@ export interface TabStripProps {
   dndMode?: TabStripDndMode;
   /** Unique scope for shared dnd tab ids. Defaults to a generated component id. */
   dndScopeId?: string;
-  /** Extra drag payload attached to tab drags. */
+  /** Extra drag payload attached to tab drags; may intentionally override `kind`. */
   getTabDragData?: (tab: TabDescriptor) => TabStripDragData | undefined;
 }
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -203,6 +203,8 @@ export {RunButton, type RunButtonProps} from './components/run-button';
 export {
   TabStrip,
   type TabDescriptor,
+  type TabStripDndMode,
+  type TabStripDragData,
   type TabStripProps,
 } from './components/tab-strip';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2395,6 +2395,12 @@ importers:
       '@ai-sdk/react':
         specifier: ^3.0.118
         version: 3.0.161(react@19.2.1)(zod@4.1.13)
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
       '@paralleldrive/cuid2':
         specifier: ^3.0.0
         version: 3.0.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2441,6 +2441,9 @@ importers:
         specifier: 4.1.13
         version: 4.1.13
     devDependencies:
+      '@jest/globals':
+        specifier: ^30.3.0
+        version: 30.3.0
       '@sqlrooms/preset-jest':
         specifier: workspace:*
         version: link:../preset-jest
@@ -2768,10 +2771,10 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.1.3
-        version: 30.3.0(@types/node@24.12.2)
+        version: 30.3.0(@types/node@25.5.0)
       ts-jest:
         specifier: ^29.4.4
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@24.12.2))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0))(typescript@5.9.3)
 
   packages/cosmos:
     dependencies:
@@ -2829,10 +2832,10 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.1.3
-        version: 30.2.0(@types/node@24.10.2)
+        version: 30.2.0(@types/node@24.12.2)
       ts-jest:
         specifier: ^29.4.4
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.2.0(@types/node@24.10.2))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.2.0(@types/node@24.12.2))(typescript@5.9.3)
 
   packages/data-table:
     dependencies:
@@ -3105,10 +3108,10 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.1.3
-        version: 30.2.0(@types/node@24.10.2)
+        version: 30.2.0(@types/node@25.5.0)
       ts-jest:
         specifier: ^29.4.4
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.2.0(@types/node@24.10.2))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.2.0(@types/node@25.5.0))(typescript@5.9.3)
 
   packages/duckdb-core:
     dependencies:
@@ -3127,10 +3130,10 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.1.3
-        version: 30.2.0(@types/node@24.10.2)
+        version: 30.2.0(@types/node@25.5.0)
       ts-jest:
         specifier: ^29.4.4
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.2.0(@types/node@24.10.2))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.2.0(@types/node@25.5.0))(typescript@5.9.3)
 
   packages/duckdb-node:
     dependencies:
@@ -3152,10 +3155,10 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.1.3
-        version: 30.2.0(@types/node@24.10.2)
+        version: 30.2.0(@types/node@25.5.0)
       ts-jest:
         specifier: ^29.4.4
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.2.0(@types/node@24.10.2))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.2.0(@types/node@25.5.0))(typescript@5.9.3)
 
   packages/kepler:
     dependencies:
@@ -3556,10 +3559,10 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       jest:
         specifier: ^30.1.3
-        version: 30.2.0(@types/node@24.10.2)
+        version: 30.2.0(@types/node@25.5.0)
       ts-jest:
         specifier: ^29.4.4
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.2.0(@types/node@24.10.2))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.2.0(@types/node@25.5.0))(typescript@5.9.3)
 
   packages/preset-eslint:
     devDependencies:
@@ -3610,13 +3613,13 @@ importers:
         version: 3.0.0
       jest:
         specifier: ^30.1.3
-        version: 30.2.0(@types/node@24.10.2)
+        version: 30.2.0(@types/node@25.5.0)
       jest-environment-jsdom:
         specifier: ^30.1.2
         version: 30.2.0
       ts-jest:
         specifier: ^29.4.4
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.2.0(@types/node@24.10.2))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.2.0(@types/node@25.5.0))(typescript@5.9.3)
 
   packages/preset-typedoc:
     dependencies:
@@ -27876,17 +27879,36 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.3.0(@types/node@24.12.2):
+  jest-cli@30.2.0(@types/node@24.12.2):
     dependencies:
-      '@jest/core': 30.3.0
-      '@jest/test-result': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/core': 30.2.0
+      '@jest/test-result': 30.2.0
+      '@jest/types': 30.2.0
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@24.12.2)
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
+      jest-config: 30.2.0(@types/node@24.12.2)
+      jest-util: 30.2.0
+      jest-validate: 30.2.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jest-cli@30.2.0(@types/node@25.5.0):
+    dependencies:
+      '@jest/core': 30.2.0
+      '@jest/test-result': 30.2.0
+      '@jest/types': 30.2.0
+      chalk: 4.1.2
+      exit-x: 0.2.2
+      import-local: 3.2.0
+      jest-config: 30.2.0(@types/node@25.5.0)
+      jest-util: 30.2.0
+      jest-validate: 30.2.0
       yargs: 17.7.2
     transitivePeerDependencies:
       - '@types/node'
@@ -27978,33 +28000,34 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.3.0(@types/node@24.12.2):
+  jest-config@30.2.0(@types/node@25.5.0):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
       '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.3.0
-      '@jest/types': 30.3.0
-      babel-jest: 30.3.0(@babel/core@7.29.0)
+      '@jest/test-sequencer': 30.2.0
+      '@jest/types': 30.2.0
+      babel-jest: 30.2.0(@babel/core@7.29.0)
       chalk: 4.1.2
       ci-info: 4.4.0
       deepmerge: 4.3.1
       glob: 10.5.0
       graceful-fs: 4.2.11
-      jest-circus: 30.3.0
+      jest-circus: 30.2.0
       jest-docblock: 30.2.0
-      jest-environment-node: 30.3.0
+      jest-environment-node: 30.2.0
       jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-runner: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
+      jest-resolve: 30.2.0
+      jest-runner: 30.2.0
+      jest-util: 30.2.0
+      jest-validate: 30.2.0
+      micromatch: 4.0.8
       parse-json: 5.2.0
-      pretty-format: 30.3.0
+      pretty-format: 30.2.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 24.12.2
+      '@types/node': 25.5.0
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -28489,12 +28512,25 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@30.3.0(@types/node@24.12.2):
+  jest@30.2.0(@types/node@24.12.2):
     dependencies:
-      '@jest/core': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/core': 30.2.0
+      '@jest/types': 30.2.0
       import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@24.12.2)
+      jest-cli: 30.2.0(@types/node@24.12.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jest@30.2.0(@types/node@25.5.0):
+    dependencies:
+      '@jest/core': 30.2.0
+      '@jest/types': 30.2.0
+      import-local: 3.2.0
+      jest-cli: 30.2.0(@types/node@25.5.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -32008,12 +32044,12 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.2.0(@types/node@24.10.2))(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.2.0(@types/node@24.12.2))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.8
-      jest: 30.2.0(@types/node@24.10.2)
+      jest: 30.2.0(@types/node@24.12.2)
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -32028,12 +32064,12 @@ snapshots:
       babel-jest: 30.3.0(@babel/core@7.29.0)
       jest-util: 30.3.0
 
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@24.12.2))(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.2.0(@types/node@25.5.0))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.8
-      jest: 30.3.0(@types/node@24.12.2)
+      jest: 30.2.0(@types/node@25.5.0)
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6


### PR DESCRIPTION
Solving https://github.com/sqlrooms/sqlrooms/issues/607

<img width="570" height="172" alt="image" src="https://github.com/user-attachments/assets/0565110c-aeba-4599-841a-c3f209c772c4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Context selector added to chat/composer with drag‑and‑drop reordering; run context is captured at analysis start and included in prompts, instructions, and tool executions.
  * Drag‑and‑drop enhancements: shared tab-strip DnD, room-level DnD provider, docking/overlay improvements, and artifact tab drag payloads.

* **Public API**
  * Exposed run-context schemas, extraction helper, context-selector exports, and a tool-execution context type.

* **Tests**
  * New/updated tests for context selection, reordering, run-context capture, and migration/parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->