### PR TITLE
feat: Adding forceMount option to TabsLayout

### DIFF
--- a/apps/sqlrooms-cli-ui/src/workspace/ArtifactsContainerPanel.tsx
+++ b/apps/sqlrooms-cli-ui/src/workspace/ArtifactsContainerPanel.tsx
@@ -41,6 +41,7 @@ export const ArtifactsContainerPanel: RoomPanelComponent = () => {
       panelKey="artifact"
       closeable={true}
       preventCloseLastTab={false}
+      forceMountContent
       dndMode="shared"
       dndScopeId="cli-artifact-tabs"
       renderTabMenu={(tab) => (

--- a/packages/artifacts/README.md
+++ b/packages/artifacts/README.md
@@ -96,6 +96,8 @@ removes the artifact registry entry.
   descriptors, open tab ids, selected id, and handlers.
 - `ArtifactTabs` is a compound component over `TabStrip` and
   `TabsLayout.TabContent`.
+- Pass `forceMountContent` to `ArtifactTabs` to keep visible artifact tab
+  panels mounted while hiding inactive panels.
 - `ArtifactTabs.useActions()` exposes the current tab adapter actions to custom
   subcomponents rendered under `ArtifactTabs`.
 - `createArtifactLayoutNode(artifactId, panelKey?)` creates a stable layout

--- a/packages/artifacts/src/artifactTabs.tsx
+++ b/packages/artifacts/src/artifactTabs.tsx
@@ -505,6 +505,12 @@ export type ArtifactTabsProps = Omit<
     ) => React.ReactNode;
     emptyContent?: React.ReactNode;
     content?: React.ReactNode;
+    /**
+     * Keep visible artifact tab panels mounted and hide inactive panels.
+     *
+     * Ignored when a custom `content` renderer is provided.
+     */
+    forceMountContent?: boolean;
     overlay?:
       | React.ReactNode
       | ((actions: UseArtifactTabsResult) => React.ReactNode);
@@ -519,6 +525,7 @@ function ArtifactTabsRoot({
   renderSearchItemActions,
   emptyContent,
   content,
+  forceMountContent = false,
   overlay,
   closeable = true,
   preventCloseLastTab = false,
@@ -575,7 +582,7 @@ function ArtifactTabsRoot({
         )}
       </TabStrip>
       <TabsLayout.TabContentContainer>
-        {content ?? <TabsLayout.TabContent />}
+        {content ?? <TabsLayout.TabContent forceMount={forceMountContent} />}
         {artifactTabs.tabs.length === 0 ? emptyContent : null}
       </TabsLayout.TabContentContainer>
       {typeof overlay === 'function' ? overlay(artifactTabs) : overlay}

--- a/packages/layout/README.md
+++ b/packages/layout/README.md
@@ -87,6 +87,18 @@ createLayoutSlice({
 });
 ```
 
+## Tabs layout composition
+
+`TabsLayout.TabContent` accepts `forceMount` to keep all visible tab contents
+mounted while hiding inactive tabs. This is useful for expensive panels that
+should preserve local state or setup work during tab changes:
+
+```tsx
+<TabsLayout.TabContentContainer>
+  <TabsLayout.TabContent forceMount />
+</TabsLayout.TabContentContainer>
+```
+
 ## Area-based panel management
 
 Named `tabs` nodes (with an `id`) act as **areas** that can be managed programmatically:

--- a/packages/layout/src/index.ts
+++ b/packages/layout/src/index.ts
@@ -108,5 +108,6 @@ export {useExpandGridPanel} from './node-renderers/leaf-node-renderer/useExpandG
 export {useLeafLayoutPanelDraggable} from './node-renderers/leaf-node-renderer/LeafLayoutPanelDraggableContext';
 export {SplitLayout} from './node-renderers/split-node-renderer/SplitLayout';
 export {TabsLayout} from './node-renderers/tabs-node-renderer/TabsLayout';
+export type {TabsLayoutTabContentProps} from './node-renderers/tabs-node-renderer/TabsLayoutTabContent';
 export {DockLayout} from './node-renderers/dock-node-renderer/DockLayout';
 export {GridLayout} from './node-renderers/grid-node-renderer/GridLayout';

--- a/packages/layout/src/node-renderers/tabs-node-renderer/TabsLayoutTabContent.tsx
+++ b/packages/layout/src/node-renderers/tabs-node-renderer/TabsLayoutTabContent.tsx
@@ -17,7 +17,7 @@ export interface TabsLayoutTabContentProps {
 export const TabsLayoutTabContent: FC<TabsLayoutTabContentProps> = ({
   forceMount = false,
 }) => {
-  const {container, node, path} = useActiveTab();
+  const {node, path} = useActiveTab();
   const {node: tabsNode, path: tabsPath} = useTabsNodeContext();
   const renderNode = useRenderNode();
 
@@ -61,6 +61,6 @@ export const TabsLayoutTabContent: FC<TabsLayoutTabContentProps> = ({
     node,
     path,
     containerType: 'tabs',
-    containerId: container.id,
+    containerId: tabsNode.id,
   });
 };

--- a/packages/layout/src/node-renderers/tabs-node-renderer/TabsLayoutTabContent.tsx
+++ b/packages/layout/src/node-renderers/tabs-node-renderer/TabsLayoutTabContent.tsx
@@ -1,13 +1,60 @@
-import {FC} from 'react';
+import {getLayoutNodeId, getVisibleTabChildren} from '@sqlrooms/layout-config';
+import {FC, useMemo} from 'react';
 import {useRenderNode} from '../RenderNodeContext';
 import {useActiveTab} from './useActiveTab';
+import {useTabsNodeContext} from '../../LayoutNodeContext';
 
-export const TabsLayoutTabContent: FC = () => {
+export interface TabsLayoutTabContentProps {
+  /**
+   * Keep all visible tab contents mounted and hide inactive tabs.
+   *
+   * This is useful for expensive panels that should preserve their local state
+   * or setup work while the user switches between tabs.
+   */
+  forceMount?: boolean;
+}
+
+export const TabsLayoutTabContent: FC<TabsLayoutTabContentProps> = ({
+  forceMount = false,
+}) => {
   const {container, node, path} = useActiveTab();
+  const {node: tabsNode, path: tabsPath} = useTabsNodeContext();
   const renderNode = useRenderNode();
+
+  const visibleChildren = useMemo(
+    () => getVisibleTabChildren(tabsNode),
+    [tabsNode],
+  );
 
   if (!node || !path) {
     return null;
+  }
+
+  if (forceMount) {
+    return (
+      <>
+        {visibleChildren.map((child, index) => {
+          const childId = getLayoutNodeId(child);
+          const childPath = [...tabsPath, childId];
+          const isActive = index === tabsNode.activeTabIndex;
+
+          return (
+            <div
+              key={childId}
+              className="min-h-0 flex-1 flex-col overflow-hidden"
+              style={{display: isActive ? 'flex' : 'none'}}
+            >
+              {renderNode({
+                node: child,
+                path: childPath,
+                containerType: 'tabs',
+                containerId: tabsNode.id,
+              })}
+            </div>
+          );
+        })}
+      </>
+    );
   }
 
   return renderNode({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to keep visible tab panels mounted so inactive tabs stay in memory while only the active content is shown.
* **Documentation**
  * Updated docs and examples demonstrating how to enable and use the new tab content mounting behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sqlrooms/sqlrooms/pull/645?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->