### PR TITLE
fix: not show tool call cancelled by user

### DIFF
--- a/packages/ai-core/src/components/AnalysisResult.tsx
+++ b/packages/ai-core/src/components/AnalysisResult.tsx
@@ -10,6 +10,7 @@ import {SquareTerminalIcon} from 'lucide-react';
 import React, {useMemo} from 'react';
 import {Components} from 'react-markdown';
 import {useStoreWithAi} from '../AiSlice';
+import {TOOL_CALL_CANCELLED} from '../constants';
 import {useAssistantMessageParts} from '../hooks/useAssistantMessageParts';
 import {
   isDynamicToolPart,
@@ -392,6 +393,9 @@ export const AnalysisResult: React.FC<AnalysisResultProps> = ({
             return null;
           })}
           {analysisResult.errorMessage &&
+            !analysisResult.errorMessage.error.startsWith(
+              TOOL_CALL_CANCELLED,
+            ) &&
             (ErrorMessageComponent ? (
               <ErrorMessageComponent
                 errorMessage={analysisResult.errorMessage.error}


### PR DESCRIPTION
A user-initiated cancel isn't really an error, so the loud destructive-red box is misleading. This PR updates the behavior not rendering this box like other chat tools (gemini, chatgpt).

 
<img width="532" height="85" alt="Screenshot 2026-06-03 at 10 02 59 PM" src="https://github.com/user-attachments/assets/3ffdfb4f-a145-4a9c-a06b-4fefd0e4b2ce" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message display to prevent unnecessary error notifications from appearing when tool operations are cancelled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->