### PR TITLE
fix: Layout: Prevent panel resize from being stuck

### DIFF
--- a/packages/documents/src/MarkdownDocumentEditor/MarkdownDocumentEditorContent.tsx
+++ b/packages/documents/src/MarkdownDocumentEditor/MarkdownDocumentEditorContent.tsx
@@ -60,7 +60,8 @@ export const MarkdownDocumentEditorContent: FC<
         <ResizableHandle className="w-px" />
         <ResizablePanel
           ref={panelRef}
-          minSize={20}
+          minSize="30%"
+          maxSize="50%"
           collapsible={true}
           collapsedSize={0}
           className="overflow-auto"
@@ -69,7 +70,6 @@ export const MarkdownDocumentEditorContent: FC<
           <div className="flex h-full flex-col">
             <div className="border-border flex h-10 shrink-0 items-center gap-2 border-b px-3">
               <FileCodeCornerIcon className="text-muted-foreground h-4 w-4" />
-              <span className="text-sm font-medium">Markdown</span>
               <div className="flex-1" />
               <Button
                 type="button"

--- a/packages/documents/src/MarkdownDocumentEditor/MarkdownDocumentEditorToolbar.tsx
+++ b/packages/documents/src/MarkdownDocumentEditor/MarkdownDocumentEditorToolbar.tsx
@@ -25,7 +25,7 @@ export const MarkdownDocumentEditorToolbar: FC<
       <div className="flex-1" />
       <Button
         type="button"
-        size="sm"
+        size="icon"
         variant={sourcePanelOpen ? 'secondary' : 'ghost'}
         className="h-8 gap-2"
         aria-pressed={sourcePanelOpen}
@@ -35,7 +35,6 @@ export const MarkdownDocumentEditorToolbar: FC<
         onClick={() => setSourcePanelOpen(!sourcePanelOpen)}
       >
         <FileCodeCornerIcon className="h-4 w-4" />
-        Markdown
       </Button>
     </div>
   );

--- a/packages/layout/src/node-renderers/split-node-renderer/SplitLayoutPanel.tsx
+++ b/packages/layout/src/node-renderers/split-node-renderer/SplitLayoutPanel.tsx
@@ -1,14 +1,7 @@
-import {FC, PropsWithChildren, ReactElement, useCallback} from 'react';
+import {FC, PropsWithChildren, ReactElement} from 'react';
 import {useSplitNodeContext} from '../../LayoutNodeContext';
-import {
-  getLayoutNodeId,
-  isLayoutNodeKey,
-  LayoutNode,
-} from '@sqlrooms/layout-config';
+import {getLayoutNodeId, LayoutNode} from '@sqlrooms/layout-config';
 import {ResizablePanel} from '@sqlrooms/ui';
-import type {PanelSize} from 'react-resizable-panels';
-import {useLayoutRendererContext} from '../../LayoutRendererContext';
-import {updateLayoutNodeById} from '../../layout-tree';
 import {CollapsiblePanelWrapper} from './CollapsiblePanelWrapper';
 import {
   convertLayoutNodeSizeToStyle,
@@ -23,50 +16,6 @@ export type SplitLayoutPanelProps = PropsWithChildren<{
   handleComponent?: ReactElement;
 }>;
 
-function formatResizedDefaultSize(
-  panelSize: PanelSize,
-  previousDefaultSize: string | number | undefined,
-) {
-  const inPixels = Math.round(panelSize.inPixels);
-  const asPercentage = Number(panelSize.asPercentage.toFixed(4));
-
-  if (typeof previousDefaultSize === 'number') {
-    return inPixels;
-  }
-
-  if (typeof previousDefaultSize === 'string') {
-    const trimmedSize = previousDefaultSize.trim();
-    if (trimmedSize.endsWith('%')) {
-      return `${asPercentage}%`;
-    }
-    if (trimmedSize.endsWith('px')) {
-      return `${inPixels}px`;
-    }
-  }
-
-  return `${asPercentage}%`;
-}
-
-function updateNodeDefaultSize(
-  node: LayoutNode,
-  defaultSize: string | number,
-): LayoutNode {
-  if (isLayoutNodeKey(node)) {
-    return {
-      type: 'panel',
-      id: node,
-      panel: node,
-      defaultSize,
-    };
-  }
-
-  if (node.defaultSize === defaultSize) {
-    return node;
-  }
-
-  return {...node, defaultSize};
-}
-
 export const SplitLayoutPanel: FC<SplitLayoutPanelProps> = ({
   node,
   nodeIndex,
@@ -74,7 +23,6 @@ export const SplitLayoutPanel: FC<SplitLayoutPanelProps> = ({
   children,
 }) => {
   const {node: parentNode} = useSplitNodeContext();
-  const {rootLayout, onLayoutChange} = useLayoutRendererContext();
 
   const panelId = getLayoutNodeId(node);
   const sizeProps = getLayoutNodeSize(node);
@@ -83,35 +31,6 @@ export const SplitLayoutPanel: FC<SplitLayoutPanelProps> = ({
   const isResizable = parentNode.resizable !== false;
 
   const handleElement = handleComponent || <SplitLayoutPanelResizableHandle />;
-  const handleResize = useCallback(
-    (
-      panelSize: PanelSize,
-      _id: string | number | undefined,
-      prevPanelSize: PanelSize | undefined,
-    ) => {
-      if (!onLayoutChange || !prevPanelSize || panelSize.inPixels <= 0) {
-        return;
-      }
-
-      const previousDefaultSize = isLayoutNodeKey(node)
-        ? undefined
-        : node.defaultSize;
-      const defaultSize = formatResizedDefaultSize(
-        panelSize,
-        previousDefaultSize,
-      );
-      const nextRootLayout = updateLayoutNodeById(
-        rootLayout,
-        panelId,
-        (currentNode) => updateNodeDefaultSize(currentNode, defaultSize),
-      );
-
-      if (nextRootLayout !== rootLayout) {
-        onLayoutChange(nextRootLayout);
-      }
-    },
-    [node, onLayoutChange, panelId, rootLayout],
-  );
 
   if (!isResizable) {
     return (
@@ -130,7 +49,6 @@ export const SplitLayoutPanel: FC<SplitLayoutPanelProps> = ({
         <CollapsiblePanelWrapper
           panelId={panelId}
           collapsed={collapsed}
-          onResize={handleResize}
           {...sizeProps}
         >
           {children}
@@ -142,7 +60,7 @@ export const SplitLayoutPanel: FC<SplitLayoutPanelProps> = ({
 
   return (
     <>
-      <ResizablePanel id={panelId} onResize={handleResize} {...sizeProps}>
+      <ResizablePanel id={panelId} {...sizeProps}>
         {children}
       </ResizablePanel>
       {!isLast && handleElement}

--- a/packages/layout/src/node-renderers/split-node-renderer/SplitLayoutPanelGroup.tsx
+++ b/packages/layout/src/node-renderers/split-node-renderer/SplitLayoutPanelGroup.tsx
@@ -17,15 +17,15 @@ export type RenderPanelProps = {
 
 function formatResizedDefaultSize(
   layoutSize: number,
-  groupSize: number,
+  panelSizeInPixels: number | undefined,
   previousDefaultSize: string | number | undefined,
 ) {
   const asPercentage = Number(layoutSize.toFixed(4));
   const inPixels =
-    groupSize > 0 ? Math.round((layoutSize / 100) * groupSize) : 0;
+    panelSizeInPixels === undefined ? undefined : Math.round(panelSizeInPixels);
 
   if (typeof previousDefaultSize === 'number') {
-    return inPixels;
+    return inPixels ?? previousDefaultSize;
   }
 
   if (typeof previousDefaultSize === 'string') {
@@ -34,11 +34,25 @@ function formatResizedDefaultSize(
       return `${asPercentage}%`;
     }
     if (trimmedSize.endsWith('px')) {
-      return `${inPixels}px`;
+      return inPixels === undefined ? previousDefaultSize : `${inPixels}px`;
     }
   }
 
   return `${asPercentage}%`;
+}
+
+function getPanelSizeInPixels(
+  groupElement: HTMLDivElement | null,
+  panelId: string,
+  direction: 'row' | 'column',
+) {
+  const panelElement = Array.from(
+    groupElement?.querySelectorAll<HTMLElement>('[data-panel]') ?? [],
+  ).find((element) => element.id === panelId);
+
+  return direction === 'column'
+    ? panelElement?.offsetHeight
+    : panelElement?.offsetWidth;
 }
 
 function updateNodeDefaultSize(
@@ -81,13 +95,6 @@ export const SplitLayoutPanelGroup: FC<PropsWithChildren> = ({children}) => {
         return;
       }
 
-      const groupElement = groupElementRef.current;
-      const groupSize = groupElement
-        ? parentNode.direction === 'column'
-          ? groupElement.offsetHeight
-          : groupElement.offsetWidth
-        : 0;
-
       let nextRootLayout = rootLayout;
 
       for (const child of parentNode.children) {
@@ -101,9 +108,14 @@ export const SplitLayoutPanelGroup: FC<PropsWithChildren> = ({children}) => {
         const previousDefaultSize = isLayoutNodeKey(child)
           ? undefined
           : child.defaultSize;
+        const panelSizeInPixels = getPanelSizeInPixels(
+          groupElementRef.current,
+          panelId,
+          parentNode.direction,
+        );
         const defaultSize = formatResizedDefaultSize(
           layoutSize,
-          groupSize,
+          panelSizeInPixels,
           previousDefaultSize,
         );
 

--- a/packages/layout/src/node-renderers/split-node-renderer/SplitLayoutPanelGroup.tsx
+++ b/packages/layout/src/node-renderers/split-node-renderer/SplitLayoutPanelGroup.tsx
@@ -1,21 +1,132 @@
-import {FC, PropsWithChildren} from 'react';
-import {LayoutNode} from '@sqlrooms/layout-config';
+import {FC, PropsWithChildren, useCallback, useRef} from 'react';
+import {
+  getLayoutNodeId,
+  isLayoutNodeKey,
+  LayoutNode,
+} from '@sqlrooms/layout-config';
 import {ResizablePanelGroup} from '@sqlrooms/ui';
 import {useSplitNodeContext} from '../../LayoutNodeContext';
+import {useLayoutRendererContext} from '../../LayoutRendererContext';
+import {updateLayoutNodeById} from '../../layout-tree';
+import type {Layout} from 'react-resizable-panels';
 
 export type RenderPanelProps = {
   node: LayoutNode;
   nodeIndex: number;
 };
 
+function formatResizedDefaultSize(
+  layoutSize: number,
+  groupSize: number,
+  previousDefaultSize: string | number | undefined,
+) {
+  const asPercentage = Number(layoutSize.toFixed(4));
+  const inPixels =
+    groupSize > 0 ? Math.round((layoutSize / 100) * groupSize) : 0;
+
+  if (typeof previousDefaultSize === 'number') {
+    return inPixels;
+  }
+
+  if (typeof previousDefaultSize === 'string') {
+    const trimmedSize = previousDefaultSize.trim();
+    if (trimmedSize.endsWith('%')) {
+      return `${asPercentage}%`;
+    }
+    if (trimmedSize.endsWith('px')) {
+      return `${inPixels}px`;
+    }
+  }
+
+  return `${asPercentage}%`;
+}
+
+function updateNodeDefaultSize(
+  node: LayoutNode,
+  defaultSize: string | number,
+): LayoutNode {
+  if (isLayoutNodeKey(node)) {
+    return {
+      type: 'panel',
+      id: node,
+      panel: node,
+      defaultSize,
+    };
+  }
+
+  if (node.defaultSize === defaultSize) {
+    return node;
+  }
+
+  return {...node, defaultSize};
+}
+
 export const SplitLayoutPanelGroup: FC<PropsWithChildren> = ({children}) => {
   const {node: parentNode} = useSplitNodeContext();
+  const {rootLayout, onLayoutChange} = useLayoutRendererContext();
+  const groupElementRef = useRef<HTMLDivElement | null>(null);
+  const didReceiveInitialLayoutRef = useRef(false);
 
   const orientation =
     parentNode.direction === 'column' ? 'vertical' : 'horizontal';
 
+  const handleLayoutChanged = useCallback(
+    (layout: Layout) => {
+      if (!didReceiveInitialLayoutRef.current) {
+        didReceiveInitialLayoutRef.current = true;
+        return;
+      }
+
+      if (!onLayoutChange) {
+        return;
+      }
+
+      const groupElement = groupElementRef.current;
+      const groupSize = groupElement
+        ? parentNode.direction === 'column'
+          ? groupElement.offsetHeight
+          : groupElement.offsetWidth
+        : 0;
+
+      let nextRootLayout = rootLayout;
+
+      for (const child of parentNode.children) {
+        const panelId = getLayoutNodeId(child);
+        const layoutSize = layout[panelId];
+
+        if (layoutSize === undefined) {
+          continue;
+        }
+
+        const previousDefaultSize = isLayoutNodeKey(child)
+          ? undefined
+          : child.defaultSize;
+        const defaultSize = formatResizedDefaultSize(
+          layoutSize,
+          groupSize,
+          previousDefaultSize,
+        );
+
+        nextRootLayout = updateLayoutNodeById(
+          nextRootLayout,
+          panelId,
+          (currentNode) => updateNodeDefaultSize(currentNode, defaultSize),
+        );
+      }
+
+      if (nextRootLayout !== rootLayout) {
+        onLayoutChange(nextRootLayout);
+      }
+    },
+    [onLayoutChange, parentNode.children, parentNode.direction, rootLayout],
+  );
+
   return (
-    <ResizablePanelGroup orientation={orientation}>
+    <ResizablePanelGroup
+      elementRef={groupElementRef}
+      orientation={orientation}
+      onLayoutChanged={handleLayoutChanged}
+    >
       {children}
     </ResizablePanelGroup>
   );


### PR DESCRIPTION
The resize persistence now happens in SplitLayoutPanelGroup.tsx, using react-resizable-panels’ onLayoutChanged after the resize gesture completes. SplitLayoutPanel.tsx no longer writes defaultSize from each panel’s live onResize, so dragging should no longer trigger panel re-registration mid-gesture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated panel resize handling so layout updates are managed at the panel-group level rather than by individual panels.

* **Style / UX**
  * Adjusted editor split sizing with percentage-based min/max limits.
  * Changed the source-toggle to an icon-only button and removed the visible "Markdown" label.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sqlrooms/sqlrooms/pull/660?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->