### PR TITLE
feat: Add primary artifact run context tools

### DIFF
--- a/apps/sqlrooms-cli-ui/README.md
+++ b/apps/sqlrooms-cli-ui/README.md
@@ -67,3 +67,16 @@ Dashboard artifacts are created with either a `dock` or `grid` Mosaic dashboard
 layout. Explicit dashboard creation commands and AI tools require `layoutType`
 so the choice is made once at creation time; auto-created dashboards from chart
 or profiler flows use `grid`.
+
+## AI Artifact Context
+
+The assistant captures selected artifact context at run start. The first
+selected item is the primary context artifact unless the run context carries an
+explicit `primaryItemId`.
+
+Direct AI tools can list and read context artifacts with
+`list_context_artifacts` and `read_context_artifact`. Mutating tools should pass
+an explicit `artifactId`; if omitted, dashboard chart tools only use an
+unambiguous primary dashboard. Reference artifacts are not implicit mutation
+targets. `set_primary_context_artifact` updates the current run and session
+context when the assistant creates or switches to a new primary artifact.

--- a/apps/sqlrooms-cli-ui/src/createArtifactContextAiTools.ts
+++ b/apps/sqlrooms-cli-ui/src/createArtifactContextAiTools.ts
@@ -1,0 +1,290 @@
+import {
+  getAiRunContextItems,
+  getAiRunContextPrimaryItem,
+  setAiRunContextPrimaryItem,
+  type AiRunContext,
+  type AiRunContextItem,
+  type AiToolExecutionContext,
+} from '@sqlrooms/ai';
+import {tool} from 'ai';
+import {z} from 'zod';
+import type {StoreApi} from 'zustand';
+import type {RoomState} from './store-types';
+
+const EmptyInput = z.object({});
+
+const ReadContextArtifactInput = z
+  .object({
+    artifactId: z
+      .string()
+      .optional()
+      .describe('Context artifact ID. Defaults to the primary context artifact.'),
+  });
+
+const SetPrimaryContextArtifactInput = z.object({
+  artifactId: z.string().describe('Artifact ID to make primary for this run.'),
+});
+
+type ContextArtifactRole = 'primary' | 'reference';
+
+function getExecutionRunContext(
+  state: RoomState,
+  context?: AiToolExecutionContext,
+): AiRunContext | undefined {
+  return (
+    context?.getAiRunContext?.() ??
+    context?.aiRunContext ??
+    state.ai.getCurrentSession()?.runContext
+  );
+}
+
+function artifactToContextItem(
+  state: RoomState,
+  artifactId: string,
+): AiRunContextItem | undefined {
+  const artifact = state.artifacts.config.artifactsById[artifactId];
+  if (!artifact) return undefined;
+  return {
+    kind: 'artifact',
+    id: artifact.id,
+    type: artifact.type,
+    title: artifact.title,
+  };
+}
+
+function contextArtifactSummary(
+  state: RoomState,
+  item: AiRunContextItem,
+  primaryItemId: string | undefined,
+) {
+  const artifact = state.artifacts.config.artifactsById[item.id];
+  return {
+    kind: item.kind,
+    artifactId: item.id,
+    id: item.id,
+    title: artifact?.title ?? item.title,
+    type: artifact?.type ?? item.type,
+    role:
+      item.id === primaryItemId
+        ? ('primary' as ContextArtifactRole)
+        : ('reference' as ContextArtifactRole),
+    missing: !artifact,
+    ...(item.subtitle ? {subtitle: item.subtitle} : {}),
+  };
+}
+
+function readArtifactPayload(state: RoomState, artifactId: string) {
+  const artifact = state.artifacts.config.artifactsById[artifactId];
+  if (!artifact) {
+    return {
+      success: false,
+      errorMessage: `Unknown artifact "${artifactId}".`,
+    };
+  }
+
+  if (artifact.type === 'document') {
+    const document = state.documents.getDocument(artifactId);
+    return {
+      success: true,
+      artifact: {
+        artifactId,
+        title: artifact.title,
+        type: artifact.type,
+      },
+      payload: {
+        kind: 'document',
+        markdown: document?.markdown ?? '',
+        assets: Object.values(document?.assets ?? {}).map((asset) => ({
+          id: asset.id,
+          filename: asset.filename,
+          mediaType: asset.mediaType,
+          encoding: asset.encoding,
+          alt: asset.alt,
+          title: asset.title,
+          createdAt: asset.createdAt,
+          updatedAt: asset.updatedAt,
+        })),
+        updatedAt: document?.updatedAt,
+      },
+    };
+  }
+
+  if (artifact.type === 'dashboard') {
+    state.dashboard.ensureDashboardArtifact(artifactId);
+    const dashboard = state.mosaicDashboard.getDashboard(artifactId);
+    return {
+      success: true,
+      artifact: {
+        artifactId,
+        title: artifact.title,
+        type: artifact.type,
+      },
+      payload: {
+        kind: 'dashboard',
+        layoutType: dashboard?.layoutType,
+        selectedTable: dashboard?.selectedTable,
+        panelCount: dashboard?.panels.length ?? 0,
+        panels: (dashboard?.panels ?? []).map((panel) => ({
+          id: panel.id,
+          type: panel.type,
+          title: panel.title,
+          source: panel.source,
+          config: panel.config,
+        })),
+      },
+    };
+  }
+
+  return {
+    success: true,
+    artifact: {
+      artifactId,
+      title: artifact.title,
+      type: artifact.type,
+    },
+    payload: {
+      kind: 'metadata-only',
+      unsupportedPayload: true,
+      details:
+        'This artifact type is available as context, but read_context_artifact only returns full payloads for document and dashboard artifacts in v1.',
+    },
+  };
+}
+
+function setPrimaryArtifact(
+  state: RoomState,
+  context: AiToolExecutionContext | undefined,
+  artifactId: string,
+) {
+  const item = artifactToContextItem(state, artifactId);
+  if (!item) {
+    return {
+      success: false,
+      errorMessage: `Unknown artifact "${artifactId}".`,
+    };
+  }
+
+  const runContext = getExecutionRunContext(state, context);
+  const nextContext = setAiRunContextPrimaryItem(runContext, item);
+  if (context?.setAiRunContext) {
+    context.setAiRunContext(nextContext);
+  } else if (context?.setPrimaryRunContextItem) {
+    context.setPrimaryRunContextItem(item);
+  } else {
+    const sessionId = context?.sessionId ?? state.ai.getCurrentSession()?.id;
+    if (sessionId) {
+      state.ai.setSessionRunContext(sessionId, nextContext);
+    }
+  }
+
+  state.setAiContextItemIds(
+    getAiRunContextItems(nextContext)
+      .filter((contextItem) => contextItem.kind === 'artifact')
+      .map((contextItem) => contextItem.id),
+    'manual',
+  );
+
+  return {
+    success: true,
+    context: nextContext,
+    item,
+  };
+}
+
+export function makeArtifactPrimaryForAiRun(
+  store: StoreApi<RoomState>,
+  artifactId: string,
+  context?: AiToolExecutionContext,
+) {
+  return setPrimaryArtifact(store.getState(), context, artifactId);
+}
+
+export function createArtifactContextAiTools(store: StoreApi<RoomState>) {
+  return {
+    list_context_artifacts: tool({
+      description:
+        'List artifacts that the user added to the current AI run context, including which artifact is primary.',
+      inputSchema: EmptyInput,
+      execute: async (_params, options) => {
+        const context = options as AiToolExecutionContext | undefined;
+        const state = store.getState();
+        const runContext = getExecutionRunContext(state, context);
+        const primaryItem = getAiRunContextPrimaryItem(runContext);
+        const artifacts = getAiRunContextItems(runContext)
+          .filter((item) => item.kind === 'artifact')
+          .map((item) =>
+            contextArtifactSummary(state, item, primaryItem?.id),
+          );
+
+        return {
+          llmResult: {
+            success: true,
+            primaryArtifactId: primaryItem?.id,
+            artifacts,
+            details: `Found ${artifacts.length} context artifact${artifacts.length === 1 ? '' : 's'}.`,
+          },
+        };
+      },
+    }),
+    read_context_artifact: tool({
+      description:
+        'Read one artifact from the current AI run context. Defaults to the primary artifact. Use list_context_artifacts first when unsure.',
+      inputSchema: ReadContextArtifactInput,
+      execute: async (params, options) => {
+        const context = options as AiToolExecutionContext | undefined;
+        const state = store.getState();
+        const runContext = getExecutionRunContext(state, context);
+        const items = getAiRunContextItems(runContext).filter(
+          (item) => item.kind === 'artifact',
+        );
+        const requestedArtifactId =
+          params.artifactId ?? getAiRunContextPrimaryItem(runContext)?.id;
+        if (!requestedArtifactId) {
+          return {
+            llmResult: {
+              success: false,
+              errorMessage:
+                'No context artifact is available. Add an artifact to context or provide one with set_primary_context_artifact first.',
+            },
+          };
+        }
+        if (!items.some((item) => item.id === requestedArtifactId)) {
+          return {
+            llmResult: {
+              success: false,
+              errorMessage: `Artifact "${requestedArtifactId}" is not in the current run context. Use set_primary_context_artifact before reading it as context.`,
+            },
+          };
+        }
+
+        return {
+          llmResult: readArtifactPayload(state, requestedArtifactId),
+        };
+      },
+    }),
+    set_primary_context_artifact: tool({
+      description:
+        'Make an existing artifact the primary artifact for this AI run. Use after creating a new artifact or when the user asks to work on a specific artifact.',
+      inputSchema: SetPrimaryContextArtifactInput,
+      execute: async (params, options) => {
+        const context = options as AiToolExecutionContext | undefined;
+        const state = store.getState();
+        const result = setPrimaryArtifact(state, context, params.artifactId);
+        if (!result.success || !result.item || !result.context) {
+          return {
+            llmResult: result,
+          };
+        }
+
+        return {
+          llmResult: {
+            success: true,
+            primaryArtifactId: result.item.id,
+            contextItems: getAiRunContextItems(result.context),
+            details: `Set artifact "${result.item.title}" (${result.item.id}) as the primary context artifact.`,
+          },
+        };
+      },
+    }),
+  };
+}

--- a/apps/sqlrooms-cli-ui/src/createArtifactContextAiTools.ts
+++ b/apps/sqlrooms-cli-ui/src/createArtifactContextAiTools.ts
@@ -1,83 +1,23 @@
 import {
-  getAiRunContextItems,
-  getAiRunContextPrimaryItem,
-  setAiRunContextPrimaryItem,
-  type AiRunContext,
-  type AiRunContextItem,
-  type AiToolExecutionContext,
-} from '@sqlrooms/ai';
-import {tool} from 'ai';
-import {z} from 'zod';
+  createArtifactContextAiTools as createReusableArtifactContextAiTools,
+  makeArtifactPrimaryForAiRun as makeReusableArtifactPrimaryForAiRun,
+  type ArtifactContextToolExecutionContext,
+  type ArtifactContextToolsOptions,
+} from '@sqlrooms/artifacts/ai';
 import type {StoreApi} from 'zustand';
 import type {RoomState} from './store-types';
 
-const EmptyInput = z.object({});
-
-const ReadContextArtifactInput = z
-  .object({
-    artifactId: z
-      .string()
-      .optional()
-      .describe('Context artifact ID. Defaults to the primary context artifact.'),
-  });
-
-const SetPrimaryContextArtifactInput = z.object({
-  artifactId: z.string().describe('Artifact ID to make primary for this run.'),
-});
-
-type ContextArtifactRole = 'primary' | 'reference';
-
-function getExecutionRunContext(
-  state: RoomState,
-  context?: AiToolExecutionContext,
-): AiRunContext | undefined {
-  return (
-    context?.getAiRunContext?.() ??
-    context?.aiRunContext ??
-    state.ai.getCurrentSession()?.runContext
-  );
-}
-
-function artifactToContextItem(
-  state: RoomState,
-  artifactId: string,
-): AiRunContextItem | undefined {
-  const artifact = state.artifacts.config.artifactsById[artifactId];
-  if (!artifact) return undefined;
-  return {
-    kind: 'artifact',
-    id: artifact.id,
-    type: artifact.type,
-    title: artifact.title,
-  };
-}
-
-function contextArtifactSummary(
-  state: RoomState,
-  item: AiRunContextItem,
-  primaryItemId: string | undefined,
-) {
-  const artifact = state.artifacts.config.artifactsById[item.id];
-  return {
-    kind: item.kind,
-    artifactId: item.id,
-    id: item.id,
-    title: artifact?.title ?? item.title,
-    type: artifact?.type ?? item.type,
-    role:
-      item.id === primaryItemId
-        ? ('primary' as ContextArtifactRole)
-        : ('reference' as ContextArtifactRole),
-    missing: !artifact,
-    ...(item.subtitle ? {subtitle: item.subtitle} : {}),
-  };
-}
-
-function readArtifactPayload(state: RoomState, artifactId: string) {
+function readCliArtifact({
+  state,
+  artifactId,
+}: {
+  state: RoomState;
+  artifactId: string;
+}) {
   const artifact = state.artifacts.config.artifactsById[artifactId];
   if (!artifact) {
     return {
-      success: false,
+      success: false as const,
       errorMessage: `Unknown artifact "${artifactId}".`,
     };
   }
@@ -85,7 +25,7 @@ function readArtifactPayload(state: RoomState, artifactId: string) {
   if (artifact.type === 'document') {
     const document = state.documents.getDocument(artifactId);
     return {
-      success: true,
+      success: true as const,
       artifact: {
         artifactId,
         title: artifact.title,
@@ -113,7 +53,7 @@ function readArtifactPayload(state: RoomState, artifactId: string) {
     state.dashboard.ensureDashboardArtifact(artifactId);
     const dashboard = state.mosaicDashboard.getDashboard(artifactId);
     return {
-      success: true,
+      success: true as const,
       artifact: {
         artifactId,
         title: artifact.title,
@@ -136,7 +76,7 @@ function readArtifactPayload(state: RoomState, artifactId: string) {
   }
 
   return {
-    success: true,
+    success: true as const,
     artifact: {
       artifactId,
       title: artifact.title,
@@ -151,140 +91,45 @@ function readArtifactPayload(state: RoomState, artifactId: string) {
   };
 }
 
-function setPrimaryArtifact(
-  state: RoomState,
-  context: AiToolExecutionContext | undefined,
-  artifactId: string,
-) {
-  const item = artifactToContextItem(state, artifactId);
-  if (!item) {
-    return {
-      success: false,
-      errorMessage: `Unknown artifact "${artifactId}".`,
-    };
-  }
-
-  const runContext = getExecutionRunContext(state, context);
-  const nextContext = setAiRunContextPrimaryItem(runContext, item);
-  if (context?.setAiRunContext) {
-    context.setAiRunContext(nextContext);
-  } else if (context?.setPrimaryRunContextItem) {
-    context.setPrimaryRunContextItem(item);
-  } else {
-    const sessionId = context?.sessionId ?? state.ai.getCurrentSession()?.id;
-    if (sessionId) {
-      state.ai.setSessionRunContext(sessionId, nextContext);
-    }
-  }
-
-  state.setAiContextItemIds(
-    getAiRunContextItems(nextContext)
-      .filter((contextItem) => contextItem.kind === 'artifact')
-      .map((contextItem) => contextItem.id),
-    'manual',
-  );
-
+function createArtifactContextOptions(
+  store: StoreApi<RoomState>,
+): ArtifactContextToolsOptions<RoomState> {
   return {
-    success: true,
-    context: nextContext,
-    item,
+    store,
+    getRunContext: ({state}) => state.ai.getCurrentSession()?.runContext,
+    setRunContext: ({state, context, runContext}) => {
+      const sessionId = context?.sessionId ?? state.ai.getCurrentSession()?.id;
+      if (sessionId) {
+        state.ai.setSessionRunContext(sessionId, runContext);
+      }
+    },
+    onContextItemsChanged: ({state, items}) => {
+      state.setAiContextItemIds(
+        items
+          .filter((item) => item.kind === 'artifact')
+          .map((item) => item.id),
+        'manual',
+      );
+    },
+    readArtifact: ({state, artifactId}) =>
+      readCliArtifact({state, artifactId}),
   };
 }
 
 export function makeArtifactPrimaryForAiRun(
   store: StoreApi<RoomState>,
   artifactId: string,
-  context?: AiToolExecutionContext,
+  context?: ArtifactContextToolExecutionContext,
 ) {
-  return setPrimaryArtifact(store.getState(), context, artifactId);
+  return makeReusableArtifactPrimaryForAiRun(
+    createArtifactContextOptions(store),
+    artifactId,
+    context,
+  );
 }
 
 export function createArtifactContextAiTools(store: StoreApi<RoomState>) {
-  return {
-    list_context_artifacts: tool({
-      description:
-        'List artifacts that the user added to the current AI run context, including which artifact is primary.',
-      inputSchema: EmptyInput,
-      execute: async (_params, options) => {
-        const context = options as AiToolExecutionContext | undefined;
-        const state = store.getState();
-        const runContext = getExecutionRunContext(state, context);
-        const primaryItem = getAiRunContextPrimaryItem(runContext);
-        const artifacts = getAiRunContextItems(runContext)
-          .filter((item) => item.kind === 'artifact')
-          .map((item) =>
-            contextArtifactSummary(state, item, primaryItem?.id),
-          );
-
-        return {
-          llmResult: {
-            success: true,
-            primaryArtifactId: primaryItem?.id,
-            artifacts,
-            details: `Found ${artifacts.length} context artifact${artifacts.length === 1 ? '' : 's'}.`,
-          },
-        };
-      },
-    }),
-    read_context_artifact: tool({
-      description:
-        'Read one artifact from the current AI run context. Defaults to the primary artifact. Use list_context_artifacts first when unsure.',
-      inputSchema: ReadContextArtifactInput,
-      execute: async (params, options) => {
-        const context = options as AiToolExecutionContext | undefined;
-        const state = store.getState();
-        const runContext = getExecutionRunContext(state, context);
-        const items = getAiRunContextItems(runContext).filter(
-          (item) => item.kind === 'artifact',
-        );
-        const requestedArtifactId =
-          params.artifactId ?? getAiRunContextPrimaryItem(runContext)?.id;
-        if (!requestedArtifactId) {
-          return {
-            llmResult: {
-              success: false,
-              errorMessage:
-                'No context artifact is available. Add an artifact to context or provide one with set_primary_context_artifact first.',
-            },
-          };
-        }
-        if (!items.some((item) => item.id === requestedArtifactId)) {
-          return {
-            llmResult: {
-              success: false,
-              errorMessage: `Artifact "${requestedArtifactId}" is not in the current run context. Use set_primary_context_artifact before reading it as context.`,
-            },
-          };
-        }
-
-        return {
-          llmResult: readArtifactPayload(state, requestedArtifactId),
-        };
-      },
-    }),
-    set_primary_context_artifact: tool({
-      description:
-        'Make an existing artifact the primary artifact for this AI run. Use after creating a new artifact or when the user asks to work on a specific artifact.',
-      inputSchema: SetPrimaryContextArtifactInput,
-      execute: async (params, options) => {
-        const context = options as AiToolExecutionContext | undefined;
-        const state = store.getState();
-        const result = setPrimaryArtifact(state, context, params.artifactId);
-        if (!result.success || !result.item || !result.context) {
-          return {
-            llmResult: result,
-          };
-        }
-
-        return {
-          llmResult: {
-            success: true,
-            primaryArtifactId: result.item.id,
-            contextItems: getAiRunContextItems(result.context),
-            details: `Set artifact "${result.item.title}" (${result.item.id}) as the primary context artifact.`,
-          },
-        };
-      },
-    }),
-  };
+  return createReusableArtifactContextAiTools(
+    createArtifactContextOptions(store),
+  );
 }

--- a/apps/sqlrooms-cli-ui/src/createArtifactContextAiTools.ts
+++ b/apps/sqlrooms-cli-ui/src/createArtifactContextAiTools.ts
@@ -94,11 +94,21 @@ function readCliArtifact({
 function createArtifactContextOptions(
   store: StoreApi<RoomState>,
 ): ArtifactContextToolsOptions<RoomState> {
+  const getContextSessionId = (
+    state: RoomState,
+    context?: ArtifactContextToolExecutionContext,
+  ) => context?.sessionId ?? state.ai.getCurrentSession()?.id;
+
   return {
     store,
-    getRunContext: ({state}) => state.ai.getCurrentSession()?.runContext,
+    getRunContext: ({state, context}) => {
+      const sessionId = getContextSessionId(state, context);
+      return sessionId
+        ? state.ai.getSessionRunContext(sessionId)
+        : state.ai.getCurrentSession()?.runContext;
+    },
     setRunContext: ({state, context, runContext}) => {
-      const sessionId = context?.sessionId ?? state.ai.getCurrentSession()?.id;
+      const sessionId = getContextSessionId(state, context);
       if (sessionId) {
         state.ai.setSessionRunContext(sessionId, runContext);
       }

--- a/apps/sqlrooms-cli-ui/src/createDashboardAiTools.ts
+++ b/apps/sqlrooms-cli-ui/src/createDashboardAiTools.ts
@@ -11,6 +11,8 @@ import {
 import {RoomState} from './store-types';
 import {StoreApi} from 'zustand';
 import {createDashboardToolDeps} from './createDashboardToolDeps';
+import {makeArtifactPrimaryForAiRun} from './createArtifactContextAiTools';
+import type {AiToolExecutionContext} from '@sqlrooms/ai';
 
 const DashboardCreateArtifactToolParameters = z.object({
   title: z.string().optional(),
@@ -62,7 +64,8 @@ export function createDashboardAiTools(store: StoreApi<RoomState>) {
       description:
         'Create a new dashboard artifact with a dock or grid layout and make it the active artifact. Use when no dashboard artifact exists yet.',
       inputSchema: DashboardCreateArtifactToolParameters,
-      execute: async (params: DashboardCreateArtifactToolParameters) => {
+      execute: async (params: DashboardCreateArtifactToolParameters, options) => {
+        const context = options as AiToolExecutionContext | undefined;
         const {title, layoutType} = params;
         const state = store.getState();
         const artifactId = state.dashboard.createDashboardArtifact(
@@ -70,6 +73,7 @@ export function createDashboardAiTools(store: StoreApi<RoomState>) {
           layoutType,
         );
         state.artifacts.setCurrentArtifact(artifactId);
+        makeArtifactPrimaryForAiRun(store, artifactId, context);
         return {
           llmResult: {
             success: true,

--- a/apps/sqlrooms-cli-ui/src/createDashboardToolDeps.ts
+++ b/apps/sqlrooms-cli-ui/src/createDashboardToolDeps.ts
@@ -17,6 +17,16 @@ function getMutableAiRunContext(context?: ChartToolExecutionContext) {
   );
 }
 
+function getMutableAiRunContext(context?: ChartToolExecutionContext) {
+  return (
+    (
+      context as
+        | (ChartToolExecutionContext & {getAiRunContext?: () => unknown})
+        | undefined
+    )?.getAiRunContext?.() ?? context?.aiRunContext
+  );
+}
+
 // Helper functions
 function getTablesWithColumns(state: RoomState): DataTable[] {
   return state.db.tables.filter(

--- a/apps/sqlrooms-cli-ui/src/createDashboardToolDeps.ts
+++ b/apps/sqlrooms-cli-ui/src/createDashboardToolDeps.ts
@@ -17,16 +17,6 @@ function getMutableAiRunContext(context?: ChartToolExecutionContext) {
   );
 }
 
-function getMutableAiRunContext(context?: ChartToolExecutionContext) {
-  return (
-    (
-      context as
-        | (ChartToolExecutionContext & {getAiRunContext?: () => unknown})
-        | undefined
-    )?.getAiRunContext?.() ?? context?.aiRunContext
-  );
-}
-
 // Helper functions
 function getTablesWithColumns(state: RoomState): DataTable[] {
   return state.db.tables.filter(

--- a/apps/sqlrooms-cli-ui/src/createDashboardToolDeps.ts
+++ b/apps/sqlrooms-cli-ui/src/createDashboardToolDeps.ts
@@ -5,7 +5,17 @@ import {
 } from '@sqlrooms/mosaic';
 import type {RoomState} from './store';
 import {DataTable} from '@sqlrooms/db';
-import {getAiRunContextItems} from '@sqlrooms/ai';
+import {getAiRunContextItems, getAiRunContextPrimaryItem} from '@sqlrooms/ai';
+
+function getMutableAiRunContext(context?: ChartToolExecutionContext) {
+  return (
+    (
+      context as
+        | (ChartToolExecutionContext & {getAiRunContext?: () => unknown})
+        | undefined
+    )?.getAiRunContext?.() ?? context?.aiRunContext
+  );
+}
 
 // Helper functions
 function getTablesWithColumns(state: RoomState): DataTable[] {
@@ -36,11 +46,12 @@ export function createDashboardToolDeps(store: {
     state: RoomState,
     context?: ChartToolExecutionContext,
   ) => {
-    const contextItems = getAiRunContextItems(context?.aiRunContext);
-    return contextItems.find((item) => {
-      const artifact = state.artifacts.config.artifactsById[item.id];
-      return artifact?.type === 'dashboard';
-    })?.id;
+    const primaryItem = getAiRunContextPrimaryItem(
+      getMutableAiRunContext(context),
+    );
+    if (!primaryItem) return undefined;
+    const artifact = state.artifacts.config.artifactsById[primaryItem.id];
+    return artifact?.type === 'dashboard' ? primaryItem.id : undefined;
   };
 
   const resolveArtifact = (
@@ -49,10 +60,23 @@ export function createDashboardToolDeps(store: {
     context?: ChartToolExecutionContext,
   ): string => {
     const state = store.getState();
+    const runContext = getMutableAiRunContext(context);
+    const hasRunContext = getAiRunContextItems(runContext).length > 0;
+    const runContextDashboardArtifactId = getRunContextDashboardArtifactId(
+      state,
+      context,
+    );
     let targetArtifactId =
       artifactId ??
-      getRunContextDashboardArtifactId(state, context) ??
-      state.dashboard.getCurrentDashboardArtifactId();
+      runContextDashboardArtifactId ??
+      (!hasRunContext
+        ? state.dashboard.getCurrentDashboardArtifactId()
+        : undefined);
+    if (!targetArtifactId && hasRunContext) {
+      throw new Error(
+        'No primary dashboard artifact is available in the current run context. Pass artifactId explicitly or use set_primary_context_artifact first.',
+      );
+    }
     if (!targetArtifactId && createIfMissing) {
       targetArtifactId = state.dashboard.createDashboardArtifact(
         undefined,

--- a/apps/sqlrooms-cli-ui/src/store.ts
+++ b/apps/sqlrooms-cli-ui/src/store.ts
@@ -2,6 +2,7 @@ import {ArtifactsSliceConfig, createArtifactsSlice} from '@sqlrooms/artifacts';
 import {
   AiSettingsSliceConfig,
   AiSliceConfig,
+  getAiRunContextPrimaryItem,
   getAiRunContextItems,
   createAiSettingsSlice,
   createAiSlice,
@@ -88,6 +89,7 @@ import {
   getDashboardAiInstructions,
 } from './createDashboardAiTools';
 import {dashboardAgentTool} from './createDashboardAgent';
+import {createArtifactContextAiTools} from './createArtifactContextAiTools';
 import {
   createDashboardCommands,
   DASHBOARD_COMMAND_OWNER,
@@ -312,11 +314,12 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
         )?.id;
       const getRunContextDashboardArtifactId = () => {
         const currentSession = get().ai.getCurrentSession();
-        const contextItems = getAiRunContextItems(currentSession?.runContext);
-        return contextItems.find((item) => {
-          const artifact = get().artifacts.config.artifactsById[item.id];
-          return artifact?.type === 'dashboard';
-        })?.id;
+        const primaryItem = getAiRunContextPrimaryItem(
+          currentSession?.runContext,
+        );
+        if (!primaryItem) return undefined;
+        const artifact = get().artifacts.config.artifactsById[primaryItem.id];
+        return artifact?.type === 'dashboard' ? primaryItem.id : undefined;
       };
 
       const dashboardSlice: RoomState['dashboard'] = {
@@ -598,6 +601,7 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
               if (items.length === 0) return undefined;
               return {
                 items,
+                primaryItemId: items[0]?.id,
                 capturedAt: Date.now(),
               } satisfies AiRunContext;
             },
@@ -606,21 +610,26 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
                 (item) => item.kind === 'artifact',
               );
               if (artifactItems.length === 0) return '';
-              const [mainItem, ...additionalItems] = artifactItems;
+              const mainItem =
+                getAiRunContextPrimaryItem(runContext) ?? artifactItems[0];
               if (!mainItem) return '';
+              const additionalItems = artifactItems.filter(
+                (item) => item.id !== mainItem.id,
+              );
               const artifactType = mainItem.type ?? 'artifact';
               return [
                 'Current artifact context:',
-                `- Main/default target: ${artifactType} "${mainItem.title}" (id: ${mainItem.id}). Tools use this artifact as the implicit target when the artifact type is supported.`,
+                `- Primary target: ${artifactType} "${mainItem.title}" (id: ${mainItem.id}). Pass this id as artifactId when using a tool that should modify it.`,
                 ...additionalItems.map(
                   (item) =>
                     `- Additional reference context: ${item.type ?? 'artifact'} "${item.title}" (id: ${item.id}).`,
                 ),
-                '- Additional context items are reference-only by default; tools will not implicitly target them.',
+                '- Additional context items are reference-only by default; tools will not implicitly target them. Use set_primary_context_artifact before modifying a reference artifact.',
               ].join('\n');
             },
             tools: {
               ...createDefaultAiTools(store, {query: {}}),
+              ...createArtifactContextAiTools(store),
               ...createDashboardAiTools(store),
               dashboard_agent: dashboardAgentTool(store),
               ...webContainerToolkit.tools,

--- a/packages/ai-config/src/index.ts
+++ b/packages/ai-config/src/index.ts
@@ -6,7 +6,9 @@ export {
   AnalysisSessionSchema,
   AnalysisResultSchema,
   ErrorMessageSchema,
+  getAiRunContextPrimaryItem,
   getAiRunContextItems,
+  setAiRunContextPrimaryItem,
 } from './schema/AnalysisSessionSchema';
 export type {
   AiRunContext,

--- a/packages/ai-config/src/schema/AnalysisSessionSchema.ts
+++ b/packages/ai-config/src/schema/AnalysisSessionSchema.ts
@@ -113,7 +113,7 @@ export function setAiRunContextPrimaryItem(
 ): AiRunContext {
   const parsedContext = AiRunContextSchema.safeParse(runContext);
   const baseContext = parsedContext.success ? parsedContext.data : undefined;
-  const existingItems = getAiRunContextItems(baseContext).filter(
+  const existingItems = getAiRunContextItems(runContext).filter(
     (existing) => !(existing.kind === item.kind && existing.id === item.id),
   );
 

--- a/packages/ai-config/src/schema/AnalysisSessionSchema.ts
+++ b/packages/ai-config/src/schema/AnalysisSessionSchema.ts
@@ -40,6 +40,7 @@ export type AiRunContextItem = z.infer<typeof AiRunContextItemSchema>;
 const AiRunContextBaseSchema = z
   .object({
     items: z.array(AiRunContextItemSchema),
+    primaryItemId: z.string().optional(),
     capturedAt: z.number(),
   })
   .passthrough();
@@ -85,6 +86,43 @@ export function getAiRunContextItems(
 
   const legacyResult = AiRunContextItemSchema.safeParse(runContext);
   return legacyResult.success ? [legacyResult.data] : [];
+}
+
+export function getAiRunContextPrimaryItem(
+  runContext: AiRunContext | unknown,
+): AiRunContextItem | undefined {
+  const items = getAiRunContextItems(runContext);
+  if (items.length === 0) return undefined;
+
+  const primaryItemId =
+    runContext &&
+    typeof runContext === 'object' &&
+    'primaryItemId' in runContext &&
+    typeof runContext.primaryItemId === 'string'
+      ? runContext.primaryItemId
+      : undefined;
+
+  return primaryItemId
+    ? items.find((item) => item.id === primaryItemId) ?? items[0]
+    : items[0];
+}
+
+export function setAiRunContextPrimaryItem(
+  runContext: AiRunContext | unknown,
+  item: AiRunContextItem,
+): AiRunContext {
+  const parsedContext = AiRunContextSchema.safeParse(runContext);
+  const baseContext = parsedContext.success ? parsedContext.data : undefined;
+  const existingItems = getAiRunContextItems(baseContext).filter(
+    (existing) => !(existing.kind === item.kind && existing.id === item.id),
+  );
+
+  return {
+    ...(baseContext ?? {}),
+    items: [item, ...existingItems],
+    primaryItemId: item.id,
+    capturedAt: baseContext?.capturedAt ?? Date.now(),
+  };
 }
 
 const AnalysisSessionBaseSchema = z.object({

--- a/packages/ai-core/__tests__/AiSlice.modelSelection.test.ts
+++ b/packages/ai-core/__tests__/AiSlice.modelSelection.test.ts
@@ -1,8 +1,12 @@
-import {AiSettingsSliceConfig} from '@sqlrooms/ai-config';
+import {
+  AiSettingsSliceConfig,
+  setAiRunContextPrimaryItem,
+} from '@sqlrooms/ai-config';
 import type {AiRunContext} from '@sqlrooms/ai-config';
 import {jest} from '@jest/globals';
 import {createStore} from 'zustand';
 import {AiSliceState, createAiSlice} from '../src/AiSlice';
+import {withRunContextTools} from '../src/chatTransport';
 
 type TestStoreState = AiSliceState & {
   aiSettings: {
@@ -156,5 +160,78 @@ describe('AiSlice model selection', () => {
       'Map B',
     );
     expect(sendMessage).toHaveBeenCalledWith({text: 'hello'});
+  });
+
+  it('keeps wrapped tool run context mutable across tool calls', async () => {
+    let runContext: AiRunContext | undefined = {
+      items: [
+        {
+          kind: 'artifact',
+          id: 'doc-1',
+          type: 'document',
+          title: 'Doc',
+        },
+      ],
+      primaryItemId: 'doc-1',
+      capturedAt: 1,
+    };
+    const setSessionRunContext = jest.fn(
+      (_sessionId: string, nextContext: AiRunContext | undefined) => {
+        runContext = nextContext;
+      },
+    );
+
+    const tools = withRunContextTools(
+      {
+        set_primary: {
+          execute: async (_input: unknown, context: any) => {
+            context.setPrimaryRunContextItem({
+              kind: 'artifact',
+              id: 'dashboard-1',
+              type: 'dashboard',
+              title: 'Dashboard',
+            });
+            return {success: true};
+          },
+        },
+        read_context: {
+          execute: async (_input: unknown, context: any) => ({
+            aiRunContextPrimaryItemId: context.aiRunContext?.primaryItemId,
+            liveRunContextPrimaryItemId:
+              context.getAiRunContext()?.primaryItemId,
+          }),
+        },
+      } as any,
+      {
+        sessionId: 'session-1',
+        aiRunContext: runContext,
+        getAiRunContext: () => runContext,
+        setAiRunContext: (nextContext) =>
+          setSessionRunContext('session-1', nextContext),
+        setPrimaryRunContextItem: (item) =>
+          setSessionRunContext(
+            'session-1',
+            setAiRunContextPrimaryItem(runContext, item),
+          ),
+        state: {
+          ai: {
+            setToolCallSession: jest.fn(),
+          },
+        } as any,
+      },
+    );
+
+    await tools.set_primary?.execute?.({}, {});
+    const result = (await tools.read_context?.execute?.({}, {})) as {
+      aiRunContextPrimaryItemId?: string;
+      liveRunContextPrimaryItemId?: string;
+    };
+
+    expect(result.aiRunContextPrimaryItemId).toBe('dashboard-1');
+    expect(result.liveRunContextPrimaryItemId).toBe('dashboard-1');
+    expect(setSessionRunContext).toHaveBeenCalledWith(
+      'session-1',
+      expect.objectContaining({primaryItemId: 'dashboard-1'}),
+    );
   });
 });

--- a/packages/ai-core/__tests__/migration.test.ts
+++ b/packages/ai-core/__tests__/migration.test.ts
@@ -1,4 +1,7 @@
-import {AnalysisSessionSchema} from '@sqlrooms/ai-config';
+import {
+  AnalysisSessionSchema,
+  getAiRunContextPrimaryItem,
+} from '@sqlrooms/ai-config';
 
 /** Minimal valid base fields required by the schema after migration */
 const baseFields = {
@@ -133,6 +136,36 @@ describe('AnalysisSession migration', () => {
       };
       const result = AnalysisSessionSchema.parse(raw);
       expect(result.runContext).toEqual(raw.runContext);
+      expect(getAiRunContextPrimaryItem(result.runContext)?.id).toBe('map-1');
+    });
+
+    it('uses primaryItemId when present in run context', () => {
+      const raw = {
+        ...baseFields,
+        uiMessages: [],
+        runContext: {
+          primaryItemId: 'dashboard-1',
+          items: [
+            {
+              kind: 'artifact',
+              id: 'map-1',
+              type: 'map',
+              title: 'Map A',
+            },
+            {
+              kind: 'artifact',
+              id: 'dashboard-1',
+              type: 'dashboard',
+              title: 'Dashboard',
+            },
+          ],
+          capturedAt: 123,
+        },
+      };
+      const result = AnalysisSessionSchema.parse(raw);
+      expect(getAiRunContextPrimaryItem(result.runContext)?.id).toBe(
+        'dashboard-1',
+      );
     });
 
     it('keeps run context optional for old sessions', () => {

--- a/packages/ai-core/src/AiSlice.ts
+++ b/packages/ai-core/src/AiSlice.ts
@@ -165,6 +165,10 @@ export type AiSliceState = {
     deleteSession: (sessionId: string) => void;
     setOpenSessionTabs: (tabs: string[]) => void;
     getCurrentSession: () => AnalysisSessionSchema | undefined;
+    setSessionRunContext: (
+      sessionId: string,
+      runContext: AiRunContext | undefined,
+    ) => void;
     setSessionUiMessages: (
       sessionId: string,
       uiMessages: UIMessage[],
@@ -666,6 +670,22 @@ export function createAiSlice<TTools extends ToolSet = ToolSet>(
           const state = get();
           const {currentSessionId, sessions} = state.ai.config;
           return sessions.find((session) => session.id === currentSessionId);
+        },
+
+        setSessionRunContext: (
+          sessionId: string,
+          runContext: AiRunContext | undefined,
+        ) => {
+          set((state) =>
+            produce(state, (draft) => {
+              const session = draft.ai.config.sessions.find(
+                (s: AnalysisSessionSchema) => s.id === sessionId,
+              );
+              if (session) {
+                session.runContext = runContext;
+              }
+            }),
+          );
         },
 
         /**

--- a/packages/ai-core/src/AiSlice.ts
+++ b/packages/ai-core/src/AiSlice.ts
@@ -165,6 +165,7 @@ export type AiSliceState = {
     deleteSession: (sessionId: string) => void;
     setOpenSessionTabs: (tabs: string[]) => void;
     getCurrentSession: () => AnalysisSessionSchema | undefined;
+    getSessionRunContext: (sessionId: string) => AiRunContext | undefined;
     setSessionRunContext: (
       sessionId: string,
       runContext: AiRunContext | undefined,
@@ -670,6 +671,13 @@ export function createAiSlice<TTools extends ToolSet = ToolSet>(
           const state = get();
           const {currentSessionId, sessions} = state.ai.config;
           return sessions.find((session) => session.id === currentSessionId);
+        },
+
+        getSessionRunContext: (sessionId: string) => {
+          const state = get();
+          return state.ai.config.sessions.find(
+            (session: AnalysisSessionSchema) => session.id === sessionId,
+          )?.runContext;
         },
 
         setSessionRunContext: (

--- a/packages/ai-core/src/chatTransport.ts
+++ b/packages/ai-core/src/chatTransport.ts
@@ -169,7 +169,9 @@ export function withRunContextTools(
               {
                 ...options,
                 sessionId: args.sessionId,
-                aiRunContext: args.getAiRunContext?.() ?? args.aiRunContext,
+                aiRunContext: args.getAiRunContext
+                  ? args.getAiRunContext()
+                  : args.aiRunContext,
                 getAiRunContext: args.getAiRunContext,
                 setAiRunContext: args.setAiRunContext,
                 setPrimaryRunContextItem: args.setPrimaryRunContextItem,

--- a/packages/ai-core/src/chatTransport.ts
+++ b/packages/ai-core/src/chatTransport.ts
@@ -1,5 +1,9 @@
 import {createOpenAICompatible} from '@ai-sdk/openai-compatible';
-import type {AnalysisSessionSchema} from '@sqlrooms/ai-config';
+import {
+  setAiRunContextPrimaryItem,
+  type AiRunContext,
+  type AnalysisSessionSchema,
+} from '@sqlrooms/ai-config';
 import type {StoreApi} from '@sqlrooms/room-store';
 import {getErrorMessageForDisplay} from '@sqlrooms/utils';
 import type {
@@ -130,10 +134,12 @@ function getSessionById(
     .ai.config.sessions.find((s: AnalysisSessionSchema) => s.id === sessionId);
 }
 
-function withRunContextTools(
+export function withRunContextTools(
   tools: ToolSet,
   args: AiToolExecutionContext & {
     state: AiSliceStateForTransport;
+    getAiRunContext?: () => AiRunContext | undefined;
+    setAiRunContext?: (runContext: AiRunContext | undefined) => void;
   },
 ): ToolSet {
   return Object.fromEntries(
@@ -163,7 +169,10 @@ function withRunContextTools(
               {
                 ...options,
                 sessionId: args.sessionId,
-                aiRunContext: args.aiRunContext,
+                aiRunContext: args.getAiRunContext?.() ?? args.aiRunContext,
+                getAiRunContext: args.getAiRunContext,
+                setAiRunContext: args.setAiRunContext,
+                setPrimaryRunContextItem: args.setPrimaryRunContextItem,
               } as never,
             );
           },
@@ -261,7 +270,11 @@ export function createLocalChatTransportFactory({
       const sessionFromBody = getSessionById(store, sessionId);
       const provider = sessionFromBody?.modelProvider || defaultProvider;
       const modelId = sessionFromBody?.model || defaultModel;
-      const aiRunContext = sessionFromBody?.runContext;
+      let aiRunContext = sessionFromBody?.runContext;
+      const setAiRunContext = (nextContext: AiRunContext | undefined) => {
+        aiRunContext = nextContext;
+        state.ai.setSessionRunContext(sessionId, nextContext);
+      };
 
       // Fetch API key and base URL dynamically to pick up settings changes
       const apiKey = state.ai.getApiKeyFromSettings();
@@ -293,6 +306,11 @@ export function createLocalChatTransportFactory({
         state,
         sessionId,
         aiRunContext,
+        getAiRunContext: () => aiRunContext,
+        setAiRunContext,
+        setPrimaryRunContextItem: (item) => {
+          setAiRunContext(setAiRunContextPrimaryItem(aiRunContext, item));
+        },
       });
 
       // get system instructions dynamically at request time to ensure fresh table schema
@@ -420,6 +438,7 @@ export function createRemoteChatTransportFactory(params: {
         modelProvider,
         model,
         instructions: getInstructions(),
+        runContext: sessionFromBody?.runContext,
         maxSteps: state.ai.getMaxStepsFromSettings(),
       };
 

--- a/packages/ai-core/src/index.ts
+++ b/packages/ai-core/src/index.ts
@@ -41,7 +41,9 @@ export {
   AiRunContextSchema,
   AiSliceConfig,
   createDefaultAiConfig,
+  getAiRunContextPrimaryItem,
   getAiRunContextItems,
+  setAiRunContextPrimaryItem,
 } from '@sqlrooms/ai-config';
 export type {AiRunContext, AiRunContextItem} from '@sqlrooms/ai-config';
 export {AiThinkingDots} from './components/AiThinkingDots';

--- a/packages/ai-core/src/types.ts
+++ b/packages/ai-core/src/types.ts
@@ -1,6 +1,7 @@
 import type {ComponentType} from 'react';
 import type {
   AiRunContext,
+  AiRunContextItem,
   AiSliceConfig,
   AnalysisSessionSchema,
 } from '@sqlrooms/ai-config';
@@ -178,6 +179,9 @@ export type AiChatSendMessage = (message: {text: string}) => void;
 export type AiToolExecutionContext = {
   sessionId?: string;
   aiRunContext?: AiRunContext;
+  getAiRunContext?: () => AiRunContext | undefined;
+  setAiRunContext?: (runContext: AiRunContext | undefined) => void;
+  setPrimaryRunContextItem?: (item: AiRunContextItem) => void;
 };
 
 /**
@@ -189,6 +193,10 @@ export interface AiStateForTransport {
   tools: StoredToolSet;
   getProviderOptions?: GetProviderOptions;
   getCurrentSession: () => AnalysisSessionSchema | undefined;
+  setSessionRunContext: (
+    sessionId: string,
+    runContext: AiRunContext | undefined,
+  ) => void;
   getAbortController: (sessionId: string) => AbortController | undefined;
   setAbortController: (
     sessionId: string,

--- a/packages/ai-core/src/types.ts
+++ b/packages/ai-core/src/types.ts
@@ -193,6 +193,7 @@ export interface AiStateForTransport {
   tools: StoredToolSet;
   getProviderOptions?: GetProviderOptions;
   getCurrentSession: () => AnalysisSessionSchema | undefined;
+  getSessionRunContext: (sessionId: string) => AiRunContext | undefined;
   setSessionRunContext: (
     sessionId: string,
     runContext: AiRunContext | undefined,

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -128,7 +128,7 @@ argument. Apps can use `getRunContext` to capture selected artifacts at the
 start of a run, expose them in `formatRunContextInstructions`, and then let
 tools update the effective primary context with `setPrimaryRunContextItem`.
 Old contexts without `primaryItemId` remain valid; the first item is treated as
-primary.
+primary. Artifact-specific context tools live in `@sqlrooms/artifacts/ai`.
 
 ## Use remote endpoint mode
 

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -123,6 +123,13 @@ createAiSlice({
 })(set, get, store);
 ```
 
+Tool `execute` callbacks receive hidden run-context helpers in their second
+argument. Apps can use `getRunContext` to capture selected artifacts at the
+start of a run, expose them in `formatRunContextInstructions`, and then let
+tools update the effective primary context with `setPrimaryRunContextItem`.
+Old contexts without `primaryItemId` remain valid; the first item is treated as
+primary.
+
 ## Use remote endpoint mode
 
 If you want server-side model calls, set `chatEndPoint` and optional `chatHeaders`:

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -159,7 +159,9 @@ export {
   AnalysisSessionSchema,
   AnalysisResultSchema,
   ErrorMessageSchema,
+  getAiRunContextPrimaryItem,
   getAiRunContextItems,
+  setAiRunContextPrimaryItem,
 } from '@sqlrooms/ai-config';
 export type {AiRunContext, AiRunContextItem} from '@sqlrooms/ai-config';
 export type {ToolUIPart, UIMessagePart} from '@sqlrooms/ai-config';

--- a/packages/artifacts/README.md
+++ b/packages/artifacts/README.md
@@ -104,3 +104,16 @@ removes the artifact registry entry.
   titles, icons, and components from the runtime type registry.
 
 Type definitions are runtime configuration and are not persisted.
+
+## AI Context Tools
+
+`@sqlrooms/artifacts/ai` provides reusable assistant tools for artifact context:
+
+- `list_context_artifacts`
+- `read_context_artifact`
+- `set_primary_context_artifact`
+
+Use `createArtifactContextAiTools({store, readArtifact})` in apps that combine
+`@sqlrooms/artifacts` with `@sqlrooms/ai`. The factory handles primary artifact
+selection and run-context updates; the app supplies artifact payload readers for
+domain-specific types such as documents or dashboards.

--- a/packages/artifacts/__tests__/ArtifactContextAiTools.test.ts
+++ b/packages/artifacts/__tests__/ArtifactContextAiTools.test.ts
@@ -1,0 +1,161 @@
+import {createStore} from 'zustand';
+import {
+  createBaseRoomSlice,
+  type BaseRoomStoreState,
+} from '@sqlrooms/room-store';
+import {
+  createArtifactContextAiTools,
+  type ArtifactContextToolExecutionContext,
+} from '../src/ai';
+import {
+  createArtifactsSlice,
+  defineArtifactTypes,
+  type ArtifactsSliceState,
+} from '../src';
+import type {AiRunContext} from '@sqlrooms/ai-config';
+
+type TestRoomState = BaseRoomStoreState & ArtifactsSliceState;
+
+function createTestStore() {
+  const artifactTypes = defineArtifactTypes({
+    document: {
+      label: 'Document',
+      defaultTitle: 'Document',
+    },
+    dashboard: {
+      label: 'Dashboard',
+      defaultTitle: 'Dashboard',
+    },
+  });
+
+  const store = createStore<TestRoomState>()((...args) => ({
+    ...createBaseRoomSlice()(...args),
+    ...createArtifactsSlice<TestRoomState>({artifactTypes})(...args),
+  }));
+
+  store.getState().artifacts.ensureArtifact('doc-1', {
+    type: 'document',
+    title: 'Doc',
+  });
+  store.getState().artifacts.ensureArtifact('dashboard-1', {
+    type: 'dashboard',
+    title: 'Dashboard',
+  });
+  store.getState().artifacts.ensureArtifact('doc-2', {
+    type: 'document',
+    title: 'Other Doc',
+  });
+
+  return store;
+}
+
+describe('createArtifactContextAiTools', () => {
+  it('lists context artifacts and moves the primary artifact', async () => {
+    const store = createTestStore();
+    let runContext: AiRunContext | undefined = {
+      items: [
+        {
+          kind: 'artifact',
+          id: 'doc-1',
+          type: 'document',
+          title: 'Doc',
+        },
+        {
+          kind: 'artifact',
+          id: 'dashboard-1',
+          type: 'dashboard',
+          title: 'Dashboard',
+        },
+      ],
+      primaryItemId: 'doc-1',
+      capturedAt: 1,
+    };
+    let selectedContextIds: string[] = [];
+    const executionContext: ArtifactContextToolExecutionContext = {
+      getAiRunContext: () => runContext,
+      setAiRunContext: (nextContext) => {
+        runContext = nextContext;
+      },
+    };
+    const tools = createArtifactContextAiTools({
+      store,
+      onContextItemsChanged: ({items}) => {
+        selectedContextIds = items.map((item) => item.id);
+      },
+    });
+
+    const listResult = await (tools.list_context_artifacts as any).execute(
+      {},
+      executionContext,
+    );
+    expect(listResult.llmResult.artifacts).toMatchObject([
+      {artifactId: 'doc-1', role: 'primary'},
+      {artifactId: 'dashboard-1', role: 'reference'},
+    ]);
+
+    const setResult = await (
+      tools.set_primary_context_artifact as any
+    ).execute({artifactId: 'dashboard-1'}, executionContext);
+
+    expect(setResult.llmResult).toMatchObject({
+      success: true,
+      primaryArtifactId: 'dashboard-1',
+    });
+    expect(runContext?.primaryItemId).toBe('dashboard-1');
+    expect(runContext?.items.map((item) => item.id)).toEqual([
+      'dashboard-1',
+      'doc-1',
+    ]);
+    expect(selectedContextIds).toEqual(['dashboard-1', 'doc-1']);
+  });
+
+  it('reads only artifacts that are present in run context', async () => {
+    const store = createTestStore();
+    const runContext: AiRunContext = {
+      items: [
+        {
+          kind: 'artifact',
+          id: 'doc-1',
+          type: 'document',
+          title: 'Doc',
+        },
+      ],
+      primaryItemId: 'doc-1',
+      capturedAt: 1,
+    };
+    const tools = createArtifactContextAiTools({
+      store,
+      readArtifact: ({artifact}) => ({
+        success: true,
+        artifact: {
+          artifactId: artifact.id,
+          title: artifact.title,
+          type: artifact.type,
+        },
+        payload: {kind: 'test-reader'},
+      }),
+    });
+
+    const readPrimaryResult = await (tools.read_context_artifact as any).execute(
+      {},
+      {getAiRunContext: () => runContext},
+    );
+    expect(readPrimaryResult.llmResult).toMatchObject({
+      success: true,
+      artifact: {artifactId: 'doc-1'},
+      payload: {kind: 'test-reader'},
+    });
+
+    const readOutsideContextResult = await (
+      tools.read_context_artifact as any
+    ).execute(
+      {artifactId: 'doc-2'},
+      {getAiRunContext: () => runContext},
+    );
+    expect(readOutsideContextResult.llmResult).toMatchObject({
+      success: false,
+      errorMessage:
+        'Artifact "doc-2" is not in the current run context. Use set_primary_context_artifact before reading it as context.',
+    });
+  });
+});

--- a/packages/artifacts/package.json
+++ b/packages/artifacts/package.json
@@ -9,6 +9,17 @@
   "author": "SQLRooms Contributors",
   "sideEffects": false,
   "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./ai": {
+      "types": "./dist/ai.d.ts",
+      "import": "./dist/ai.js"
+    }
+  },
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -25,9 +36,11 @@
   },
   "dependencies": {
     "@paralleldrive/cuid2": "^3.0.0",
+    "@sqlrooms/ai-config": "workspace:*",
     "@sqlrooms/layout": "workspace:*",
     "@sqlrooms/room-store": "workspace:*",
     "@sqlrooms/ui": "workspace:*",
+    "ai": "^6.0.154",
     "immer": "^11.0.1",
     "lucide-react": "^0.556.0",
     "zod": "^4.1.8"

--- a/packages/artifacts/src/ai.ts
+++ b/packages/artifacts/src/ai.ts
@@ -1,0 +1,407 @@
+/**
+ * AI tool helpers for SQLRooms apps that use the artifacts slice.
+ *
+ * This subpath intentionally lives in `@sqlrooms/artifacts/ai` rather than
+ * `@sqlrooms/ai`: the AI packages own generic run-context transport, while this
+ * module owns the artifact-specific interpretation of that context. Apps supply
+ * artifact payload readers for their domain types, and this module handles the
+ * common assistant-facing tools for listing context artifacts, reading only
+ * artifacts that were added to the run context, and updating the primary
+ * artifact for the current AI run.
+ *
+ * @packageDocumentation
+ */
+
+import {
+  getAiRunContextItems,
+  getAiRunContextPrimaryItem,
+  setAiRunContextPrimaryItem,
+  type AiRunContext,
+  type AiRunContextItem,
+} from '@sqlrooms/ai-config';
+import {tool} from 'ai';
+import {z} from 'zod';
+import type {ArtifactsSliceState} from './ArtifactsSlice';
+import type {ArtifactMetadata as ArtifactMetadataType} from './ArtifactsSliceConfig';
+
+const EmptyInput = z.object({});
+
+const ReadContextArtifactInput = z.object({
+  artifactId: z
+    .string()
+    .optional()
+    .describe('Context artifact ID. Defaults to the primary context artifact.'),
+});
+
+const SetPrimaryContextArtifactInput = z.object({
+  artifactId: z.string().describe('Artifact ID to make primary for this run.'),
+});
+
+/**
+ * Hidden execution context that `@sqlrooms/ai-core` passes as the second
+ * argument to AI SDK tool `execute` callbacks.
+ *
+ * Apps normally do not construct this object manually. It is accepted here so
+ * the reusable artifact tools can read and update the current run context
+ * without depending on `@sqlrooms/ai-core`.
+ */
+export type ArtifactContextToolExecutionContext = {
+  /** AI session that owns the current tool call, when known. */
+  sessionId?: string;
+  /** Snapshot of the run context captured when the current AI run started. */
+  aiRunContext?: AiRunContext;
+  /** Returns the latest mutable run context for the current tool loop. */
+  getAiRunContext?: () => AiRunContext | undefined;
+  /** Replaces the latest mutable run context for the current tool loop. */
+  setAiRunContext?: (runContext: AiRunContext | undefined) => void;
+  /** Convenience helper for making a context item the primary run target. */
+  setPrimaryRunContextItem?: (item: AiRunContextItem) => void;
+};
+
+/**
+ * Minimal store interface required by the artifact context tools.
+ *
+ * This is intentionally narrower than Zustand's `StoreApi` so host apps can
+ * pass any object that can return a state containing `ArtifactsSliceState`.
+ */
+export type ArtifactContextToolStore<TState extends ArtifactsSliceState> = {
+  getState: () => TState;
+};
+
+/**
+ * Standard result shape returned by app-provided artifact readers.
+ *
+ * `payload` is deliberately `unknown`: each app owns the readable shape for its
+ * artifact types, such as Markdown for document artifacts or panel summaries
+ * for dashboard artifacts.
+ */
+export type ArtifactContextReadResult =
+  | {
+      success: false;
+      errorMessage: string;
+    }
+  | {
+      success: true;
+      artifact: {
+        artifactId: string;
+        title: string;
+        type: string;
+      };
+      payload: unknown;
+    };
+
+/**
+ * Adapter options for creating artifact context tools.
+ *
+ * The artifact package owns artifact metadata, but not app-specific artifact
+ * payloads or AI session storage. These callbacks provide those seams without
+ * making `@sqlrooms/artifacts` depend on higher-level packages or concrete app
+ * state.
+ */
+export type ArtifactContextToolsOptions<TState extends ArtifactsSliceState> = {
+  /** Store containing the artifacts slice and any app-specific state readers need. */
+  store: ArtifactContextToolStore<TState>;
+  /**
+   * Fallback source for persisted run context when the AI tool execution
+   * context does not provide live context helpers.
+   */
+  getRunContext?: (args: {
+    state: TState;
+    context?: ArtifactContextToolExecutionContext;
+  }) => AiRunContext | undefined;
+  /**
+   * Fallback sink for persisted run context when the AI tool execution context
+   * does not provide a live setter.
+   */
+  setRunContext?: (args: {
+    state: TState;
+    context?: ArtifactContextToolExecutionContext;
+    runContext: AiRunContext | undefined;
+  }) => void;
+  /**
+   * Called after `set_primary_context_artifact` or
+   * `makeArtifactPrimaryForAiRun` changes the context item list.
+   *
+   * Host apps can use this to keep visible context selectors in sync with the
+   * persisted run context.
+   */
+  onContextItemsChanged?: (args: {
+    state: TState;
+    context?: ArtifactContextToolExecutionContext;
+    runContext: AiRunContext;
+    items: AiRunContextItem[];
+  }) => void;
+  /**
+   * Reads an artifact payload for `read_context_artifact`.
+   *
+   * If omitted, `read_context_artifact` returns metadata-only payloads. The
+   * reader is only called after the requested artifact has been validated as
+   * present in the current run context.
+   */
+  readArtifact?: (args: {
+    state: TState;
+    context?: ArtifactContextToolExecutionContext;
+    artifactId: string;
+    artifact: ArtifactMetadataType;
+  }) => ArtifactContextReadResult | Promise<ArtifactContextReadResult>;
+};
+
+function getExecutionRunContext<TState extends ArtifactsSliceState>(
+  options: ArtifactContextToolsOptions<TState>,
+  state: TState,
+  context?: ArtifactContextToolExecutionContext,
+): AiRunContext | undefined {
+  return (
+    context?.getAiRunContext?.() ??
+    context?.aiRunContext ??
+    options.getRunContext?.({state, context})
+  );
+}
+
+function artifactToContextItem<TState extends ArtifactsSliceState>(
+  state: TState,
+  artifactId: string,
+): AiRunContextItem | undefined {
+  const artifact = state.artifacts.config.artifactsById[artifactId];
+  if (!artifact) return undefined;
+  return {
+    kind: 'artifact',
+    id: artifact.id,
+    type: artifact.type,
+    title: artifact.title,
+  };
+}
+
+function contextArtifactSummary<TState extends ArtifactsSliceState>(
+  state: TState,
+  item: AiRunContextItem,
+  primaryItemId: string | undefined,
+) {
+  const artifact = state.artifacts.config.artifactsById[item.id];
+  return {
+    kind: item.kind,
+    artifactId: item.id,
+    id: item.id,
+    title: artifact?.title ?? item.title,
+    type: artifact?.type ?? item.type,
+    role: item.id === primaryItemId ? 'primary' : 'reference',
+    missing: !artifact,
+    ...(item.subtitle ? {subtitle: item.subtitle} : {}),
+  };
+}
+
+function readArtifactMetadataOnly(
+  artifactId: string,
+  artifact: ArtifactMetadataType,
+): ArtifactContextReadResult {
+  return {
+    success: true,
+    artifact: {
+      artifactId,
+      title: artifact.title,
+      type: artifact.type,
+    },
+    payload: {
+      kind: 'metadata-only',
+      unsupportedPayload: true,
+      details:
+        'This artifact type is available as context, but no artifact reader was provided for its full payload.',
+    },
+  };
+}
+
+function setPrimaryArtifact<TState extends ArtifactsSliceState>(
+  options: ArtifactContextToolsOptions<TState>,
+  state: TState,
+  context: ArtifactContextToolExecutionContext | undefined,
+  artifactId: string,
+) {
+  const item = artifactToContextItem(state, artifactId);
+  if (!item) {
+    return {
+      success: false,
+      errorMessage: `Unknown artifact "${artifactId}".`,
+    };
+  }
+
+  const runContext = getExecutionRunContext(options, state, context);
+  const nextContext = setAiRunContextPrimaryItem(runContext, item);
+  if (context?.setAiRunContext) {
+    context.setAiRunContext(nextContext);
+  } else if (context?.setPrimaryRunContextItem) {
+    context.setPrimaryRunContextItem(item);
+  } else {
+    options.setRunContext?.({state, context, runContext: nextContext});
+  }
+
+  const items = getAiRunContextItems(nextContext);
+  options.onContextItemsChanged?.({
+    state,
+    context,
+    runContext: nextContext,
+    items,
+  });
+
+  return {
+    success: true,
+    context: nextContext,
+    item,
+  };
+}
+
+/**
+ * Programmatically make an artifact the primary artifact for the current AI run.
+ *
+ * Domain tools should call this after creating or selecting an artifact that
+ * subsequent tool calls should treat as the default target. The helper updates
+ * live AI tool context when available and falls back to the adapter's
+ * `setRunContext` callback otherwise.
+ *
+ * @returns A success object with the updated context and primary item, or an
+ * error object when the artifact id is unknown.
+ */
+export function makeArtifactPrimaryForAiRun<TState extends ArtifactsSliceState>(
+  options: ArtifactContextToolsOptions<TState>,
+  artifactId: string,
+  context?: ArtifactContextToolExecutionContext,
+) {
+  return setPrimaryArtifact(
+    options,
+    options.store.getState(),
+    context,
+    artifactId,
+  );
+}
+
+/**
+ * Create reusable AI SDK tools for artifact run context.
+ *
+ * The returned tool set contains:
+ *
+ * - `list_context_artifacts`: lists context artifacts and their primary or
+ *   reference role.
+ * - `read_context_artifact`: reads the primary context artifact by default, or
+ *   a requested artifact id if it is already in context.
+ * - `set_primary_context_artifact`: validates an artifact and makes it primary
+ *   for the current run.
+ *
+ * These tools never expose the whole artifact registry as a mutation target.
+ * Reading is restricted to artifacts already present in run context, while
+ * setting a primary artifact is the explicit operation that can add an existing
+ * artifact to that context.
+ */
+export function createArtifactContextAiTools<
+  TState extends ArtifactsSliceState,
+>(options: ArtifactContextToolsOptions<TState>) {
+  return {
+    list_context_artifacts: tool({
+      description:
+        'List artifacts that the user added to the current AI run context, including which artifact is primary.',
+      inputSchema: EmptyInput,
+      execute: async (_params, executionOptions) => {
+        const context =
+          executionOptions as ArtifactContextToolExecutionContext | undefined;
+        const state = options.store.getState();
+        const runContext = getExecutionRunContext(options, state, context);
+        const primaryItem = getAiRunContextPrimaryItem(runContext);
+        const artifacts = getAiRunContextItems(runContext)
+          .filter((item) => item.kind === 'artifact')
+          .map((item) =>
+            contextArtifactSummary(state, item, primaryItem?.id),
+          );
+
+        return {
+          llmResult: {
+            success: true,
+            primaryArtifactId: primaryItem?.id,
+            artifacts,
+            details: `Found ${artifacts.length} context artifact${artifacts.length === 1 ? '' : 's'}.`,
+          },
+        };
+      },
+    }),
+    read_context_artifact: tool({
+      description:
+        'Read one artifact from the current AI run context. Defaults to the primary artifact. Use list_context_artifacts first when unsure.',
+      inputSchema: ReadContextArtifactInput,
+      execute: async (params, executionOptions) => {
+        const context =
+          executionOptions as ArtifactContextToolExecutionContext | undefined;
+        const state = options.store.getState();
+        const runContext = getExecutionRunContext(options, state, context);
+        const items = getAiRunContextItems(runContext).filter(
+          (item) => item.kind === 'artifact',
+        );
+        const requestedArtifactId =
+          params.artifactId ?? getAiRunContextPrimaryItem(runContext)?.id;
+        if (!requestedArtifactId) {
+          return {
+            llmResult: {
+              success: false,
+              errorMessage:
+                'No context artifact is available. Add an artifact to context or provide one with set_primary_context_artifact first.',
+            },
+          };
+        }
+        if (!items.some((item) => item.id === requestedArtifactId)) {
+          return {
+            llmResult: {
+              success: false,
+              errorMessage: `Artifact "${requestedArtifactId}" is not in the current run context. Use set_primary_context_artifact before reading it as context.`,
+            },
+          };
+        }
+
+        const artifact = state.artifacts.config.artifactsById[requestedArtifactId];
+        if (!artifact) {
+          return {
+            llmResult: {
+              success: false,
+              errorMessage: `Unknown artifact "${requestedArtifactId}".`,
+            },
+          };
+        }
+
+        return {
+          llmResult:
+            (await options.readArtifact?.({
+              state,
+              context,
+              artifactId: requestedArtifactId,
+              artifact,
+            })) ?? readArtifactMetadataOnly(requestedArtifactId, artifact),
+        };
+      },
+    }),
+    set_primary_context_artifact: tool({
+      description:
+        'Make an existing artifact the primary artifact for this AI run. Use after creating a new artifact or when the user asks to work on a specific artifact.',
+      inputSchema: SetPrimaryContextArtifactInput,
+      execute: async (params, executionOptions) => {
+        const context =
+          executionOptions as ArtifactContextToolExecutionContext | undefined;
+        const state = options.store.getState();
+        const result = setPrimaryArtifact(
+          options,
+          state,
+          context,
+          params.artifactId,
+        );
+        if (!result.success || !result.item || !result.context) {
+          return {
+            llmResult: result,
+          };
+        }
+
+        return {
+          llmResult: {
+            success: true,
+            primaryArtifactId: result.item.id,
+            contextItems: getAiRunContextItems(result.context),
+            details: `Set artifact "${result.item.title}" (${result.item.id}) as the primary context artifact.`,
+          },
+        };
+      },
+    }),
+  };
+}

--- a/packages/mosaic/README.md
+++ b/packages/mosaic/README.md
@@ -230,10 +230,11 @@ live outside persisted dashboard config.
 
 `createChartTools` generates assistant tools for the built-in chart types. The
 injected `DashboardToolDeps` provides `resolveArtifact` and `resolveTable`
-methods that receive tool execution context. Client apps should prefer
-execution-scoped context, such as a captured AI run context, over live UI state
-when resolving implicit dashboard targets. Explicit `artifactId` parameters
-should still take precedence.
+methods that receive tool execution context. Client apps should prefer explicit
+`artifactId` parameters; if omitted, resolve only an unambiguous primary
+dashboard from execution-scoped context. Do not implicitly target reference-only
+context artifacts. Live UI state should be a fallback only when there is no run
+context.
 
 ```ts
 import {
@@ -246,15 +247,18 @@ const deps: DashboardToolDeps = {
   resolveArtifact: (artifactId, createIfMissing, context) => {
     const sessionId = context?.sessionId;
     const runContext = context?.aiRunContext;
-    const contextArtifactId = getDashboardArtifactIdFromRunContext(
-      runContext,
-      sessionId,
-    );
+    const primaryDashboardArtifactId =
+      getPrimaryDashboardArtifactIdFromRunContext(
+        runContext,
+        sessionId,
+      );
 
-    // Prefer execution-scoped context over live UI state for implicit targets.
-    // Explicit tool input still wins over anything derived from context.
+    // Explicit tool input wins. Only a primary dashboard context may be used
+    // implicitly; reference artifacts should require artifactId.
     const targetArtifactId =
-      artifactId ?? contextArtifactId ?? getCurrentDashboardArtifactId();
+      artifactId ??
+      primaryDashboardArtifactId ??
+      getCurrentDashboardArtifactId();
 
     if (!targetArtifactId && createIfMissing) {
       return createDashboardArtifact();

--- a/packages/mosaic/src/chart-types/tool-schemas.ts
+++ b/packages/mosaic/src/chart-types/tool-schemas.ts
@@ -4,7 +4,9 @@ export const BaseChartToolParameters = z.object({
   artifactId: z
     .string()
     .optional()
-    .describe('Optional dashboard artifact ID. Defaults to current dashboard.'),
+    .describe(
+      'Optional dashboard artifact ID. Prefer passing this explicitly; if omitted, the host may use an unambiguous primary dashboard context.',
+    ),
   tableName: z
     .string()
     .optional()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2557,6 +2557,9 @@ importers:
       '@paralleldrive/cuid2':
         specifier: ^3.0.0
         version: 3.3.0
+      '@sqlrooms/ai-config':
+        specifier: workspace:*
+        version: link:../ai-config
       '@sqlrooms/layout':
         specifier: workspace:*
         version: link:../layout
@@ -2566,6 +2569,9 @@ importers:
       '@sqlrooms/ui':
         specifier: workspace:*
         version: link:../ui
+      ai:
+        specifier: ^6.0.154
+        version: 6.0.177(zod@4.1.13)
       immer:
         specifier: ^11.0.1
         version: 11.1.8


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Primary artifact context for AI runs with CLI/UI support and tools to list, read, and set the current primary artifact.

* **Behavior Changes**
  * Dashboard/chart tools now prefer an explicit artifact ID; if run context exists without a primary dashboard, callers are asked to supply one instead of silently falling back.

* **Documentation**
  * Updated READMEs explaining primary artifact selection and AI tool targeting.

* **Tests**
  * Added tests covering artifact-context tools and run-context handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sqlrooms/sqlrooms/pull/646?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->