### PR TITLE
fix: Query result timestamp formatting for Arrow values

### DIFF
--- a/packages/data-table/__tests__/ArrowCellValue.test.ts
+++ b/packages/data-table/__tests__/ArrowCellValue.test.ts
@@ -1,0 +1,33 @@
+import * as arrow from 'apache-arrow';
+import {valueToString} from '../src/ArrowCellValue';
+
+function getArrowValue(type: arrow.DataType, value: unknown): unknown {
+  return arrow.vectorFromArray([value], type).get(0);
+}
+
+describe('valueToString', () => {
+  it.each([
+    new arrow.TimestampSecond(),
+    new arrow.TimestampMillisecond(),
+    new arrow.TimestampMicrosecond(),
+    new arrow.TimestampNanosecond(),
+  ])('formats %s values returned by Arrow as epoch milliseconds', (type) => {
+    const timestampMs = Date.parse('2026-06-01T21:15:42.000Z');
+    const value = getArrowValue(type, timestampMs);
+
+    expect(valueToString(type, value)).toBe('2026-06-01T21:15:42.000Z');
+  });
+
+  it('formats DateDay values returned by Arrow as epoch milliseconds', () => {
+    const type = new arrow.DateDay();
+    const value = getArrowValue(type, Date.parse('2024-02-05T00:00:00.000Z'));
+
+    expect(valueToString(type, value)).toBe('2024-02-05');
+  });
+
+  it('still formats time values according to their storage unit', () => {
+    const type = new arrow.TimeMicrosecond();
+
+    expect(valueToString(type, 45_000_000_000n)).toBe('12:30:00');
+  });
+});

--- a/packages/data-table/jest.config.js
+++ b/packages/data-table/jest.config.js
@@ -1,0 +1,6 @@
+import nodeConfig from '@sqlrooms/preset-jest/node.js';
+
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+export default {
+  ...nodeConfig,
+};

--- a/packages/data-table/package.json
+++ b/packages/data-table/package.json
@@ -20,7 +20,7 @@
     "dev": "tsc -w",
     "lint": "eslint .",
     "test": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest",
-    "test:watch": "jest --watch",
+    "test:watch": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest --watch",
     "typecheck": "tsc --noEmit",
     "typedoc": "typedoc"
   },

--- a/packages/data-table/package.json
+++ b/packages/data-table/package.json
@@ -33,6 +33,12 @@
     "@tanstack/table-core": "^8.21.3",
     "lucide-react": "^0.556.0"
   },
+  "devDependencies": {
+    "@sqlrooms/preset-jest": "workspace:*",
+    "@types/jest": "^30.0.0",
+    "jest": "^30.1.3",
+    "ts-jest": "^29.4.4"
+  },
   "peerDependencies": {
     "apache-arrow": ">=17",
     "react": ">=18",

--- a/packages/data-table/package.json
+++ b/packages/data-table/package.json
@@ -19,6 +19,8 @@
     "build": "tsc",
     "dev": "tsc -w",
     "lint": "eslint .",
+    "test": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest",
+    "test:watch": "jest --watch",
     "typecheck": "tsc --noEmit",
     "typedoc": "typedoc"
   },

--- a/packages/data-table/src/ArrowCellValue.tsx
+++ b/packages/data-table/src/ArrowCellValue.tsx
@@ -1,5 +1,11 @@
 import {JsonCodeMirrorEditor} from '@sqlrooms/codemirror';
-import {Button, Popover, PopoverContent, PopoverTrigger} from '@sqlrooms/ui';
+import {
+  Button,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  ScrollArea,
+} from '@sqlrooms/ui';
 import {safeJsonParse, shorten, toDecimalString} from '@sqlrooms/utils';
 import * as arrow from 'apache-arrow';
 import {ClipboardIcon} from 'lucide-react';
@@ -182,9 +188,10 @@ export function ArrowCellValue({
             <span className="text-muted-foreground shrink-0">{`(${type})`}</span>
           </div>
 
-          <div className="max-h-[300px] min-h-[100px] overflow-auto">
+          <ScrollArea className="h-[300px] max-h-[60vh] min-h-[100px] rounded-sm">
             {isJsonValue && parsedJson !== undefined ? (
               <JsonCodeMirrorEditor
+                className="h-auto min-h-full pr-3 [&_.cm-editor]:h-auto [&_.cm-editor]:min-h-full [&_.cm-scroller]:overflow-visible"
                 value={parsedJson === null ? 'null' : parsedJson}
                 readOnly={true}
                 options={{
@@ -193,11 +200,11 @@ export function ArrowCellValue({
                 }}
               />
             ) : (
-              <div className="font-mono text-xs wrap-break-word whitespace-pre-wrap">
+              <div className="pr-3 font-mono text-xs wrap-break-word whitespace-pre-wrap">
                 {valueStr}
               </div>
             )}
-          </div>
+          </ScrollArea>
 
           <div className="mt-2 flex justify-end">
             <Button

--- a/packages/data-table/src/ArrowCellValue.tsx
+++ b/packages/data-table/src/ArrowCellValue.tsx
@@ -19,14 +19,17 @@ function parseArrowTemporalValue(
     return undefined;
   }
 
+  // Arrow JS Vector.get() returns epoch milliseconds for dates and
+  // timestamps regardless of their storage unit.
   if (arrow.DataType.isDate(type)) {
-    const unit = (type as arrow.Date_).unit;
-    return unit === arrow.DateUnit.DAY
-      ? numericValue * 86_400_000
-      : numericValue;
+    return numericValue;
   }
 
-  const unit = (type as arrow.Timestamp | arrow.Time).unit;
+  if (arrow.DataType.isTimestamp(type)) {
+    return numericValue;
+  }
+
+  const unit = (type as arrow.Time).unit;
   switch (unit) {
     case arrow.TimeUnit.SECOND:
       return numericValue * 1000;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2956,6 +2956,19 @@ importers:
       react-dom:
         specifier: 19.2.1
         version: 19.2.1(react@19.2.1)
+    devDependencies:
+      '@sqlrooms/preset-jest':
+        specifier: workspace:*
+        version: link:../preset-jest
+      '@types/jest':
+        specifier: ^30.0.0
+        version: 30.0.0
+      jest:
+        specifier: ^30.1.3
+        version: 30.4.2(@types/node@24.12.4)
+      ts-jest:
+        specifier: ^29.4.4
+        version: 29.4.9(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(jest-util@30.4.1)(jest@30.4.2(@types/node@24.12.4))(typescript@5.9.3)
 
   packages/db:
     dependencies:


### PR DESCRIPTION

<img width="2124" height="652" alt="image" src="https://github.com/user-attachments/assets/c6378520-87de-44fc-baa1-c30783e8266c" />


## Summary
- Correct Arrow-backed query result rendering so timestamps and dates are treated as epoch milliseconds, avoiding the accidental 1970 conversion.
- Keep time-of-day formatting unit-aware.
- Add regression coverage for Arrow timestamp/date values and restore package-level Jest support for `@sqlrooms/data-table`.

## Testing
- Added unit tests covering Arrow timestamp, date, and time formatting behavior.
- Verified the package with lint, typecheck, and build checks.
- Not run (not requested): browser/UI validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected formatting of Apache Arrow temporal values (dates, timestamps) for consistent display.

* **Refactor**
  * Improved long-value popover to use a scrollable container and adjusted layout for better readability.

* **Chores**
  * Added Jest configuration and test scripts with TypeScript test support.

* **Tests**
  * Added tests covering Apache Arrow cell value formatting and temporal type behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->