### PR TITLE
chore: Add copy icon to AI tool call details

### DIFF
--- a/packages/ai-core/src/components/FlatAgentRenderer.tsx
+++ b/packages/ai-core/src/components/FlatAgentRenderer.tsx
@@ -271,48 +271,56 @@ const ToolCallDetailHover: React.FC<{
       </div>
       {toolCall.input != null && (
         <>
-          <div className="my-2 flex h-5 items-center gap-1">
+          <div className="my-2 flex h-5 items-center">
             <span className="text-[10px] font-medium text-gray-500 dark:text-gray-400">
               Input
             </span>
-            <CopyButton
-              text={
-                typeof toolCall.input === 'string'
-                  ? toolCall.input
-                  : JSON.stringify(toolCall.input, null, 2)
-              }
-              size="xs"
-              className="h-5 w-5"
-            />
           </div>
-          <pre className="mt-0.5 max-h-32 overflow-auto rounded bg-gray-50 p-1.5 font-mono text-[10px] text-gray-600 dark:bg-gray-900 dark:text-gray-300">
-            {typeof toolCall.input === 'string'
-              ? toolCall.input
-              : JSON.stringify(toolCall.input, null, 2)}
-          </pre>
+          <div className="relative">
+            <pre className="mt-0.5 max-h-32 overflow-auto rounded bg-gray-50 p-1.5 pr-7 font-mono text-[10px] text-gray-600 dark:bg-gray-900 dark:text-gray-300">
+              {typeof toolCall.input === 'string'
+                ? toolCall.input
+                : JSON.stringify(toolCall.input, null, 2)}
+            </pre>
+            <div className="absolute top-1 right-1">
+              <CopyButton
+                text={
+                  typeof toolCall.input === 'string'
+                    ? toolCall.input
+                    : JSON.stringify(toolCall.input, null, 2)
+                }
+                size="xs"
+                className="h-5 w-5"
+              />
+            </div>
+          </div>
         </>
       )}
       {toolCall.output != null && (
         <>
-          <div className="my-2 flex h-5 items-center gap-1">
+          <div className="my-2 flex h-5 items-center">
             <span className="text-[10px] font-medium text-gray-500 dark:text-gray-400">
               Output
             </span>
-            <CopyButton
-              text={
-                typeof toolCall.output === 'string'
-                  ? toolCall.output
-                  : JSON.stringify(toolCall.output, null, 2)
-              }
-              size="xs"
-              className="h-5 w-5"
-            />
           </div>
-          <pre className="mt-0.5 max-h-32 overflow-auto rounded bg-gray-50 p-1.5 font-mono text-[10px] text-gray-600 dark:bg-gray-900 dark:text-gray-300">
-            {typeof toolCall.output === 'string'
-              ? toolCall.output
-              : JSON.stringify(toolCall.output, null, 2)}
-          </pre>
+          <div className="relative">
+            <pre className="mt-0.5 max-h-32 overflow-auto rounded bg-gray-50 p-1.5 pr-7 font-mono text-[10px] text-gray-600 dark:bg-gray-900 dark:text-gray-300">
+              {typeof toolCall.output === 'string'
+                ? toolCall.output
+                : JSON.stringify(toolCall.output, null, 2)}
+            </pre>
+            <div className="absolute top-1 right-1">
+              <CopyButton
+                text={
+                  typeof toolCall.output === 'string'
+                    ? toolCall.output
+                    : JSON.stringify(toolCall.output, null, 2)
+                }
+                size="xs"
+                className="h-5 w-5"
+              />
+            </div>
+          </div>
         </>
       )}
       {toolCall.errorText && (

--- a/packages/ai-core/src/components/FlatAgentRenderer.tsx
+++ b/packages/ai-core/src/components/FlatAgentRenderer.tsx
@@ -1,7 +1,13 @@
 import React, {createContext, useContext, useMemo} from 'react';
 import {CircleXIcon, Loader2, CircleDotIcon, CircleIcon} from 'lucide-react';
 import {formatShortDuration} from '@sqlrooms/utils';
-import {cn, HoverCard, HoverCardContent, HoverCardTrigger} from '@sqlrooms/ui';
+import {
+  cn,
+  CopyButton,
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from '@sqlrooms/ui';
 import type {UIMessagePart} from '@sqlrooms/ai-config';
 import {useStoreWithAi} from '../AiSlice';
 import type {AgentToolCall} from '../types';
@@ -265,8 +271,19 @@ const ToolCallDetailHover: React.FC<{
       </div>
       {toolCall.input != null && (
         <>
-          <div className="mt-1.5 text-[10px] font-medium text-gray-500 dark:text-gray-400">
-            Input
+          <div className="my-2 flex h-5 items-center gap-1">
+            <span className="text-[10px] font-medium text-gray-500 dark:text-gray-400">
+              Input
+            </span>
+            <CopyButton
+              text={
+                typeof toolCall.input === 'string'
+                  ? toolCall.input
+                  : JSON.stringify(toolCall.input, null, 2)
+              }
+              size="xs"
+              className="h-5 w-5"
+            />
           </div>
           <pre className="mt-0.5 max-h-32 overflow-auto rounded bg-gray-50 p-1.5 font-mono text-[10px] text-gray-600 dark:bg-gray-900 dark:text-gray-300">
             {typeof toolCall.input === 'string'
@@ -277,8 +294,19 @@ const ToolCallDetailHover: React.FC<{
       )}
       {toolCall.output != null && (
         <>
-          <div className="mt-1.5 text-[10px] font-medium text-gray-500 dark:text-gray-400">
-            Output
+          <div className="my-2 flex h-5 items-center gap-1">
+            <span className="text-[10px] font-medium text-gray-500 dark:text-gray-400">
+              Output
+            </span>
+            <CopyButton
+              text={
+                typeof toolCall.output === 'string'
+                  ? toolCall.output
+                  : JSON.stringify(toolCall.output, null, 2)
+              }
+              size="xs"
+              className="h-5 w-5"
+            />
           </div>
           <pre className="mt-0.5 max-h-32 overflow-auto rounded bg-gray-50 p-1.5 font-mono text-[10px] text-gray-600 dark:bg-gray-900 dark:text-gray-300">
             {typeof toolCall.output === 'string'


### PR DESCRIPTION
This pull request updates`ToolCallDetailHover` component in the `FlatAgentRenderer` by adding copy-to-clipboard functionality for both tool input and output fields. This allows users to easily copy the displayed data for further use.

**UI/UX Improvements:**

* Added a `CopyButton` next to the "Input" and "Output" labels in the tool call hover details, enabling users to quickly copy the respective values. The button handles both string and object values by stringifying objects as needed. 

### Before
<img width="291" height="329" alt="Screenshot 2026-05-14 at 4 08 41 PM" src="https://github.com/user-attachments/assets/3e176d21-82b0-468c-8843-db70fa7d6416" />

### After
<img width="301" height="359" alt="Screenshot 2026-05-14 at 4 03 29 PM" src="https://github.com/user-attachments/assets/b4aa1115-0635-47aa-a24b-4c8eb7d64638" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added copy button functionality to tool call hover cards, allowing quick copying of inputs and outputs with intelligent handling of text and structured data.

* **UI Improvements**
  * Updated tool call detail hover cards to show labeled "Input"/"Output" headers with code-style display blocks for clearer, more readable presentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sqlrooms/sqlrooms/pull/626)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->