### PR TITLE
fix: Pass AI run context into dashboard chart tool resolution

### DIFF
--- a/apps/sqlrooms-cli-ui/src/createChartToolDeps.ts
+++ b/apps/sqlrooms-cli-ui/src/createChartToolDeps.ts
@@ -3,9 +3,11 @@ import {
   createDefaultChartTypes,
   type ChartToolDeps,
   type ChartBuilderColumn,
+  type ChartToolExecutionContext,
 } from '@sqlrooms/mosaic';
 import type {RoomState} from './store';
 import {DataTable} from '@sqlrooms/db';
+import {getAiRunContextItems} from '@sqlrooms/ai';
 
 const aiChartTypes = createDefaultChartTypes({includeCustomSpec: false});
 
@@ -34,13 +36,27 @@ function findTableColumns(
 export function createChartToolDeps(store: {
   getState: () => RoomState;
 }): ChartToolDeps {
+  const getRunContextDashboardArtifactId = (
+    state: RoomState,
+    context?: ChartToolExecutionContext,
+  ) => {
+    const contextItems = getAiRunContextItems(context?.aiRunContext);
+    return contextItems.find((item) => {
+      const artifact = state.artifacts.config.artifactsById[item.id];
+      return artifact?.type === 'dashboard';
+    })?.id;
+  };
+
   const resolveArtifact = (
     artifactId?: string,
     createIfMissing?: boolean,
+    context?: ChartToolExecutionContext,
   ): string => {
     const state = store.getState();
     let targetArtifactId =
-      artifactId ?? state.dashboard.getCurrentDashboardArtifactId();
+      artifactId ??
+      getRunContextDashboardArtifactId(state, context) ??
+      state.dashboard.getCurrentDashboardArtifactId();
     if (!targetArtifactId && createIfMissing) {
       targetArtifactId = state.dashboard.createDashboardArtifact(
         undefined,
@@ -109,10 +125,11 @@ export function createChartToolDeps(store: {
   };
 
   return {
-    resolveResources: (params) => {
+    resolveResources: (params, context) => {
       const artifactId = resolveArtifact(
         params.artifactId,
         params.createArtifactIfMissing,
+        context,
       );
       const {tableName, columns} = resolveTable(artifactId, params.tableName);
       return {artifactId, tableName, columns};

--- a/packages/mosaic/README.md
+++ b/packages/mosaic/README.md
@@ -235,6 +235,46 @@ execution-scoped context, such as a captured AI run context, over live UI state
 when resolving implicit dashboard targets. Explicit `params.artifactId` should
 still take precedence.
 
+```ts
+import {
+  createChartTools,
+  createDefaultChartTypes,
+  type ChartToolDeps,
+} from '@sqlrooms/mosaic';
+
+const deps: ChartToolDeps = {
+  resolveResources: (params, context) => {
+    const sessionId = context?.sessionId;
+    const runContext = context?.aiRunContext;
+    const contextArtifactId = getDashboardArtifactIdFromRunContext(
+      runContext,
+      sessionId,
+    );
+
+    // Prefer execution-scoped context over live UI state for implicit targets.
+    // Explicit tool input still wins over anything derived from context.
+    const artifactId =
+      params.artifactId ??
+      contextArtifactId ??
+      getCurrentDashboardArtifactId();
+    const tableName = params.tableName ?? getSelectedTableName(artifactId);
+
+    return {
+      artifactId,
+      tableName,
+      columns: getTableColumns(tableName),
+    };
+  },
+  createChart: ({artifactId, tableName, title, config}) =>
+    addChartPanel({artifactId, tableName, title, config}),
+};
+
+const chartTools = createChartTools(
+  createDefaultChartTypes({includeCustomSpec: false}),
+  deps,
+);
+```
+
 ### Box Plot Chart Type
 
 The built-in Box Plot chart type (`'box-plot'`) is a specialized chart that uses

--- a/packages/mosaic/README.md
+++ b/packages/mosaic/README.md
@@ -226,6 +226,15 @@ panel omits a source it falls back to the dashboard selected table. Panel render
 definitions and chart builder definitions are runtime-only and intentionally
 live outside persisted dashboard config.
 
+### AI Chart Tools
+
+`createChartTools` generates assistant tools for the built-in chart types. The
+injected `ChartToolDeps.resolveResources(params, context)` callback receives the
+tool execution context as its second argument. Client apps should prefer
+execution-scoped context, such as a captured AI run context, over live UI state
+when resolving implicit dashboard targets. Explicit `params.artifactId` should
+still take precedence.
+
 ### Box Plot Chart Type
 
 The built-in Box Plot chart type (`'box-plot'`) is a specialized chart that uses

--- a/packages/mosaic/src/chart-types/base-types.ts
+++ b/packages/mosaic/src/chart-types/base-types.ts
@@ -46,11 +46,14 @@ export interface ChartBuilderField {
  * Provides the resources and operations needed to create charts.
  */
 export interface ChartToolDeps {
-  resolveResources: (params: {
-    artifactId?: string;
-    tableName?: string;
-    createArtifactIfMissing?: boolean;
-  }) => {
+  resolveResources: (
+    params: {
+      artifactId?: string;
+      tableName?: string;
+      createArtifactIfMissing?: boolean;
+    },
+    context?: ChartToolExecutionContext,
+  ) => {
     artifactId: string;
     tableName: string;
     columns: ChartBuilderColumn[];
@@ -68,6 +71,11 @@ export interface ChartToolDeps {
     config: any;
   };
 }
+
+export type ChartToolExecutionContext = object & {
+  sessionId?: string;
+  aiRunContext?: unknown;
+};
 
 export type ChartBuilderPanelSource = {
   tableName?: string;

--- a/packages/mosaic/src/chart-types/box-plot/tool.ts
+++ b/packages/mosaic/src/chart-types/box-plot/tool.ts
@@ -30,9 +30,12 @@ Best for: comparing distributions between groups, finding outliers per category,
 
 Do NOT use for: single distribution (use histogram), time trends (use line-chart), simple counts (use count-plot).`,
     inputSchema: BoxPlotToolParameters,
-    execute: async (params) => {
+    execute: async (params, context) => {
       try {
-        const {artifactId, tableName, columns} = deps.resolveResources(params);
+        const {artifactId, tableName, columns} = deps.resolveResources(
+          params,
+          context,
+        );
 
         // Validate settings
         validateColumnExists(

--- a/packages/mosaic/src/chart-types/bubble-chart/tool.ts
+++ b/packages/mosaic/src/chart-types/bubble-chart/tool.ts
@@ -24,9 +24,12 @@ Optional: size can encode a third numeric dimension (magnitude, frequency, count
 
 Do NOT use for: distributions (use histogram), categorical counts (use count-plot), trends over time (use line-chart).`,
     inputSchema: BubbleChartToolParameters,
-    execute: async (params) => {
+    execute: async (params, context) => {
       try {
-        const {artifactId, tableName, columns} = deps.resolveResources(params);
+        const {artifactId, tableName, columns} = deps.resolveResources(
+          params,
+          context,
+        );
 
         // Validate settings
         validateColumnExists(

--- a/packages/mosaic/src/chart-types/count-plot/tool.ts
+++ b/packages/mosaic/src/chart-types/count-plot/tool.ts
@@ -24,9 +24,12 @@ Required: field must be categorical/text (${CATEGORICAL_COLUMN_TYPES.join(', ')}
 CRITICAL: Only for categorical data (text, categories, enums).
 Do NOT use for: numeric distributions (use histogram), relationships between columns (use bubble-chart), time series (use line-chart).`,
     inputSchema: CountPlotToolParameters,
-    execute: async (params) => {
+    execute: async (params, context) => {
       try {
-        const {artifactId, tableName, columns} = deps.resolveResources(params);
+        const {artifactId, tableName, columns} = deps.resolveResources(
+          params,
+          context,
+        );
 
         // Validate settings - expect categorical columns
         validateColumnExists(

--- a/packages/mosaic/src/chart-types/heatmap/tool.ts
+++ b/packages/mosaic/src/chart-types/heatmap/tool.ts
@@ -25,9 +25,12 @@ Best for: large datasets with overlapping points, finding patterns/hotspots in 2
 
 Do NOT use for: individual point plots (use bubble-chart), single variable distribution (use histogram), time trends (use line-chart).`,
     inputSchema: HeatmapToolParameters,
-    execute: async (params) => {
+    execute: async (params, context) => {
       try {
-        const {artifactId, tableName, columns} = deps.resolveResources(params);
+        const {artifactId, tableName, columns} = deps.resolveResources(
+          params,
+          context,
+        );
 
         // Validate settings
 

--- a/packages/mosaic/src/chart-types/histogram/tool.ts
+++ b/packages/mosaic/src/chart-types/histogram/tool.ts
@@ -24,9 +24,12 @@ Required: field must be quantitative not text/categorical: (${QUANTITATIVE_COLUM
 CRITICAL: Only for quantitative continuous data to see distribution shape, outliers, skewness.
 Do NOT use for: categorical data (use count-plot), relationships between columns (use bubble-chart), time series trends (use line-chart).`,
     inputSchema: HistogramToolParameters,
-    execute: async (params) => {
+    execute: async (params, context) => {
       try {
-        const {artifactId, tableName, columns} = deps.resolveResources(params);
+        const {artifactId, tableName, columns} = deps.resolveResources(
+          params,
+          context,
+        );
 
         // Validate settings
         validateColumnExists(

--- a/packages/mosaic/src/chart-types/line-chart/tool.ts
+++ b/packages/mosaic/src/chart-types/line-chart/tool.ts
@@ -35,9 +35,12 @@ Multiple yFields create multi-line chart for comparing metrics.
 
 Do NOT use for: single point distributions (use histogram), categorical counts (use count-plot), two-variable correlations (use bubble-chart).`,
     inputSchema: LineChartToolParameters,
-    execute: async (params) => {
+    execute: async (params, context) => {
       try {
-        const {artifactId, tableName, columns} = deps.resolveResources(params);
+        const {artifactId, tableName, columns} = deps.resolveResources(
+          params,
+          context,
+        );
 
         // Validate settings
         validateColumnExists(

--- a/packages/mosaic/src/index.ts
+++ b/packages/mosaic/src/index.ts
@@ -216,6 +216,7 @@ export type {
   ChartSettings,
   ChartType,
   ChartToolDeps,
+  ChartToolExecutionContext,
   ResolvedChartResources,
   CreateChartParams,
   CreateChartResult,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chart tools now accept an execution context so tools can infer the active dashboard/artifact and table from runtime AI session data when not explicitly provided.

* **Documentation**
  * Added docs describing how execution context influences resource resolution and examples for using chart tools with AI run/session context.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sqlrooms/sqlrooms/pull/627)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->