### PR TITLE
feat: Add reusable SQL query blocks and artifact tabs

### DIFF
--- a/apps/sqlrooms-cli-ui/README.md
+++ b/apps/sqlrooms-cli-ui/README.md
@@ -73,7 +73,7 @@ or Data Table Explorer flows use `grid`.
 Worksheet artifacts are block-composed documents for active analytical work.
 They can contain rich text, images, standalone Mosaic/vgplot chart blocks, and
 direct stateful blocks such as dashboards, pivot tables, Data Table Explorers,
-and Markdown documents.
+SQL queries, and Markdown documents.
 
 Standalone chart blocks reuse the same Mosaic chart view and settings panel as
 dashboard charts. Charts with the same `selectionGroupId` in one Worksheet share
@@ -83,6 +83,9 @@ Hosted dashboards are stored as direct stateful blocks keyed by their block
 instance id. Each hosted dashboard keeps its own Mosaic dashboard state and
 selection scope, so multiple dashboards in one Worksheet crossfilter
 independently.
+
+Hosted SQL queries reuse the `@sqlrooms/sql-editor` single-query block surface.
+The same query block can also be opened as a top-level SQL Query artifact tab.
 
 ## AI Artifact Context
 

--- a/apps/sqlrooms-cli-ui/src/artifactTypes.tsx
+++ b/apps/sqlrooms-cli-ui/src/artifactTypes.tsx
@@ -12,6 +12,7 @@ import {
   FileStackIcon,
   LayoutDashboardIcon,
 } from 'lucide-react';
+import {createSqlQueryBlockDefinition} from '@sqlrooms/sql-editor';
 import type {RoomState} from './store-types';
 import {STATEFUL_BLOCK_ARTIFACT_CONFIGS} from './statefulBlockArtifactConfigs';
 import {WorksheetArtifact} from './workspace/WorksheetArtifact';
@@ -26,6 +27,7 @@ export const CLI_ARTIFACT_TYPES = [
   'pivot',
   'notebook',
   'document',
+  'sql-query',
   'canvas',
   'app',
 ] as const;
@@ -48,6 +50,11 @@ const markdownDocumentBlockDefinition =
     label: STATEFUL_BLOCK_ARTIFACT_CONFIGS.document.label,
     defaultTitle: STATEFUL_BLOCK_ARTIFACT_CONFIGS.document.defaultTitle,
   });
+
+const sqlQueryBlockDefinition = createSqlQueryBlockDefinition<RoomState>({
+  label: STATEFUL_BLOCK_ARTIFACT_CONFIGS['sql-query'].label,
+  defaultTitle: STATEFUL_BLOCK_ARTIFACT_CONFIGS['sql-query'].defaultTitle,
+});
 
 export const ARTIFACT_TYPES = defineArtifactTypes({
   worksheet: {
@@ -85,6 +92,7 @@ export const ARTIFACT_TYPES = defineArtifactTypes({
   document: createArtifactTypeFromStatefulBlock(
     markdownDocumentBlockDefinition,
   ),
+  'sql-query': createArtifactTypeFromStatefulBlock(sqlQueryBlockDefinition),
   canvas: {
     label: 'Canvas',
     defaultTitle: 'Canvas',

--- a/apps/sqlrooms-cli-ui/src/context/createArtifactContextAiTools.ts
+++ b/apps/sqlrooms-cli-ui/src/context/createArtifactContextAiTools.ts
@@ -10,9 +10,11 @@ import type {RoomState} from '../store-types';
 function readCliArtifact({
   state,
   artifactId,
+  store,
 }: {
   state: RoomState;
   artifactId: string;
+  store: StoreApi<RoomState>;
 }) {
   const artifact = state.artifacts.config.artifactsById[artifactId];
   if (!artifact) {
@@ -102,10 +104,21 @@ function readCliArtifact({
   }
 
   if (artifact.type === 'sql-query') {
-    const query = state.sqlEditor.config.queries.find(
+    let query = state.sqlEditor.config.queries.find(
       (candidate) => candidate.id === artifactId,
     );
-    const result = state.sqlEditor.queryResultsById[artifactId];
+    let result = state.sqlEditor.queryResultsById[artifactId];
+    if (!query) {
+      const ensuredQuery = state.sqlEditor.ensureQuery(artifactId, {
+        name: artifact.title,
+      });
+      const nextState = store.getState();
+      query =
+        nextState.sqlEditor.config.queries.find(
+          (candidate) => candidate.id === artifactId,
+        ) ?? ensuredQuery;
+      result = nextState.sqlEditor.queryResultsById[artifactId];
+    }
     return {
       success: true as const,
       artifact: {
@@ -168,7 +181,8 @@ function createArtifactContextOptions(
         'manual',
       );
     },
-    readArtifact: ({state, artifactId}) => readCliArtifact({state, artifactId}),
+    readArtifact: ({state, artifactId}) =>
+      readCliArtifact({state, artifactId, store}),
   };
 }
 

--- a/apps/sqlrooms-cli-ui/src/context/createArtifactContextAiTools.ts
+++ b/apps/sqlrooms-cli-ui/src/context/createArtifactContextAiTools.ts
@@ -101,6 +101,29 @@ function readCliArtifact({
     };
   }
 
+  if (artifact.type === 'sql-query') {
+    const query = state.sqlEditor.config.queries.find(
+      (candidate) => candidate.id === artifactId,
+    );
+    const result = state.sqlEditor.queryResultsById[artifactId];
+    return {
+      success: true as const,
+      artifact: {
+        artifactId,
+        title: artifact.title,
+        type: artifact.type,
+      },
+      payload: {
+        kind: 'sql-query',
+        name: query?.name ?? artifact.title,
+        query: query?.query ?? '',
+        resultStatus: result?.status,
+        lastQueryStatement:
+          result?.status === 'success' ? result.lastQueryStatement : undefined,
+      },
+    };
+  }
+
   return {
     success: true as const,
     artifact: {

--- a/apps/sqlrooms-cli-ui/src/createDashboardCommands.ts
+++ b/apps/sqlrooms-cli-ui/src/createDashboardCommands.ts
@@ -10,6 +10,7 @@ type CliArtifactType =
   | 'pivot'
   | 'notebook'
   | 'document'
+  | 'sql-query'
   | 'canvas'
   | 'app';
 
@@ -93,6 +94,8 @@ function createArtifactCommand(
         state.blockDocuments.ensureBlockDocument(artifactId);
       } else if (artifactType === 'document') {
         state.documents.ensureDocument(artifactId);
+      } else if (artifactType === 'sql-query') {
+        state.sqlEditor.ensureQuery(artifactId, {name: uniqueTitle});
       } else if (artifactType === 'canvas') {
         state.canvas.ensureArtifact(artifactId);
       } else if (artifactType === 'pivot') {
@@ -196,6 +199,9 @@ export function createDashboardCommands(): RoomCommand<RoomState>[] {
         if (artifact.type === 'document') {
           state.documents.ensureDocument(artifactId);
         }
+        if (artifact.type === 'sql-query') {
+          state.sqlEditor.ensureQuery(artifactId, {name: artifact.title});
+        }
         if (artifact.type === 'canvas') {
           state.canvas.ensureArtifact(artifactId);
         }
@@ -218,6 +224,7 @@ export function createDashboardCommands(): RoomCommand<RoomState>[] {
     createArtifactCommand('pivot', 'Pivot Table'),
     createArtifactCommand('notebook', 'Notebook'),
     createArtifactCommand('document', 'Document'),
+    createArtifactCommand('sql-query', 'SQL Query'),
     createArtifactCommand('canvas', 'Canvas'),
     createArtifactCommand('app', 'App'),
     createDashboardCreateArtifactCommand(),

--- a/apps/sqlrooms-cli-ui/src/statefulBlockArtifactConfigs.ts
+++ b/apps/sqlrooms-cli-ui/src/statefulBlockArtifactConfigs.ts
@@ -95,6 +95,31 @@ export const STATEFUL_BLOCK_ARTIFACT_CONFIGS = {
       state.documents.removeDocument(artifactId);
     },
   },
+  'sql-query': {
+    artifactType: 'sql-query',
+    label: 'SQL Query',
+    defaultTitle: 'SQL Query',
+    embeddedTitle: 'Embedded SQL Query',
+    embeddedDescription: 'Embedded SQL query editor and result table',
+    resizableHeight: true,
+    defaultHeight: 720,
+    minHeight: 420,
+    maxHeight: 1600,
+    requireScrollModifier: true,
+    scrollHintLabel: 'this SQL query',
+    ensureState: (state, artifactId, title, options) => {
+      state.sqlEditor.ensureQuery(artifactId, {
+        name: title,
+        query: options?.initialText,
+      });
+    },
+    deleteState: (state, artifactId) => {
+      state.sqlEditor.removeQuery(artifactId);
+    },
+    renameState: (state, artifactId, title) => {
+      state.sqlEditor.renameQuery(artifactId, title);
+    },
+  },
 } as const satisfies Record<string, StatefulBlockArtifactConfig>;
 
 export type StatefulBlockArtifactType =

--- a/apps/sqlrooms-cli-ui/src/statefulBlockArtifactConfigs.ts
+++ b/apps/sqlrooms-cli-ui/src/statefulBlockArtifactConfigs.ts
@@ -101,12 +101,6 @@ export const STATEFUL_BLOCK_ARTIFACT_CONFIGS = {
     defaultTitle: 'SQL Query',
     embeddedTitle: 'Embedded SQL Query',
     embeddedDescription: 'Embedded SQL query editor and result table',
-    resizableHeight: true,
-    defaultHeight: 720,
-    minHeight: 420,
-    maxHeight: 1600,
-    requireScrollModifier: true,
-    scrollHintLabel: 'this SQL query',
     ensureState: (state, artifactId, title, options) => {
       state.sqlEditor.ensureQuery(artifactId, {
         name: title,

--- a/apps/sqlrooms-cli-ui/src/workspace/WorksheetArtifact.tsx
+++ b/apps/sqlrooms-cli-ui/src/workspace/WorksheetArtifact.tsx
@@ -17,6 +17,7 @@ import {WorksheetChartRenderer} from './WorksheetChartRenderer';
 import {WorksheetDashboardBlockRenderer} from './WorksheetDashboardBlockRenderer';
 import {WorksheetMarkdownDocumentBlockRenderer} from './WorksheetMarkdownDocumentBlockRenderer';
 import {WorksheetPivotBlockRenderer} from './WorksheetPivotBlockRenderer';
+import {WorksheetSqlQueryBlockRenderer} from './WorksheetSqlQueryBlockRenderer';
 
 function normalizeStatefulBlockOwnership(ownership: string | undefined) {
   return ownership === 'owned' ||
@@ -70,6 +71,7 @@ const WORKSHEET_STATEFUL_BLOCK_RENDERERS = {
   pivot: WorksheetPivotBlockRenderer,
   'data-table': WorksheetDataTableBlockRenderer,
   document: WorksheetMarkdownDocumentBlockRenderer,
+  'sql-query': WorksheetSqlQueryBlockRenderer,
 } satisfies Record<
   StatefulBlockArtifactType,
   BlockDocumentStatefulBlockRenderer

--- a/apps/sqlrooms-cli-ui/src/workspace/WorksheetSqlQueryBlockRenderer.tsx
+++ b/apps/sqlrooms-cli-ui/src/workspace/WorksheetSqlQueryBlockRenderer.tsx
@@ -1,0 +1,29 @@
+import {
+  SqlQueryBlock,
+  SQL_QUERY_BLOCK_TYPE,
+} from '@sqlrooms/sql-editor';
+import type {BlockDocumentStatefulBlockRendererProps} from '@sqlrooms/documents';
+
+export const WorksheetSqlQueryBlockRenderer = ({
+  blockInstanceId,
+  blockType,
+  title,
+  readOnly,
+}: BlockDocumentStatefulBlockRendererProps) => {
+  if (!blockInstanceId || blockType !== SQL_QUERY_BLOCK_TYPE) {
+    return (
+      <div className="text-muted-foreground p-4 text-sm">
+        Unsupported stateful block type: {blockType || 'Unconfigured'}
+      </div>
+    );
+  }
+
+  return (
+    <SqlQueryBlock
+      queryId={blockInstanceId}
+      title={title ?? 'SQL Query'}
+      readOnly={readOnly}
+      className="h-full"
+    />
+  );
+};

--- a/apps/sqlrooms-cli-ui/src/workspace/WorksheetSqlQueryBlockRenderer.tsx
+++ b/apps/sqlrooms-cli-ui/src/workspace/WorksheetSqlQueryBlockRenderer.tsx
@@ -23,7 +23,7 @@ export const WorksheetSqlQueryBlockRenderer = ({
       queryId={blockInstanceId}
       title={title ?? 'SQL Query'}
       readOnly={readOnly}
-      className="h-full"
+      compact
     />
   );
 };

--- a/dev-docs/tasks/sql-query-block-artifacts.md
+++ b/dev-docs/tasks/sql-query-block-artifacts.md
@@ -1,0 +1,89 @@
+# SQL Query Block and Artifact
+
+## Summary
+
+Add a reusable SQL query block by refactoring `@sqlrooms/sql-editor` around
+query instances and compound UI parts. Do not route this through
+`@sqlrooms/cells` or create a one-cell artifact. The first implementation should
+support both embedded worksheet blocks and top-level SQL query artifact tabs via
+`createArtifactTypeFromStatefulBlock()`.
+
+## Key Changes
+
+- In `@sqlrooms/sql-editor`, make query execution id-addressable:
+  - Add actions like `ensureQuery(queryId, options)`, `removeQuery(queryId)`,
+    `runQueryById(queryId, query?)`, `abortQueryById(queryId)`, and
+    `renameQuery(queryId, name)`.
+  - Keep existing tab-oriented APIs (`parseAndRunCurrentQuery`,
+    `parseAndRunQuery`, `abortCurrentQuery`) as compatibility wrappers around
+    the id-based actions.
+  - Keep persisted query state in `SqlEditorSliceConfig.queries` and runtime
+    results in `queryResultsById`; do not introduce a separate SQL query slice.
+- Refactor SQL editor UI into reusable compound parts:
+  - Export a new `SqlQuery` compound component from `@sqlrooms/sql-editor`, with
+    parts such as `Root`, `Header`/`Toolbar`, `Editor`, `Actions`/`RunButton`,
+    and `Results`.
+  - Existing components like `QueryEditorPanel`, `QueryEditorPanelEditor`,
+    `QueryEditorPanelActions`, and `QueryResultPanel` should remain exported and
+    be updated to accept an optional `queryId`, defaulting to the selected tab
+    for backwards compatibility.
+  - Keyboard run from the editor must run the query by its own `queryId`, not
+    whichever tab is globally selected.
+- Add a reusable SQL query stateful block definition:
+  - Export `SqlQueryBlock` and `createSqlQueryBlockDefinition<TRoomState>()`
+    from `@sqlrooms/sql-editor`.
+  - The block uses `blockId`/`blockInstanceId` as the query id, ensures query
+    state on create/ensure, removes query state on delete, and mirrors
+    artifact/block title into the query name on rename.
+  - Mark capabilities as stateful/executable; do not claim DAG or
+    relation-producing capabilities for v1.
+- Wire it into the CLI app:
+  - Add `sql-query` to `STATEFUL_BLOCK_ARTIFACT_CONFIGS` so worksheets can
+    insert SQL query blocks through the existing BlockDocument stateful block
+    menu and commands.
+  - Register the block renderer in `WorksheetArtifact`.
+  - Add `sql-query` to `CLI_ARTIFACT_TYPES` and `ARTIFACT_TYPES` using
+    `createArtifactTypeFromStatefulBlock(sqlQueryBlockDefinition)`, so queries
+    can open as artifact tabs.
+  - Use the same `SqlQueryBlock` UI for both embedded blocks and top-level query
+    artifacts, with layout/style differences handled by props or compound
+    composition.
+
+## Public API / Interface Additions
+
+- `@sqlrooms/sql-editor` exports:
+  - `SqlQuery`
+  - `SqlQueryBlock`
+  - `createSqlQueryBlockDefinition`
+  - id-based query slice actions on `SqlEditorSliceState`
+- Existing SQL editor exports remain source-compatible.
+- Existing persisted `sqlEditor` config shape remains compatible; adding query
+  entries for block-backed queries uses the existing query record shape.
+
+## Test Plan
+
+- Add or update `@sqlrooms/sql-editor` tests for:
+  - `ensureQuery` creates an id-stable query without selecting/opening it unless
+    requested.
+  - `runQueryById` stores loading/success/error/aborted results under that query
+    id.
+  - selected-tab APIs still behave as before by delegating to id-based actions.
+  - deleting a query removes its runtime result and does not break remaining
+    tabs.
+- Add component coverage where practical:
+  - `QueryResultPanel queryId` reads the requested query result.
+  - `QueryEditorPanelEditor` keyboard run executes its own query id.
+- Add CLI integration coverage or focused smoke tests:
+  - Worksheet stateful block creation creates/ensures SQL query backing state.
+  - Removing an owned SQL query block deletes its query state.
+  - Creating a top-level SQL query artifact uses the same backing state and
+    renderer.
+
+## Assumptions
+
+- V1 SQL query blocks are standalone query/result snippets, not notebook cells
+  and not DAG participants.
+- V1 query results use the current SQL editor result behavior, including result
+  limits, rather than materializing reusable relations.
+- The reusable implementation lives in `@sqlrooms/sql-editor`; the CLI app only
+  registers it as a worksheet block and artifact type.

--- a/packages/data-table/src/DataTablePaginated.tsx
+++ b/packages/data-table/src/DataTablePaginated.tsx
@@ -230,7 +230,7 @@ export function DataTablePaginated<Data extends object>({
                   key={row.id}
                   data-state={row.getIsSelected() ? 'selected' : undefined}
                   className={cn(
-                    'hover:bg-muted bg-background last:border-b-0 last:[&>td]:border-b-0',
+                    'hover:bg-muted bg-background [&>td]:border-b last:[&>td]:border-b-0',
                     row.getIsSelected() && 'bg-muted',
                   )}
                   onClick={

--- a/packages/data-table/src/DataTablePaginated.tsx
+++ b/packages/data-table/src/DataTablePaginated.tsx
@@ -169,11 +169,11 @@ export function DataTablePaginated<Data extends object>({
         )}
       >
         <ScrollArea className="h-full overflow-auto">
-          <Table disableWrapper>
-            <TableHeader>
+          <Table disableWrapper className="border-separate border-spacing-0">
+            <TableHeader className="[&_tr]:!border-b-0">
               {table.getHeaderGroups().map((headerGroup) => (
-                <TableRow key={headerGroup.id}>
-                  <TableHead className="bg-background sticky -top-px left-0 z-10 w-auto min-w-[40px] border-r py-2 text-center whitespace-nowrap">
+                <TableRow key={headerGroup.id} className="!border-b-0">
+                  <TableHead className="bg-background sticky top-0 left-0 z-10 h-auto w-auto min-w-[40px] border-r border-b py-[3px] text-center whitespace-nowrap">
                     {isFetching ? (
                       <div className="border-primary h-4 w-4 animate-spin rounded-full border-2 border-t-transparent" />
                     ) : null}
@@ -186,7 +186,7 @@ export function DataTablePaginated<Data extends object>({
                         key={header.id}
                         colSpan={header.colSpan}
                         className={cn(
-                          'bg-background hover:bg-muted sticky -top-px z-10 w-auto border-r py-2 whitespace-nowrap',
+                          'bg-background hover:bg-muted sticky top-0 z-10 h-auto w-auto border-r border-b py-[3px] whitespace-nowrap',
                           pagination ? 'cursor-pointer' : '',
                           meta?.isNumeric ? 'text-right' : 'text-left',
                           fontSizeClass,
@@ -220,7 +220,7 @@ export function DataTablePaginated<Data extends object>({
                       </TableHead>
                     );
                   })}
-                  <TableHead className="bg-background sticky -top-px w-full border-t border-r py-2 whitespace-nowrap" />
+                  <TableHead className="bg-background sticky top-0 h-auto w-full border-b py-[3px] whitespace-nowrap" />
                 </TableRow>
               ))}
             </TableHeader>
@@ -230,7 +230,7 @@ export function DataTablePaginated<Data extends object>({
                   key={row.id}
                   data-state={row.getIsSelected() ? 'selected' : undefined}
                   className={cn(
-                    'hover:bg-muted bg-background',
+                    'hover:bg-muted bg-background last:border-b-0 last:[&>td]:border-b-0',
                     row.getIsSelected() && 'bg-muted',
                   )}
                   onClick={

--- a/packages/data-table/src/DataTablePaginated.tsx
+++ b/packages/data-table/src/DataTablePaginated.tsx
@@ -170,9 +170,9 @@ export function DataTablePaginated<Data extends object>({
       >
         <ScrollArea className="h-full overflow-auto">
           <Table disableWrapper className="border-separate border-spacing-0">
-            <TableHeader className="[&_tr]:!border-b-0">
+            <TableHeader className="[&_tr]:border-b-0!">
               {table.getHeaderGroups().map((headerGroup) => (
-                <TableRow key={headerGroup.id} className="!border-b-0">
+                <TableRow key={headerGroup.id} className="border-b-0!">
                   <TableHead className="bg-background sticky top-0 left-0 z-10 h-auto w-auto min-w-[40px] border-r border-b py-[3px] text-center whitespace-nowrap">
                     {isFetching ? (
                       <div className="border-primary h-4 w-4 animate-spin rounded-full border-2 border-t-transparent" />

--- a/packages/data-table/src/DataTablePaginatedFooter.tsx
+++ b/packages/data-table/src/DataTablePaginatedFooter.tsx
@@ -69,7 +69,7 @@ export function DataTablePaginatedFooter<Data extends object>({
   };
 
   return (
-    <div className="bg-background sticky bottom-0 left-0 flex h-[45px] items-center gap-2 border-t px-2">
+    <div className="bg-background relative z-20 flex h-[45px] shrink-0 items-center gap-2 border-t px-2">
       {isFetching ? (
         <div className="ml-2 text-xs">Loading...</div>
       ) : (

--- a/packages/documents/README.md
+++ b/packages/documents/README.md
@@ -207,7 +207,7 @@ hosts can use it to seed stateful blocks such as embedded Markdown documents.
 Stateful block types can opt into persisted vertical resizing with
 `resizableHeight`, `defaultHeight`, `minHeight`, and `maxHeight`; the editor
 stores the resulting `height` on the block node and renders a bottom resize
-handle for writable documents. Interactive blocks can also opt into
+handle just below the block for writable documents. Interactive blocks can also opt into
 `requireScrollModifier`; ordinary wheel gestures then keep scrolling the
 document and show a short hint, while Cmd+scroll on macOS or Ctrl+scroll
 elsewhere scrolls nested overflow regions inside the block. Use

--- a/packages/documents/src/BlockDocumentEditor/node-views/BlockDocumentStatefulBlockNodeView.tsx
+++ b/packages/documents/src/BlockDocumentEditor/node-views/BlockDocumentStatefulBlockNodeView.tsx
@@ -352,13 +352,13 @@ export const BlockDocumentStatefulBlockNodeView: FC<
         )}
         {resizableHeight && !readOnly ? (
           <div
-            className="absolute right-0 bottom-0 left-0 flex h-3 cursor-row-resize items-end justify-center opacity-0 transition-opacity group-hover/stateful-block:opacity-100"
+            className="absolute right-0 -bottom-4 left-0 z-10 flex h-3 cursor-row-resize items-start justify-center opacity-0 transition-opacity group-hover/stateful-block:opacity-100"
             onMouseDown={handleResizeMouseDown}
             role="separator"
             aria-orientation="horizontal"
             aria-label="Resize block height"
           >
-            <div className="bg-muted-foreground/50 mb-1 h-1 w-10 rounded-full" />
+            <div className="bg-muted-foreground/50 mt-0.5 h-1 w-10 rounded-full" />
           </div>
         ) : null}
         <ModifierScrollOverlay

--- a/packages/sql-editor/README.md
+++ b/packages/sql-editor/README.md
@@ -129,7 +129,8 @@ export function QueryBlock() {
 ```
 
 `SqlQuery.Results` accepts the same props as `QueryResultPanel`, including
-`footerDetails` for small metadata rendered at the end of the result footer.
+`footerDetails` for small metadata rendered at the end of the result footer and
+`dataTableClassName` for styling the inner paginated table.
 
 Use `createSqlQueryBlockDefinition()` when a SQL query should be both embeddable
 as a stateful block and openable as an artifact shell.

--- a/packages/sql-editor/README.md
+++ b/packages/sql-editor/README.md
@@ -128,6 +128,9 @@ export function QueryBlock() {
 }
 ```
 
+`SqlQuery.Results` accepts the same props as `QueryResultPanel`, including
+`footerDetails` for small metadata rendered at the end of the result footer.
+
 Use `createSqlQueryBlockDefinition()` when a SQL query should be both embeddable
 as a stateful block and openable as an artifact shell.
 

--- a/packages/sql-editor/README.md
+++ b/packages/sql-editor/README.md
@@ -4,6 +4,8 @@ This package provides:
 
 - `createSqlEditorSlice()` for query tabs, execution, and results state
 - `SqlEditor` and `SqlEditorModal` UI
+- `SqlQuery` compound components and `SqlQueryBlock` for reusable single-query
+  surfaces
 - `SqlMonacoEditor` standalone SQL editor
 - helpers/components for query results, table structure, and SQL data sources
 
@@ -94,6 +96,40 @@ function RunQueryButton() {
   return <Button onClick={() => void run()}>Run query</Button>;
 }
 ```
+
+For reusable single-query surfaces, use id-addressable query actions:
+
+```tsx
+const ensureQuery = useRoomStore((state) => state.sqlEditor.ensureQuery);
+const runQueryById = useRoomStore((state) => state.sqlEditor.runQueryById);
+
+ensureQuery('query-1', {name: 'Top Airports', query: 'SELECT * FROM airports'});
+await runQueryById('query-1');
+```
+
+## Single Query UI
+
+`SqlQuery` is a compound component for rearranging and styling a single query
+experience without the full tabbed workbench:
+
+```tsx
+import {SqlQuery} from '@sqlrooms/sql-editor';
+
+export function QueryBlock() {
+  return (
+    <SqlQuery.Root queryId="query-1" name="Top Airports">
+      <SqlQuery.Header title="Top Airports">
+        <SqlQuery.Actions />
+      </SqlQuery.Header>
+      <SqlQuery.Editor />
+      <SqlQuery.Results />
+    </SqlQuery.Root>
+  );
+}
+```
+
+Use `createSqlQueryBlockDefinition()` when a SQL query should be both embeddable
+as a stateful block and openable as an artifact shell.
 
 ## Standalone editor (without SQLRooms store)
 

--- a/packages/sql-editor/package.json
+++ b/packages/sql-editor/package.json
@@ -33,6 +33,7 @@
     "@marimo-team/codemirror-sql": "^0.2.0",
     "@monaco-editor/react": "^4.7.0",
     "@paralleldrive/cuid2": "^3.0.0",
+    "@sqlrooms/blocks": "workspace:*",
     "@sqlrooms/codemirror": "workspace:*",
     "@sqlrooms/data-table": "workspace:*",
     "@sqlrooms/db": "workspace:*",

--- a/packages/sql-editor/src/SqlCodeMirrorEditor.tsx
+++ b/packages/sql-editor/src/SqlCodeMirrorEditor.tsx
@@ -24,6 +24,8 @@ export interface SqlCodeMirrorEditorProps extends Omit<
   connector?: DuckDbConnector;
   /** Table schemas for autocompletion and hover tooltips */
   tableSchemas?: DataTable[];
+  /** Hide all editor gutters. Useful for compact embedded editors. */
+  hideGutter?: boolean;
   /** Callback to get the latest table schemas */
   getLatestSchemas?: () => {tableSchemas: DataTable[]};
   /** Callback when Cmd+Enter is pressed (selected text or full document) */
@@ -47,6 +49,7 @@ export const SqlCodeMirrorEditor: React.FC<SqlCodeMirrorEditorProps> = ({
   dialect = SqlDialects.DuckDb,
   connector,
   tableSchemas = [],
+  hideGutter,
   getLatestSchemas,
   onRunQuery,
   onMount,
@@ -72,9 +75,9 @@ export const SqlCodeMirrorEditor: React.FC<SqlCodeMirrorEditorProps> = ({
         connector,
       }),
       createSqlKeymap(onRunQuery),
-      createSqlTheme(),
+      createSqlTheme({hideGutter}),
     ];
-  }, [dialect, currentSchemas, onRunQuery, connector]);
+  }, [dialect, currentSchemas, onRunQuery, connector, hideGutter]);
 
   // Handle editor mount
   const handleEditorMount = useCallback(

--- a/packages/sql-editor/src/SqlEditorSlice.tsx
+++ b/packages/sql-editor/src/SqlEditorSlice.tsx
@@ -324,18 +324,6 @@ export function createSqlEditorSlice({
               config.openTabs = config.openTabs.filter((id) => id !== queryId);
               delete draft.sqlEditor.queryResultsById[queryId];
 
-              if (config.queries.length === 0) {
-                config.queries.push({
-                  id: 'default',
-                  name: 'SQL',
-                  query: '',
-                  lastOpenedAt: Date.now(),
-                });
-                config.openTabs = ['default'];
-                config.selectedQueryId = 'default';
-                return;
-              }
-
               if (wasSelected) {
                 const nextSelectedId =
                   config.openTabs[0] ?? config.queries[0]?.id;
@@ -344,6 +332,8 @@ export function createSqlEditorSlice({
                   if (!config.openTabs.includes(nextSelectedId)) {
                     config.openTabs.push(nextSelectedId);
                   }
+                } else {
+                  config.selectedQueryId = '';
                 }
               }
             }),

--- a/packages/sql-editor/src/SqlEditorSlice.tsx
+++ b/packages/sql-editor/src/SqlEditorSlice.tsx
@@ -39,21 +39,30 @@ export type EnsureSqlQueryOptions = {
 };
 
 export type QueryResult =
-  | {status: 'loading'; isBeingAborted?: boolean; controller: AbortController}
-  | {status: 'aborted'}
-  | {status: 'error'; error: string}
+  | {
+      status: 'loading';
+      isBeingAborted?: boolean;
+      controller: AbortController;
+      startedAt?: number;
+    }
+  | {status: 'aborted'; durationMs?: number; completedAt?: number}
+  | {status: 'error'; error: string; durationMs?: number; completedAt?: number}
   | {
       status: 'success';
       type: 'pragma' | 'explain' | 'select';
       result: arrow.Table | undefined;
       query: string;
       lastQueryStatement: string;
+      durationMs?: number;
+      completedAt?: number;
     }
   | {
       status: 'success';
       type: 'exec';
       query: string;
       lastQueryStatement: string;
+      durationMs?: number;
+      completedAt?: number;
     };
 
 export function isQueryWithResult(
@@ -121,6 +130,11 @@ export type SqlEditorSliceState = {
      * Abort a running query by id.
      */
     abortQueryById(queryId: string): void;
+
+    /**
+     * Clear the runtime result for a query id.
+     */
+    clearQueryResult(queryId: string): void;
 
     /**
      * Run the currently selected query.
@@ -561,6 +575,18 @@ export function createSqlEditorSlice({
           );
         },
 
+        clearQueryResult: (queryId) => {
+          const currentResult = get().sqlEditor.queryResultsById[queryId];
+          if (currentResult?.status === 'loading') {
+            currentResult.controller.abort();
+          }
+          set((state) =>
+            produce(state, (draft) => {
+              delete draft.sqlEditor.queryResultsById[queryId];
+            }),
+          );
+        },
+
         parseAndRunQuery: async (query): Promise<void> =>
           get().sqlEditor.runQueryById(
             get().sqlEditor.config.selectedQueryId,
@@ -585,6 +611,7 @@ export function createSqlEditorSlice({
 
           // Create abort controller for this query execution
           const queryController = new AbortController();
+          const startedAt = Date.now();
 
           // First update loading state and clear results
           set((state) =>
@@ -594,6 +621,7 @@ export function createSqlEditorSlice({
                 status: 'loading',
                 isBeingAborted: false,
                 controller: queryController,
+                startedAt,
               };
             }),
           );
@@ -646,6 +674,7 @@ export function createSqlEditorSlice({
                 query,
                 lastQueryStatement,
                 result,
+                durationMs: Date.now() - startedAt,
               };
             } else {
               // Run the complete query as it is
@@ -680,6 +709,7 @@ export function createSqlEditorSlice({
                   query,
                   lastQueryStatement,
                   result,
+                  durationMs: Date.now() - startedAt,
                 };
               } else if (/^(PRAGMA)/i.test(lastQueryStatement)) {
                 queryResult = {
@@ -688,6 +718,7 @@ export function createSqlEditorSlice({
                   query,
                   lastQueryStatement,
                   result,
+                  durationMs: Date.now() - startedAt,
                 };
               } else {
                 queryResult = {
@@ -695,6 +726,7 @@ export function createSqlEditorSlice({
                   type: 'exec',
                   query,
                   lastQueryStatement,
+                  durationMs: Date.now() - startedAt,
                 };
               }
             }
@@ -716,14 +748,19 @@ export function createSqlEditorSlice({
               errorMessage === 'Query aborted' ||
               queryController.signal.aborted
             ) {
-              queryResult = {status: 'aborted'};
+              queryResult = {
+                status: 'aborted',
+                durationMs: Date.now() - startedAt,
+              };
             } else {
               queryResult = {
                 status: 'error',
                 error: errorMessage,
+                durationMs: Date.now() - startedAt,
               };
             }
           }
+          queryResult = {...queryResult, completedAt: Date.now()};
 
           // Update state without Immer since Arrow Tables don't play well with drafts.
           set((state) => {

--- a/packages/sql-editor/src/SqlEditorSlice.tsx
+++ b/packages/sql-editor/src/SqlEditorSlice.tsx
@@ -29,6 +29,15 @@ import {z} from 'zod';
 
 const SQL_EDITOR_COMMAND_OWNER = '@sqlrooms/sql-editor';
 
+export type SqlEditorQuery = SqlEditorSliceConfig['queries'][number];
+
+export type EnsureSqlQueryOptions = {
+  name?: string;
+  query?: string;
+  open?: boolean;
+  select?: boolean;
+};
+
 export type QueryResult =
   | {status: 'loading'; isBeingAborted?: boolean; controller: AbortController}
   | {status: 'aborted'}
@@ -86,6 +95,32 @@ export type SqlEditorSliceState = {
      * Set the config for the sql editor slice.
      */
     setConfig(config: SqlEditorSliceConfig): void;
+
+    /**
+     * Ensure an id-addressable query exists without requiring it to be an open
+     * workbench tab.
+     */
+    ensureQuery(queryId: string, options?: EnsureSqlQueryOptions): SqlEditorQuery;
+
+    /**
+     * Remove an id-addressable query and its runtime result.
+     */
+    removeQuery(queryId: string): void;
+
+    /**
+     * Rename an id-addressable query.
+     */
+    renameQuery(queryId: string, name: string): void;
+
+    /**
+     * Run a query by id, optionally overriding its stored SQL text first.
+     */
+    runQueryById(queryId: string, query?: string): Promise<void>;
+
+    /**
+     * Abort a running query by id.
+     */
+    abortQueryById(queryId: string): void;
 
     /**
      * Run the currently selected query.
@@ -216,6 +251,104 @@ export function createSqlEditorSlice({
           );
         },
 
+        ensureQuery: (queryId, options = {}) => {
+          const now = Date.now();
+          const existingQuery = get().sqlEditor.config.queries.find(
+            (query) => query.id === queryId,
+          );
+          const shouldOpen = Boolean(options.open || options.select);
+          const nextQuery: SqlEditorQuery = existingQuery
+            ? {
+                ...existingQuery,
+                ...(options.name !== undefined ? {name: options.name} : {}),
+                ...(options.query !== undefined ? {query: options.query} : {}),
+                ...(options.select ? {lastOpenedAt: now} : {}),
+              }
+            : {
+                id: queryId,
+                name: options.name ?? 'SQL Query',
+                query: options.query ?? '',
+                ...(options.select ? {lastOpenedAt: now} : {}),
+              };
+
+          set((state) =>
+            produce(state, (draft) => {
+              const config = draft.sqlEditor.config;
+              const index = config.queries.findIndex(
+                (query) => query.id === queryId,
+              );
+              if (index >= 0) {
+                config.queries[index] = nextQuery;
+              } else {
+                config.queries.push(nextQuery);
+              }
+              if (shouldOpen && !config.openTabs.includes(queryId)) {
+                config.openTabs.push(queryId);
+              }
+              if (options.select) {
+                config.selectedQueryId = queryId;
+              }
+            }),
+          );
+
+          return nextQuery;
+        },
+
+        removeQuery: (queryId) => {
+          const currentResult = get().sqlEditor.queryResultsById[queryId];
+          if (currentResult?.status === 'loading') {
+            currentResult.controller.abort();
+          }
+
+          set((state) =>
+            produce(state, (draft) => {
+              const config = draft.sqlEditor.config;
+              const wasSelected = config.selectedQueryId === queryId;
+              config.queries = config.queries.filter(
+                (query) => query.id !== queryId,
+              );
+              config.openTabs = config.openTabs.filter((id) => id !== queryId);
+              delete draft.sqlEditor.queryResultsById[queryId];
+
+              if (config.queries.length === 0) {
+                config.queries.push({
+                  id: 'default',
+                  name: 'SQL',
+                  query: '',
+                  lastOpenedAt: Date.now(),
+                });
+                config.openTabs = ['default'];
+                config.selectedQueryId = 'default';
+                return;
+              }
+
+              if (wasSelected) {
+                const nextSelectedId =
+                  config.openTabs[0] ?? config.queries[0]?.id;
+                if (nextSelectedId) {
+                  config.selectedQueryId = nextSelectedId;
+                  if (!config.openTabs.includes(nextSelectedId)) {
+                    config.openTabs.push(nextSelectedId);
+                  }
+                }
+              }
+            }),
+          );
+        },
+
+        renameQuery: (queryId, name) => {
+          set((state) =>
+            produce(state, (draft) => {
+              const query = draft.sqlEditor.config.queries.find(
+                (candidate) => candidate.id === queryId,
+              );
+              if (query) {
+                query.name = name || query.name;
+              }
+            }),
+          );
+        },
+
         exportResultsToCsv: (results, filename) => {
           if (!results) return;
           const blob = new Blob([csvFormat(results.toArray())], {
@@ -307,16 +440,7 @@ export function createSqlEditorSlice({
         },
 
         renameQueryTab: (queryId, newName) => {
-          set((state) =>
-            produce(state, (draft) => {
-              const query = draft.sqlEditor.config.queries.find(
-                (q) => q.id === queryId,
-              );
-              if (query) {
-                query.name = newName || query.name;
-              }
-            }),
-          );
+          get().sqlEditor.renameQuery(queryId, newName);
         },
 
         closeQueryTab: (queryId) => {
@@ -407,24 +531,10 @@ export function createSqlEditorSlice({
         },
 
         parseAndRunCurrentQuery: async (): Promise<void> =>
-          get().sqlEditor.parseAndRunQuery(get().sqlEditor.getCurrentQuery()),
+          get().sqlEditor.runQueryById(get().sqlEditor.config.selectedQueryId),
 
         abortCurrentQuery: () => {
-          const selectedQueryId = get().sqlEditor.config.selectedQueryId;
-          const currentResult =
-            get().sqlEditor.queryResultsById[selectedQueryId];
-          if (currentResult?.status === 'loading' && currentResult.controller) {
-            currentResult.controller.abort();
-          }
-
-          set((state) =>
-            produce(state, (draft) => {
-              const result = draft.sqlEditor.queryResultsById[selectedQueryId];
-              if (result?.status === 'loading') {
-                result.isBeingAborted = true;
-              }
-            }),
-          );
+          get().sqlEditor.abortQueryById(get().sqlEditor.config.selectedQueryId);
         },
 
         setQueryResultLimit: (limit) => {
@@ -435,16 +545,43 @@ export function createSqlEditorSlice({
           );
         },
 
-        parseAndRunQuery: async (query): Promise<void> => {
-          const selectedQueryId = get().sqlEditor.config.selectedQueryId;
+        abortQueryById: (queryId) => {
+          const currentResult = get().sqlEditor.queryResultsById[queryId];
+          if (currentResult?.status === 'loading' && currentResult.controller) {
+            currentResult.controller.abort();
+          }
+
+          set((state) =>
+            produce(state, (draft) => {
+              const result = draft.sqlEditor.queryResultsById[queryId];
+              if (result?.status === 'loading') {
+                result.isBeingAborted = true;
+              }
+            }),
+          );
+        },
+
+        parseAndRunQuery: async (query): Promise<void> =>
+          get().sqlEditor.runQueryById(
+            get().sqlEditor.config.selectedQueryId,
+            query,
+          ),
+
+        runQueryById: async (queryId, queryOverride): Promise<void> => {
+          const storedQuery = get().sqlEditor.config.queries.find(
+            (query) => query.id === queryId,
+          );
+          const query = queryOverride ?? storedQuery?.query ?? '';
           const existingResult =
-            get().sqlEditor.queryResultsById[selectedQueryId];
+            get().sqlEditor.queryResultsById[queryId];
           if (existingResult?.status === 'loading') {
             throw new Error('Query already running');
           }
           if (!query.trim()) {
             return;
           }
+
+          get().sqlEditor.ensureQuery(queryId, {query});
 
           // Create abort controller for this query execution
           const queryController = new AbortController();
@@ -453,7 +590,7 @@ export function createSqlEditorSlice({
           set((state) =>
             produce(state, (draft) => {
               draft.sqlEditor.selectedTable = undefined;
-              draft.sqlEditor.queryResultsById[selectedQueryId] = {
+              draft.sqlEditor.queryResultsById[queryId] = {
                 status: 'loading',
                 isBeingAborted: false,
                 controller: queryController,
@@ -589,16 +726,30 @@ export function createSqlEditorSlice({
           }
 
           // Update state without Immer since Arrow Tables don't play well with drafts.
-          set((state) => ({
-            ...state,
-            sqlEditor: {
-              ...state.sqlEditor,
-              queryResultsById: {
-                ...state.sqlEditor.queryResultsById,
-                [selectedQueryId]: queryResult,
+          set((state) => {
+            const currentResult = state.sqlEditor.queryResultsById[queryId];
+            const queryStillExists = state.sqlEditor.config.queries.some(
+              (candidate) => candidate.id === queryId,
+            );
+            if (
+              !queryStillExists ||
+              currentResult?.status !== 'loading' ||
+              currentResult.controller !== queryController
+            ) {
+              return state;
+            }
+
+            return {
+              ...state,
+              sqlEditor: {
+                ...state.sqlEditor,
+                queryResultsById: {
+                  ...state.sqlEditor.queryResultsById,
+                  [queryId]: queryResult,
+                },
               },
-            },
-          }));
+            };
+          });
         },
       },
     } satisfies SqlEditorSliceState;

--- a/packages/sql-editor/src/SqlQuery.tsx
+++ b/packages/sql-editor/src/SqlQuery.tsx
@@ -1,0 +1,146 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  type FC,
+  type PropsWithChildren,
+  type ReactNode,
+} from 'react';
+import {cn} from '@sqlrooms/ui';
+import {QueryEditorPanelActions} from './components/QueryEditorPanelActions';
+import {QueryEditorPanelEditor} from './components/QueryEditorPanelEditor';
+import {
+  QueryResultPanel,
+  type QueryResultPanelProps,
+} from './components/QueryResultPanel';
+import {useStoreWithSqlEditor} from './SqlEditorSlice';
+
+type SqlQueryContextValue = {
+  queryId: string;
+  readOnly?: boolean;
+};
+
+const SqlQueryContext = createContext<SqlQueryContextValue | null>(null);
+
+function useSqlQueryContext() {
+  const context = useContext(SqlQueryContext);
+  if (!context) {
+    throw new Error(
+      'SqlQuery compound components must be used within SqlQuery.Root',
+    );
+  }
+  return context;
+}
+
+export type SqlQueryRootProps = PropsWithChildren<{
+  queryId: string;
+  name?: string;
+  initialQuery?: string;
+  readOnly?: boolean;
+  className?: string;
+}>;
+
+const SqlQueryRoot: FC<SqlQueryRootProps> = ({
+  queryId,
+  name,
+  initialQuery,
+  readOnly,
+  className,
+  children,
+}) => {
+  const ensureQuery = useStoreWithSqlEditor(
+    (state) => state.sqlEditor.ensureQuery,
+  );
+
+  useEffect(() => {
+    ensureQuery(queryId, {name, query: initialQuery});
+  }, [ensureQuery, initialQuery, name, queryId]);
+
+  return (
+    <SqlQueryContext.Provider value={{queryId, readOnly}}>
+      <div className={cn('flex h-full min-h-0 flex-col', className)}>
+        {children}
+      </div>
+    </SqlQueryContext.Provider>
+  );
+};
+
+export type SqlQueryHeaderProps = PropsWithChildren<{
+  title?: ReactNode;
+  className?: string;
+}>;
+
+const SqlQueryHeader: FC<SqlQueryHeaderProps> = ({
+  title,
+  className,
+  children,
+}) => {
+  if (!title && !children) return null;
+
+  return (
+    <div
+      className={cn(
+        'border-border flex items-center gap-2 border-b px-3 py-2',
+        className,
+      )}
+    >
+      {title ? (
+        <div className="min-w-0 flex-1 truncate text-sm font-medium">
+          {title}
+        </div>
+      ) : null}
+      {children}
+    </div>
+  );
+};
+
+export type SqlQueryToolbarProps = PropsWithChildren<{
+  className?: string;
+}>;
+
+const SqlQueryToolbar: FC<SqlQueryToolbarProps> = ({className, children}) => (
+  <div className={cn('flex items-center gap-2 px-3 py-2', className)}>
+    {children}
+  </div>
+);
+
+export type SqlQueryActionsProps = {
+  className?: string;
+};
+
+const SqlQueryActions: FC<SqlQueryActionsProps> = ({className}) => {
+  const {queryId, readOnly} = useSqlQueryContext();
+  if (readOnly) return null;
+  return <QueryEditorPanelActions queryId={queryId} className={className} />;
+};
+
+export type SqlQueryEditorProps = {
+  className?: string;
+};
+
+const SqlQueryEditor: FC<SqlQueryEditorProps> = ({className}) => {
+  const {queryId, readOnly} = useSqlQueryContext();
+  return (
+    <QueryEditorPanelEditor
+      queryId={queryId}
+      readOnly={readOnly}
+      className={className}
+    />
+  );
+};
+
+export type SqlQueryResultsProps = Omit<QueryResultPanelProps, 'queryId'>;
+
+const SqlQueryResults: FC<SqlQueryResultsProps> = (props) => {
+  const {queryId} = useSqlQueryContext();
+  return <QueryResultPanel {...props} queryId={queryId} />;
+};
+
+export const SqlQuery = Object.assign(SqlQueryRoot, {
+  Root: SqlQueryRoot,
+  Header: SqlQueryHeader,
+  Toolbar: SqlQueryToolbar,
+  Actions: SqlQueryActions,
+  Editor: SqlQueryEditor,
+  Results: SqlQueryResults,
+});

--- a/packages/sql-editor/src/SqlQuery.tsx
+++ b/packages/sql-editor/src/SqlQuery.tsx
@@ -116,15 +116,23 @@ const SqlQueryActions: FC<SqlQueryActionsProps> = ({className}) => {
 
 export type SqlQueryEditorProps = {
   className?: string;
+  autoHeight?: boolean;
+  compact?: boolean;
 };
 
-const SqlQueryEditor: FC<SqlQueryEditorProps> = ({className}) => {
+const SqlQueryEditor: FC<SqlQueryEditorProps> = ({
+  className,
+  autoHeight,
+  compact,
+}) => {
   const {queryId, readOnly} = useSqlQueryContext();
   return (
     <QueryEditorPanelEditor
       queryId={queryId}
       readOnly={readOnly}
       className={className}
+      autoHeight={autoHeight}
+      compact={compact}
     />
   );
 };

--- a/packages/sql-editor/src/SqlQueryBlock.tsx
+++ b/packages/sql-editor/src/SqlQueryBlock.tsx
@@ -3,17 +3,39 @@ import type {
   StatefulBlockRenderProps,
 } from '@sqlrooms/blocks';
 import type {BaseRoomStoreState} from '@sqlrooms/room-shell';
-import {cn} from '@sqlrooms/ui';
-import {Code2Icon} from 'lucide-react';
-import type {ComponentType, FC} from 'react';
+import {formatDateTime} from '@sqlrooms/utils';
+import {
+  Button,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+  cn,
+  Spinner,
+} from '@sqlrooms/ui';
+import {Code2Icon, PlayIcon, SquareIcon, XIcon} from 'lucide-react';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ComponentType,
+  type FC,
+  type MouseEvent as ReactMouseEvent,
+} from 'react';
 import {SqlQuery} from './SqlQuery';
-import type {SqlEditorSliceState} from './SqlEditorSlice';
+import {
+  useStoreWithSqlEditor,
+  type QueryResult,
+  type SqlEditorSliceState,
+} from './SqlEditorSlice';
 
 export type SqlQueryBlockProps = Partial<StatefulBlockRenderProps> & {
   queryId?: string;
   className?: string;
   editorClassName?: string;
   resultsClassName?: string;
+  compact?: boolean;
 };
 
 export const SQL_QUERY_BLOCK_TYPE = 'sql-query';
@@ -26,6 +48,7 @@ export const SqlQueryBlock: FC<SqlQueryBlockProps> = ({
   className,
   editorClassName,
   resultsClassName,
+  compact,
 }) => {
   const resolvedQueryId = queryId ?? blockId;
 
@@ -34,6 +57,19 @@ export const SqlQueryBlock: FC<SqlQueryBlockProps> = ({
       <div className="text-muted-foreground p-4 text-sm">
         SQL query block is missing a query id.
       </div>
+    );
+  }
+
+  if (compact) {
+    return (
+      <CompactSqlQueryBlock
+        queryId={resolvedQueryId}
+        title={title}
+        readOnly={readOnly}
+        className={className}
+        editorClassName={editorClassName}
+        resultsClassName={resultsClassName}
+      />
     );
   }
 
@@ -51,16 +87,256 @@ export const SqlQueryBlock: FC<SqlQueryBlockProps> = ({
         <SqlQuery.Editor className={cn('min-h-[220px]', editorClassName)} />
       </div>
       <div
-        className={cn(
-          'border-border min-h-[220px] border-t',
-          resultsClassName,
-        )}
+        className={cn('border-border min-h-[220px] border-t', resultsClassName)}
       >
         <SqlQuery.Results />
       </div>
     </SqlQuery.Root>
   );
 };
+
+type CompactSqlQueryBlockProps = {
+  queryId: string;
+  title?: string;
+  readOnly?: boolean;
+  className?: string;
+  editorClassName?: string;
+  resultsClassName?: string;
+};
+
+const CompactSqlQueryBlock: FC<CompactSqlQueryBlockProps> = ({
+  queryId,
+  title,
+  readOnly,
+  className,
+  editorClassName,
+  resultsClassName,
+}) => {
+  const runQueryById = useStoreWithSqlEditor(
+    (state) => state.sqlEditor.runQueryById,
+  );
+  const abortQueryById = useStoreWithSqlEditor(
+    (state) => state.sqlEditor.abortQueryById,
+  );
+  const clearQueryResult = useStoreWithSqlEditor(
+    (state) => state.sqlEditor.clearQueryResult,
+  );
+  const queryResult = useStoreWithSqlEditor(
+    (state) => state.sqlEditor.queryResultsById[queryId],
+  );
+  const isLoading = queryResult?.status === 'loading';
+  const isCancelling = isLoading && queryResult.isBeingAborted;
+  const [now, setNow] = useState(() => Date.now());
+  const resultCompletedAt = getQueryResultCompletedAt(queryResult);
+  const displayNow = Math.max(now, resultCompletedAt ?? now);
+  const resultLabel = getCompactResultLabel(queryResult, displayNow);
+  const resultTooltip = getCompactResultTooltip(queryResult, displayNow);
+  const [resultHeight, setResultHeight] = useState(256);
+  const resizeCleanupRef = useRef<(() => void) | null>(null);
+
+  const handleResizeMouseDown = useCallback(
+    (event: ReactMouseEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      const startY = event.clientY;
+      const startHeight = resultHeight;
+      resizeCleanupRef.current?.();
+
+      const handleMouseMove = (moveEvent: MouseEvent) => {
+        setResultHeight(
+          Math.max(128, Math.round(startHeight + moveEvent.clientY - startY)),
+        );
+      };
+
+      const handleMouseUp = (upEvent: MouseEvent) => {
+        setResultHeight(
+          Math.max(128, Math.round(startHeight + upEvent.clientY - startY)),
+        );
+        resizeCleanupRef.current?.();
+      };
+
+      resizeCleanupRef.current = () => {
+        window.removeEventListener('mousemove', handleMouseMove);
+        window.removeEventListener('mouseup', handleMouseUp);
+        resizeCleanupRef.current = null;
+      };
+      window.addEventListener('mousemove', handleMouseMove);
+      window.addEventListener('mouseup', handleMouseUp);
+    },
+    [resultHeight],
+  );
+
+  useEffect(() => {
+    return () => {
+      resizeCleanupRef.current?.();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!resultCompletedAt) return;
+    const intervalId = window.setInterval(() => {
+      setNow(Date.now());
+    }, 30_000);
+    return () => window.clearInterval(intervalId);
+  }, [resultCompletedAt]);
+
+  return (
+    <SqlQuery.Root
+      queryId={queryId}
+      name={title ?? 'SQL Query'}
+      readOnly={readOnly}
+      className={cn(
+        'bg-background min-h-0 overflow-hidden rounded-md',
+        className,
+      )}
+    >
+      <div className="flex items-start gap-2 py-2 pr-2 pl-0">
+        <div className="min-w-0 flex-1">
+          <SqlQuery.Editor
+            autoHeight
+            compact
+            className={cn(
+              'text-sm [&_.cm-content]:pl-0 [&_.cm-line]:pl-0',
+              editorClassName,
+            )}
+          />
+        </div>
+        {readOnly ? null : (
+          <TooltipProvider delayDuration={200}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  size="icon"
+                  variant={isLoading ? 'destructive' : 'secondary'}
+                  className="mt-1 h-6 w-6 shrink-0 rounded-md p-0"
+                  onClick={() =>
+                    isLoading
+                      ? abortQueryById(queryId)
+                      : void runQueryById(queryId)
+                  }
+                  disabled={isCancelling}
+                  aria-label={isLoading ? 'Cancel query' : 'Run query'}
+                >
+                  {isCancelling ? (
+                    <Spinner className="h-3 w-3 text-current" />
+                  ) : isLoading ? (
+                    <SquareIcon className="h-3 w-3" />
+                  ) : (
+                    <PlayIcon className="h-3 w-3" />
+                  )}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent align="end">
+                {isLoading ? 'Cancel query' : 'Run query'}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )}
+      </div>
+      {queryResult ? (
+        <div className={cn('border-border border-t', resultsClassName)}>
+          <div className="bg-background flex items-center gap-2 px-2 py-1">
+            {resultTooltip ? (
+              <TooltipProvider delayDuration={200}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div className="text-muted-foreground flex-1 cursor-default text-xs">
+                      {resultLabel}
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent align="start" className="space-y-1 text-xs">
+                    {resultTooltip.map((line) => (
+                      <div key={line}>{line}</div>
+                    ))}
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            ) : (
+              <div className="text-muted-foreground flex-1 text-xs">
+                {resultLabel}
+              </div>
+            )}
+            <Button
+              size="icon"
+              variant="ghost"
+              className="h-6 w-6"
+              onClick={() => clearQueryResult(queryId)}
+              title="Close result"
+            >
+              <XIcon className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+          <div
+            className="relative min-h-32 overflow-auto"
+            style={{height: resultHeight}}
+          >
+            <SqlQuery.Results className="h-full" />
+            <div
+              className="absolute right-0 bottom-0 left-0 flex h-3 cursor-row-resize items-end justify-center"
+              onMouseDown={handleResizeMouseDown}
+              role="separator"
+              aria-orientation="horizontal"
+              aria-label="Resize query result height"
+            >
+              <div className="bg-muted-foreground/50 mb-1 h-1 w-10 rounded-full" />
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </SqlQuery.Root>
+  );
+};
+
+function getCompactResultLabel(queryResult: QueryResult | undefined, now: number) {
+  if (!queryResult) return '';
+  if (queryResult.status === 'loading') return 'Running query...';
+  if (!queryResult.completedAt) return 'Last run';
+  return formatCompactRelativeTime(queryResult.completedAt, now);
+}
+
+function getCompactResultTooltip(
+  queryResult: QueryResult | undefined,
+  now: number,
+) {
+  if (!queryResult || queryResult.status === 'loading') return undefined;
+  const completedAt = queryResult.completedAt;
+  const lines: string[] = [];
+  if (completedAt) {
+    lines.push(`Last run: ${formatCompactRelativeTime(completedAt, now)}`);
+    lines.push(`Completed: ${formatDateTime(completedAt)}`);
+  }
+  if (queryResult.durationMs != null) {
+    lines.push(`Query time: ${formatQueryDuration(queryResult.durationMs)}`);
+  }
+  if (queryResult.status === 'error') lines.push('Status: Failed');
+  if (queryResult.status === 'aborted') lines.push('Status: Cancelled');
+  return lines.length > 0 ? lines : undefined;
+}
+
+function getQueryResultCompletedAt(queryResult: QueryResult | undefined) {
+  return queryResult?.status === 'loading' ? undefined : queryResult?.completedAt;
+}
+
+function formatCompactRelativeTime(timestamp: number, now: number) {
+  const elapsedMs = Math.max(0, now - timestamp);
+  const elapsedSeconds = Math.floor(elapsedMs / 1000);
+  if (elapsedSeconds < 60) return 'Just now';
+
+  const elapsedMinutes = Math.floor(elapsedSeconds / 60);
+  if (elapsedMinutes < 60) return `${elapsedMinutes}m ago`;
+
+  const elapsedHours = Math.floor(elapsedMinutes / 60);
+  if (elapsedHours < 24) return `${elapsedHours}h ago`;
+
+  const elapsedDays = Math.floor(elapsedHours / 24);
+  return `${elapsedDays}d ago`;
+}
+
+function formatQueryDuration(durationMs: number) {
+  if (durationMs < 1000) return `${durationMs.toFixed(2)} ms`;
+  return `${(durationMs / 1000).toFixed(2)} s`;
+}
 
 export type CreateSqlQueryBlockDefinitionOptions<
   TRoomState extends BaseRoomStoreState & SqlEditorSliceState,
@@ -76,9 +352,7 @@ export function createSqlQueryBlockDefinition<
   label = 'SQL Query',
   defaultTitle = 'SQL Query',
   render = SqlQueryBlock as ComponentType<StatefulBlockRenderProps<TRoomState>>,
-}: CreateSqlQueryBlockDefinitionOptions<
-  TRoomState
-> = {}): StatefulBlockDefinition<TRoomState> {
+}: CreateSqlQueryBlockDefinitionOptions<TRoomState> = {}): StatefulBlockDefinition<TRoomState> {
   return {
     type: SQL_QUERY_BLOCK_TYPE,
     label,

--- a/packages/sql-editor/src/SqlQueryBlock.tsx
+++ b/packages/sql-editor/src/SqlQueryBlock.tsx
@@ -192,7 +192,7 @@ const CompactSqlQueryBlock: FC<CompactSqlQueryBlockProps> = ({
       name={title ?? 'SQL Query'}
       readOnly={readOnly}
       className={cn(
-        'bg-background relative min-h-0 overflow-visible rounded-md',
+        'bg-background relative min-h-0 overflow-visible rounded-md [&_.cm-editor]:rounded-t-md',
         className,
       )}
     >
@@ -320,11 +320,12 @@ const CompactSqlQueryBlock: FC<CompactSqlQueryBlockProps> = ({
             </div>
           ) : (
             <div
-              className="relative min-h-32"
+              className="relative min-h-32 overflow-hidden rounded-b-md"
               style={{height: resultHeight}}
             >
               <SqlQuery.Results
                 className="h-full"
+                dataTableClassName="border-0"
                 footerDetails={
                   resultTooltip ? (
                     <CompactResultTimestampTooltip

--- a/packages/sql-editor/src/SqlQueryBlock.tsx
+++ b/packages/sql-editor/src/SqlQueryBlock.tsx
@@ -1,0 +1,104 @@
+import type {
+  StatefulBlockDefinition,
+  StatefulBlockRenderProps,
+} from '@sqlrooms/blocks';
+import type {BaseRoomStoreState} from '@sqlrooms/room-shell';
+import {cn} from '@sqlrooms/ui';
+import {Code2Icon} from 'lucide-react';
+import type {ComponentType, FC} from 'react';
+import {SqlQuery} from './SqlQuery';
+import type {SqlEditorSliceState} from './SqlEditorSlice';
+
+export type SqlQueryBlockProps = Partial<StatefulBlockRenderProps> & {
+  queryId?: string;
+  className?: string;
+  editorClassName?: string;
+  resultsClassName?: string;
+};
+
+export const SQL_QUERY_BLOCK_TYPE = 'sql-query';
+
+export const SqlQueryBlock: FC<SqlQueryBlockProps> = ({
+  blockId,
+  queryId,
+  title,
+  readOnly,
+  className,
+  editorClassName,
+  resultsClassName,
+}) => {
+  const resolvedQueryId = queryId ?? blockId;
+
+  if (!resolvedQueryId) {
+    return (
+      <div className="text-muted-foreground p-4 text-sm">
+        SQL query block is missing a query id.
+      </div>
+    );
+  }
+
+  return (
+    <SqlQuery.Root
+      queryId={resolvedQueryId}
+      name={title ?? 'SQL Query'}
+      readOnly={readOnly}
+      className={cn('bg-background h-full min-h-[420px]', className)}
+    >
+      <SqlQuery.Header title={title ?? 'SQL Query'}>
+        <SqlQuery.Actions />
+      </SqlQuery.Header>
+      <div className="min-h-[220px] flex-1">
+        <SqlQuery.Editor className={cn('min-h-[220px]', editorClassName)} />
+      </div>
+      <div
+        className={cn(
+          'border-border min-h-[220px] border-t',
+          resultsClassName,
+        )}
+      >
+        <SqlQuery.Results />
+      </div>
+    </SqlQuery.Root>
+  );
+};
+
+export type CreateSqlQueryBlockDefinitionOptions<
+  TRoomState extends BaseRoomStoreState & SqlEditorSliceState,
+> = {
+  label?: string;
+  defaultTitle?: string;
+  render?: ComponentType<StatefulBlockRenderProps<TRoomState>>;
+};
+
+export function createSqlQueryBlockDefinition<
+  TRoomState extends BaseRoomStoreState & SqlEditorSliceState,
+>({
+  label = 'SQL Query',
+  defaultTitle = 'SQL Query',
+  render = SqlQueryBlock as ComponentType<StatefulBlockRenderProps<TRoomState>>,
+}: CreateSqlQueryBlockDefinitionOptions<
+  TRoomState
+> = {}): StatefulBlockDefinition<TRoomState> {
+  return {
+    type: SQL_QUERY_BLOCK_TYPE,
+    label,
+    defaultTitle,
+    icon: Code2Icon,
+    capabilities: {
+      stateful: true,
+      executable: true,
+    },
+    ensureState: ({blockId, title, getState}) => {
+      getState().sqlEditor.ensureQuery(blockId, {
+        name: title ?? defaultTitle,
+      });
+    },
+    deleteState: ({blockId, getState}) => {
+      getState().sqlEditor.removeQuery(blockId);
+    },
+    rename: ({blockId, title, getState}) => {
+      getState().sqlEditor.renameQuery(blockId, title);
+    },
+    render,
+  };
+}

--- a/packages/sql-editor/src/SqlQueryBlock.tsx
+++ b/packages/sql-editor/src/SqlQueryBlock.tsx
@@ -13,7 +13,13 @@ import {
   cn,
   Spinner,
 } from '@sqlrooms/ui';
-import {Code2Icon, PlayIcon, SquareIcon, XIcon} from 'lucide-react';
+import {
+  ChevronDownIcon,
+  ChevronRightIcon,
+  Code2Icon,
+  PlayIcon,
+  SquareIcon,
+} from 'lucide-react';
 import {
   useCallback,
   useEffect,
@@ -118,9 +124,6 @@ const CompactSqlQueryBlock: FC<CompactSqlQueryBlockProps> = ({
   const abortQueryById = useStoreWithSqlEditor(
     (state) => state.sqlEditor.abortQueryById,
   );
-  const clearQueryResult = useStoreWithSqlEditor(
-    (state) => state.sqlEditor.clearQueryResult,
-  );
   const queryResult = useStoreWithSqlEditor(
     (state) => state.sqlEditor.queryResultsById[queryId],
   );
@@ -131,6 +134,8 @@ const CompactSqlQueryBlock: FC<CompactSqlQueryBlockProps> = ({
   const displayNow = Math.max(now, resultCompletedAt ?? now);
   const resultLabel = getCompactResultLabel(queryResult, displayNow);
   const resultTooltip = getCompactResultTooltip(queryResult, displayNow);
+  const [isQueryCollapsed, setIsQueryCollapsed] = useState(false);
+  const [isResultCollapsed, setIsResultCollapsed] = useState(false);
   const [resultHeight, setResultHeight] = useState(256);
   const resizeCleanupRef = useRef<(() => void) | null>(null);
 
@@ -187,21 +192,46 @@ const CompactSqlQueryBlock: FC<CompactSqlQueryBlockProps> = ({
       name={title ?? 'SQL Query'}
       readOnly={readOnly}
       className={cn(
-        'bg-background min-h-0 overflow-hidden rounded-md',
+        'bg-background relative min-h-0 overflow-visible rounded-md',
         className,
       )}
     >
-      <div className="flex items-start gap-2 py-2 pr-2 pl-0">
-        <div className="min-w-0 flex-1">
-          <SqlQuery.Editor
-            autoHeight
-            compact
-            className={cn(
-              'text-sm [&_.cm-content]:pl-0 [&_.cm-line]:pl-0',
-              editorClassName,
-            )}
-          />
-        </div>
+      <Button
+        size="icon"
+        variant="ghost"
+        className="absolute top-2 -left-6 h-5 w-5 shrink-0 p-0"
+        onClick={() => setIsQueryCollapsed((collapsed) => !collapsed)}
+        aria-expanded={!isQueryCollapsed}
+        aria-label={isQueryCollapsed ? 'Expand query' : 'Collapse query'}
+      >
+        {isQueryCollapsed ? (
+          <ChevronRightIcon className="h-3 w-3" />
+        ) : (
+          <ChevronDownIcon className="h-3 w-3" />
+        )}
+      </Button>
+      <div
+        className={cn(
+          'flex items-start gap-2 pr-2 pl-0',
+          isQueryCollapsed ? 'py-1' : 'py-2',
+        )}
+      >
+        {isQueryCollapsed ? (
+          <div className="text-muted-foreground min-w-0 flex-1 py-1 pl-4 text-xs italic">
+            Query collapsed
+          </div>
+        ) : (
+          <div className="min-w-0 flex-1">
+            <SqlQuery.Editor
+              autoHeight
+              compact
+              className={cn(
+                'text-sm [&_.cm-content]:pl-0 [&_.cm-line]:pl-0',
+                editorClassName,
+              )}
+            />
+          </div>
+        )}
         {readOnly ? null : (
           <TooltipProvider delayDuration={200}>
             <Tooltip>
@@ -209,7 +239,10 @@ const CompactSqlQueryBlock: FC<CompactSqlQueryBlockProps> = ({
                 <Button
                   size="icon"
                   variant={isLoading ? 'destructive' : 'secondary'}
-                  className="mt-1 h-6 w-6 shrink-0 rounded-md p-0"
+                  className={cn(
+                    'shrink-0 rounded-md p-0',
+                    isQueryCollapsed ? 'mt-0.5 h-5 w-5' : 'mt-1 h-6 w-6',
+                  )}
                   onClick={() =>
                     isLoading
                       ? abortQueryById(queryId)
@@ -219,11 +252,20 @@ const CompactSqlQueryBlock: FC<CompactSqlQueryBlockProps> = ({
                   aria-label={isLoading ? 'Cancel query' : 'Run query'}
                 >
                   {isCancelling ? (
-                    <Spinner className="h-3 w-3 text-current" />
+                    <Spinner
+                      className={cn(
+                        'text-current',
+                        isQueryCollapsed ? 'h-2.5 w-2.5' : 'h-3 w-3',
+                      )}
+                    />
                   ) : isLoading ? (
-                    <SquareIcon className="h-3 w-3" />
+                    <SquareIcon
+                      className={isQueryCollapsed ? 'h-2.5 w-2.5' : 'h-3 w-3'}
+                    />
                   ) : (
-                    <PlayIcon className="h-3 w-3" />
+                    <PlayIcon
+                      className={isQueryCollapsed ? 'h-2.5 w-2.5' : 'h-3 w-3'}
+                    />
                   )}
                 </Button>
               </TooltipTrigger>
@@ -235,58 +277,108 @@ const CompactSqlQueryBlock: FC<CompactSqlQueryBlockProps> = ({
         )}
       </div>
       {queryResult ? (
-        <div className={cn('border-border border-t', resultsClassName)}>
-          <div className="bg-background flex items-center gap-2 px-2 py-1">
-            {resultTooltip ? (
-              <TooltipProvider delayDuration={200}>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <div className="text-muted-foreground flex-1 cursor-default text-xs">
-                      {resultLabel}
-                    </div>
-                  </TooltipTrigger>
-                  <TooltipContent align="start" className="space-y-1 text-xs">
-                    {resultTooltip.map((line) => (
-                      <div key={line}>{line}</div>
-                    ))}
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            ) : (
-              <div className="text-muted-foreground flex-1 text-xs">
-                {resultLabel}
-              </div>
-            )}
-            <Button
-              size="icon"
-              variant="ghost"
-              className="h-6 w-6"
-              onClick={() => clearQueryResult(queryId)}
-              title="Close result"
-            >
-              <XIcon className="h-3.5 w-3.5" />
-            </Button>
-          </div>
-          <div
-            className="relative min-h-32 overflow-auto"
-            style={{height: resultHeight}}
+        <div className={cn('border-border relative border-t', resultsClassName)}>
+          <Button
+            size="icon"
+            variant="ghost"
+            className="absolute top-2 -left-6 h-5 w-5 shrink-0 p-0"
+            onClick={() => setIsResultCollapsed((collapsed) => !collapsed)}
+            aria-expanded={!isResultCollapsed}
+            aria-label={isResultCollapsed ? 'Expand result' : 'Collapse result'}
           >
-            <SqlQuery.Results className="h-full" />
-            <div
-              className="absolute right-0 bottom-0 left-0 flex h-3 cursor-row-resize items-end justify-center"
-              onMouseDown={handleResizeMouseDown}
-              role="separator"
-              aria-orientation="horizontal"
-              aria-label="Resize query result height"
-            >
-              <div className="bg-muted-foreground/50 mb-1 h-1 w-10 rounded-full" />
+            {isResultCollapsed ? (
+              <ChevronRightIcon className="h-3 w-3" />
+            ) : (
+              <ChevronDownIcon className="h-3 w-3" />
+            )}
+          </Button>
+          {isResultCollapsed ? (
+            <div className="bg-background flex items-center gap-2 py-2 pr-4 pl-4">
+              <div className="text-muted-foreground min-w-0 flex-1 text-xs italic">
+                Result collapsed
+              </div>
+              {resultTooltip ? (
+                <TooltipProvider delayDuration={200}>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <div className="text-muted-foreground cursor-default text-right text-xs">
+                        {resultLabel}
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent align="start" className="space-y-1 text-xs">
+                      {resultTooltip.map((line) => (
+                        <div key={line}>{line}</div>
+                      ))}
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              ) : (
+                <div className="text-muted-foreground text-right text-xs">
+                  {resultLabel}
+                </div>
+              )}
             </div>
-          </div>
+          ) : (
+            <div
+              className="relative min-h-32"
+              style={{height: resultHeight}}
+            >
+              <SqlQuery.Results
+                className="h-full"
+                footerDetails={
+                  resultTooltip ? (
+                    <CompactResultTimestampTooltip
+                      label={resultLabel}
+                      lines={resultTooltip}
+                    />
+                  ) : (
+                    <span className="text-muted-foreground text-xs">
+                      {resultLabel}
+                    </span>
+                  )
+                }
+              />
+              <div
+                className="absolute right-0 -bottom-4 left-0 z-10 flex h-3 cursor-row-resize items-start justify-center"
+                onMouseDown={handleResizeMouseDown}
+                role="separator"
+                aria-orientation="horizontal"
+                aria-label="Resize query result height"
+              >
+                <div className="bg-muted-foreground/50 mt-0.5 h-1 w-10 rounded-full" />
+              </div>
+            </div>
+          )}
         </div>
       ) : null}
     </SqlQuery.Root>
   );
 };
+
+function CompactResultTimestampTooltip({
+  label,
+  lines,
+}: {
+  label: string;
+  lines: string[];
+}) {
+  return (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="text-muted-foreground cursor-default text-xs">
+            {label}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent align="start" className="space-y-1 text-xs">
+          {lines.map((line) => (
+            <div key={line}>{line}</div>
+          ))}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
 
 function getCompactResultLabel(queryResult: QueryResult | undefined, now: number) {
   if (!queryResult) return '';

--- a/packages/sql-editor/src/components/QueryEditorPanel.tsx
+++ b/packages/sql-editor/src/components/QueryEditorPanel.tsx
@@ -10,6 +10,12 @@ export interface QueryEditorPanelProps {
   className?: string;
 }
 
+/**
+ * Ready-made tabbed SQL workbench editor panel.
+ *
+ * Prefer `SqlQuery.Root` with `SqlQuery.Editor`, `SqlQuery.Actions`, and
+ * `SqlQuery.Results` when composing a single-query surface or embedded block.
+ */
 export const QueryEditorPanel: React.FC<QueryEditorPanelProps> = ({
   className,
 }) => {

--- a/packages/sql-editor/src/components/QueryEditorPanelActions.tsx
+++ b/packages/sql-editor/src/components/QueryEditorPanelActions.tsx
@@ -3,6 +3,11 @@ import {isMacOS} from '@sqlrooms/utils';
 import React from 'react';
 import {useStoreWithSqlEditor} from '../SqlEditorSlice';
 
+/**
+ * @deprecated Prefer `SqlQuery.Actions` for newly composed single-query
+ * surfaces. This component remains for compatibility with the legacy tabbed
+ * query panel.
+ */
 export const QueryEditorPanelActions: React.FC<{
   className?: string;
   queryId?: string;

--- a/packages/sql-editor/src/components/QueryEditorPanelActions.tsx
+++ b/packages/sql-editor/src/components/QueryEditorPanelActions.tsx
@@ -3,18 +3,26 @@ import {isMacOS} from '@sqlrooms/utils';
 import React from 'react';
 import {useStoreWithSqlEditor} from '../SqlEditorSlice';
 
-export const QueryEditorPanelActions: React.FC<{className?: string}> = ({
-  className,
-}) => {
+export const QueryEditorPanelActions: React.FC<{
+  className?: string;
+  queryId?: string;
+}> = ({className, queryId}) => {
   const runCurrentQuery = useStoreWithSqlEditor(
     (s) => s.sqlEditor.parseAndRunCurrentQuery,
   );
   const abortCurrentQuery = useStoreWithSqlEditor(
     (s) => s.sqlEditor.abortCurrentQuery,
   );
+  const runQueryById = useStoreWithSqlEditor((s) => s.sqlEditor.runQueryById);
+  const abortQueryById = useStoreWithSqlEditor(
+    (s) => s.sqlEditor.abortQueryById,
+  );
+  const selectedQueryId = useStoreWithSqlEditor(
+    (s) => s.sqlEditor.config.selectedQueryId,
+  );
   const selectedQueryResult = useStoreWithSqlEditor((s) => {
-    const selectedId = s.sqlEditor.config.selectedQueryId;
-    return s.sqlEditor.queryResultsById[selectedId];
+    const resolvedQueryId = queryId ?? s.sqlEditor.config.selectedQueryId;
+    return s.sqlEditor.queryResultsById[resolvedQueryId];
   });
   const isMac = isMacOS();
 
@@ -31,8 +39,16 @@ export const QueryEditorPanelActions: React.FC<{className?: string}> = ({
         <div>
           <RunButton
             state={state}
-            onRun={runCurrentQuery}
-            onCancel={abortCurrentQuery}
+            onRun={
+              queryId
+                ? () => runQueryById(queryId)
+                : () => runCurrentQuery()
+            }
+            onCancel={
+              queryId
+                ? () => abortQueryById(queryId)
+                : () => abortCurrentQuery()
+            }
             variant="default"
             cancelVariant="default"
             className={className}
@@ -42,7 +58,9 @@ export const QueryEditorPanelActions: React.FC<{className?: string}> = ({
       <TooltipContent align="end">
         {isLoading
           ? 'Cancel the running query'
-          : `Run query (${isMac ? 'Cmd' : 'Ctrl'}+Enter)`}
+          : `Run ${
+              queryId && queryId !== selectedQueryId ? 'this ' : ''
+            }query (${isMac ? 'Cmd' : 'Ctrl'}+Enter)`}
       </TooltipContent>
     </Tooltip>
   );

--- a/packages/sql-editor/src/components/QueryEditorPanelEditor.tsx
+++ b/packages/sql-editor/src/components/QueryEditorPanelEditor.tsx
@@ -51,9 +51,13 @@ export const QueryEditorPanelEditor: React.FC<{
   const editorOptions = useMemo(
     () => ({
       ...CODEMIRROR_OPTIONS,
-      lineNumbers: compact ? false : undefined,
-      foldGutter: compact ? false : undefined,
-      highlightActiveLine: compact ? false : undefined,
+      ...(compact
+        ? {
+            lineNumbers: false,
+            foldGutter: false,
+            highlightActiveLine: false,
+          }
+        : {}),
     }),
     [compact],
   );

--- a/packages/sql-editor/src/components/QueryEditorPanelEditor.tsx
+++ b/packages/sql-editor/src/components/QueryEditorPanelEditor.tsx
@@ -9,6 +9,11 @@ const CODEMIRROR_OPTIONS = {
   highlightActiveLine: true,
 };
 
+/**
+ * @deprecated Prefer `SqlQuery.Editor` for newly composed single-query
+ * surfaces. This component remains for compatibility with the legacy tabbed
+ * query panel.
+ */
 export const QueryEditorPanelEditor: React.FC<{
   className?: string;
   queryId: string;

--- a/packages/sql-editor/src/components/QueryEditorPanelEditor.tsx
+++ b/packages/sql-editor/src/components/QueryEditorPanelEditor.tsx
@@ -1,5 +1,5 @@
 import {cn} from '@sqlrooms/ui';
-import {useCallback} from 'react';
+import {useCallback, useMemo} from 'react';
 import {useStoreWithSqlEditor} from '../SqlEditorSlice';
 import {SqlCodeMirrorEditor} from '../SqlCodeMirrorEditor';
 
@@ -18,7 +18,9 @@ export const QueryEditorPanelEditor: React.FC<{
   className?: string;
   queryId: string;
   readOnly?: boolean;
-}> = ({className, queryId, readOnly}) => {
+  autoHeight?: boolean;
+  compact?: boolean;
+}> = ({className, queryId, readOnly, autoHeight, compact}) => {
   const tableSchemas = useStoreWithSqlEditor((s) => s.db.tables);
   const runQueryById = useStoreWithSqlEditor((s) => s.sqlEditor.runQueryById);
   const connector = useStoreWithSqlEditor((s) => s.db.connector);
@@ -33,8 +35,7 @@ export const QueryEditorPanelEditor: React.FC<{
   // Handle query text update
   const handleUpdateQuery = useCallback(
     (value: string | undefined) => {
-      if (!value) return;
-      updateQueryText(queryId, value);
+      updateQueryText(queryId, value ?? '');
     },
     [queryId, updateQueryText],
   );
@@ -47,17 +48,38 @@ export const QueryEditorPanelEditor: React.FC<{
     [queryId, runQueryById],
   );
 
+  const editorOptions = useMemo(
+    () => ({
+      ...CODEMIRROR_OPTIONS,
+      lineNumbers: compact ? false : undefined,
+      foldGutter: compact ? false : undefined,
+      highlightActiveLine: compact ? false : undefined,
+    }),
+    [compact],
+  );
+
   return (
     <SqlCodeMirrorEditor
       key={queryId}
       connector={connector}
       value={queryText ?? ''}
       onChange={handleUpdateQuery}
-      className={cn('h-full w-full grow', className)}
-      options={CODEMIRROR_OPTIONS}
+      className={cn(
+        autoHeight
+          ? [
+              'h-auto min-h-0 w-full grow',
+              '[&_.cm-content]:min-h-12',
+              '[&_.cm-editor]:h-auto [&_.cm-editor]:min-h-12',
+              '[&_.cm-scroller]:overflow-visible',
+            ]
+          : 'h-full w-full grow',
+        className,
+      )}
+      options={editorOptions}
       onRunQuery={handleRunQuery}
       tableSchemas={tableSchemas}
       readOnly={readOnly}
+      hideGutter={compact}
     />
   );
 };

--- a/packages/sql-editor/src/components/QueryEditorPanelEditor.tsx
+++ b/packages/sql-editor/src/components/QueryEditorPanelEditor.tsx
@@ -12,9 +12,10 @@ const CODEMIRROR_OPTIONS = {
 export const QueryEditorPanelEditor: React.FC<{
   className?: string;
   queryId: string;
-}> = ({className, queryId}) => {
+  readOnly?: boolean;
+}> = ({className, queryId, readOnly}) => {
   const tableSchemas = useStoreWithSqlEditor((s) => s.db.tables);
-  const runQuery = useStoreWithSqlEditor((s) => s.sqlEditor.parseAndRunQuery);
+  const runQueryById = useStoreWithSqlEditor((s) => s.sqlEditor.runQueryById);
   const connector = useStoreWithSqlEditor((s) => s.db.connector);
 
   const queryText = useStoreWithSqlEditor(
@@ -36,9 +37,9 @@ export const QueryEditorPanelEditor: React.FC<{
   // Handle query execution via keyboard shortcut
   const handleRunQuery = useCallback(
     (query: string) => {
-      runQuery(query);
+      runQueryById(queryId, query);
     },
-    [runQuery],
+    [queryId, runQueryById],
   );
 
   return (
@@ -51,6 +52,7 @@ export const QueryEditorPanelEditor: React.FC<{
       options={CODEMIRROR_OPTIONS}
       onRunQuery={handleRunQuery}
       tableSchemas={tableSchemas}
+      readOnly={readOnly}
     />
   );
 };

--- a/packages/sql-editor/src/components/QueryResultLimitSelect.tsx
+++ b/packages/sql-editor/src/components/QueryResultLimitSelect.tsx
@@ -1,11 +1,13 @@
 import {
   cn,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
 } from '@sqlrooms/ui';
 import {formatCount} from '@sqlrooms/utils';
+import {ChevronDown} from 'lucide-react';
 import React, {useMemo} from 'react';
 
 export interface QueryResultLimitSelectProps {
@@ -47,22 +49,33 @@ export const QueryResultLimitSelect: React.FC<QueryResultLimitSelectProps> = ({
   }, [options, value]);
 
   return (
-    <Select
-      value={value.toString()}
-      onValueChange={(v) => onChange(parseInt(v))}
-    >
-      <SelectTrigger className={cn('h-6 w-fit', className)}>
-        <div className="text-xs text-gray-500">
-          {`Limit results to ${formatCount(value)} rows`}
-        </div>
-      </SelectTrigger>
-      <SelectContent>
-        {limitOptions.map((limit) => (
-          <SelectItem key={limit} value={limit.toString()}>
-            {`${formatCount(limit)} rows`}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
+    <DropdownMenu modal={false}>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            'border-input bg-background flex h-6 w-fit items-center justify-between gap-1 rounded-md border px-2 py-1 shadow-sm outline-hidden focus:ring-1 disabled:cursor-not-allowed disabled:opacity-50',
+            className,
+          )}
+        >
+          <span className="text-xs text-gray-500">
+            {`Limit results to ${formatCount(value)} rows`}
+          </span>
+          <ChevronDown className="h-3 w-3 opacity-50" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuRadioGroup
+          value={value.toString()}
+          onValueChange={(v) => onChange(parseInt(v, 10))}
+        >
+          {limitOptions.map((limit) => (
+            <DropdownMenuRadioItem key={limit} value={limit.toString()}>
+              {`${formatCount(limit)} rows`}
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 };

--- a/packages/sql-editor/src/components/QueryResultPanel.tsx
+++ b/packages/sql-editor/src/components/QueryResultPanel.tsx
@@ -93,6 +93,8 @@ export interface QueryResultPanelProps {
   formatValue?: ArrowDataTableValueFormatter;
   /** Additional content rendered in the result footer next to the row count. */
   footerDetails?: React.ReactNode;
+  /** Custom class name for the inner paginated data table. */
+  dataTableClassName?: string;
 }
 
 /**
@@ -115,6 +117,7 @@ const QueryResultPanelRoot: React.FC<QueryResultPanelProps> = ({
   onRowSelectionChange,
   formatValue,
   footerDetails,
+  dataTableClassName,
 }) => {
   const queryResult = useStoreWithSqlEditor((s) => {
     const resolvedQueryId = queryId ?? s.sqlEditor.config.selectedQueryId;
@@ -220,7 +223,7 @@ const QueryResultPanelRoot: React.FC<QueryResultPanelProps> = ({
             <pre className="flex-1 overflow-auto p-4 font-mono text-xs leading-tight wrap-break-word whitespace-pre-wrap">
               {explainText}
             </pre>
-            <div className="bg-background flex w-full items-center gap-2 px-4 py-1">
+            <div className="bg-background flex w-full items-center gap-2 border-t px-4 py-1">
               <div className="font-mono text-xs">EXPLAIN</div>
               <div className="flex-1" />
               {renderActions
@@ -240,7 +243,7 @@ const QueryResultPanelRoot: React.FC<QueryResultPanelProps> = ({
             <DataTablePaginated
               data={arrowTableData?.data}
               columns={arrowTableData?.columns}
-              className="grow overflow-hidden"
+              className={cn('grow overflow-hidden', dataTableClassName)}
               fontSize={fontSize}
               isFetching={false}
               onRowClick={onRowClick}
@@ -249,7 +252,7 @@ const QueryResultPanelRoot: React.FC<QueryResultPanelProps> = ({
               rowSelection={rowSelection}
               onRowSelectionChange={onRowSelectionChange}
             />
-            <div className="bg-background flex w-full items-center gap-2 px-4 py-1">
+            <div className="bg-background flex w-full items-center gap-2 border-t px-4 py-1">
               {queryResult.result ? (
                 <>
                   <div className="font-mono text-xs">

--- a/packages/sql-editor/src/components/QueryResultPanel.tsx
+++ b/packages/sql-editor/src/components/QueryResultPanel.tsx
@@ -49,6 +49,8 @@ function arrowTableToExplainText(result: any): string {
 export interface QueryResultPanelProps {
   /** Custom class name for styling */
   className?: string;
+  /** Query id to render results for. Defaults to the selected query tab. */
+  queryId?: string;
   /** Custom actions to render in the query result panel */
   renderActions?: (query: string) => React.ReactNode;
   /** Custom font size for the table e.g. text-xs, text-sm, text-md, text-lg, text-base */
@@ -93,6 +95,7 @@ export interface QueryResultPanelProps {
 
 const QueryResultPanelRoot: React.FC<QueryResultPanelProps> = ({
   className,
+  queryId,
   renderActions,
   fontSize = 'text-xs',
   onRowClick,
@@ -105,12 +108,16 @@ const QueryResultPanelRoot: React.FC<QueryResultPanelProps> = ({
   formatValue,
 }) => {
   const queryResult = useStoreWithSqlEditor((s) => {
-    const selectedId = s.sqlEditor.config.selectedQueryId;
-    return s.sqlEditor.queryResultsById[selectedId];
+    const resolvedQueryId = queryId ?? s.sqlEditor.config.selectedQueryId;
+    return s.sqlEditor.queryResultsById[resolvedQueryId];
   });
-  const getCurrentQuery = useStoreWithSqlEditor(
-    (s) => s.sqlEditor.getCurrentQuery,
-  );
+  const currentQuery = useStoreWithSqlEditor((s) => {
+    if (!queryId) return s.sqlEditor.getCurrentQuery();
+    return (
+      s.sqlEditor.config.queries.find((query) => query.id === queryId)?.query ??
+      ''
+    );
+  });
   const setQueryResultLimit = useStoreWithSqlEditor(
     (s) => s.sqlEditor.setQueryResultLimit,
   );
@@ -137,11 +144,10 @@ const QueryResultPanelRoot: React.FC<QueryResultPanelProps> = ({
 
   const handleAskAiAboutError = React.useCallback(() => {
     if (queryResult?.status === 'error' && onAskAiAboutError) {
-      const currentQuery = getCurrentQuery();
       const errorText = queryResult.error;
       onAskAiAboutError?.(currentQuery, errorText);
     }
-  }, [queryResult, getCurrentQuery, onAskAiAboutError]);
+  }, [queryResult, currentQuery, onAskAiAboutError]);
 
   if (!queryResult) {
     return null;
@@ -274,6 +280,8 @@ const QueryResultPanelRoot: React.FC<QueryResultPanelProps> = ({
 };
 
 export interface QueryResultPanelAskAiProps {
+  /** Query id to read the error/query from. Defaults to the selected query tab. */
+  queryId?: string;
   /** Called when clicked with the current query and error message */
   onClick?: (query: string, error: string) => void;
   /** Custom icon (defaults to MessageCircleQuestion) */
@@ -287,20 +295,28 @@ export interface QueryResultPanelAskAiProps {
 const QueryResultPanelAskAi = React.forwardRef<
   HTMLButtonElement,
   QueryResultPanelAskAiProps
->(({onClick, icon, className, tooltipContent = 'Ask AI for help'}, ref) => {
+>(
+  (
+    {queryId, onClick, icon, className, tooltipContent = 'Ask AI for help'},
+    ref,
+  ) => {
   const queryResult = useStoreWithSqlEditor((s) => {
-    const selectedId = s.sqlEditor.config.selectedQueryId;
-    return s.sqlEditor.queryResultsById[selectedId];
+    const resolvedQueryId = queryId ?? s.sqlEditor.config.selectedQueryId;
+    return s.sqlEditor.queryResultsById[resolvedQueryId];
   });
-  const getCurrentQuery = useStoreWithSqlEditor(
-    (s) => s.sqlEditor.getCurrentQuery,
-  );
+  const currentQuery = useStoreWithSqlEditor((s) => {
+    if (!queryId) return s.sqlEditor.getCurrentQuery();
+    return (
+      s.sqlEditor.config.queries.find((query) => query.id === queryId)?.query ??
+      ''
+    );
+  });
 
   // Only render in error state
   if (queryResult?.status !== 'error') return null;
 
   const handleClick = () => {
-    onClick?.(getCurrentQuery(), queryResult.error);
+    onClick?.(currentQuery, queryResult.error);
   };
 
   return (
@@ -323,7 +339,8 @@ const QueryResultPanelAskAi = React.forwardRef<
       </Tooltip>
     </TooltipProvider>
   );
-});
+  },
+);
 QueryResultPanelAskAi.displayName = 'QueryResultPanel.AskAi';
 
 export const QueryResultPanel = Object.assign(QueryResultPanelRoot, {

--- a/packages/sql-editor/src/components/QueryResultPanel.tsx
+++ b/packages/sql-editor/src/components/QueryResultPanel.tsx
@@ -93,6 +93,12 @@ export interface QueryResultPanelProps {
   formatValue?: ArrowDataTableValueFormatter;
 }
 
+/**
+ * Result table for a SQL editor query.
+ *
+ * Prefer `SqlQuery.Results` when composing a complete single-query surface. Use
+ * this component directly when only the result panel is needed.
+ */
 const QueryResultPanelRoot: React.FC<QueryResultPanelProps> = ({
   className,
   queryId,

--- a/packages/sql-editor/src/components/QueryResultPanel.tsx
+++ b/packages/sql-editor/src/components/QueryResultPanel.tsx
@@ -91,6 +91,8 @@ export interface QueryResultPanelProps {
   onRowSelectionChange?: (rowSelection: RowSelectionState) => void;
   /** Custom value formatter for arrow data */
   formatValue?: ArrowDataTableValueFormatter;
+  /** Additional content rendered in the result footer next to the row count. */
+  footerDetails?: React.ReactNode;
 }
 
 /**
@@ -112,6 +114,7 @@ const QueryResultPanelRoot: React.FC<QueryResultPanelProps> = ({
   rowSelection,
   onRowSelectionChange,
   formatValue,
+  footerDetails,
 }) => {
   const queryResult = useStoreWithSqlEditor((s) => {
     const resolvedQueryId = queryId ?? s.sqlEditor.config.selectedQueryId;
@@ -263,6 +266,7 @@ const QueryResultPanelRoot: React.FC<QueryResultPanelProps> = ({
                 </>
               ) : null}
               <div className="flex-1" />
+              {footerDetails}
               {renderActions
                 ? renderActions(queryResult.lastQueryStatement)
                 : undefined}

--- a/packages/sql-editor/src/index.ts
+++ b/packages/sql-editor/src/index.ts
@@ -11,7 +11,12 @@ export {default as SqlEditor} from './SqlEditor';
 export type {SqlEditorProps} from './SqlEditor';
 export {default as SqlEditorModal} from './SqlEditorModal';
 export {createSqlEditorSlice} from './SqlEditorSlice';
-export type {QueryResult, SqlEditorSliceState} from './SqlEditorSlice';
+export type {
+  EnsureSqlQueryOptions,
+  QueryResult,
+  SqlEditorQuery,
+  SqlEditorSliceState,
+} from './SqlEditorSlice';
 export {SqlQueryDataSourcesPanel} from './components/SqlQueryDataSourcesPanel';
 /**
  * @deprecated Use SqlCodeMirrorEditor instead.
@@ -28,6 +33,24 @@ export type {
 } from './SqlMonacoEditor';
 export {SqlCodeMirrorEditor} from './SqlCodeMirrorEditor';
 export type {SqlCodeMirrorEditorProps} from './SqlCodeMirrorEditor';
+export {SqlQuery} from './SqlQuery';
+export type {
+  SqlQueryRootProps,
+  SqlQueryHeaderProps,
+  SqlQueryToolbarProps,
+  SqlQueryActionsProps,
+  SqlQueryEditorProps,
+  SqlQueryResultsProps,
+} from './SqlQuery';
+export {
+  SQL_QUERY_BLOCK_TYPE,
+  SqlQueryBlock,
+  createSqlQueryBlockDefinition,
+} from './SqlQueryBlock';
+export type {
+  SqlQueryBlockProps,
+  CreateSqlQueryBlockDefinitionOptions,
+} from './SqlQueryBlock';
 export {SqlDialects} from './codemirror/extensions/create-sql-extension';
 export type {SqlDialect} from './codemirror/extensions/create-sql-extension';
 export {SchemaExplorer} from './components/SchemaExplorer';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4066,6 +4066,9 @@ importers:
       '@paralleldrive/cuid2':
         specifier: ^3.0.0
         version: 3.3.0
+      '@sqlrooms/blocks':
+        specifier: workspace:*
+        version: link:../blocks
       '@sqlrooms/codemirror':
         specifier: workspace:*
         version: link:../codemirror


### PR DESCRIPTION
## Summary
- Refactor `@sqlrooms/sql-editor` around id-addressable queries and a new `SqlQuery` compound surface.
- Add `SqlQueryBlock` plus `createSqlQueryBlockDefinition()` so SQL queries can be embedded in BlockDocuments or opened as top-level artifact tabs.
- Wire the new `sql-query` type into the CLI app’s stateful block registry, artifact types, renderer, and AI context tooling.
- Update docs and package exports to guide new consumers toward `SqlQuery.*` while keeping legacy workbench components compatible.

## Testing
- Typecheck passed for `@sqlrooms/sql-editor` and the CLI app.
- Production builds completed for `@sqlrooms/sql-editor` and the CLI app.
- Lint passed for the CLI app; `@sqlrooms/sql-editor` retained one pre-existing warning in `CreateTableModal.tsx`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SQL Query artifacts can be created, embedded in worksheets, and opened as top-level query tabs.
  * New reusable SqlQuery component and compact query block with resizable results and independent run/cancel behavior.
  * Query execution now supports ID-addressable operations so queries can be managed independently.

* **Improvements**
  * Editor: optional gutter hiding and improved run/cancel controls that target specific queries.
  * Results: per-query results rendering, customizable footer, and refined pagination styling.

* **Documentation**
  * Guides updated for SQL Query artifacts and single-query surfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->