### PR TITLE
feat: Refine schema catalog loading

### DIFF
--- a/apps/sqlrooms-cli-ui/src/store.ts
+++ b/apps/sqlrooms-cli-ui/src/store.ts
@@ -25,8 +25,10 @@ import {
 import {
   createDefaultLoadTableSchemasFilter,
   createWebSocketDuckDbConnector,
+  defaultLoadSchemaCatalogFilter,
   type DataTable,
   QualifiedTableName,
+  type SchemaCatalogFilterEntry,
 } from '@sqlrooms/duckdb';
 import {
   createCrdtSlice,
@@ -490,6 +492,26 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
                   );
                 };
               })(),
+              loadSchemaCatalogFilter: (entry: SchemaCatalogFilterEntry) => {
+                if (!defaultLoadSchemaCatalogFilter(entry)) {
+                  return false;
+                }
+                if (
+                  entry.type === 'schema' &&
+                  entry.database === get().db.currentDatabase &&
+                  entry.schema === 'mosaic'
+                ) {
+                  return false;
+                }
+                if (
+                  entry.type === 'table' &&
+                  entry.table.database === get().db.currentDatabase &&
+                  entry.table.schema === 'mosaic'
+                ) {
+                  return false;
+                }
+                return true;
+              },
             },
           },
         })(set, get, store),

--- a/packages/duckdb-core/src/index.ts
+++ b/packages/duckdb-core/src/index.ts
@@ -58,7 +58,7 @@ export {
   type TableNodeObject,
   type SchemaNodeObject,
   type DatabaseNodeObject,
-  type QualifiedSchema,
+  type SchemaWithTables,
 } from './schema-tree/types';
 
 export {type TableColumn, type DataTable} from './types';

--- a/packages/duckdb-core/src/schema-tree/__tests__/schemaTree.test.ts
+++ b/packages/duckdb-core/src/schema-tree/__tests__/schemaTree.test.ts
@@ -1,11 +1,11 @@
 import {createDbSchemaTrees} from '../schemaTree';
-import type {QualifiedSchema} from '../types';
+import type {SchemaWithTables} from '../types';
 
 describe('schemaTree', () => {
   describe('createDbSchemaTrees', () => {
     describe('basic functionality', () => {
       it('should create a tree with databases, schemas, and tables', () => {
-        const schemas: QualifiedSchema[] = [
+        const schemas: SchemaWithTables[] = [
           {
             database: 'db1',
             schema: 'schema1',
@@ -51,7 +51,7 @@ describe('schemaTree', () => {
       });
 
       it('should preserve empty schemas (tables: []) as schema nodes with no table children', () => {
-        const schemas: QualifiedSchema[] = [
+        const schemas: SchemaWithTables[] = [
           {database: 'db1', schema: 'empty_schema', tables: []},
         ];
 

--- a/packages/duckdb-core/src/schema-tree/schemaTree.ts
+++ b/packages/duckdb-core/src/schema-tree/schemaTree.ts
@@ -1,6 +1,6 @@
 import type {DataTable} from '../types';
 import {getDuckDbTypeCategory} from './typeCategories';
-import type {DbSchemaNode, QualifiedSchema} from './types';
+import type {DbSchemaNode, SchemaWithTables} from './types';
 
 /**
  * Build a tree of databases → schemas → tables → columns from the grouped schema list.
@@ -9,7 +9,7 @@ import type {DbSchemaNode, QualifiedSchema} from './types';
  * @returns An array of database nodes
  */
 export function createDbSchemaTrees(
-  schemas: QualifiedSchema[],
+  schemas: SchemaWithTables[],
 ): DbSchemaNode[] {
   const databaseMap = new Map<string, Map<string, DbSchemaNode[]>>();
 

--- a/packages/duckdb-core/src/schema-tree/types.ts
+++ b/packages/duckdb-core/src/schema-tree/types.ts
@@ -36,7 +36,7 @@ export type DatabaseNodeObject = BaseNodeObject & {
   type: 'database';
 };
 
-export type QualifiedSchema = {
+export type SchemaWithTables = {
   database: string;
   schema: string;
   tables: DataTable[];

--- a/packages/duckdb/README.md
+++ b/packages/duckdb/README.md
@@ -236,6 +236,27 @@ function QualifiedTableOps() {
 }
 ```
 
+### Loading the Schema Catalog
+
+Use `loadSchemaCatalog()` when you need the database/schema/table hierarchy,
+including empty schemas and attached databases whose `main` schema has no
+tables yet. The catalog filter receives typed entries for databases, schemas,
+and tables, so schema visibility does not depend on fake table names.
+
+```ts
+import {
+  defaultLoadSchemaCatalogFilter,
+  loadSchemaCatalog,
+} from '@sqlrooms/duckdb';
+
+const catalog = await loadSchemaCatalog(connector, {
+  filterFunction: (entry) =>
+    entry.type === 'schema' && entry.schema === 'scratch'
+      ? false
+      : defaultLoadSchemaCatalogFilter(entry),
+});
+```
+
 ## Loading Data from Files
 
 ### Using Load Functions Directly

--- a/packages/duckdb/__tests__/DuckDbSlice.test.ts
+++ b/packages/duckdb/__tests__/DuckDbSlice.test.ts
@@ -1,8 +1,14 @@
 import {createStore} from 'zustand';
 import {createNodeDuckDbConnector} from '@sqlrooms/duckdb-node';
-import {createDuckDbSlice, DuckDbSliceState} from '../src/DuckDbSlice';
+import {
+  createDuckDbSlice,
+  defaultLoadSchemaCatalogFilter,
+  DuckDbSliceState,
+} from '../src/DuckDbSlice';
 import {createBaseRoomSlice, BaseRoomStoreState} from '@sqlrooms/room-store';
 import * as arrow from 'apache-arrow';
+import {DuckDbConnector} from '@sqlrooms/duckdb-core';
+import {loadSchemaCatalog} from '../src/loadTableSchemas';
 
 type TestStoreState = BaseRoomStoreState & DuckDbSliceState;
 
@@ -266,6 +272,109 @@ describe('DuckDbSlice', () => {
 
       expect(rows.length).toBe(1);
       expect(rows[0]?.table_name).toBe('schema_test1');
+    });
+  });
+
+  describe('loadSchemaCatalog', () => {
+    it('should preserve empty schemas and empty attached database main schemas', async () => {
+      const connector = await store.getState().db.getConnector();
+
+      await connector.query('CREATE SCHEMA empty_schema');
+      await connector.query("ATTACH ':memory:' AS attached_empty");
+      await connector.query('CREATE TABLE main.visible_table (id INT)');
+
+      const catalog = await loadSchemaCatalog(connector, {
+        filterFunction: defaultLoadSchemaCatalogFilter,
+      });
+
+      expect(
+        catalog.find(
+          (entry) =>
+            entry.database === 'memory' && entry.schema === 'empty_schema',
+        ),
+      ).toEqual({database: 'memory', schema: 'empty_schema', tables: []});
+
+      expect(
+        catalog.find(
+          (entry) =>
+            entry.database === 'attached_empty' && entry.schema === 'main',
+        ),
+      ).toEqual({database: 'attached_empty', schema: 'main', tables: []});
+
+      expect(
+        catalog
+          .find(
+            (entry) => entry.database === 'memory' && entry.schema === 'main',
+          )
+          ?.tables.map((table) => table.tableName),
+      ).toContain('visible_table');
+    });
+
+    it('should hide the temp database catalog by default', async () => {
+      const connector = await store.getState().db.getConnector();
+
+      await connector.query('CREATE TEMP TABLE temp_table (id INT)');
+
+      const catalog = await loadSchemaCatalog(connector, {
+        filterFunction: defaultLoadSchemaCatalogFilter,
+      });
+
+      expect(catalog.some((entry) => entry.database === 'temp')).toBe(false);
+    });
+
+    it('should keep schemas when a table catalog filter removes their tables', async () => {
+      const connector = await store.getState().db.getConnector();
+
+      await connector.query('CREATE SCHEMA filtered_schema');
+      await connector.query(
+        'CREATE TABLE filtered_schema.hidden_table (id INT)',
+      );
+
+      const catalog = await loadSchemaCatalog(connector, {
+        filterFunction: (entry) =>
+          entry.type === 'table'
+            ? entry.table.table !== 'hidden_table'
+            : defaultLoadSchemaCatalogFilter(entry),
+      });
+
+      expect(
+        catalog.find(
+          (entry) =>
+            entry.database === 'memory' && entry.schema === 'filtered_schema',
+        ),
+      ).toEqual({database: 'memory', schema: 'filtered_schema', tables: []});
+    });
+  });
+
+  describe('refreshTableSchemas', () => {
+    it('should issue a single catalog metadata query per refresh', async () => {
+      const connector = createNodeDuckDbConnector({dbPath: ':memory:'});
+      const querySql: string[] = [];
+      const countedConnector: DuckDbConnector = {
+        ...connector,
+        query(sql, options) {
+          querySql.push(sql);
+          return connector.query(sql, options);
+        },
+      };
+      const countedStore = createStore<TestStoreState>()((...args) => ({
+        ...createBaseRoomSlice()(...args),
+        ...createDuckDbSlice({connector: countedConnector})(...args),
+      }));
+
+      try {
+        await countedStore.getState().db.initialize();
+        await countedStore.getState().db.refreshTableSchemas();
+        querySql.length = 0;
+
+        await countedStore.getState().db.refreshTableSchemas();
+
+        expect(querySql).toHaveLength(2);
+        expect(querySql[0]).toContain('current_schema()');
+        expect(querySql[1]).toContain('FROM duckdb_schemas()');
+      } finally {
+        await countedStore.getState().db.destroy();
+      }
     });
   });
 

--- a/packages/duckdb/src/DuckDbSlice.ts
+++ b/packages/duckdb/src/DuckDbSlice.ts
@@ -10,7 +10,7 @@ import {
   makeQualifiedTableName,
   QualifiedTableName,
   QueryHandle,
-  QualifiedSchema,
+  SchemaWithTables,
   separateLastStatement,
 } from '@sqlrooms/duckdb-core';
 import {
@@ -28,7 +28,8 @@ import {z} from 'zod';
 import {StateCreator} from 'zustand';
 import {createWasmDuckDbConnector} from './connectors/createDuckDbConnector';
 import {
-  loadSchemasWithTables,
+  loadSchemaCatalog,
+  LoadSchemaCatalogFilterFunction,
   loadTableSchemas,
   LoadTableSchemasFilter,
   LoadTableSchemasFilterFunction,
@@ -68,6 +69,30 @@ export const defaultLoadTableSchemasFilter: LoadTableSchemasFilterFunction = (
 export function createDefaultLoadTableSchemasFilter(): LoadTableSchemasFilterFunction {
   return defaultLoadTableSchemasFilter;
 }
+
+/**
+ * Default catalog visibility predicate for the data source panel.
+ * Hides SQLRooms internal objects and DuckDB's temporary database catalog.
+ */
+export const defaultLoadSchemaCatalogFilter: LoadSchemaCatalogFilterFunction = (
+  entry,
+): boolean => {
+  switch (entry.type) {
+    case 'database':
+      return (
+        !entry.database.startsWith(INTERNAL_SQLROOMS_PREFIX) &&
+        entry.database !== DUCKDB_TEMP_DATABASE
+      );
+    case 'schema':
+      return (
+        !entry.database.startsWith(INTERNAL_SQLROOMS_PREFIX) &&
+        entry.database !== DUCKDB_TEMP_DATABASE &&
+        !entry.schema.startsWith(INTERNAL_SQLROOMS_PREFIX)
+      );
+    case 'table':
+      return defaultLoadTableSchemasFilter(entry.table);
+  }
+};
 
 const DropTableCommandInput = z.object({
   tableName: z.string().describe('Name of the table to drop.'),
@@ -323,10 +348,16 @@ export type DuckDbSliceState = {
 export type CreateDuckDbSliceProps = {
   connector?: DuckDbConnector;
   /**
-   * Optional filter for which tables/schemas/databases appear in the data source panel.
-   * Defaults to {@link createDefaultLoadTableSchemasFilter} (hides `__sqlrooms_*` and the DuckDB `temp` database).
+   * Optional table visibility filter.
+   * Defaults to {@link createDefaultLoadTableSchemasFilter}.
    */
   loadTableSchemasFilter?: LoadTableSchemasFilterFunction | null;
+  /**
+   * Optional catalog visibility filter for the data source panel.
+   * Defaults to {@link defaultLoadSchemaCatalogFilter}. When omitted, custom
+   * table filters still apply to table entries while schemas/databases use the default.
+   */
+  loadSchemaCatalogFilter?: LoadSchemaCatalogFilterFunction | null;
 };
 
 /**
@@ -335,9 +366,22 @@ export type CreateDuckDbSliceProps = {
 export function createDuckDbSlice({
   connector = createWasmDuckDbConnector(),
   loadTableSchemasFilter = defaultLoadTableSchemasFilter,
+  loadSchemaCatalogFilter,
 }: CreateDuckDbSliceProps = {}): StateCreator<DuckDbSliceState> {
   let refreshPromise: Promise<DataTable[]> | null = null;
   let pendingSchemaRefresh = false;
+  const effectiveSchemaCatalogFilter =
+    loadSchemaCatalogFilter ??
+    (loadTableSchemasFilter === null
+      ? null
+      : (((entry) => {
+          if (entry.type === 'table') {
+            return loadTableSchemasFilter
+              ? loadTableSchemasFilter(entry.table)
+              : true;
+          }
+          return defaultLoadSchemaCatalogFilter(entry);
+        }) satisfies LoadSchemaCatalogFilterFunction));
   return createSlice<DuckDbSliceState, BaseRoomStoreState & DuckDbSliceState>(
     (set, get, store) => {
       /**
@@ -673,7 +717,7 @@ export function createDuckDbSlice({
             );
             refreshPromise = (async () => {
               try {
-                let schemasWithTables: QualifiedSchema[] = [];
+                let schemasWithTables: SchemaWithTables[] = [];
                 do {
                   pendingSchemaRefresh = false;
                   const connector = await get().db.getConnector();
@@ -690,10 +734,9 @@ export function createDuckDbSlice({
                         ?.get(0);
                     }),
                   );
-                  schemasWithTables = await loadSchemasWithTables(
-                    connector,
-                    loadTableSchemasFilter ?? undefined,
-                  );
+                  schemasWithTables = await loadSchemaCatalog(connector, {
+                    filterFunction: effectiveSchemaCatalogFilter,
+                  });
                 } while (pendingSchemaRefresh);
 
                 const newTables = schemasWithTables.flatMap((s) => s.tables);

--- a/packages/duckdb/src/index.ts
+++ b/packages/duckdb/src/index.ts
@@ -31,14 +31,17 @@ export {
   createDuckDbSlice,
   useStoreWithDuckDb,
   createDefaultLoadTableSchemasFilter,
+  defaultLoadSchemaCatalogFilter,
   defaultLoadTableSchemasFilter,
   type CreateDuckDbSliceProps,
   type DuckDbSliceState,
 } from './DuckDbSlice';
 
 export {
+  loadSchemaCatalog,
+  type LoadSchemaCatalogFilterFunction,
+  type SchemaCatalogFilterEntry,
   type LoadTableSchemasFilter,
-  loadSchemasWithTables,
 } from './loadTableSchemas';
 
 export {useExportToCsv, type UseExportToCsvReturn} from './use-export-to-csv';
@@ -104,7 +107,7 @@ export {
   type QueryHandle,
   type QueryOptions,
   type SchemaNodeObject,
-  type QualifiedSchema,
+  type SchemaWithTables,
   type SeparatedStatements,
   type TableColumn,
   type TableNodeObject,

--- a/packages/duckdb/src/loadTableSchemas.ts
+++ b/packages/duckdb/src/loadTableSchemas.ts
@@ -4,7 +4,7 @@ import {
   escapeVal,
   makeQualifiedTableName,
   QualifiedTableName,
-  QualifiedSchema,
+  SchemaWithTables,
   TableColumn,
 } from '@sqlrooms/duckdb-core';
 
@@ -20,6 +20,19 @@ export type LoadTableSchemasFilter = {
 
 export type LoadTableSchemasOptions = LoadTableSchemasFilter & {
   filterFunction?: LoadTableSchemasFilterFunction | null;
+};
+
+export type SchemaCatalogFilterEntry =
+  | {type: 'database'; database: string}
+  | {type: 'schema'; database: string; schema: string}
+  | {type: 'table'; table: QualifiedTableName};
+
+export type LoadSchemaCatalogFilterFunction = (
+  entry: SchemaCatalogFilterEntry,
+) => boolean;
+
+export type LoadSchemaCatalogOptions = LoadTableSchemasFilter & {
+  filterFunction?: LoadSchemaCatalogFilterFunction | null;
 };
 
 /**
@@ -50,85 +63,56 @@ export async function loadTableSchemas(
 }
 
 /**
- * Load all schemas (including empty ones) grouped with their tables.
- *
- * If provided, `filter` is applied at two layers:
- * - schemas: invoked with a qualified name where `table === ''` (schemas with no
- *   tables are still surfaced this way)
- * - tables: invoked with the full qualified name as in `loadTableSchemas`
- *
- * @param connector - The DuckDB connector
- * @param filter - Optional visibility filter; omit or pass `null` to include everything
- * @returns Schemas grouped by database, each carrying their (filtered) tables
+ * Load the visible DuckDB schema catalog in one metadata query.
+ * Starts from schemas, then left-joins tables, views, and columns so empty
+ * schemas and empty attached database `main` schemas are preserved.
  */
-export async function loadSchemasWithTables(
+export async function loadSchemaCatalog(
   connector: DuckDbConnector,
-  filter?: LoadTableSchemasFilterFunction | null,
-): Promise<QualifiedSchema[]> {
-  const [tables, schemaRows] = await Promise.all([
-    loadTableSchemas(connector, {filterFunction: filter ?? undefined}),
-    queryAllSchemas(connector),
-  ]);
+  options: LoadSchemaCatalogOptions = {},
+): Promise<SchemaWithTables[]> {
+  const {filterFunction, ...filter} = options;
+  const result = await connector.query(buildSchemaCatalogQuery(filter));
+  const groups = new Map<string, SchemaWithTables>();
+  const includedDatabases = new Set<string>();
+  const keyOf = (database: string, schema: string) =>
+    `${database}\x00${schema}`;
 
-  const groups = new Map<string, QualifiedSchema>();
-  const keyOf = (database: string, schema: string) => `${database}\x00${schema}`;
+  for (let i = 0; i < result.numRows; i++) {
+    const database = String(result.getChild('database')?.get(i) ?? '').trim();
+    const schema = String(result.getChild('schema')?.get(i) ?? '').trim();
+    if (!database || !schema) continue;
 
-  for (const {database, schema} of schemaRows) {
-    if (filter) {
-      const shouldInclude = filter(
-        makeQualifiedTableName({database, schema, table: ''}),
-      );
-      if (!shouldInclude) continue;
+    if (!includedDatabases.has(database)) {
+      if (filterFunction?.({type: 'database', database}) === false) {
+        continue;
+      } else {
+        includedDatabases.add(database);
+      }
     }
-    const key = keyOf(database, schema);
-    if (!groups.has(key)) {
-      groups.set(key, {database, schema, tables: []});
-    }
-  }
 
-  for (const table of tables) {
-    const database = table.database || '';
-    const schema = table.schema || '';
+    if (filterFunction?.({type: 'schema', database, schema}) === false) {
+      continue;
+    }
+
     const key = keyOf(database, schema);
     let group = groups.get(key);
+
     if (!group) {
       group = {database, schema, tables: []};
       groups.set(key, group);
     }
-    group.tables.push(table);
+
+    const table = parseSchemaCatalogTableRow(result, i);
+    if (
+      table &&
+      (!filterFunction || filterFunction({type: 'table', table: table.table}))
+    ) {
+      group.tables.push(table);
+    }
   }
 
   return Array.from(groups.values());
-}
-
-async function queryAllSchemas(
-  connector: DuckDbConnector,
-): Promise<Array<{database: string; schema: string}>> {
-  const sql = `
-    SELECT DISTINCT
-      COALESCE(
-        NULLIF(CAST(database_name AS VARCHAR), ''),
-        current_database()
-      ) AS database,
-      CAST(schema_name AS VARCHAR) AS schema
-    FROM duckdb_schemas()
-    WHERE (database_name IS NULL OR database_name != 'system')
-      AND (internal = false OR CAST(schema_name AS VARCHAR) = 'main')
-      AND schema_name IS NOT NULL
-    ORDER BY 1, 2
-  `;
-  const result = await connector.query(sql);
-  const out: Array<{database: string; schema: string}> = [];
-  for (let i = 0; i < result.numRows; i++) {
-    const database = result.getChild('database')?.get(i);
-    const schema = result.getChild('schema')?.get(i);
-    if (schema == null || database == null) continue;
-    const schemaStr = String(schema).trim();
-    const databaseStr = String(database).trim();
-    if (schemaStr === '' || databaseStr === '') continue;
-    out.push({database: databaseStr, schema: schemaStr});
-  }
-  return out;
 }
 
 function isDuckDbPlaceholderViewColumn(
@@ -189,6 +173,15 @@ function parseTableSchemaRow(describeResults: any, index: number): DataTable {
   };
 }
 
+function parseSchemaCatalogTableRow(
+  result: any,
+  index: number,
+): DataTable | null {
+  const rowTable = result.getChild('name')?.get(index);
+  if (rowTable == null) return null;
+  return parseTableSchemaRow(result, index);
+}
+
 function buildMetadataWhereClause(
   nameColumn: string,
   filter: LoadTableSchemasFilter,
@@ -203,6 +196,80 @@ function buildMetadataWhereClause(
   ]
     .filter(Boolean)
     .join(' AND ');
+}
+
+function buildSchemaWhereClause(filter: LoadTableSchemasFilter): string {
+  const {schema, database} = filter;
+  return [
+    database
+      ? `database_name = ${escapeVal(database)}`
+      : `database_name != 'system'`,
+    schema ? `schema_name = ${escapeVal(schema)}` : 'schema_name IS NOT NULL',
+    `(internal = false OR schema_name = 'main')`,
+  ]
+    .filter(Boolean)
+    .join(' AND ');
+}
+
+function buildSchemaCatalogQuery(filter: LoadTableSchemasFilter): string {
+  const schemaWhereClause = buildSchemaWhereClause(filter);
+  const tableWhereClause = buildMetadataWhereClause('table_name', filter);
+  const viewWhereClause = buildMetadataWhereClause('view_name', filter);
+
+  return `WITH schemas AS (
+    FROM duckdb_schemas() SELECT DISTINCT
+      COALESCE(
+        NULLIF(CAST(database_name AS VARCHAR), ''),
+        current_database()
+      ) AS database,
+      CAST(schema_name AS VARCHAR) AS schema
+    WHERE ${schemaWhereClause}
+  ),
+  tables_and_views AS (
+    FROM duckdb_tables() SELECT
+      database_name AS database,
+      schema_name AS schema,
+      table_name AS name,
+      sql,
+      comment,
+      estimated_size,
+      FALSE AS isView
+    WHERE ${tableWhereClause}
+    UNION ALL
+    FROM duckdb_views() SELECT
+      database_name AS database,
+      schema_name AS schema,
+      view_name AS name,
+      sql,
+      comment,
+      NULL AS estimated_size,
+      TRUE AS isView
+    WHERE ${viewWhereClause}
+  ),
+  columns AS (
+    FROM duckdb_columns() SELECT
+      database_name AS database,
+      schema_name AS schema,
+      table_name AS name,
+      list(column_name ORDER BY column_index) AS column_names,
+      list(data_type ORDER BY column_index) AS column_types
+    WHERE ${tableWhereClause}
+    GROUP BY database_name, schema_name, table_name
+  )
+  SELECT
+    tables_and_views.isView AS isView,
+    schemas.database AS database,
+    schemas.schema AS schema,
+    tables_and_views.name AS name,
+    columns.column_names AS column_names,
+    columns.column_types AS column_types,
+    tables_and_views.sql AS sql,
+    tables_and_views.comment AS comment,
+    tables_and_views.estimated_size AS estimated_size
+  FROM schemas
+  LEFT JOIN tables_and_views USING (database, schema)
+  LEFT JOIN columns USING (database, schema, name)
+  ORDER BY schemas.database, schemas.schema, tables_and_views.isView, tables_and_views.name`;
 }
 
 /**

--- a/packages/ui/src/components/tree.tsx
+++ b/packages/ui/src/components/tree.tsx
@@ -48,12 +48,7 @@ function TreeNode<T>(props: TreeNodeProps<T>): React.ReactElement | null {
   const hasChildren = Boolean(children?.length);
   const [isOpen, setIsOpen] = useState(Boolean(treeData.isInitialOpen));
   if (!hasChildren) {
-    return (
-      <div className="flex w-full items-center space-x-1">
-        <div className="shrink-0" style={{width: '18px'}} />
-        {renderNode(treeData, isOpen)}
-      </div>
-    );
+    return <div className="pl-4">{renderNode(treeData, isOpen)}</div>;
   }
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>

--- a/packages/ui/src/components/tree.tsx
+++ b/packages/ui/src/components/tree.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import {Collapsible, CollapsibleContent} from '@radix-ui/react-collapsible';
-import React, {useState} from 'react';
+import { Collapsible, CollapsibleContent } from '@radix-ui/react-collapsible';
+import React, { useState } from 'react';
 
-import {ChevronRightIcon} from 'lucide-react';
-import {cn} from '../lib/utils';
-import {CollapsibleTrigger} from './collapsible';
+import { ChevronRightIcon } from 'lucide-react';
+import { cn } from '../lib/utils';
+import { CollapsibleTrigger } from './collapsible';
 
 export type TreeNodeData<T> = {
   key: string;
@@ -26,7 +26,7 @@ type TreeProps<T> = {
  * @param renderNode - A function that renders a tree node.
  */
 export function Tree<T>(props: TreeProps<T>): React.ReactElement {
-  const {className, treeData, renderNode} = props;
+  const { className, treeData, renderNode } = props;
   return (
     <div className={cn('flex flex-col', className)}>
       <TreeNode<T> treeData={treeData} renderNode={renderNode} />
@@ -43,12 +43,17 @@ type TreeNodeProps<T> = {
  * Component that renders a tree node.
  */
 function TreeNode<T>(props: TreeNodeProps<T>): React.ReactElement | null {
-  const {treeData, renderNode} = props;
-  const {children} = treeData;
+  const { treeData, renderNode } = props;
+  const { children } = treeData;
   const hasChildren = Boolean(children?.length);
   const [isOpen, setIsOpen] = useState(Boolean(treeData.isInitialOpen));
   if (!hasChildren) {
-    return <div className="pl-4">{renderNode(treeData, isOpen)}</div>;
+    return (
+      <div className="flex w-full items-center space-x-1">
+        <div className="shrink-0" style={{ width: '18px' }} />
+        {renderNode(treeData, isOpen)}
+      </div>
+    );
   }
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>
@@ -66,12 +71,12 @@ function TreeNode<T>(props: TreeNodeProps<T>): React.ReactElement | null {
       <CollapsibleContent className="pl-4">
         {isOpen
           ? children?.map((child) => (
-              <TreeNode<T>
-                key={child.key}
-                treeData={child}
-                renderNode={renderNode}
-              />
-            ))
+            <TreeNode<T>
+              key={child.key}
+              treeData={child}
+              renderNode={renderNode}
+            />
+          ))
           : null}
       </CollapsibleContent>
     </Collapsible>


### PR DESCRIPTION
## Summary

This stacks on top of `feat/schema-tree-empty-schemas` and reshapes the implementation around an explicit schema catalog model.

- replaces the two-query `loadSchemasWithTables` path with `loadSchemaCatalog`, which starts from DuckDB schemas and left-joins tables/views/columns in one metadata query
- renames the grouped tree input from `QualifiedSchema` to `SchemaWithTables`
- adds a typed catalog visibility filter for database/schema/table entries, avoiding fake table names for schema filtering
- keeps custom table filters table-only by default, while allowing callers such as the CLI UI to hide full schemas through `loadSchemaCatalogFilter`
- reverts the generic `Tree` leaf-layout change so schema-tree-specific behavior does not affect every tree consumer
- documents `loadSchemaCatalog` and adds integration coverage for empty schemas, empty attached DBs, temp hiding, table-filtered schemas, and refresh query count

## Validation

- `pnpm build`
- `CI=true pnpm --filter @sqlrooms/duckdb test -- DuckDbSlice`
- `pnpm --filter @sqlrooms/duckdb-core test -- schemaTree`
- pre-push hook: `knip`, full `turbo typecheck`, full `turbo test`