### PR TITLE
feat: add maxBins configuration to histogram 

### DIFF
--- a/packages/mosaic/src/chart-types/histogram/HistogramSettings.tsx
+++ b/packages/mosaic/src/chart-types/histogram/HistogramSettings.tsx
@@ -1,7 +1,9 @@
 import {type FC} from 'react';
+import {Input} from '@sqlrooms/ui';
 import {Field} from '../../chart-builders/Field';
 import {ColumnSelector} from '../../chart-builders/ColumnSelector';
 import {useChartSettingsContext} from '../../chart/chart-settings/ChartSettingsContext';
+import {MIN_BINS_COUNT, MAX_BINS_COUNT, DEFAULT_BINS_COUNT} from './schema';
 
 export const HistogramSettingsComponent: FC = () => {
   const {onChangeConfig, config} = useChartSettingsContext('histogram');
@@ -12,6 +14,19 @@ export const HistogramSettingsComponent: FC = () => {
         <ColumnSelector.Quantitative
           value={config.settings.field}
           onChange={(field) => onChangeConfig('field', field)}
+        />
+      </Field>
+      <Field label="Max Bins">
+        <Input
+          type="number"
+          min={MIN_BINS_COUNT}
+          max={MAX_BINS_COUNT}
+          value={config.settings.maxBins ?? DEFAULT_BINS_COUNT}
+          className="no-spinner"
+          onChange={(e) =>
+            onChangeConfig('maxBins', parseInt(e.target.value, 10))
+          }
+          placeholder={String(DEFAULT_BINS_COUNT)}
         />
       </Field>
     </div>

--- a/packages/mosaic/src/chart-types/histogram/schema.ts
+++ b/packages/mosaic/src/chart-types/histogram/schema.ts
@@ -1,10 +1,24 @@
 import {z} from 'zod';
 
+export const MIN_BINS_COUNT = 1;
+export const MAX_BINS_COUNT = 1000;
+export const DEFAULT_BINS_COUNT = 20;
+
 export const HistogramChartSettings = z.object({
   field: z
     .string()
     .optional()
     .describe('Numeric column to create histogram distribution for'),
+  maxBins: z
+    .number()
+    .int()
+    .min(MIN_BINS_COUNT)
+    .max(MAX_BINS_COUNT)
+    .default(DEFAULT_BINS_COUNT)
+    .optional()
+    .describe(
+      `Maximum number of bins for the histogram (default: ${DEFAULT_BINS_COUNT})`,
+    ),
 });
 
 export type HistogramChartSettings = z.infer<typeof HistogramChartSettings>;

--- a/packages/mosaic/src/chart-types/histogram/spec.ts
+++ b/packages/mosaic/src/chart-types/histogram/spec.ts
@@ -1,5 +1,5 @@
 import type {Spec} from '@uwdata/mosaic-spec';
-import {HistogramChartSettings} from './schema';
+import {HistogramChartSettings, DEFAULT_BINS_COUNT} from './schema';
 import {SpecGenerationError} from '../errors';
 
 const BG_COLOR = 'var(--color-chart-overlay)';
@@ -7,7 +7,7 @@ const FG_COLOR = 'var(--color-chart-1)';
 
 export function createHistogramSpec(
   tableName: string,
-  {field}: HistogramChartSettings,
+  {field, maxBins = DEFAULT_BINS_COUNT}: HistogramChartSettings,
 ): Spec {
   if (!field) {
     throw new SpecGenerationError('Field is required for histogram');
@@ -18,7 +18,7 @@ export function createHistogramSpec(
       {
         mark: 'rectY',
         data: {from: tableName},
-        x: {bin: field, maxbins: 40},
+        x: {bin: field, steps: maxBins},
         y: {count: null},
         fill: BG_COLOR,
         inset: 0.5,
@@ -26,7 +26,7 @@ export function createHistogramSpec(
       {
         mark: 'rectY',
         data: {from: tableName, filterBy: '$brush'},
-        x: {bin: field, maxbins: 40},
+        x: {bin: field, steps: maxBins},
         y: {count: null},
         fill: FG_COLOR,
         inset: 0.5,

--- a/packages/mosaic/src/chart-types/histogram/tool.ts
+++ b/packages/mosaic/src/chart-types/histogram/tool.ts
@@ -1,6 +1,11 @@
 import {tool} from 'ai';
 import {z} from 'zod';
-import {HistogramChartSettings} from './schema';
+import {
+  HistogramChartSettings,
+  MIN_BINS_COUNT,
+  MAX_BINS_COUNT,
+  DEFAULT_BINS_COUNT,
+} from './schema';
 import {BaseChartToolParameters} from '../tool-schemas';
 import type {ChartToolDeps} from '../base-types';
 import {validateColumnExists} from '../tool-validation';
@@ -20,6 +25,8 @@ Use when: user asks about "distribution of [numeric column]", "spread of", "rang
 Example queries: "distribution of population density", "show elevation distribution", "histogram of parcel areas", "how are building heights spread", "temperature range distribution".
 
 Required: field must be quantitative not text/categorical: (${QUANTITATIVE_COLUMN_TYPES.join(', ')}).
+
+Optional: maxBins (${MIN_BINS_COUNT}-${MAX_BINS_COUNT}, default ${DEFAULT_BINS_COUNT}) controls the number of bins/bars in the histogram. Use fewer bins for coarse overview, more bins for detailed distribution.
 
 CRITICAL: Only for quantitative continuous data to see distribution shape, outliers, skewness.
 Do NOT use for: categorical data (use count-plot), relationships between columns (use bubble-chart), time series trends (use line-chart).`,


### PR DESCRIPTION
<img width="871" height="648" alt="image" src="https://github.com/user-attachments/assets/27164531-3ab9-47df-a4d1-3edbfcbe4477" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable "Max Bins" setting for histograms, allowing users to customize histogram granularity
  * Users can set bin counts between 1 and 1,000 with a default of 20
  * Histograms now dynamically adjust binning based on user-configured settings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sqlrooms/sqlrooms/pull/637?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->