### PR TITLE
fix: fix zindex of dialog content

### DIFF
--- a/packages/ai-core/src/components/ActivityBox.tsx
+++ b/packages/ai-core/src/components/ActivityBox.tsx
@@ -148,7 +148,7 @@ export const ActivityBox: React.FC<ActivityBoxProps> = ({
         >
           <div
             ref={innerRef}
-            className="text-muted-foreground w-full min-w-0 overflow-hidden p-2.5 text-xs break-words"
+            className="text-muted-foreground w-full min-w-0 overflow-hidden p-2.5 text-xs break-words hyphens-auto"
           >
             {children}
           </div>

--- a/packages/ai-core/src/components/ActivityBox.tsx
+++ b/packages/ai-core/src/components/ActivityBox.tsx
@@ -1,5 +1,5 @@
 import {cn} from '@sqlrooms/ui';
-import {ChevronDown, ChevronsUp} from 'lucide-react';
+import {ChevronDown, ChevronRight, ChevronsUp} from 'lucide-react';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 const DEFAULT_MAX_HEIGHT = 100;
@@ -11,6 +11,13 @@ type ActivityBoxProps = {
   /** When true, the box auto-scrolls to the bottom as content changes. */
   isRunning?: boolean;
   className?: string;
+  /**
+   * When provided, the box can be fully hidden behind a single clickable
+   * summary line (e.g. "Worked with 4 tools"). Clicking the line toggles
+   * visibility of the full activity box. While `isRunning` is true the
+   * box is always shown regardless of this prop.
+   */
+  summaryLabel?: string;
 };
 
 /**
@@ -24,6 +31,7 @@ export const ActivityBox: React.FC<ActivityBoxProps> = ({
   maxCollapsedHeight = DEFAULT_MAX_HEIGHT,
   isRunning = false,
   className,
+  summaryLabel,
 }) => {
   const scrollRef = useRef<HTMLDivElement>(null);
   const innerRef = useRef<HTMLDivElement>(null);
@@ -31,6 +39,11 @@ export const ActivityBox: React.FC<ActivityBoxProps> = ({
   const [overflows, setOverflows] = useState(false);
   const [canScrollUp, setCanScrollUp] = useState(false);
   const [canScrollDown, setCanScrollDown] = useState(false);
+  // Tracks which summaryLabel the user explicitly expanded. When the label
+  // changes (e.g. tool count updates) the override resets, auto-collapsing again.
+  const [expandedForLabel, setExpandedForLabel] = useState<string | null>(null);
+
+  const visible = !summaryLabel || expandedForLabel === summaryLabel;
 
   const measure = useCallback(() => {
     const el = innerRef.current;
@@ -67,7 +80,7 @@ export const ActivityBox: React.FC<ActivityBoxProps> = ({
       ro.disconnect();
       mo.disconnect();
     };
-  }, [measure, updateScrollFlags]);
+  }, [measure, updateScrollFlags, visible]);
 
   useEffect(() => {
     const el = scrollRef.current;
@@ -75,7 +88,7 @@ export const ActivityBox: React.FC<ActivityBoxProps> = ({
     const handler = () => updateScrollFlags();
     el.addEventListener('scroll', handler, {passive: true});
     return () => el.removeEventListener('scroll', handler);
-  }, [updateScrollFlags]);
+  }, [updateScrollFlags, visible]);
 
   // Auto-scroll to bottom when running and content changes
   useEffect(() => {
@@ -92,6 +105,22 @@ export const ActivityBox: React.FC<ActivityBoxProps> = ({
   }, [expanded, overflows, updateScrollFlags]);
 
   const showOverlay = overflows && !expanded;
+  const showBox = isRunning || !summaryLabel || visible;
+
+  if (!showBox) {
+    return (
+      <button
+        onClick={() => setExpandedForLabel(summaryLabel ?? null)}
+        className={cn(
+          'text-muted-foreground hover:text-foreground ml-4 flex w-full cursor-pointer items-center gap-1 py-0.5 text-xs transition-colors',
+          className,
+        )}
+      >
+        <ChevronRight className="h-3 w-3 shrink-0" />
+        <span>{summaryLabel}</span>
+      </button>
+    );
+  }
 
   return (
     <div
@@ -100,6 +129,15 @@ export const ActivityBox: React.FC<ActivityBoxProps> = ({
         className,
       )}
     >
+      {summaryLabel && !isRunning && (
+        <button
+          onClick={() => setExpandedForLabel(null)}
+          className="text-muted-foreground hover:text-foreground flex w-full cursor-pointer items-center gap-1 px-1.5 pt-1 pb-0.5 text-xs transition-colors"
+        >
+          <ChevronDown className="h-3 w-3 shrink-0" />
+          <span>{summaryLabel}</span>
+        </button>
+      )}
       <div className="relative">
         <div
           ref={scrollRef}

--- a/packages/ai-core/src/components/AnalysisResult.tsx
+++ b/packages/ai-core/src/components/AnalysisResult.tsx
@@ -203,9 +203,18 @@ export const AnalysisResult: React.FC<AnalysisResultProps> = ({
                   s !== 'output-denied'
                 );
               });
+              const toolCount = seg.parts.length;
+              const allToolsDone = !anyPending && toolCount > 0;
+              const summaryLabel =
+                allToolsDone && analysisResult.isCompleted
+                  ? `Worked with ${toolCount} tool${toolCount === 1 ? '' : 's'}`
+                  : undefined;
               return (
                 <React.Fragment key={`tg-${segIdx}`}>
-                  <ActivityBox isRunning={anyPending}>
+                  <ActivityBox
+                    isRunning={anyPending}
+                    summaryLabel={summaryLabel}
+                  >
                     {seg.parts.map((p) => {
                       const toolName = getToolName(p.part);
                       const isHoisted =

--- a/packages/ai-core/src/components/FlatAgentRenderer.tsx
+++ b/packages/ai-core/src/components/FlatAgentRenderer.tsx
@@ -417,12 +417,14 @@ const FlatSegmentList: React.FC<{
   hoistableSet: ReadonlySet<string>;
   toolRenderers: Record<string, unknown>;
   isPassthroughTool?: (tc: AgentToolCall) => boolean;
+  isAgentComplete?: boolean;
 }> = ({
   segments,
   agentProgress,
   hoistableSet,
   toolRenderers,
   isPassthroughTool,
+  isAgentComplete,
 }) => {
   return (
     <>
@@ -432,9 +434,16 @@ const FlatSegmentList: React.FC<{
             (t) => t.state === 'pending' || t.state === 'approval-requested',
           );
 
+          const toolCount = seg.tools.length;
+          const allToolsDone = !anyPending && toolCount > 0;
+          const summaryLabel =
+            allToolsDone && isAgentComplete
+              ? `Worked with ${toolCount} tool${toolCount === 1 ? '' : 's'}`
+              : undefined;
+
           return (
             <React.Fragment key={`tg-${idx}`}>
-              <ActivityBox isRunning={anyPending}>
+              <ActivityBox isRunning={anyPending} summaryLabel={summaryLabel}>
                 {seg.tools.map((tc) => {
                   const isHoisted =
                     hoistableSet.has(tc.toolName) &&
@@ -513,6 +522,7 @@ const FlatSegmentList: React.FC<{
               hoistableSet={hoistableSet}
               toolRenderers={toolRenderers}
               isPassthroughTool={isPassthroughTool}
+              isAgentComplete={isComplete}
             />
           </React.Fragment>
         );
@@ -702,6 +712,7 @@ export const FlatAgentRenderer: React.FC<{
         hoistableSet={hoistableSet}
         toolRenderers={toolRenderers}
         isPassthroughTool={isPassthroughTool}
+        isAgentComplete={!!isComplete}
       />
     </div>
   );

--- a/packages/ai-core/src/components/FlatAgentRenderer.tsx
+++ b/packages/ai-core/src/components/FlatAgentRenderer.tsx
@@ -129,7 +129,7 @@ const ActivityLogLine: React.FC<{
       </span>
       <span
         className={cn(
-          'min-w-0 leading-4 break-all whitespace-normal',
+          'min-w-0 leading-4 break-words hyphens-auto whitespace-normal',
           reasoning && 'italic',
         )}
       >
@@ -619,7 +619,7 @@ const OrchestratorLogLineInner: React.FC<{
       </span>
       <span
         className={cn(
-          'min-w-0 leading-4 break-all whitespace-normal',
+          'min-w-0 leading-4 break-words hyphens-auto whitespace-normal',
           reasoning && 'italic',
         )}
       >

--- a/packages/kepler/src/components/CustomMapLegend.tsx
+++ b/packages/kepler/src/components/CustomMapLegend.tsx
@@ -44,11 +44,14 @@ export function CustomMapLegendFactory(
   LayerLegendHeader: ReturnType<typeof LayerLegendHeaderFactory>,
   LayerLegendContent: ReturnType<typeof LayerLegendContentFactory>,
 ) {
-  const MapLegend: React.FC<MapLegendProps & {mapIndex?: number}> = ({
+  const MapLegend: React.FC<
+    MapLegendProps & {mapIndex?: number; onClose?: () => void}
+  > = ({
     layers = [],
     width,
     isExport,
     mapIndex: mapIndexProp,
+    onClose,
     ...restProps
   }) => {
     const containerW = width || DIMENSIONS.mapControl.width;
@@ -63,7 +66,11 @@ export function CustomMapLegendFactory(
     );
     const handleClose = (evt: React.MouseEvent<HTMLButtonElement>) => {
       evt.stopPropagation();
-      dispatchAction(mapId, toggleMapControl('mapLegend', 0));
+      if (onClose) {
+        onClose();
+      } else {
+        dispatchAction(mapId, toggleMapControl('mapLegend', 0));
+      }
     };
 
     const isSplit = splitMaps && splitMaps.length > 1;

--- a/packages/kepler/src/components/CustomMapLegendPanel.tsx
+++ b/packages/kepler/src/components/CustomMapLegendPanel.tsx
@@ -1,4 +1,10 @@
+import {useCallback, useState} from 'react';
 import {
+  Icons,
+  MapControlButton,
+  MapControlPanelFactory,
+  MapControlTooltipFactory,
+  MapLegendFactory,
   MapLegendPanelFactory,
   MapLegendPanelProps,
 } from '@kepler.gl/components';
@@ -6,19 +12,81 @@ import {
 CustomMapLegendPanelFactory.deps = MapLegendPanelFactory.deps;
 
 export function CustomMapLegendPanelFactory(
-  ...deps: Parameters<typeof MapLegendPanelFactory>
+  MapControlTooltip: ReturnType<typeof MapControlTooltipFactory>,
+  MapControlPanel: ReturnType<typeof MapControlPanelFactory>,
+  MapLegend: ReturnType<typeof MapLegendFactory>,
 ): ReturnType<typeof MapLegendPanelFactory> {
-  const MapLegendPanel = MapLegendPanelFactory(...deps);
-  const CustomMapLegendPanel = (
+  const OriginalMapLegendPanel = MapLegendPanelFactory(
+    MapControlTooltip,
+    MapControlPanel,
+    MapLegend,
+  );
+
+  const SplitPaneLegend = (
     props: MapLegendPanelProps & {mapIndex?: number},
   ) => {
+    const [isActive, setIsActive] = useState(false);
+    const mapLegend = props.mapControls?.mapLegend;
+
+    const toggleLegend = useCallback((e?: React.MouseEvent) => {
+      e?.preventDefault();
+      setIsActive((prev) => !prev);
+    }, []);
+
+    if (!mapLegend?.show) return null;
+
+    return isActive ? (
+      <>
+        <style>{`.split-legend .map-control__panel-header { display: none !important; }`}</style>
+        <div className="split-legend">
+          <MapControlPanel
+            scale={props.scale}
+            header="header.layerLegend"
+            onClick={toggleLegend}
+            pinnable={false}
+            disableClose={false}
+            isExport={props.isExport}
+            logoComponent={props.logoComponent}
+          >
+            <MapLegend
+              layers={props.layers}
+              mapState={props.mapState}
+              disableEdit={mapLegend.disableEdit}
+              isExport={props.isExport}
+              onLayerVisConfigChange={props.onLayerVisConfigChange}
+              onToggleLayerVisibility={props.onToggleLayerVisibility}
+              {...({onClose: toggleLegend} as any)}
+            />
+          </MapControlPanel>
+        </div>
+      </>
+    ) : (
+      <MapControlTooltip id="show-legend" message="tooltip.showLegend">
+        <MapControlButton
+          className="map-control-button show-legend"
+          onClick={toggleLegend}
+        >
+          <Icons.Legend height="22px" />
+        </MapControlButton>
+      </MapControlTooltip>
+    );
+  };
+
+  const CustomMapLegendPanel = (
+    props: MapLegendPanelProps & {mapIndex?: number; isSplit?: boolean},
+  ) => {
+    if (props.isSplit) {
+      return <SplitPaneLegend {...props} />;
+    }
+
     return (
       <>
         <style>{`.draggable-legend .map-control__panel-header { display: none !important; }`}</style>
-        <MapLegendPanel {...props} />
+        <OriginalMapLegendPanel {...props} />
       </>
     );
   };
+
   CustomMapLegendPanel.displayName = 'CustomMapLegendPanel';
   return CustomMapLegendPanel;
 }

--- a/packages/kepler/src/components/KeplerMapContainer.tsx
+++ b/packages/kepler/src/components/KeplerMapContainer.tsx
@@ -130,10 +130,26 @@ const KeplerGl: FC<{
     return getAnimatableVisibleLayers(layers).length > 0;
   }, [keplerState?.visState?.layers]);
 
-  const bottomWidgetFields =
-    hasFilters || hasAnimatableLayers
-      ? bottomWidgetSelector(mergedKeplerProps, theme)
-      : null;
+  const bottomWidgetFields = useMemo(() => {
+    if (!hasFilters && !hasAnimatableLayers) return null;
+    const fields = bottomWidgetSelector(mergedKeplerProps, theme);
+    // The legend is rendered as a draggable, portaled overlay so the
+    // BottomWidget should not shrink to reserve space for it.  Mask
+    // mapLegend.active so the upstream spaceForLegendWidth stays 0.
+    return {
+      ...fields,
+      uiState: {
+        ...fields.uiState,
+        mapControls: {
+          ...fields.uiState.mapControls,
+          mapLegend: {
+            ...fields.uiState.mapControls?.mapLegend,
+            active: false,
+          },
+        },
+      },
+    };
+  }, [hasFilters, hasAnimatableLayers, mergedKeplerProps, theme]);
 
   const modalContainerFields = keplerState?.visState
     ? modalContainerSelector(mergedKeplerProps, containerNode)

--- a/packages/kepler/src/components/KeplerMapContainer.tsx
+++ b/packages/kepler/src/components/KeplerMapContainer.tsx
@@ -144,6 +144,7 @@ const KeplerGl: FC<{
           ...fields.uiState.mapControls,
           mapLegend: {
             ...fields.uiState.mapControls?.mapLegend,
+            show: fields.uiState.mapControls?.mapLegend?.show ?? false,
             active: false,
           },
         },

--- a/packages/mosaic/src/tableInterop.ts
+++ b/packages/mosaic/src/tableInterop.ts
@@ -93,10 +93,10 @@ export function createMosaicTableFromArrowTable(
   const arrowTableRef =
     typeof WeakRef === 'undefined' ? undefined : new WeakRef(arrowTable);
 
-  return attachTableInterop(decodeIPC(ipcBytes), {
+  return attachTableInterop(decodeIPC(ipcBytes) as unknown as MosaicTable, {
     ipcBytes,
     decodeArrowTable: (bytes) => arrowTableRef?.deref() ?? tableFromIPC(bytes),
-  }) as MosaicTable;
+  });
 }
 
 /**

--- a/packages/ui/src/components/context-menu.tsx
+++ b/packages/ui/src/components/context-menu.tsx
@@ -46,7 +46,7 @@ const ContextMenuSubContent = React.forwardRef<
   <ContextMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-32 origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg',
+      'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-1100 min-w-32 origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg',
       className,
     )}
     {...props}
@@ -62,7 +62,7 @@ const ContextMenuContent = React.forwardRef<
     <ContextMenuPrimitive.Content
       ref={ref}
       className={cn(
-        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-context-menu-content-available-height) min-w-32 origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
+        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-1100 max-h-(--radix-context-menu-content-available-height) min-w-32 origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
         className,
       )}
       {...props}

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -21,7 +21,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80',
+      'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-1000 bg-black/80',
       className,
     )}
     {...props}
@@ -44,7 +44,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:rounded-lg',
+        'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-1000 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:rounded-lg',
         className,
       )}
       {...props}

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -47,7 +47,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-32 overflow-hidden rounded-md border p-1 shadow-lg',
+      'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-1100 min-w-32 overflow-hidden rounded-md border p-1 shadow-lg',
       className,
     )}
     {...props}
@@ -65,7 +65,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        'bg-popover text-popover-foreground z-50 min-w-32 overflow-hidden rounded-md border p-1 shadow-md',
+        'bg-popover text-popover-foreground z-1100 min-w-32 overflow-hidden rounded-md border p-1 shadow-md',
         'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         className,
       )}

--- a/packages/ui/src/components/hover-card.tsx
+++ b/packages/ui/src/components/hover-card.tsx
@@ -32,7 +32,7 @@ function HoverCardContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-lg p-2.5 text-sm shadow-md ring-1 outline-hidden duration-100',
+          'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground z-1100 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-lg p-2.5 text-sm shadow-md ring-1 outline-hidden duration-100',
           className,
         )}
         {...props}

--- a/packages/ui/src/components/menu-bar.tsx
+++ b/packages/ui/src/components/menu-bar.tsx
@@ -94,7 +94,7 @@ const MenubarSubContent = React.forwardRef<
   <MenubarPrimitive.SubContent
     ref={ref}
     className={cn(
-      'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-32 origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg',
+      'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-1100 min-w-32 origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg',
       className,
     )}
     {...props}
@@ -117,7 +117,7 @@ const MenubarContent = React.forwardRef<
         alignOffset={alignOffset}
         sideOffset={sideOffset}
         className={cn(
-          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-48 origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-md',
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-1100 min-w-48 origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-md',
           className,
         )}
         {...props}

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -21,7 +21,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 rounded-md border p-4 shadow-md outline-hidden',
+        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-1100 w-72 rounded-md border p-4 shadow-md outline-hidden',
         className,
       )}
       {...props}

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -75,7 +75,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-96 min-w-32 overflow-hidden rounded-md border shadow-md',
+        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-1100 max-h-96 min-w-32 overflow-hidden rounded-md border shadow-md',
         position === 'popper' &&
           'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
         className,

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -19,7 +19,7 @@ const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        'bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 overflow-hidden rounded-md px-3 py-1.5 text-xs',
+        'bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-1100 overflow-hidden rounded-md px-3 py-1.5 text-xs',
         className,
       )}
       {...props}

--- a/packages/vega/src/VegaChartToolResult.tsx
+++ b/packages/vega/src/VegaChartToolResult.tsx
@@ -32,6 +32,7 @@ export type VegaChartToolResultProps = ToolRendererProps<
  */
 export function VegaChartToolResult({
   className,
+  input,
   output,
   options,
   editorMode = 'both',
@@ -45,6 +46,11 @@ export function VegaChartToolResult({
 
   return (
     <div className={cn('flex max-w-full flex-col gap-2', className)}>
+      {input?.reasoning && (
+        <p className="text-tiny text-muted-foreground ml-4">
+          {input.reasoning}
+        </p>
+      )}
       <VegaChartContainer
         spec={vegaLiteSpec}
         sqlQuery={sqlQuery}


### PR DESCRIPTION
Fix the ordering z-index of the dialogs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ActivityBox now supports collapsible summaries to expand/collapse activity displays
  * Tool completion summaries display in analysis results when tasks complete
  * Map legend supports split-pane toggle mode for improved layout control
  * Tool reasoning displays above Vega charts when available

* **Improvements**
  * Enhanced z-index stacking order for overlays, dropdowns, popovers, and tooltips across the UI
  * Map legend panel accepts custom close handler for better integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->