### PR TITLE
fix: fixes to overlay mode regressions

### DIFF
--- a/packages/deck/src/DeckJsonMap.tsx
+++ b/packages/deck/src/DeckJsonMap.tsx
@@ -247,20 +247,15 @@ export function DeckJsonMap({
     layers: mergedLayers,
   };
 
-  // MapboxOverlay ignores viewState/initialViewState/controller — separate them
-  // so they don't cause unnecessary setProps on the overlay.
+  // MapboxOverlay ignores viewState/initialViewState/controller — strip them
+  // so they don't cause unnecessary setProps calls on the overlay.
   const {
     initialViewState,
-    viewState,
+    viewState: _viewState,
     controller: _controller,
-    onViewStateChange,
+    onViewStateChange: _onViewStateChange,
     ...overlayDeckProps
-  } = mergedDeckProps as Record<string, unknown> & {
-    initialViewState?: Record<string, unknown>;
-    viewState?: Record<string, unknown>;
-    controller?: unknown;
-    onViewStateChange?: (info: {viewState: unknown}) => void;
-  };
+  } = mergedDeckProps as Record<string, unknown>;
 
   const {resolvedTheme} = useTheme();
 
@@ -293,11 +288,9 @@ export function DeckJsonMap({
 
       <Map
         {...(mergedMapProps as object)}
-        {...(viewState
-          ? {...(viewState as object), onMove: onViewStateChange}
-          : initialViewState
-            ? {initialViewState: initialViewState as object}
-            : {})}
+        {...(initialViewState
+          ? {initialViewState: initialViewState as object}
+          : {})}
         style={{width: '100%', height: '100%', ...mapProps?.style}}
       >
         <DeckOverlayControl interleaved={interleaved} {...overlayDeckProps} />

--- a/packages/deck/src/DeckJsonMap.tsx
+++ b/packages/deck/src/DeckJsonMap.tsx
@@ -138,10 +138,24 @@ function DeckOverlayControl({
   interleaved,
   ...deckProps
 }: {interleaved: boolean} & Record<string, unknown>) {
-  const overlay = useControl<MapboxOverlay>(
-    () => new MapboxOverlay({interleaved}),
-  );
+  const overlayRef = useRef<MapboxOverlay | null>(null);
+  const overlay = useControl<MapboxOverlay>(() => {
+    const instance = new MapboxOverlay({interleaved});
+    overlayRef.current = instance;
+    return instance;
+  });
   overlay.setProps(deckProps);
+
+  // Force a redraw when layers change so filtered data renders immediately
+  // without requiring user interaction.
+  const layers = deckProps.layers;
+  useEffect(() => {
+    const deck = (overlayRef.current as any)?._deck;
+    if (deck?.isInitialized) {
+      deck.redraw();
+    }
+  }, [layers]);
+
   return null;
 }
 
@@ -247,6 +261,15 @@ export function DeckJsonMap({
     layers: mergedLayers,
   };
 
+  // MapboxOverlay ignores viewState/initialViewState/controller — separate them
+  // so they don't cause unnecessary setProps churn on the overlay.
+  const {
+    initialViewState,
+    viewState: _viewState,
+    controller: _controller,
+    ...overlayDeckProps
+  } = mergedDeckProps as Record<string, unknown>;
+
   const {resolvedTheme} = useTheme();
 
   const mergedMapProps = {
@@ -278,9 +301,12 @@ export function DeckJsonMap({
 
       <Map
         {...(mergedMapProps as object)}
+        {...(initialViewState
+          ? {initialViewState: initialViewState as object}
+          : {})}
         style={{width: '100%', height: '100%', ...mapProps?.style}}
       >
-        <DeckOverlayControl interleaved={interleaved} {...mergedDeckProps} />
+        <DeckOverlayControl interleaved={interleaved} {...overlayDeckProps} />
         {children}
       </Map>
 

--- a/packages/deck/src/DeckJsonMap.tsx
+++ b/packages/deck/src/DeckJsonMap.tsx
@@ -145,7 +145,6 @@ function DeckOverlayControl({
     return instance;
   });
   overlay.setProps(deckProps);
-
   return null;
 }
 

--- a/packages/deck/src/DeckJsonMap.tsx
+++ b/packages/deck/src/DeckJsonMap.tsx
@@ -146,16 +146,6 @@ function DeckOverlayControl({
   });
   overlay.setProps(deckProps);
 
-  // Force a redraw when layers change so filtered data renders immediately
-  // without requiring user interaction.
-  const layers = deckProps.layers;
-  useEffect(() => {
-    const deck = (overlayRef.current as any)?._deck;
-    if (deck?.isInitialized) {
-      deck.redraw();
-    }
-  }, [layers]);
-
   return null;
 }
 

--- a/packages/deck/src/DeckJsonMap.tsx
+++ b/packages/deck/src/DeckJsonMap.tsx
@@ -254,10 +254,16 @@ export function DeckJsonMap({
   // so they don't cause unnecessary setProps churn on the overlay.
   const {
     initialViewState,
-    viewState: _viewState,
+    viewState,
     controller: _controller,
+    onViewStateChange,
     ...overlayDeckProps
-  } = mergedDeckProps as Record<string, unknown>;
+  } = mergedDeckProps as Record<string, unknown> & {
+    initialViewState?: Record<string, unknown>;
+    viewState?: Record<string, unknown>;
+    controller?: unknown;
+    onViewStateChange?: (info: {viewState: unknown}) => void;
+  };
 
   const {resolvedTheme} = useTheme();
 
@@ -290,9 +296,11 @@ export function DeckJsonMap({
 
       <Map
         {...(mergedMapProps as object)}
-        {...(initialViewState
-          ? {initialViewState: initialViewState as object}
-          : {})}
+        {...(viewState
+          ? {...(viewState as object), onMove: onViewStateChange}
+          : initialViewState
+            ? {initialViewState: initialViewState as object}
+            : {})}
         style={{width: '100%', height: '100%', ...mapProps?.style}}
       >
         <DeckOverlayControl interleaved={interleaved} {...overlayDeckProps} />

--- a/packages/deck/src/DeckJsonMap.tsx
+++ b/packages/deck/src/DeckJsonMap.tsx
@@ -248,7 +248,7 @@ export function DeckJsonMap({
   };
 
   // MapboxOverlay ignores viewState/initialViewState/controller — separate them
-  // so they don't cause unnecessary setProps churn on the overlay.
+  // so they don't cause unnecessary setProps on the overlay.
   const {
     initialViewState,
     viewState,

--- a/packages/deck/src/DeckJsonMap.tsx
+++ b/packages/deck/src/DeckJsonMap.tsx
@@ -252,8 +252,6 @@ export function DeckJsonMap({
   const {
     initialViewState,
     viewState: _viewState,
-    controller: _controller,
-    onViewStateChange: _onViewStateChange,
     ...overlayDeckProps
   } = mergedDeckProps as Record<string, unknown>;
 

--- a/packages/deck/src/DeckJsonMap.tsx
+++ b/packages/deck/src/DeckJsonMap.tsx
@@ -138,12 +138,9 @@ function DeckOverlayControl({
   interleaved,
   ...deckProps
 }: {interleaved: boolean} & Record<string, unknown>) {
-  const overlayRef = useRef<MapboxOverlay | null>(null);
-  const overlay = useControl<MapboxOverlay>(() => {
-    const instance = new MapboxOverlay({interleaved});
-    overlayRef.current = instance;
-    return instance;
-  });
+  const overlay = useControl<MapboxOverlay>(
+    () => new MapboxOverlay({interleaved}),
+  );
   overlay.setProps(deckProps);
   return null;
 }

--- a/packages/deck/src/DeckJsonMap.tsx
+++ b/packages/deck/src/DeckJsonMap.tsx
@@ -247,8 +247,7 @@ export function DeckJsonMap({
     layers: mergedLayers,
   };
 
-  // MapboxOverlay ignores viewState/initialViewState/controller — strip them
-  // so they don't cause unnecessary setProps calls on the overlay.
+  // overlayDeckProps should not contain viewState/initialViewState
   const {
     initialViewState,
     viewState: _viewState,


### PR DESCRIPTION
- fix for cross-filtering - reset to initial view state (?)
- fix for cross-filtering - data reset 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Initial map view is now applied directly to the base map, while overlay settings are passed separately to the overlay control. This reduces redundant overlay updates, yields smoother map interactions, and ensures more reliable initial view behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->