### PR TITLE
feat: show all schemas in the datasource panel

### DIFF
--- a/apps/sqlrooms-cli-ui/src/store.ts
+++ b/apps/sqlrooms-cli-ui/src/store.ts
@@ -478,15 +478,18 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
           layout: createLayout({store}),
           createDbProps: {
             duckDb: {
-              loadTableSchemasFilter: (table: QualifiedTableName) => {
-                return (
-                  createDefaultLoadTableSchemasFilter(table) &&
-                  !(
-                    table.database === get().db.currentDatabase &&
-                    table.schema === 'mosaic'
-                  )
-                );
-              },
+              loadTableSchemasFilter: (() => {
+                const filter = createDefaultLoadTableSchemasFilter();
+                return (table: QualifiedTableName) => {
+                  return (
+                    filter(table) &&
+                    !(
+                      table.database === get().db.currentDatabase &&
+                      table.schema === 'mosaic'
+                    )
+                  );
+                };
+              })(),
             },
           },
         })(set, get, store),

--- a/apps/sqlrooms-cli-ui/src/store.ts
+++ b/apps/sqlrooms-cli-ui/src/store.ts
@@ -478,18 +478,15 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
           layout: createLayout({store}),
           createDbProps: {
             duckDb: {
-              loadTableSchemasFilter: (() => {
-                const filter = createDefaultLoadTableSchemasFilter();
-                return (table: QualifiedTableName) => {
-                  return (
-                    filter(table) &&
-                    !(
-                      table.database === get().db.currentDatabase &&
-                      table.schema === 'mosaic'
-                    )
-                  );
-                };
-              })(),
+              loadTableSchemasFilter: (table: QualifiedTableName) => {
+                return (
+                  createDefaultLoadTableSchemasFilter(table) &&
+                  !(
+                    table.database === get().db.currentDatabase &&
+                    table.schema === 'mosaic'
+                  )
+                );
+              },
             },
           },
         })(set, get, store),

--- a/apps/sqlrooms-cli-ui/src/store.ts
+++ b/apps/sqlrooms-cli-ui/src/store.ts
@@ -25,8 +25,10 @@ import {
 import {
   createDefaultLoadTableSchemasFilter,
   createWebSocketDuckDbConnector,
+  defaultLoadSchemaCatalogFilter,
   type DataTable,
   QualifiedTableName,
+  type SchemaCatalogFilterEntry,
 } from '@sqlrooms/duckdb';
 import {
   createCrdtSlice,
@@ -490,6 +492,26 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
                   );
                 };
               })(),
+              loadSchemaCatalogFilter: (entry: SchemaCatalogFilterEntry) => {
+                if (!defaultLoadSchemaCatalogFilter(entry)) {
+                  return false;
+                }
+                if (
+                  entry.type === 'schema' &&
+                  entry.database === get().db.currentDatabase &&
+                  entry.schema === 'mosaic'
+                ) {
+                  return false;
+                }
+                if (
+                  entry.type === 'table' &&
+                  entry.table.database === get().db.currentDatabase &&
+                  entry.table.schema === 'mosaic'
+                ) {
+                  return false;
+                }
+                return true;
+              },
             },
           },
         })(set, get, store),

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -132,6 +132,77 @@ This release introduces explicit panel identity and dock boundaries, replacing t
 - **`draggable` property**: Removed from split and tabs nodes
 - **`pathSegment` property**: Removed from split and tabs nodes
 
+### `@sqlrooms/duckdb-core`, `@sqlrooms/duckdb`: schema catalog loader and `createDbSchemaTrees()` input changed (breaking)
+
+`createDbSchemaTrees()` now takes a grouped `SchemaWithTables[]` instead of a flat `DataTable[]`, and the loader pair changed:
+
+- `loadSchemasWithTables()` → replaced by `loadSchemaCatalog()` (single metadata query, preserves empty schemas and empty `main` schemas of attached databases)
+- Filter API: instead of a single `(QualifiedTableName) => boolean` invoked with a fake `table === ''` for schemas, the new `loadSchemaCatalogFilter` receives a typed `SchemaCatalogFilterEntry` discriminated union (`{type: 'database' | 'schema' | 'table', ...}`)
+- `DuckDbSlice` accepts a new `loadSchemaCatalogFilter` prop alongside `loadTableSchemasFilter`. If you only set `loadTableSchemasFilter`, it is bridged for `entry.type === 'table'` only — schemas/databases fall through to `defaultLoadSchemaCatalogFilter`, so any reserved schemas/databases you previously hid via the table filter must move to a `loadSchemaCatalogFilter`.
+
+#### Signature change
+
+```ts
+// Before
+function createDbSchemaTrees(tables: DataTable[]): DbSchemaNode[];
+
+// After
+function createDbSchemaTrees(schemas: SchemaWithTables[]): DbSchemaNode[];
+
+type SchemaWithTables = {
+  database: string;
+  schema: string;
+  tables: DataTable[];
+};
+```
+
+`SchemaWithTables` is exported from both `@sqlrooms/duckdb-core` and `@sqlrooms/duckdb`.
+
+#### Before
+
+```ts
+import {createDbSchemaTrees, type DataTable} from '@sqlrooms/duckdb-core';
+
+const tables: DataTable[] = await loadTableSchemas(connector);
+const trees = createDbSchemaTrees(tables);
+```
+
+#### After
+
+Use the new `loadSchemaCatalog()` from `@sqlrooms/duckdb`, which returns `SchemaWithTables[]` directly:
+
+```ts
+import {createDbSchemaTrees} from '@sqlrooms/duckdb-core';
+import {
+  defaultLoadSchemaCatalogFilter,
+  loadSchemaCatalog,
+} from '@sqlrooms/duckdb';
+
+const schemas = await loadSchemaCatalog(connector, {
+  filterFunction: (entry) =>
+    entry.type === 'schema' && entry.schema === 'scratch'
+      ? false
+      : defaultLoadSchemaCatalogFilter(entry),
+});
+const trees = createDbSchemaTrees(schemas);
+```
+
+If you only have a flat `DataTable[]`, group it before passing to `createDbSchemaTrees`:
+
+```ts
+const grouped = new Map<string, SchemaWithTables>();
+for (const t of tables) {
+  const key = `${t.database}\x00${t.schema}`;
+  let g = grouped.get(key);
+  if (!g) {
+    g = {database: t.database ?? '', schema: t.schema, tables: []};
+    grouped.set(key, g);
+  }
+  g.tables.push(t);
+}
+const trees = createDbSchemaTrees(Array.from(grouped.values()));
+```
+
 ### `@sqlrooms/ai-core`, `@sqlrooms/ai`: Upgraded to AI SDK v6 with `ToolLoopAgent` (breaking)
 
 The AI SDK dependency has been upgraded from v5 to v6. Tool execution now uses `ToolLoopAgent` instead of `streamText`. If you only use `createAiSlice` without customization, no changes are needed — the transport layer is updated internally.
@@ -482,65 +553,6 @@ return createAgentUIStreamResponse({
 - `convertToAiSDKTools` — removed (tools are now native AI SDK tools)
 - `findToolComponent` — replaced by `findToolRenderer`
 - `VegaChartToolParametersType` from `@sqlrooms/vega` — removed (use `VegaChartToolParameters` directly)
-
-### `@sqlrooms/duckdb-core`: `createDbSchemaTrees()` input type changed in v0.29.0 (breaking)
-
-`createDbSchemaTrees()` now takes a grouped `SchemaWithTables[]` instead of a flat `DataTable[]`. This lets the tree preserve empty schemas (and empty `main` schemas of attached databases) as leaf-less nodes — previously, schemas with no tables could not appear in the tree because the input was just a list of tables.
-
-#### Signature change
-
-```ts
-// Before
-function createDbSchemaTrees(tables: DataTable[]): DbSchemaNode[];
-
-// After
-function createDbSchemaTrees(schemas: SchemaWithTables[]): DbSchemaNode[];
-
-type SchemaWithTables = {
-  database: string;
-  schema: string;
-  tables: DataTable[];
-};
-```
-
-`SchemaWithTables` is exported from both `@sqlrooms/duckdb-core` and `@sqlrooms/duckdb`.
-
-#### Before
-
-```ts
-import {createDbSchemaTrees, type DataTable} from '@sqlrooms/duckdb-core';
-
-const tables: DataTable[] = await loadTableSchemas(connector);
-const trees = createDbSchemaTrees(tables);
-```
-
-#### After
-
-Use the new `loadSchemaCatalog()` from `@sqlrooms/duckdb`, which returns `SchemaWithTables[]` directly:
-
-```ts
-import {createDbSchemaTrees} from '@sqlrooms/duckdb-core';
-import {loadSchemaCatalog} from '@sqlrooms/duckdb';
-
-const schemas = await loadSchemaCatalog(connector);
-const trees = createDbSchemaTrees(schemas);
-```
-
-If you only have a flat `DataTable[]`, group it before passing to `createDbSchemaTrees`:
-
-```ts
-const grouped = new Map<string, SchemaWithTables>();
-for (const t of tables) {
-  const key = `${t.database}\x00${t.schema}`;
-  let g = grouped.get(key);
-  if (!g) {
-    g = {database: t.database ?? '', schema: t.schema, tables: []};
-    grouped.set(key, g);
-  }
-  g.tables.push(t);
-}
-const trees = createDbSchemaTrees(Array.from(grouped.values()));
-```
 
 ### `@sqlrooms/layout`, `@sqlrooms/layout-config`: Layout config refactored (breaking)
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -483,7 +483,7 @@ return createAgentUIStreamResponse({
 - `findToolComponent` — replaced by `findToolRenderer`
 - `VegaChartToolParametersType` from `@sqlrooms/vega` — removed (use `VegaChartToolParameters` directly)
 
-### `@sqlrooms/duckdb-core`: `createDbSchemaTrees()` input type changed (breaking)
+### `@sqlrooms/duckdb-core`: `createDbSchemaTrees()` input type changed in v0.29.0 (breaking)
 
 `createDbSchemaTrees()` now takes a grouped `SchemaWithTables[]` instead of a flat `DataTable[]`. This lets the tree preserve empty schemas (and empty `main` schemas of attached databases) as leaf-less nodes — previously, schemas with no tables could not appear in the tree because the input was just a list of tables.
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -483,6 +483,65 @@ return createAgentUIStreamResponse({
 - `findToolComponent` — replaced by `findToolRenderer`
 - `VegaChartToolParametersType` from `@sqlrooms/vega` — removed (use `VegaChartToolParameters` directly)
 
+### `@sqlrooms/duckdb-core`: `createDbSchemaTrees()` input type changed (breaking)
+
+`createDbSchemaTrees()` now takes a grouped `SchemaWithTables[]` instead of a flat `DataTable[]`. This lets the tree preserve empty schemas (and empty `main` schemas of attached databases) as leaf-less nodes — previously, schemas with no tables could not appear in the tree because the input was just a list of tables.
+
+#### Signature change
+
+```ts
+// Before
+function createDbSchemaTrees(tables: DataTable[]): DbSchemaNode[];
+
+// After
+function createDbSchemaTrees(schemas: SchemaWithTables[]): DbSchemaNode[];
+
+type SchemaWithTables = {
+  database: string;
+  schema: string;
+  tables: DataTable[];
+};
+```
+
+`SchemaWithTables` is exported from both `@sqlrooms/duckdb-core` and `@sqlrooms/duckdb`.
+
+#### Before
+
+```ts
+import {createDbSchemaTrees, type DataTable} from '@sqlrooms/duckdb-core';
+
+const tables: DataTable[] = await loadTableSchemas(connector);
+const trees = createDbSchemaTrees(tables);
+```
+
+#### After
+
+Use the new `loadSchemaCatalog()` from `@sqlrooms/duckdb`, which returns `SchemaWithTables[]` directly:
+
+```ts
+import {createDbSchemaTrees} from '@sqlrooms/duckdb-core';
+import {loadSchemaCatalog} from '@sqlrooms/duckdb';
+
+const schemas = await loadSchemaCatalog(connector);
+const trees = createDbSchemaTrees(schemas);
+```
+
+If you only have a flat `DataTable[]`, group it before passing to `createDbSchemaTrees`:
+
+```ts
+const grouped = new Map<string, SchemaWithTables>();
+for (const t of tables) {
+  const key = `${t.database}\x00${t.schema}`;
+  let g = grouped.get(key);
+  if (!g) {
+    g = {database: t.database ?? '', schema: t.schema, tables: []};
+    grouped.set(key, g);
+  }
+  g.tables.push(t);
+}
+const trees = createDbSchemaTrees(Array.from(grouped.values()));
+```
+
 ### `@sqlrooms/layout`, `@sqlrooms/layout-config`: Layout config refactored (breaking)
 
 The layout system has been significantly refactored. `LayoutConfig` is now `LayoutNode | null` directly — the outer `{ type: 'mosaic', nodes: ... }` wrapper is gone. Type names have been renamed from `MosaicLayout*` to `Layout*`, and `react-resizable-panels` now handles all layout rendering.

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -5,7 +5,11 @@
 
 export {createHttpDbBridge} from './bridge';
 export {createCoreDuckDbConnection} from './connectors/duckdb';
-export {createDbSlice, useStoreWithDb} from './DbSlice';
+export {
+  createDbSlice,
+  useStoreWithDb,
+  type CreateDbSliceProps,
+} from './DbSlice';
 export {getCoreDuckDbConnectionId, isCoreDuckDbConnection} from './helpers';
 export {DbConnection, RuntimeSupport, DbEngineId} from './types';
 export type {

--- a/packages/duckdb-core/src/index.ts
+++ b/packages/duckdb-core/src/index.ts
@@ -58,7 +58,7 @@ export {
   type TableNodeObject,
   type SchemaNodeObject,
   type DatabaseNodeObject,
-  type QualifiedSchema,
+  type SchemaWithTables,
 } from './schema-tree/types';
 
 export {type TableColumn, type DataTable} from './types';

--- a/packages/duckdb-core/src/index.ts
+++ b/packages/duckdb-core/src/index.ts
@@ -58,6 +58,7 @@ export {
   type TableNodeObject,
   type SchemaNodeObject,
   type DatabaseNodeObject,
+  type QualifiedSchema,
 } from './schema-tree/types';
 
 export {type TableColumn, type DataTable} from './types';

--- a/packages/duckdb-core/src/schema-tree/__tests__/schemaTree.test.ts
+++ b/packages/duckdb-core/src/schema-tree/__tests__/schemaTree.test.ts
@@ -1,11 +1,11 @@
 import {createDbSchemaTrees} from '../schemaTree';
-import type {QualifiedSchema} from '../types';
+import type {SchemaWithTables} from '../types';
 
 describe('schemaTree', () => {
   describe('createDbSchemaTrees', () => {
     describe('basic functionality', () => {
       it('should create a tree with databases, schemas, and tables', () => {
-        const schemas: QualifiedSchema[] = [
+        const schemas: SchemaWithTables[] = [
           {
             database: 'db1',
             schema: 'schema1',
@@ -51,7 +51,7 @@ describe('schemaTree', () => {
       });
 
       it('should preserve empty schemas (tables: []) as schema nodes with no table children', () => {
-        const schemas: QualifiedSchema[] = [
+        const schemas: SchemaWithTables[] = [
           {database: 'db1', schema: 'empty_schema', tables: []},
         ];
 

--- a/packages/duckdb-core/src/schema-tree/__tests__/schemaTree.test.ts
+++ b/packages/duckdb-core/src/schema-tree/__tests__/schemaTree.test.ts
@@ -1,30 +1,36 @@
 import {createDbSchemaTrees} from '../schemaTree';
-import type {DataTable} from '../../types';
+import type {QualifiedSchema} from '../types';
 
 describe('schemaTree', () => {
   describe('createDbSchemaTrees', () => {
     describe('basic functionality', () => {
       it('should create a tree with databases, schemas, and tables', () => {
-        const tables: DataTable[] = [
+        const schemas: QualifiedSchema[] = [
           {
-            table: {
-              database: 'db1',
-              schema: 'schema1',
-              table: 'table1',
-              toString: () => 'db1.schema1.table1',
-            },
-            isView: false,
             database: 'db1',
             schema: 'schema1',
-            tableName: 'table1',
-            columns: [
-              {name: 'col1', type: 'INTEGER'},
-              {name: 'col2', type: 'VARCHAR'},
+            tables: [
+              {
+                table: {
+                  database: 'db1',
+                  schema: 'schema1',
+                  table: 'table1',
+                  toString: () => 'db1.schema1.table1',
+                },
+                isView: false,
+                database: 'db1',
+                schema: 'schema1',
+                tableName: 'table1',
+                columns: [
+                  {name: 'col1', type: 'INTEGER'},
+                  {name: 'col2', type: 'VARCHAR'},
+                ],
+              },
             ],
           },
         ];
 
-        const result = createDbSchemaTrees(tables);
+        const result = createDbSchemaTrees(schemas);
 
         expect(result).toHaveLength(1);
         expect(result[0]?.object.type).toBe('database');

--- a/packages/duckdb-core/src/schema-tree/__tests__/schemaTree.test.ts
+++ b/packages/duckdb-core/src/schema-tree/__tests__/schemaTree.test.ts
@@ -49,6 +49,22 @@ describe('schemaTree', () => {
           2,
         );
       });
+
+      it('should preserve empty schemas (tables: []) as schema nodes with no table children', () => {
+        const schemas: QualifiedSchema[] = [
+          {database: 'db1', schema: 'empty_schema', tables: []},
+        ];
+
+        const result = createDbSchemaTrees(schemas);
+
+        expect(result).toHaveLength(1);
+        expect(result[0]?.object.type).toBe('database');
+        expect(result[0]?.object.name).toBe('db1');
+        expect(result[0]?.children).toHaveLength(1);
+        expect(result[0]?.children?.[0]?.object.type).toBe('schema');
+        expect(result[0]?.children?.[0]?.object.name).toBe('empty_schema');
+        expect(result[0]?.children?.[0]?.children).toHaveLength(0);
+      });
     });
   });
 });

--- a/packages/duckdb-core/src/schema-tree/schemaTree.ts
+++ b/packages/duckdb-core/src/schema-tree/schemaTree.ts
@@ -5,10 +5,27 @@ import type {DbSchemaNode} from './types';
 /**
  * Group tables by database, schema and create a tree of databases, schemas, tables, and columns.
  * @param tables - The tables to group
+ * @param schemas - Optional list of all schemas (including empty ones)
  * @returns An array of database nodes containing schemas, tables and columns
  */
-export function createDbSchemaTrees(tables: DataTable[]): DbSchemaNode[] {
+export function createDbSchemaTrees(
+  tables: DataTable[],
+  schemas?: Array<{database: string; schema: string}>,
+): DbSchemaNode[] {
   const databaseMap = new Map<string, Map<string, DbSchemaNode[]>>();
+
+  if (schemas) {
+    for (const {database, schema} of schemas) {
+      const db = database ?? 'default';
+      if (!databaseMap.has(db)) {
+        databaseMap.set(db, new Map<string, DbSchemaNode[]>());
+      }
+      const schemaMap = databaseMap.get(db)!;
+      if (!schemaMap.has(schema)) {
+        schemaMap.set(schema, []);
+      }
+    }
+  }
 
   for (const table of tables) {
     const database = table.database ?? 'default';

--- a/packages/duckdb-core/src/schema-tree/schemaTree.ts
+++ b/packages/duckdb-core/src/schema-tree/schemaTree.ts
@@ -1,6 +1,6 @@
 import type {DataTable} from '../types';
 import {getDuckDbTypeCategory} from './typeCategories';
-import type {DbSchemaNode, QualifiedSchema} from './types';
+import type {DbSchemaNode, SchemaWithTables} from './types';
 
 /**
  * Build a tree of databases → schemas → tables → columns from the grouped schema list.
@@ -9,7 +9,7 @@ import type {DbSchemaNode, QualifiedSchema} from './types';
  * @returns An array of database nodes
  */
 export function createDbSchemaTrees(
-  schemas: QualifiedSchema[],
+  schemas: SchemaWithTables[],
 ): DbSchemaNode[] {
   const databaseMap = new Map<string, Map<string, DbSchemaNode[]>>();
 

--- a/packages/duckdb-core/src/schema-tree/schemaTree.ts
+++ b/packages/duckdb-core/src/schema-tree/schemaTree.ts
@@ -1,62 +1,40 @@
 import type {DataTable} from '../types';
 import {getDuckDbTypeCategory} from './typeCategories';
-import type {DbSchemaNode} from './types';
+import type {DbSchemaNode, QualifiedSchema} from './types';
 
 /**
- * Group tables by database, schema and create a tree of databases, schemas, tables, and columns.
- * @param tables - The tables to group
- * @param schemas - Optional list of all schemas (including empty ones)
- * @returns An array of database nodes containing schemas, tables and columns
+ * Build a tree of databases → schemas → tables → columns from the grouped schema list.
+ * Empty schemas (`tables: []`) are preserved as leaf-less schema nodes.
+ * @param schemas - Schemas grouped by database, each carrying its tables (may be empty)
+ * @returns An array of database nodes
  */
 export function createDbSchemaTrees(
-  tables: DataTable[],
-  schemas?: Array<{database: string; schema: string}>,
+  schemas: QualifiedSchema[],
 ): DbSchemaNode[] {
   const databaseMap = new Map<string, Map<string, DbSchemaNode[]>>();
 
-  if (schemas) {
-    for (const {database, schema} of schemas) {
-      const db = database ?? 'default';
-      if (!databaseMap.has(db)) {
-        databaseMap.set(db, new Map<string, DbSchemaNode[]>());
-      }
-      const schemaMap = databaseMap.get(db)!;
-      if (!schemaMap.has(schema)) {
-        schemaMap.set(schema, []);
-      }
+  for (const {database, schema, tables} of schemas) {
+    const db = database || 'default';
+    if (!databaseMap.has(db)) {
+      databaseMap.set(db, new Map<string, DbSchemaNode[]>());
     }
-  }
-
-  for (const table of tables) {
-    const database = table.database ?? 'default';
-    const schema = table.schema;
-    const tableName = table.tableName;
-
-    const columnNodes = table.columns.map((column) =>
-      createColumnNode(schema, tableName, column.name, column.type),
-    );
-
-    const tableNode = createTableNode(table, columnNodes);
-
-    if (!databaseMap.has(database)) {
-      databaseMap.set(database, new Map<string, DbSchemaNode[]>());
-    }
-
-    const schemaMap = databaseMap.get(database)!;
-
+    const schemaMap = databaseMap.get(db)!;
     if (!schemaMap.has(schema)) {
       schemaMap.set(schema, []);
     }
-
-    schemaMap.get(schema)?.push(tableNode);
+    const schemaTables = schemaMap.get(schema)!;
+    for (const table of tables) {
+      const columnNodes = table.columns.map((column) =>
+        createColumnNode(schema, table.tableName, column.name, column.type),
+      );
+      schemaTables.push(createTableNode(table, columnNodes));
+    }
   }
 
-  // Create database nodes
   return Array.from(databaseMap.entries()).map(([database, schemaMap]) => {
     const schemaNodes = Array.from(schemaMap.entries()).map(
       ([schema, tables]) => createSchemaTreeNode(schema, tables),
     );
-
     return createDatabaseTreeNode(database, schemaNodes);
   });
 }

--- a/packages/duckdb-core/src/schema-tree/types.ts
+++ b/packages/duckdb-core/src/schema-tree/types.ts
@@ -35,3 +35,9 @@ export type SchemaNodeObject = BaseNodeObject & {
 export type DatabaseNodeObject = BaseNodeObject & {
   type: 'database';
 };
+
+export type QualifiedSchema = {
+  database: string;
+  schema: string;
+  tables: DataTable[];
+};

--- a/packages/duckdb-core/src/schema-tree/types.ts
+++ b/packages/duckdb-core/src/schema-tree/types.ts
@@ -36,7 +36,7 @@ export type DatabaseNodeObject = BaseNodeObject & {
   type: 'database';
 };
 
-export type QualifiedSchema = {
+export type SchemaWithTables = {
   database: string;
   schema: string;
   tables: DataTable[];

--- a/packages/duckdb/README.md
+++ b/packages/duckdb/README.md
@@ -236,6 +236,27 @@ function QualifiedTableOps() {
 }
 ```
 
+### Loading the Schema Catalog
+
+Use `loadSchemaCatalog()` when you need the database/schema/table hierarchy,
+including empty schemas and attached databases whose `main` schema has no
+tables yet. The catalog filter receives typed entries for databases, schemas,
+and tables, so schema visibility does not depend on fake table names.
+
+```ts
+import {
+  defaultLoadSchemaCatalogFilter,
+  loadSchemaCatalog,
+} from '@sqlrooms/duckdb';
+
+const catalog = await loadSchemaCatalog(connector, {
+  filterFunction: (entry) =>
+    entry.type === 'schema' && entry.schema === 'scratch'
+      ? false
+      : defaultLoadSchemaCatalogFilter(entry),
+});
+```
+
 ## Loading Data from Files
 
 ### Using Load Functions Directly

--- a/packages/duckdb/__tests__/DuckDbSlice.test.ts
+++ b/packages/duckdb/__tests__/DuckDbSlice.test.ts
@@ -1,8 +1,14 @@
 import {createStore} from 'zustand';
 import {createNodeDuckDbConnector} from '@sqlrooms/duckdb-node';
-import {createDuckDbSlice, DuckDbSliceState} from '../src/DuckDbSlice';
+import {
+  createDuckDbSlice,
+  defaultLoadSchemaCatalogFilter,
+  DuckDbSliceState,
+} from '../src/DuckDbSlice';
 import {createBaseRoomSlice, BaseRoomStoreState} from '@sqlrooms/room-store';
 import * as arrow from 'apache-arrow';
+import {DuckDbConnector} from '@sqlrooms/duckdb-core';
+import {loadSchemaCatalog} from '../src/loadTableSchemas';
 
 type TestStoreState = BaseRoomStoreState & DuckDbSliceState;
 
@@ -266,6 +272,109 @@ describe('DuckDbSlice', () => {
 
       expect(rows.length).toBe(1);
       expect(rows[0]?.table_name).toBe('schema_test1');
+    });
+  });
+
+  describe('loadSchemaCatalog', () => {
+    it('should preserve empty schemas and empty attached database main schemas', async () => {
+      const connector = await store.getState().db.getConnector();
+
+      await connector.query('CREATE SCHEMA empty_schema');
+      await connector.query("ATTACH ':memory:' AS attached_empty");
+      await connector.query('CREATE TABLE main.visible_table (id INT)');
+
+      const catalog = await loadSchemaCatalog(connector, {
+        filterFunction: defaultLoadSchemaCatalogFilter,
+      });
+
+      expect(
+        catalog.find(
+          (entry) =>
+            entry.database === 'memory' && entry.schema === 'empty_schema',
+        ),
+      ).toEqual({database: 'memory', schema: 'empty_schema', tables: []});
+
+      expect(
+        catalog.find(
+          (entry) =>
+            entry.database === 'attached_empty' && entry.schema === 'main',
+        ),
+      ).toEqual({database: 'attached_empty', schema: 'main', tables: []});
+
+      expect(
+        catalog
+          .find(
+            (entry) => entry.database === 'memory' && entry.schema === 'main',
+          )
+          ?.tables.map((table) => table.tableName),
+      ).toContain('visible_table');
+    });
+
+    it('should hide the temp database catalog by default', async () => {
+      const connector = await store.getState().db.getConnector();
+
+      await connector.query('CREATE TEMP TABLE temp_table (id INT)');
+
+      const catalog = await loadSchemaCatalog(connector, {
+        filterFunction: defaultLoadSchemaCatalogFilter,
+      });
+
+      expect(catalog.some((entry) => entry.database === 'temp')).toBe(false);
+    });
+
+    it('should keep schemas when a table catalog filter removes their tables', async () => {
+      const connector = await store.getState().db.getConnector();
+
+      await connector.query('CREATE SCHEMA filtered_schema');
+      await connector.query(
+        'CREATE TABLE filtered_schema.hidden_table (id INT)',
+      );
+
+      const catalog = await loadSchemaCatalog(connector, {
+        filterFunction: (entry) =>
+          entry.type === 'table'
+            ? entry.table.table !== 'hidden_table'
+            : defaultLoadSchemaCatalogFilter(entry),
+      });
+
+      expect(
+        catalog.find(
+          (entry) =>
+            entry.database === 'memory' && entry.schema === 'filtered_schema',
+        ),
+      ).toEqual({database: 'memory', schema: 'filtered_schema', tables: []});
+    });
+  });
+
+  describe('refreshTableSchemas', () => {
+    it('should issue a single catalog metadata query per refresh', async () => {
+      const connector = createNodeDuckDbConnector({dbPath: ':memory:'});
+      const querySql: string[] = [];
+      const countedConnector: DuckDbConnector = {
+        ...connector,
+        query(sql, options) {
+          querySql.push(sql);
+          return connector.query(sql, options);
+        },
+      };
+      const countedStore = createStore<TestStoreState>()((...args) => ({
+        ...createBaseRoomSlice()(...args),
+        ...createDuckDbSlice({connector: countedConnector})(...args),
+      }));
+
+      try {
+        await countedStore.getState().db.initialize();
+        await countedStore.getState().db.refreshTableSchemas();
+        querySql.length = 0;
+
+        await countedStore.getState().db.refreshTableSchemas();
+
+        expect(querySql).toHaveLength(2);
+        expect(querySql[0]).toContain('current_schema()');
+        expect(querySql[1]).toContain('FROM duckdb_schemas()');
+      } finally {
+        await countedStore.getState().db.destroy();
+      }
     });
   });
 

--- a/packages/duckdb/src/DuckDbSlice.ts
+++ b/packages/duckdb/src/DuckDbSlice.ts
@@ -10,7 +10,7 @@ import {
   makeQualifiedTableName,
   QualifiedTableName,
   QueryHandle,
-  QualifiedSchema,
+  SchemaWithTables,
   separateLastStatement,
 } from '@sqlrooms/duckdb-core';
 import {
@@ -28,7 +28,8 @@ import {z} from 'zod';
 import {StateCreator} from 'zustand';
 import {createWasmDuckDbConnector} from './connectors/createDuckDbConnector';
 import {
-  loadSchemasWithTables,
+  loadSchemaCatalog,
+  LoadSchemaCatalogFilterFunction,
   loadTableSchemas,
   LoadTableSchemasFilter,
   LoadTableSchemasFilterFunction,
@@ -68,6 +69,30 @@ export const defaultLoadTableSchemasFilter: LoadTableSchemasFilterFunction = (
 export function createDefaultLoadTableSchemasFilter(): LoadTableSchemasFilterFunction {
   return defaultLoadTableSchemasFilter;
 }
+
+/**
+ * Default catalog visibility predicate for the data source panel.
+ * Hides SQLRooms internal objects and DuckDB's temporary database catalog.
+ */
+export const defaultLoadSchemaCatalogFilter: LoadSchemaCatalogFilterFunction = (
+  entry,
+): boolean => {
+  switch (entry.type) {
+    case 'database':
+      return (
+        !entry.database.startsWith(INTERNAL_SQLROOMS_PREFIX) &&
+        entry.database !== DUCKDB_TEMP_DATABASE
+      );
+    case 'schema':
+      return (
+        !entry.database.startsWith(INTERNAL_SQLROOMS_PREFIX) &&
+        entry.database !== DUCKDB_TEMP_DATABASE &&
+        !entry.schema.startsWith(INTERNAL_SQLROOMS_PREFIX)
+      );
+    case 'table':
+      return defaultLoadTableSchemasFilter(entry.table);
+  }
+};
 
 const DropTableCommandInput = z.object({
   tableName: z.string().describe('Name of the table to drop.'),
@@ -323,10 +348,16 @@ export type DuckDbSliceState = {
 export type CreateDuckDbSliceProps = {
   connector?: DuckDbConnector;
   /**
-   * Optional filter for which tables/schemas/databases appear in the data source panel.
-   * Defaults to {@link createDefaultLoadTableSchemasFilter} (hides `__sqlrooms_*` and the DuckDB `temp` database).
+   * Optional table visibility filter.
+   * Defaults to {@link createDefaultLoadTableSchemasFilter}.
    */
   loadTableSchemasFilter?: LoadTableSchemasFilterFunction | null;
+  /**
+   * Optional catalog visibility filter for the data source panel.
+   * Defaults to {@link defaultLoadSchemaCatalogFilter}. When omitted, custom
+   * table filters still apply to table entries while schemas/databases use the default.
+   */
+  loadSchemaCatalogFilter?: LoadSchemaCatalogFilterFunction | null;
 };
 
 /**
@@ -335,9 +366,22 @@ export type CreateDuckDbSliceProps = {
 export function createDuckDbSlice({
   connector = createWasmDuckDbConnector(),
   loadTableSchemasFilter = defaultLoadTableSchemasFilter,
+  loadSchemaCatalogFilter,
 }: CreateDuckDbSliceProps = {}): StateCreator<DuckDbSliceState> {
   let refreshPromise: Promise<DataTable[]> | null = null;
   let pendingSchemaRefresh = false;
+  const effectiveSchemaCatalogFilter =
+    loadSchemaCatalogFilter ??
+    (loadTableSchemasFilter === null
+      ? null
+      : (((entry) => {
+          if (entry.type === 'table') {
+            return loadTableSchemasFilter
+              ? loadTableSchemasFilter(entry.table)
+              : true;
+          }
+          return defaultLoadSchemaCatalogFilter(entry);
+        }) satisfies LoadSchemaCatalogFilterFunction));
   return createSlice<DuckDbSliceState, BaseRoomStoreState & DuckDbSliceState>(
     (set, get, store) => {
       /**
@@ -673,7 +717,7 @@ export function createDuckDbSlice({
             );
             refreshPromise = (async () => {
               try {
-                let schemasWithTables: QualifiedSchema[] = [];
+                let schemasWithTables: SchemaWithTables[] = [];
                 do {
                   pendingSchemaRefresh = false;
                   const connector = await get().db.getConnector();
@@ -690,10 +734,9 @@ export function createDuckDbSlice({
                         ?.get(0);
                     }),
                   );
-                  schemasWithTables = await loadSchemasWithTables(
-                    connector,
-                    loadTableSchemasFilter ?? undefined,
-                  );
+                  schemasWithTables = await loadSchemaCatalog(connector, {
+                    filterFunction: effectiveSchemaCatalogFilter,
+                  });
                 } while (pendingSchemaRefresh);
 
                 const newTables = schemasWithTables.flatMap((s) => s.tables);

--- a/packages/duckdb/src/DuckDbSlice.ts
+++ b/packages/duckdb/src/DuckDbSlice.ts
@@ -27,6 +27,7 @@ import {z} from 'zod';
 import {StateCreator} from 'zustand';
 import {createWasmDuckDbConnector} from './connectors/createDuckDbConnector';
 import {
+  loadAllSchemas,
   loadTableSchemas,
   LoadTableSchemasFilter,
   LoadTableSchemasFilterFunction,
@@ -35,17 +36,37 @@ import {
 const DUCKDB_COMMAND_OWNER = '@sqlrooms/duckdb';
 const INTERNAL_SQLROOMS_PREFIX = '__sqlrooms';
 
+/** DuckDB's temporary database catalog; never show in the default data source tree. */
+const DUCKDB_TEMP_DATABASE = 'temp';
+
 /**
- * Default filter to exclude internal SQLRooms tables, schemas, and databases
+ * Default predicate: which tables/schemas/databases appear in the data source panel.
+ * Hides `__sqlrooms_*` names and DuckDB's `temp` database.
+ * Apps can pass {@link CreateDuckDbSliceProps.loadTableSchemasFilter} to add more rules.
  */
-export function createDefaultLoadTableSchemasFilter(): LoadTableSchemasFilterFunction {
-  return (table: QualifiedTableName): boolean => {
-    return (
-      !table.table?.startsWith(INTERNAL_SQLROOMS_PREFIX) &&
-      !table.database?.startsWith(INTERNAL_SQLROOMS_PREFIX) &&
-      !table.schema?.startsWith(INTERNAL_SQLROOMS_PREFIX)
-    );
-  };
+export function createDefaultLoadTableSchemasFilter(
+  table: QualifiedTableName,
+): boolean {
+  if (
+    table.table?.startsWith(INTERNAL_SQLROOMS_PREFIX) ||
+    table.database?.startsWith(INTERNAL_SQLROOMS_PREFIX) ||
+    table.schema?.startsWith(INTERNAL_SQLROOMS_PREFIX)
+  ) {
+    return false;
+  }
+  if (table.database === DUCKDB_TEMP_DATABASE) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Factory form of {@link createDefaultLoadTableSchemasFilter} for APIs that expect
+ * `() => LoadTableSchemasFilterFunction` (e.g. dependency injection). Behavior matches
+ * using the predicate from {@link createDefaultLoadTableSchemasFilter} directly.
+ */
+export function createDefaultLoadTableSchemasFilterFactory(): LoadTableSchemasFilterFunction {
+  return createDefaultLoadTableSchemasFilter;
 }
 
 const DropTableCommandInput = z.object({
@@ -302,10 +323,8 @@ export type DuckDbSliceState = {
 export type CreateDuckDbSliceProps = {
   connector?: DuckDbConnector;
   /**
-   * Optional filter function to control which tables are included when loading schemas.
-   * By default, filters out tables/schemas/databases starting with '__sqlrooms_'.
-   * @param table - The qualified table name to evaluate
-   * @returns true to include the table, false to exclude it
+   * Optional filter for which tables/schemas/databases appear in the data source panel.
+   * Defaults to {@link createDefaultLoadTableSchemasFilter} (hides `__sqlrooms_*` and the DuckDB `temp` database).
    */
   loadTableSchemasFilter?: LoadTableSchemasFilterFunction | null;
 };
@@ -315,7 +334,7 @@ export type CreateDuckDbSliceProps = {
  */
 export function createDuckDbSlice({
   connector = createWasmDuckDbConnector(),
-  loadTableSchemasFilter = createDefaultLoadTableSchemasFilter(),
+  loadTableSchemasFilter = createDefaultLoadTableSchemasFilter,
 }: CreateDuckDbSliceProps = {}): StateCreator<DuckDbSliceState> {
   let refreshPromise: Promise<DataTable[]> | null = null;
   let pendingSchemaRefresh = false;
@@ -655,6 +674,7 @@ export function createDuckDbSlice({
             refreshPromise = (async () => {
               try {
                 let newTables: DataTable[];
+                let allSchemas: Array<{database: string; schema: string}> = [];
                 do {
                   pendingSchemaRefresh = false;
                   const connector = await get().db.getConnector();
@@ -671,13 +691,30 @@ export function createDuckDbSlice({
                         ?.get(0);
                     }),
                   );
-                  newTables = await get().db.loadTableSchemas();
+                  newTables = await loadTableSchemas(connector, {
+                    filterFunction: loadTableSchemasFilter ?? undefined,
+                  });
+                  allSchemas = await loadAllSchemas(
+                    connector,
+                    loadTableSchemasFilter ?? undefined,
+                  );
                 } while (pendingSchemaRefresh);
-                if (!deepEquals(newTables, get().db.tables)) {
+
+                const currentTables = get().db.tables;
+                const currentSchemaTrees = get().db.schemaTrees;
+                const newSchemaTrees = createDbSchemaTrees(
+                  newTables,
+                  allSchemas,
+                );
+
+                if (
+                  !deepEquals(newTables, currentTables) ||
+                  !deepEquals(newSchemaTrees, currentSchemaTrees)
+                ) {
                   set((state) =>
                     produce(state, (draft) => {
                       draft.db.tables = newTables;
-                      draft.db.schemaTrees = createDbSchemaTrees(newTables);
+                      draft.db.schemaTrees = newSchemaTrees;
                     }),
                   );
                 }

--- a/packages/duckdb/src/DuckDbSlice.ts
+++ b/packages/duckdb/src/DuckDbSlice.ts
@@ -10,6 +10,7 @@ import {
   makeQualifiedTableName,
   QualifiedTableName,
   QueryHandle,
+  QualifiedSchema,
   separateLastStatement,
 } from '@sqlrooms/duckdb-core';
 import {
@@ -27,7 +28,7 @@ import {z} from 'zod';
 import {StateCreator} from 'zustand';
 import {createWasmDuckDbConnector} from './connectors/createDuckDbConnector';
 import {
-  loadAllSchemas,
+  loadSchemasWithTables,
   loadTableSchemas,
   LoadTableSchemasFilter,
   LoadTableSchemasFilterFunction,
@@ -42,11 +43,10 @@ const DUCKDB_TEMP_DATABASE = 'temp';
 /**
  * Default predicate: which tables/schemas/databases appear in the data source panel.
  * Hides `__sqlrooms_*` names and DuckDB's `temp` database.
- * Apps can pass {@link CreateDuckDbSliceProps.loadTableSchemasFilter} to add more rules.
  */
-export function createDefaultLoadTableSchemasFilter(
+export const defaultLoadTableSchemasFilter: LoadTableSchemasFilterFunction = (
   table: QualifiedTableName,
-): boolean {
+): boolean => {
   if (
     table.table?.startsWith(INTERNAL_SQLROOMS_PREFIX) ||
     table.database?.startsWith(INTERNAL_SQLROOMS_PREFIX) ||
@@ -58,15 +58,15 @@ export function createDefaultLoadTableSchemasFilter(
     return false;
   }
   return true;
-}
+};
 
 /**
- * Factory form of {@link createDefaultLoadTableSchemasFilter} for APIs that expect
- * `() => LoadTableSchemasFilterFunction` (e.g. dependency injection). Behavior matches
- * using the predicate from {@link createDefaultLoadTableSchemasFilter} directly.
+ * Factory returning {@link defaultLoadTableSchemasFilter}.
+ * Hides `__sqlrooms_*` names and DuckDB's `temp` database.
+ * Apps can pass {@link CreateDuckDbSliceProps.loadTableSchemasFilter} to add more rules.
  */
-export function createDefaultLoadTableSchemasFilterFactory(): LoadTableSchemasFilterFunction {
-  return createDefaultLoadTableSchemasFilter;
+export function createDefaultLoadTableSchemasFilter(): LoadTableSchemasFilterFunction {
+  return defaultLoadTableSchemasFilter;
 }
 
 const DropTableCommandInput = z.object({
@@ -334,7 +334,7 @@ export type CreateDuckDbSliceProps = {
  */
 export function createDuckDbSlice({
   connector = createWasmDuckDbConnector(),
-  loadTableSchemasFilter = createDefaultLoadTableSchemasFilter,
+  loadTableSchemasFilter = defaultLoadTableSchemasFilter,
 }: CreateDuckDbSliceProps = {}): StateCreator<DuckDbSliceState> {
   let refreshPromise: Promise<DataTable[]> | null = null;
   let pendingSchemaRefresh = false;
@@ -673,8 +673,7 @@ export function createDuckDbSlice({
             );
             refreshPromise = (async () => {
               try {
-                let newTables: DataTable[];
-                let allSchemas: Array<{database: string; schema: string}> = [];
+                let schemasWithTables: QualifiedSchema[] = [];
                 do {
                   pendingSchemaRefresh = false;
                   const connector = await get().db.getConnector();
@@ -691,21 +690,16 @@ export function createDuckDbSlice({
                         ?.get(0);
                     }),
                   );
-                  newTables = await loadTableSchemas(connector, {
-                    filterFunction: loadTableSchemasFilter ?? undefined,
-                  });
-                  allSchemas = await loadAllSchemas(
+                  schemasWithTables = await loadSchemasWithTables(
                     connector,
                     loadTableSchemasFilter ?? undefined,
                   );
                 } while (pendingSchemaRefresh);
 
+                const newTables = schemasWithTables.flatMap((s) => s.tables);
                 const currentTables = get().db.tables;
                 const currentSchemaTrees = get().db.schemaTrees;
-                const newSchemaTrees = createDbSchemaTrees(
-                  newTables,
-                  allSchemas,
-                );
+                const newSchemaTrees = createDbSchemaTrees(schemasWithTables);
 
                 if (
                   !deepEquals(newTables, currentTables) ||

--- a/packages/duckdb/src/index.ts
+++ b/packages/duckdb/src/index.ts
@@ -31,11 +31,12 @@ export {
   createDuckDbSlice,
   useStoreWithDuckDb,
   createDefaultLoadTableSchemasFilter,
+  createDefaultLoadTableSchemasFilterFactory,
   type CreateDuckDbSliceProps,
   type DuckDbSliceState,
 } from './DuckDbSlice';
 
-export {type LoadTableSchemasFilter} from './loadTableSchemas';
+export {type LoadTableSchemasFilter, loadAllSchemas} from './loadTableSchemas';
 
 export {useExportToCsv, type UseExportToCsvReturn} from './use-export-to-csv';
 

--- a/packages/duckdb/src/index.ts
+++ b/packages/duckdb/src/index.ts
@@ -31,12 +31,15 @@ export {
   createDuckDbSlice,
   useStoreWithDuckDb,
   createDefaultLoadTableSchemasFilter,
-  createDefaultLoadTableSchemasFilterFactory,
+  defaultLoadTableSchemasFilter,
   type CreateDuckDbSliceProps,
   type DuckDbSliceState,
 } from './DuckDbSlice';
 
-export {type LoadTableSchemasFilter, loadAllSchemas} from './loadTableSchemas';
+export {
+  type LoadTableSchemasFilter,
+  loadSchemasWithTables,
+} from './loadTableSchemas';
 
 export {useExportToCsv, type UseExportToCsvReturn} from './use-export-to-csv';
 
@@ -101,6 +104,7 @@ export {
   type QueryHandle,
   type QueryOptions,
   type SchemaNodeObject,
+  type QualifiedSchema,
   type SeparatedStatements,
   type TableColumn,
   type TableNodeObject,

--- a/packages/duckdb/src/index.ts
+++ b/packages/duckdb/src/index.ts
@@ -31,14 +31,17 @@ export {
   createDuckDbSlice,
   useStoreWithDuckDb,
   createDefaultLoadTableSchemasFilter,
+  defaultLoadSchemaCatalogFilter,
   defaultLoadTableSchemasFilter,
   type CreateDuckDbSliceProps,
   type DuckDbSliceState,
 } from './DuckDbSlice';
 
 export {
+  loadSchemaCatalog,
+  type LoadSchemaCatalogFilterFunction,
+  type SchemaCatalogFilterEntry,
   type LoadTableSchemasFilter,
-  loadSchemasWithTables,
 } from './loadTableSchemas';
 
 export {useExportToCsv, type UseExportToCsvReturn} from './use-export-to-csv';
@@ -104,7 +107,7 @@ export {
   type QueryHandle,
   type QueryOptions,
   type SchemaNodeObject,
-  type QualifiedSchema,
+  type SchemaWithTables,
   type SeparatedStatements,
   type TableColumn,
   type TableNodeObject,

--- a/packages/duckdb/src/loadTableSchemas.ts
+++ b/packages/duckdb/src/loadTableSchemas.ts
@@ -4,6 +4,7 @@ import {
   escapeVal,
   makeQualifiedTableName,
   QualifiedTableName,
+  QualifiedSchema,
   TableColumn,
 } from '@sqlrooms/duckdb-core';
 
@@ -49,21 +50,59 @@ export async function loadTableSchemas(
 }
 
 /**
- * Load all schemas from the database (including empty schemas).
+ * Load all schemas (including empty ones) grouped with their tables.
  *
- * If provided, `filter` reuses the same `LoadTableSchemasFilterFunction` type as
- * `loadTableSchemas`, but it is invoked with a schema-only qualified name:
- * `database` and `schema` are populated and `table` is an empty string.
- * Filters that rely on a real, non-empty table name may therefore behave
- * differently when used here.
+ * If provided, `filter` is applied at two layers:
+ * - schemas: invoked with a qualified name where `table === ''` (schemas with no
+ *   tables are still surfaced this way)
+ * - tables: invoked with the full qualified name as in `loadTableSchemas`
  *
  * @param connector - The DuckDB connector
- * @param filter - Optional filter function applied to schema entries via a qualified name with `table: ''`; omit or pass `null` for no filter
- * @returns An array of {database, schema} objects
+ * @param filter - Optional visibility filter; omit or pass `null` to include everything
+ * @returns Schemas grouped by database, each carrying their (filtered) tables
  */
-export async function loadAllSchemas(
+export async function loadSchemasWithTables(
   connector: DuckDbConnector,
   filter?: LoadTableSchemasFilterFunction | null,
+): Promise<QualifiedSchema[]> {
+  const [tables, schemaRows] = await Promise.all([
+    loadTableSchemas(connector, {filterFunction: filter ?? undefined}),
+    queryAllSchemas(connector),
+  ]);
+
+  const groups = new Map<string, QualifiedSchema>();
+  const keyOf = (database: string, schema: string) => `${database}\x00${schema}`;
+
+  for (const {database, schema} of schemaRows) {
+    if (filter) {
+      const shouldInclude = filter(
+        makeQualifiedTableName({database, schema, table: ''}),
+      );
+      if (!shouldInclude) continue;
+    }
+    const key = keyOf(database, schema);
+    if (!groups.has(key)) {
+      groups.set(key, {database, schema, tables: []});
+    }
+  }
+
+  for (const table of tables) {
+    const database = table.database || '';
+    const schema = table.schema || '';
+    const key = keyOf(database, schema);
+    let group = groups.get(key);
+    if (!group) {
+      group = {database, schema, tables: []};
+      groups.set(key, group);
+    }
+    group.tables.push(table);
+  }
+
+  return Array.from(groups.values());
+}
+
+async function queryAllSchemas(
+  connector: DuckDbConnector,
 ): Promise<Array<{database: string; schema: string}>> {
   const sql = `
     SELECT DISTINCT
@@ -79,34 +118,17 @@ export async function loadAllSchemas(
     ORDER BY 1, 2
   `;
   const result = await connector.query(sql);
-  const schemas: Array<{database: string; schema: string}> = [];
-
+  const out: Array<{database: string; schema: string}> = [];
   for (let i = 0; i < result.numRows; i++) {
     const database = result.getChild('database')?.get(i);
     const schema = result.getChild('schema')?.get(i);
-
-    if (schema == null) continue;
+    if (schema == null || database == null) continue;
     const schemaStr = String(schema).trim();
-    if (schemaStr === '') continue;
-    if (database == null) continue;
     const databaseStr = String(database).trim();
-    if (databaseStr === '') continue;
-
-    if (filter) {
-      const shouldInclude = filter(
-        makeQualifiedTableName({
-          database: databaseStr,
-          schema: schemaStr,
-          table: '',
-        }),
-      );
-      if (!shouldInclude) continue;
-    }
-
-    schemas.push({database: databaseStr, schema: schemaStr});
+    if (schemaStr === '' || databaseStr === '') continue;
+    out.push({database: databaseStr, schema: schemaStr});
   }
-
-  return schemas;
+  return out;
 }
 
 function isDuckDbPlaceholderViewColumn(

--- a/packages/duckdb/src/loadTableSchemas.ts
+++ b/packages/duckdb/src/loadTableSchemas.ts
@@ -4,7 +4,7 @@ import {
   escapeVal,
   makeQualifiedTableName,
   QualifiedTableName,
-  QualifiedSchema,
+  SchemaWithTables,
   TableColumn,
 } from '@sqlrooms/duckdb-core';
 
@@ -20,6 +20,19 @@ export type LoadTableSchemasFilter = {
 
 export type LoadTableSchemasOptions = LoadTableSchemasFilter & {
   filterFunction?: LoadTableSchemasFilterFunction | null;
+};
+
+export type SchemaCatalogFilterEntry =
+  | {type: 'database'; database: string}
+  | {type: 'schema'; database: string; schema: string}
+  | {type: 'table'; table: QualifiedTableName};
+
+export type LoadSchemaCatalogFilterFunction = (
+  entry: SchemaCatalogFilterEntry,
+) => boolean;
+
+export type LoadSchemaCatalogOptions = LoadTableSchemasFilter & {
+  filterFunction?: LoadSchemaCatalogFilterFunction | null;
 };
 
 /**
@@ -50,85 +63,56 @@ export async function loadTableSchemas(
 }
 
 /**
- * Load all schemas (including empty ones) grouped with their tables.
- *
- * If provided, `filter` is applied at two layers:
- * - schemas: invoked with a qualified name where `table === ''` (schemas with no
- *   tables are still surfaced this way)
- * - tables: invoked with the full qualified name as in `loadTableSchemas`
- *
- * @param connector - The DuckDB connector
- * @param filter - Optional visibility filter; omit or pass `null` to include everything
- * @returns Schemas grouped by database, each carrying their (filtered) tables
+ * Load the visible DuckDB schema catalog in one metadata query.
+ * Starts from schemas, then left-joins tables, views, and columns so empty
+ * schemas and empty attached database `main` schemas are preserved.
  */
-export async function loadSchemasWithTables(
+export async function loadSchemaCatalog(
   connector: DuckDbConnector,
-  filter?: LoadTableSchemasFilterFunction | null,
-): Promise<QualifiedSchema[]> {
-  const [tables, schemaRows] = await Promise.all([
-    loadTableSchemas(connector, {filterFunction: filter ?? undefined}),
-    queryAllSchemas(connector),
-  ]);
+  options: LoadSchemaCatalogOptions = {},
+): Promise<SchemaWithTables[]> {
+  const {filterFunction, ...filter} = options;
+  const result = await connector.query(buildSchemaCatalogQuery(filter));
+  const groups = new Map<string, SchemaWithTables>();
+  const includedDatabases = new Set<string>();
+  const keyOf = (database: string, schema: string) =>
+    `${database}\x00${schema}`;
 
-  const groups = new Map<string, QualifiedSchema>();
-  const keyOf = (database: string, schema: string) => `${database}\x00${schema}`;
+  for (let i = 0; i < result.numRows; i++) {
+    const database = String(result.getChild('database')?.get(i) ?? '').trim();
+    const schema = String(result.getChild('schema')?.get(i) ?? '').trim();
+    if (!database || !schema) continue;
 
-  for (const {database, schema} of schemaRows) {
-    if (filter) {
-      const shouldInclude = filter(
-        makeQualifiedTableName({database, schema, table: ''}),
-      );
-      if (!shouldInclude) continue;
+    if (!includedDatabases.has(database)) {
+      if (filterFunction?.({type: 'database', database}) === false) {
+        continue;
+      } else {
+        includedDatabases.add(database);
+      }
     }
-    const key = keyOf(database, schema);
-    if (!groups.has(key)) {
-      groups.set(key, {database, schema, tables: []});
-    }
-  }
 
-  for (const table of tables) {
-    const database = table.database || '';
-    const schema = table.schema || '';
+    if (filterFunction?.({type: 'schema', database, schema}) === false) {
+      continue;
+    }
+
     const key = keyOf(database, schema);
     let group = groups.get(key);
+
     if (!group) {
       group = {database, schema, tables: []};
       groups.set(key, group);
     }
-    group.tables.push(table);
+
+    const table = parseSchemaCatalogTableRow(result, i);
+    if (
+      table &&
+      (!filterFunction || filterFunction({type: 'table', table: table.table}))
+    ) {
+      group.tables.push(table);
+    }
   }
 
   return Array.from(groups.values());
-}
-
-async function queryAllSchemas(
-  connector: DuckDbConnector,
-): Promise<Array<{database: string; schema: string}>> {
-  const sql = `
-    SELECT DISTINCT
-      COALESCE(
-        NULLIF(CAST(database_name AS VARCHAR), ''),
-        current_database()
-      ) AS database,
-      CAST(schema_name AS VARCHAR) AS schema
-    FROM duckdb_schemas()
-    WHERE (database_name IS NULL OR database_name != 'system')
-      AND (internal = false OR CAST(schema_name AS VARCHAR) = 'main')
-      AND schema_name IS NOT NULL
-    ORDER BY 1, 2
-  `;
-  const result = await connector.query(sql);
-  const out: Array<{database: string; schema: string}> = [];
-  for (let i = 0; i < result.numRows; i++) {
-    const database = result.getChild('database')?.get(i);
-    const schema = result.getChild('schema')?.get(i);
-    if (schema == null || database == null) continue;
-    const schemaStr = String(schema).trim();
-    const databaseStr = String(database).trim();
-    if (schemaStr === '' || databaseStr === '') continue;
-    out.push({database: databaseStr, schema: schemaStr});
-  }
-  return out;
 }
 
 function isDuckDbPlaceholderViewColumn(
@@ -189,6 +173,15 @@ function parseTableSchemaRow(describeResults: any, index: number): DataTable {
   };
 }
 
+function parseSchemaCatalogTableRow(
+  result: any,
+  index: number,
+): DataTable | null {
+  const rowTable = result.getChild('name')?.get(index);
+  if (rowTable == null) return null;
+  return parseTableSchemaRow(result, index);
+}
+
 function buildMetadataWhereClause(
   nameColumn: string,
   filter: LoadTableSchemasFilter,
@@ -203,6 +196,80 @@ function buildMetadataWhereClause(
   ]
     .filter(Boolean)
     .join(' AND ');
+}
+
+function buildSchemaWhereClause(filter: LoadTableSchemasFilter): string {
+  const {schema, database} = filter;
+  return [
+    database
+      ? `database_name = ${escapeVal(database)}`
+      : `database_name != 'system'`,
+    schema ? `schema_name = ${escapeVal(schema)}` : 'schema_name IS NOT NULL',
+    `(internal = false OR schema_name = 'main')`,
+  ]
+    .filter(Boolean)
+    .join(' AND ');
+}
+
+function buildSchemaCatalogQuery(filter: LoadTableSchemasFilter): string {
+  const schemaWhereClause = buildSchemaWhereClause(filter);
+  const tableWhereClause = buildMetadataWhereClause('table_name', filter);
+  const viewWhereClause = buildMetadataWhereClause('view_name', filter);
+
+  return `WITH schemas AS (
+    FROM duckdb_schemas() SELECT DISTINCT
+      COALESCE(
+        NULLIF(CAST(database_name AS VARCHAR), ''),
+        current_database()
+      ) AS database,
+      CAST(schema_name AS VARCHAR) AS schema
+    WHERE ${schemaWhereClause}
+  ),
+  tables_and_views AS (
+    FROM duckdb_tables() SELECT
+      database_name AS database,
+      schema_name AS schema,
+      table_name AS name,
+      sql,
+      comment,
+      estimated_size,
+      FALSE AS isView
+    WHERE ${tableWhereClause}
+    UNION ALL
+    FROM duckdb_views() SELECT
+      database_name AS database,
+      schema_name AS schema,
+      view_name AS name,
+      sql,
+      comment,
+      NULL AS estimated_size,
+      TRUE AS isView
+    WHERE ${viewWhereClause}
+  ),
+  columns AS (
+    FROM duckdb_columns() SELECT
+      database_name AS database,
+      schema_name AS schema,
+      table_name AS name,
+      list(column_name ORDER BY column_index) AS column_names,
+      list(data_type ORDER BY column_index) AS column_types
+    WHERE ${tableWhereClause}
+    GROUP BY database_name, schema_name, table_name
+  )
+  SELECT
+    tables_and_views.isView AS isView,
+    schemas.database AS database,
+    schemas.schema AS schema,
+    tables_and_views.name AS name,
+    columns.column_names AS column_names,
+    columns.column_types AS column_types,
+    tables_and_views.sql AS sql,
+    tables_and_views.comment AS comment,
+    tables_and_views.estimated_size AS estimated_size
+  FROM schemas
+  LEFT JOIN tables_and_views USING (database, schema)
+  LEFT JOIN columns USING (database, schema, name)
+  ORDER BY schemas.database, schemas.schema, tables_and_views.isView, tables_and_views.name`;
 }
 
 /**

--- a/packages/duckdb/src/loadTableSchemas.ts
+++ b/packages/duckdb/src/loadTableSchemas.ts
@@ -48,6 +48,67 @@ export async function loadTableSchemas(
   return tables;
 }
 
+/**
+ * Load all schemas from the database (including empty schemas).
+ *
+ * If provided, `filter` reuses the same `LoadTableSchemasFilterFunction` type as
+ * `loadTableSchemas`, but it is invoked with a schema-only qualified name:
+ * `database` and `schema` are populated and `table` is an empty string.
+ * Filters that rely on a real, non-empty table name may therefore behave
+ * differently when used here.
+ *
+ * @param connector - The DuckDB connector
+ * @param filter - Optional filter function applied to schema entries via a qualified name with `table: ''`; omit or pass `null` for no filter
+ * @returns An array of {database, schema} objects
+ */
+export async function loadAllSchemas(
+  connector: DuckDbConnector,
+  filter?: LoadTableSchemasFilterFunction | null,
+): Promise<Array<{database: string; schema: string}>> {
+  const sql = `
+    SELECT DISTINCT
+      COALESCE(
+        NULLIF(CAST(database_name AS VARCHAR), ''),
+        current_database()
+      ) AS database,
+      CAST(schema_name AS VARCHAR) AS schema
+    FROM duckdb_schemas()
+    WHERE (database_name IS NULL OR database_name != 'system')
+      AND (internal = false OR CAST(schema_name AS VARCHAR) = 'main')
+      AND schema_name IS NOT NULL
+    ORDER BY 1, 2
+  `;
+  const result = await connector.query(sql);
+  const schemas: Array<{database: string; schema: string}> = [];
+
+  for (let i = 0; i < result.numRows; i++) {
+    const database = result.getChild('database')?.get(i);
+    const schema = result.getChild('schema')?.get(i);
+
+    if (schema == null) continue;
+    const schemaStr = String(schema).trim();
+    if (schemaStr === '') continue;
+    if (database == null) continue;
+    const databaseStr = String(database).trim();
+    if (databaseStr === '') continue;
+
+    if (filter) {
+      const shouldInclude = filter(
+        makeQualifiedTableName({
+          database: databaseStr,
+          schema: schemaStr,
+          table: '',
+        }),
+      );
+      if (!shouldInclude) continue;
+    }
+
+    schemas.push({database: databaseStr, schema: schemaStr});
+  }
+
+  return schemas;
+}
+
 function isDuckDbPlaceholderViewColumn(
   columnName: string,
   columnType: string,

--- a/packages/room-shell/src/RoomShellSlice.ts
+++ b/packages/room-shell/src/RoomShellSlice.ts
@@ -1,4 +1,8 @@
-import {DbSliceState, createDbSlice} from '@sqlrooms/db';
+import {
+  createDbSlice,
+  type CreateDbSliceProps,
+  DbSliceState,
+} from '@sqlrooms/db';
 import {DataTable, DuckDbConnector, LoadFileOptions} from '@sqlrooms/duckdb';
 import {
   CreateLayoutSliceProps,
@@ -42,7 +46,6 @@ import {produce} from 'immer';
 import {ReactNode} from 'react';
 import {z} from 'zod';
 import {StateCreator, StoreApi} from 'zustand';
-import {CreateDbSliceProps} from '../../db/dist/DbSlice';
 import {
   DataSourceState,
   DataSourceStatus,

--- a/packages/schema-tree/src/TableSchemaTree.tsx
+++ b/packages/schema-tree/src/TableSchemaTree.tsx
@@ -36,16 +36,32 @@ const TableSchemaTreeRoot: FC<{
 }) => {
   const trees = useMemo(() => {
     if (!schemaTrees) return [];
-    return skipSingleDatabaseOrSchema
-      ? schemaTrees.length > 1
-        ? schemaTrees
-        : schemaTrees[0]?.children && schemaTrees[0]?.children?.length > 1
-          ? schemaTrees[0].children
-          : schemaTrees[0]?.children?.[0]?.children
-      : schemaTrees;
+    if (!skipSingleDatabaseOrSchema) {
+      return schemaTrees;
+    }
+    if (schemaTrees.length > 1) {
+      return schemaTrees;
+    }
+    const dbNode = schemaTrees[0];
+    const schemaChildren = dbNode?.children;
+    if (!schemaChildren?.length) {
+      return schemaTrees;
+    }
+    if (schemaChildren.length > 1) {
+      return schemaChildren;
+    }
+    const onlySchema = schemaChildren[0];
+    if (!onlySchema) {
+      return schemaTrees;
+    }
+    const tableChildren = onlySchema.children ?? [];
+    if (tableChildren.length === 0) {
+      return [onlySchema];
+    }
+    return tableChildren;
   }, [schemaTrees, skipSingleDatabaseOrSchema]);
 
-  if (!trees?.length || trees.every((tree) => tree.children?.length === 0)) {
+  if (!trees?.length) {
     return (
       <div
         className={cn(

--- a/packages/ui/src/components/tree.tsx
+++ b/packages/ui/src/components/tree.tsx
@@ -48,7 +48,12 @@ function TreeNode<T>(props: TreeNodeProps<T>): React.ReactElement | null {
   const hasChildren = Boolean(children?.length);
   const [isOpen, setIsOpen] = useState(Boolean(treeData.isInitialOpen));
   if (!hasChildren) {
-    return <div className="pl-4">{renderNode(treeData, isOpen)}</div>;
+    return (
+      <div className="flex w-full items-center space-x-1">
+        <div className="shrink-0" style={{width: '18px'}} />
+        {renderNode(treeData, isOpen)}
+      </div>
+    );
   }
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>

--- a/packages/ui/src/components/tree.tsx
+++ b/packages/ui/src/components/tree.tsx
@@ -7,6 +7,8 @@ import { ChevronRightIcon } from 'lucide-react';
 import { cn } from '../lib/utils';
 import { CollapsibleTrigger } from './collapsible';
 
+const DROPDOWN_ICON_PLACEHOLDER_WIDTH = '18px';
+
 export type TreeNodeData<T> = {
   key: string;
   object: T;
@@ -50,7 +52,7 @@ function TreeNode<T>(props: TreeNodeProps<T>): React.ReactElement | null {
   if (!hasChildren) {
     return (
       <div className="flex w-full items-center space-x-1">
-        <div className="shrink-0" style={{ width: '18px' }} />
+        <div className="shrink-0" style={{ width: DROPDOWN_ICON_PLACEHOLDER_WIDTH }} />
         {renderNode(treeData, isOpen)}
       </div>
     );
@@ -63,7 +65,7 @@ function TreeNode<T>(props: TreeNodeProps<T>): React.ReactElement | null {
             className={cn('shrink-0 text-gray-500', {
               'rotate-90 transform': isOpen,
             })}
-            size="18px"
+            size={DROPDOWN_ICON_PLACEHOLDER_WIDTH}
           />
           {renderNode(treeData, isOpen)}
         </div>

--- a/packages/ui/src/components/tree.tsx
+++ b/packages/ui/src/components/tree.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import {Collapsible, CollapsibleContent} from '@radix-ui/react-collapsible';
-import React, {useState} from 'react';
+import { Collapsible, CollapsibleContent } from '@radix-ui/react-collapsible';
+import React, { useState } from 'react';
 
-import {ChevronRightIcon} from 'lucide-react';
-import {cn} from '../lib/utils';
-import {CollapsibleTrigger} from './collapsible';
+import { ChevronRightIcon } from 'lucide-react';
+import { cn } from '../lib/utils';
+import { CollapsibleTrigger } from './collapsible';
 
 export type TreeNodeData<T> = {
   key: string;
@@ -26,7 +26,7 @@ type TreeProps<T> = {
  * @param renderNode - A function that renders a tree node.
  */
 export function Tree<T>(props: TreeProps<T>): React.ReactElement {
-  const {className, treeData, renderNode} = props;
+  const { className, treeData, renderNode } = props;
   return (
     <div className={cn('flex flex-col', className)}>
       <TreeNode<T> treeData={treeData} renderNode={renderNode} />
@@ -43,14 +43,14 @@ type TreeNodeProps<T> = {
  * Component that renders a tree node.
  */
 function TreeNode<T>(props: TreeNodeProps<T>): React.ReactElement | null {
-  const {treeData, renderNode} = props;
-  const {children} = treeData;
+  const { treeData, renderNode } = props;
+  const { children } = treeData;
   const hasChildren = Boolean(children?.length);
   const [isOpen, setIsOpen] = useState(Boolean(treeData.isInitialOpen));
   if (!hasChildren) {
     return (
       <div className="flex w-full items-center space-x-1">
-        <div className="shrink-0" style={{width: '18px'}} />
+        <div className="shrink-0" style={{ width: '18px' }} />
         {renderNode(treeData, isOpen)}
       </div>
     );
@@ -71,12 +71,12 @@ function TreeNode<T>(props: TreeNodeProps<T>): React.ReactElement | null {
       <CollapsibleContent className="pl-4">
         {isOpen
           ? children?.map((child) => (
-              <TreeNode<T>
-                key={child.key}
-                treeData={child}
-                renderNode={renderNode}
-              />
-            ))
+            <TreeNode<T>
+              key={child.key}
+              treeData={child}
+              renderNode={renderNode}
+            />
+          ))
           : null}
       </CollapsibleContent>
     </Collapsible>


### PR DESCRIPTION
 Show empty schemas in data source panel (previously hidden when no tables)
 Reserved/internal schemas + databases stay hidden via composable filter.
 
<img width="1065" height="756" alt="Screenshot 2026-05-19 at 17 22 45" src="https://github.com/user-attachments/assets/ffb88f63-d7a1-4553-94c7-7c962c823a0c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added schema-catalog loader, a grouped SchemaWithTables type, and new export helpers/filters.
* **Bug Fixes**
  * Preserve empty schemas and hide temporary/internal catalogs by default.
* **Style**
  * Improved leaf-node layout for consistent tree spacing.
* **Refactor**
  * Consolidated schema/table loading and filtering; refreshed schema-tree generation and refresh flow.
* **Documentation**
  * Added docs and migration examples for the schema catalog API.
* **Tests**
  * Added tests for catalog loading, empty schemas, filters, and refresh queries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sqlrooms/sqlrooms/pull/639?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->