### PR TITLE
fix: Persist split panel resize state

### DIFF
--- a/apps/sqlrooms-cli-ui/README.md
+++ b/apps/sqlrooms-cli-ui/README.md
@@ -10,21 +10,21 @@ In production (published `sqlrooms` wheel), the UI is served as **static assets*
 
 ## Dev mode (UI + Python server together)
 
-From `python/sqlrooms-cli`:
+From the repo root:
 
 ```bash
-pnpm dev
+pnpm dev cli
 ```
 
 This starts:
 
-- the Python server on `http://127.0.0.1:4173`
+- the Python API server on `http://127.0.0.1:4173` without serving static UI
 - the Vite UI on `http://localhost:4174` (proxying `/api` and `/config.json` to 4173)
 
 If you hit `address already in use`, pass different ports to the Python server:
 
 ```bash
-pnpm dev:server -- --port 4176 --ws-port 4002
+pnpm dev cli -- --port 4176 --ws-port 4002
 ```
 
 Then also update the Vite proxy target in `vite.config.ts` (or run Vite with a different proxy setup).
@@ -35,7 +35,7 @@ Terminal A (Python server):
 
 ```bash
 cd python/sqlrooms-cli
-pnpm dev:server
+pnpm dev -- --no-ui
 ```
 
 Terminal B (UI):

--- a/packages/layout/src/__tests__/layout-tree.test.ts
+++ b/packages/layout/src/__tests__/layout-tree.test.ts
@@ -5,6 +5,7 @@ import {
   getVisibleLayoutPanels,
   findNearestDockAncestor,
   isDockablePanel,
+  updateLayoutNodeById,
 } from '../layout-tree';
 import type {
   LayoutNode,
@@ -438,6 +439,60 @@ describe('layout-tree', () => {
       };
 
       expect(isDockablePanel(layout, 'non-existent')).toBe(false);
+    });
+  });
+
+  describe('updateLayoutNodeById', () => {
+    it('updates a nested layout node without changing siblings', () => {
+      const layout: LayoutNode = {
+        type: 'split',
+        id: 'root-split',
+        direction: 'row',
+        children: [
+          {type: 'panel', id: 'left', panel: 'left', defaultSize: '30%'},
+          {type: 'panel', id: 'right', panel: 'right', defaultSize: '70%'},
+        ],
+      };
+
+      const nextLayout = updateLayoutNodeById(layout, 'right', (node) =>
+        typeof node === 'string' ? node : {...node, defaultSize: '420px'},
+      );
+
+      expect(nextLayout).toEqual({
+        type: 'split',
+        id: 'root-split',
+        direction: 'row',
+        children: [
+          {type: 'panel', id: 'left', panel: 'left', defaultSize: '30%'},
+          {type: 'panel', id: 'right', panel: 'right', defaultSize: '420px'},
+        ],
+      });
+      expect(nextLayout).not.toBe(layout);
+    });
+
+    it('can replace a string panel key with a panel node', () => {
+      const layout: LayoutNode = {
+        type: 'split',
+        id: 'root-split',
+        direction: 'row',
+        children: ['left', 'right'],
+      };
+
+      const nextLayout = updateLayoutNodeById(layout, 'right', (node) =>
+        typeof node === 'string'
+          ? {type: 'panel', id: node, panel: node, defaultSize: '40%'}
+          : node,
+      );
+
+      expect(nextLayout).toEqual({
+        type: 'split',
+        id: 'root-split',
+        direction: 'row',
+        children: [
+          'left',
+          {type: 'panel', id: 'right', panel: 'right', defaultSize: '40%'},
+        ],
+      });
     });
   });
 });

--- a/packages/layout/src/__tests__/layout-tree.test.ts
+++ b/packages/layout/src/__tests__/layout-tree.test.ts
@@ -494,5 +494,118 @@ describe('layout-tree', () => {
         ],
       });
     });
+
+    it('updates a node inside dock.root', () => {
+      const layout: LayoutNode = {
+        type: 'dock',
+        id: 'dock-1',
+        panel: 'dock-1',
+        root: {
+          type: 'split',
+          id: 'split-1',
+          direction: 'row',
+          children: [
+            {type: 'panel', id: 'panel-1', panel: 'panel-1', defaultSize: '50%'},
+            {type: 'panel', id: 'panel-2', panel: 'panel-2', defaultSize: '50%'},
+          ],
+        },
+      };
+
+      const nextLayout = updateLayoutNodeById(layout, 'panel-1', (node) =>
+        typeof node === 'string' ? node : {...node, defaultSize: '30%'},
+      );
+
+      expect(nextLayout).not.toBe(layout);
+      expect(nextLayout).toMatchObject({
+        type: 'dock',
+        id: 'dock-1',
+        root: {
+          type: 'split',
+          children: [
+            {id: 'panel-1', defaultSize: '30%'},
+            {id: 'panel-2', defaultSize: '50%'},
+          ],
+        },
+      });
+    });
+
+    it('updates a node inside a tabs subtree', () => {
+      const layout: LayoutNode = {
+        type: 'tabs',
+        id: 'tabs-1',
+        activeTabIndex: 0,
+        children: [
+          {type: 'panel', id: 'tab-a', panel: 'tab-a'},
+          {type: 'panel', id: 'tab-b', panel: 'tab-b'},
+        ],
+      };
+
+      const nextLayout = updateLayoutNodeById(layout, 'tab-b', (node) =>
+        typeof node === 'string' ? node : {...node, defaultSize: '60%'},
+      );
+
+      expect(nextLayout).not.toBe(layout);
+      expect(nextLayout).toMatchObject({
+        type: 'tabs',
+        children: [{id: 'tab-a'}, {id: 'tab-b', defaultSize: '60%'}],
+      });
+    });
+
+    it('updates a node inside a grid subtree', () => {
+      const layout: LayoutGridNode = {
+        type: 'grid',
+        id: 'grid-1',
+        panel: {key: 'dashboard', meta: {}},
+        children: [
+          {type: 'panel', id: 'cell-1', panel: 'cell-1'},
+          {type: 'panel', id: 'cell-2', panel: 'cell-2'},
+        ],
+      };
+
+      const nextLayout = updateLayoutNodeById(layout, 'cell-2', (node) =>
+        typeof node === 'string' ? node : {...node, defaultSize: '200px'},
+      );
+
+      expect(nextLayout).not.toBe(layout);
+      expect(nextLayout).toMatchObject({
+        type: 'grid',
+        children: [{id: 'cell-1'}, {id: 'cell-2', defaultSize: '200px'}],
+      });
+    });
+
+    it('preserves referential equality when target is not found', () => {
+      const layout: LayoutNode = {
+        type: 'dock',
+        id: 'dock-1',
+        panel: 'dock-1',
+        root: {type: 'panel', id: 'panel-1', panel: 'panel-1'},
+      };
+
+      const nextLayout = updateLayoutNodeById(layout, 'non-existent', (node) =>
+        typeof node === 'string' ? node : {...node, defaultSize: '100%'},
+      );
+
+      expect(nextLayout).toBe(layout);
+    });
+
+    it('preserves referential equality when updater returns same reference', () => {
+      const layout: LayoutNode = {
+        type: 'split',
+        id: 'root-split',
+        direction: 'row',
+        children: [
+          {type: 'panel', id: 'left', panel: 'left', defaultSize: '30%'},
+          {type: 'panel', id: 'right', panel: 'right', defaultSize: '70%'},
+        ],
+      };
+
+      const nextLayout = updateLayoutNodeById(
+        layout,
+        'right',
+        (node) => node,
+      );
+
+      expect(nextLayout).toBe(layout);
+    });
   });
 });

--- a/packages/layout/src/layout-tree.ts
+++ b/packages/layout/src/layout-tree.ts
@@ -240,6 +240,48 @@ export function findNodeById(
   return undefined;
 }
 
+export function updateLayoutNodeById(
+  root: LayoutNode,
+  nodeId: string,
+  updater: (node: LayoutNode) => LayoutNode,
+): LayoutNode {
+  if (isLayoutNodeKey(root)) {
+    return root === nodeId ? updater(root) : root;
+  }
+
+  if (isLayoutPanelNode(root)) {
+    return root.id === nodeId ? updater(root) : root;
+  }
+
+  if (root.id === nodeId) {
+    return updater(root);
+  }
+
+  if (isLayoutDockNode(root)) {
+    const nextRoot = updateLayoutNodeById(root.root, nodeId, updater);
+    return nextRoot === root.root ? root : {...root, root: nextRoot};
+  }
+
+  if (
+    isLayoutSplitNode(root) ||
+    isLayoutTabsNode(root) ||
+    isLayoutGridNode(root)
+  ) {
+    let changed = false;
+    const children = root.children.map((child) => {
+      const nextChild = updateLayoutNodeById(child, nodeId, updater);
+      if (nextChild !== child) {
+        changed = true;
+      }
+      return nextChild;
+    });
+
+    return changed ? {...root, children} : root;
+  }
+
+  return root;
+}
+
 export function findTabsNodeForPanel(
   root: LayoutNode,
   panelId: string,

--- a/packages/layout/src/node-renderers/split-node-renderer/CollapsiblePanelWrapper.tsx
+++ b/packages/layout/src/node-renderers/split-node-renderer/CollapsiblePanelWrapper.tsx
@@ -1,6 +1,9 @@
 import {ResizablePanel} from '@sqlrooms/ui';
 import {FC, PropsWithChildren, useCallback, useEffect, useRef} from 'react';
-import {type PanelImperativeHandle} from 'react-resizable-panels';
+import {
+  type PanelImperativeHandle,
+  type PanelSize,
+} from 'react-resizable-panels';
 import {useLayoutRendererContext} from '../../LayoutRendererContext';
 import {LayoutNodeSize} from '@sqlrooms/layout-config';
 
@@ -13,6 +16,11 @@ const DEFAULT_COLLAPSIBLE_MIN_SIZE = '10%';
 export type CollapsiblePanelWrapperProps = {
   panelId: string;
   collapsed: boolean;
+  onResize?: (
+    panelSize: PanelSize,
+    id: string | number | undefined,
+    prevPanelSize: PanelSize | undefined,
+  ) => void;
 } & LayoutNodeSize;
 
 export const CollapsiblePanelWrapper: FC<
@@ -25,6 +33,7 @@ export const CollapsiblePanelWrapper: FC<
   defaultSize,
   minSize,
   maxSize,
+  onResize,
   children,
 }) => {
   const {onCollapse, onExpand} = useLayoutRendererContext();
@@ -45,19 +54,28 @@ export const CollapsiblePanelWrapper: FC<
     }
   }, [collapsed]);
 
-  const handleResize = useCallback(() => {
-    const handle = panelRef.current;
+  const handleResize = useCallback(
+    (
+      panelSize: PanelSize,
+      id: string | number | undefined,
+      prevPanelSize: PanelSize | undefined,
+    ) => {
+      const handle = panelRef.current;
 
-    if (!panelId || !handle) {
-      return;
-    }
+      if (!panelId || !handle) {
+        return;
+      }
 
-    if (collapsed && !handle.isCollapsed()) {
-      onExpand?.(panelId);
-    } else if (!collapsed && handle.isCollapsed()) {
-      onCollapse?.(panelId);
-    }
-  }, [panelId, collapsed, onExpand, onCollapse]);
+      if (collapsed && !handle.isCollapsed()) {
+        onExpand?.(panelId);
+      } else if (!collapsed && handle.isCollapsed()) {
+        onCollapse?.(panelId);
+      }
+
+      onResize?.(panelSize, id, prevPanelSize);
+    },
+    [panelId, collapsed, onExpand, onCollapse, onResize],
+  );
 
   const effectiveMinSize =
     minSize ?? (collapsible ? DEFAULT_COLLAPSIBLE_MIN_SIZE : undefined);

--- a/packages/layout/src/node-renderers/split-node-renderer/SplitLayoutPanel.tsx
+++ b/packages/layout/src/node-renderers/split-node-renderer/SplitLayoutPanel.tsx
@@ -60,6 +60,10 @@ function updateNodeDefaultSize(
     };
   }
 
+  if (node.defaultSize === defaultSize) {
+    return node;
+  }
+
   return {...node, defaultSize};
 }
 

--- a/packages/layout/src/node-renderers/split-node-renderer/SplitLayoutPanel.tsx
+++ b/packages/layout/src/node-renderers/split-node-renderer/SplitLayoutPanel.tsx
@@ -1,7 +1,14 @@
-import {FC, PropsWithChildren, ReactElement} from 'react';
+import {FC, PropsWithChildren, ReactElement, useCallback} from 'react';
 import {useSplitNodeContext} from '../../LayoutNodeContext';
-import {getLayoutNodeId, LayoutNode} from '@sqlrooms/layout-config';
+import {
+  getLayoutNodeId,
+  isLayoutNodeKey,
+  LayoutNode,
+} from '@sqlrooms/layout-config';
 import {ResizablePanel} from '@sqlrooms/ui';
+import type {PanelSize} from 'react-resizable-panels';
+import {useLayoutRendererContext} from '../../LayoutRendererContext';
+import {updateLayoutNodeById} from '../../layout-tree';
 import {CollapsiblePanelWrapper} from './CollapsiblePanelWrapper';
 import {
   convertLayoutNodeSizeToStyle,
@@ -16,6 +23,46 @@ export type SplitLayoutPanelProps = PropsWithChildren<{
   handleComponent?: ReactElement;
 }>;
 
+function formatResizedDefaultSize(
+  panelSize: PanelSize,
+  previousDefaultSize: string | number | undefined,
+) {
+  const inPixels = Math.round(panelSize.inPixels);
+  const asPercentage = Number(panelSize.asPercentage.toFixed(4));
+
+  if (typeof previousDefaultSize === 'number') {
+    return inPixels;
+  }
+
+  if (typeof previousDefaultSize === 'string') {
+    const trimmedSize = previousDefaultSize.trim();
+    if (trimmedSize.endsWith('%')) {
+      return `${asPercentage}%`;
+    }
+    if (trimmedSize.endsWith('px')) {
+      return `${inPixels}px`;
+    }
+  }
+
+  return `${asPercentage}%`;
+}
+
+function updateNodeDefaultSize(
+  node: LayoutNode,
+  defaultSize: string | number,
+): LayoutNode {
+  if (isLayoutNodeKey(node)) {
+    return {
+      type: 'panel',
+      id: node,
+      panel: node,
+      defaultSize,
+    };
+  }
+
+  return {...node, defaultSize};
+}
+
 export const SplitLayoutPanel: FC<SplitLayoutPanelProps> = ({
   node,
   nodeIndex,
@@ -23,6 +70,7 @@ export const SplitLayoutPanel: FC<SplitLayoutPanelProps> = ({
   children,
 }) => {
   const {node: parentNode} = useSplitNodeContext();
+  const {rootLayout, onLayoutChange} = useLayoutRendererContext();
 
   const panelId = getLayoutNodeId(node);
   const sizeProps = getLayoutNodeSize(node);
@@ -31,6 +79,35 @@ export const SplitLayoutPanel: FC<SplitLayoutPanelProps> = ({
   const isResizable = parentNode.resizable !== false;
 
   const handleElement = handleComponent || <SplitLayoutPanelResizableHandle />;
+  const handleResize = useCallback(
+    (
+      panelSize: PanelSize,
+      _id: string | number | undefined,
+      prevPanelSize: PanelSize | undefined,
+    ) => {
+      if (!onLayoutChange || !prevPanelSize || panelSize.inPixels <= 0) {
+        return;
+      }
+
+      const previousDefaultSize = isLayoutNodeKey(node)
+        ? undefined
+        : node.defaultSize;
+      const defaultSize = formatResizedDefaultSize(
+        panelSize,
+        previousDefaultSize,
+      );
+      const nextRootLayout = updateLayoutNodeById(
+        rootLayout,
+        panelId,
+        (currentNode) => updateNodeDefaultSize(currentNode, defaultSize),
+      );
+
+      if (nextRootLayout !== rootLayout) {
+        onLayoutChange(nextRootLayout);
+      }
+    },
+    [node, onLayoutChange, panelId, rootLayout],
+  );
 
   if (!isResizable) {
     return (
@@ -49,6 +126,7 @@ export const SplitLayoutPanel: FC<SplitLayoutPanelProps> = ({
         <CollapsiblePanelWrapper
           panelId={panelId}
           collapsed={collapsed}
+          onResize={handleResize}
           {...sizeProps}
         >
           {children}
@@ -60,7 +138,7 @@ export const SplitLayoutPanel: FC<SplitLayoutPanelProps> = ({
 
   return (
     <>
-      <ResizablePanel id={panelId} {...sizeProps}>
+      <ResizablePanel id={panelId} onResize={handleResize} {...sizeProps}>
         {children}
       </ResizablePanel>
       {!isLast && handleElement}


### PR DESCRIPTION
## Summary

Persist split panel resize state in `@sqlrooms/layout` by writing resized panel dimensions back into the layout tree via `onLayoutChange`.

## Why

Resizable split panels currently update only the mounted `react-resizable-panels` state. Consumers that persist `LayoutRenderer` state can save collapse/expand changes, but resized widths/heights are lost after remount or reload because the layout node `defaultSize` is never updated.

## Changes

- Added `updateLayoutNodeById` to update nested layout nodes immutably.
- Wired split panel `onResize` to update the resized node's `defaultSize` and emit `onLayoutChange`.
- Preserved existing size unit style where possible: percent stays percent, px stays px, numeric sizes stay numeric pixels.
- Forwarded resize events through `CollapsiblePanelWrapper` while keeping collapse/expand bookkeeping intact.
- Added layout-tree tests for nested node updates and string panel key replacement.

## Validation

- `pnpm --filter @sqlrooms/layout typecheck`
- `pnpm --filter @sqlrooms/layout test`
- `pnpm --filter @sqlrooms/layout build`
- `pnpm --filter @sqlrooms/layout lint` (passes with existing unrelated warnings)
- Pre-commit lint-staged checks
- Pre-push `knip`
- Pre-push `turbo typecheck`
- Pre-push `turbo test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Panel resize events are now exposed and persisted so custom panel sizes are preserved.
  * Layout updates can be applied to individual nodes, minimizing unrelated changes.

* **Tests**
  * Added tests ensuring node updates work immutably across nested layouts and panel replacements.

* **Documentation**
  * Updated CLI UI README with clearer dev workflow and run commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sqlrooms/sqlrooms/pull/631?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->