### PR TITLE
fix: ai-core tool auto-resume

### DIFF
--- a/packages/ai-core/src/hooks/useSessionChat.ts
+++ b/packages/ai-core/src/hooks/useSessionChat.ts
@@ -3,6 +3,7 @@ import {useChat} from '@ai-sdk/react';
 import {
   DefaultChatTransport,
   lastAssistantMessageIsCompleteWithApprovalResponses,
+  lastAssistantMessageIsCompleteWithToolCalls,
 } from 'ai';
 import type {AbstractChat, ChatStatus, UIMessage} from 'ai';
 import {useStoreWithAi} from '../AiSlice';
@@ -123,7 +124,7 @@ export function useSessionChat(sessionId: string): UseSessionChatResult {
     id: `${sessionId}::${messagesRevision}`,
     transport,
     messages: initialMessages,
-    // Auto-resend after all approval responses are provided (approve/deny),
+    // Auto-resend after all client-side tool outputs or approval responses are provided,
     // but skip if the session was aborted.
     sendAutomaticallyWhen: (
       options: Parameters<
@@ -131,7 +132,10 @@ export function useSessionChat(sessionId: string): UseSessionChatResult {
       >[0],
     ) => {
       if (isAbortedRef.current) return false;
-      return lastAssistantMessageIsCompleteWithApprovalResponses(options);
+      return (
+        lastAssistantMessageIsCompleteWithToolCalls(options) ||
+        lastAssistantMessageIsCompleteWithApprovalResponses(options)
+      );
     },
     onFinish: ({messages}) => onChatFinish?.({sessionId, messages}),
     onError: (error) => onChatError?.(sessionId, error),


### PR DESCRIPTION
## Summary

Fixes client-side AI tool auto-resume in `@sqlrooms/ai-core`.

`useSessionChat` now continues the chat loop when either normal client-side tool outputs are complete or approval responses are complete. This preserves approval-gated behavior while adding the missing no-server-execute tool path.

## Context

In Chordshell, the remote chat endpoint exposes tool schemas to the model, but workspace mutations happen in client-side tool renderers. Those renderers apply the local mutation and then call `ai.getAddToolOutput(sessionId)({ tool, toolCallId, output })`.

Before this change, a normal client-side tool such as `create_artifact` could finish the stream with `finishReason: "tool-calls"`; the renderer would add the output, but `useChat` would not send the next request back to the model. The UI could then remain stuck after showing the completed tool work.

## Root Cause

`packages/ai-core/src/hooks/useSessionChat.ts` configured `sendAutomaticallyWhen` with only `lastAssistantMessageIsCompleteWithApprovalResponses`. That handles approval-gated tools, but it does not return true for ordinary completed client-side tool calls. AI SDK exposes `lastAssistantMessageIsCompleteWithToolCalls` for that auto-resume case.

## Validation

- `pnpm --filter @sqlrooms/ai-core build`
- pre-push hook: `knip`
- pre-push hook: `turbo typecheck`
- pre-push hook: `turbo test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced chat auto-send behavior to trigger automatically when the assistant completes processing tool calls on the client-side, in addition to existing approval response scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sqlrooms/sqlrooms/pull/630?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->