### PR TITLE
fix: Collapse reasoning messages in chat

### DIFF
--- a/packages/ai-core/src/components/AnalysisResult.tsx
+++ b/packages/ai-core/src/components/AnalysisResult.tsx
@@ -117,6 +117,31 @@ function groupPartsIntoSegments(
   return segments;
 }
 
+const ReasoningBox: React.FC<{text: string; isRunning: boolean}> = ({
+  text,
+  isRunning,
+}) => {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+
+  return (
+    <details className="border-border bg-muted/30 text-muted-foreground group rounded-md border text-xs">
+      <summary className="hover:bg-muted/50 flex cursor-pointer items-center justify-between gap-2 px-3 py-2 font-medium select-none">
+        <span>{isRunning ? 'Thinking...' : 'Thinking'}</span>
+        <span className="text-muted-foreground/70 text-[11px] font-normal group-open:hidden">
+          show
+        </span>
+        <span className="text-muted-foreground/70 hidden text-[11px] font-normal group-open:inline">
+          hide
+        </span>
+      </summary>
+      <div className="border-border/70 max-h-64 overflow-auto border-t px-3 py-2 leading-relaxed whitespace-pre-wrap">
+        {text}
+      </div>
+    </details>
+  );
+};
+
 // ---------------------------------------------------------------------------
 // AnalysisResult
 // ---------------------------------------------------------------------------
@@ -283,12 +308,11 @@ export const AnalysisResult: React.FC<AnalysisResultProps> = ({
 
             if (isReasoningPart(part)) {
               return (
-                <div
+                <ReasoningBox
                   key={`reasoning-${index}`}
-                  className="text-muted-foreground text-xs"
-                >
-                  {part.text}
-                </div>
+                  text={part.text}
+                  isRunning={!analysisResult.isCompleted}
+                />
               );
             }
 


### PR DESCRIPTION
## Summary

- Render AI reasoning parts inside a collapsed `Thinking` details box instead of inline muted text.
- Keep reasoning available for inspection while preventing long thinking streams from dominating chat output.
- Label the box as `Thinking...` while a response is running and `Thinking` once complete.

## Why

Reasoning-capable models can stream a lot of internal planning text. Rendering that text inline makes the chat hard to scan and can push the actual answer/tool activity far down the panel. Collapsing reasoning by default keeps the UI calm while preserving the text for debugging or curious users.

## Validation

- `pnpm --filter @sqlrooms/ai-core typecheck`
- Pre-push `knip`
- Pre-push `turbo typecheck`
- Pre-push `turbo test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Analysis results now display reasoning in interactive collapsible "Thinking" sections that enhance readability. Users can expand or collapse these sections to optimize interface layout and focus on key findings. The display dynamically reflects analysis processing status, providing real-time visual feedback throughout the workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sqlrooms/sqlrooms/pull/632?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->