### PR TITLE
feat: support brush selection in vega-lite chart

### DIFF
--- a/packages/ai-core/src/components/ContextUsageIndicator.tsx
+++ b/packages/ai-core/src/components/ContextUsageIndicator.tsx
@@ -151,7 +151,7 @@ export const ContextUsageIndicator: React.FC<ContextUsageIndicatorProps> = ({
       const newSessionId = state.ai.config.currentSessionId;
       if (!newSessionId) return;
 
-      const contextMessage = `Please use the following context from a previous session and only respond "Got it" to this message:\n\n${summary}`;
+      const contextMessage = `Please use the following context from a previous session:\n\n${summary}\n\nONLY respond "Got it" to this message`;
       state.ai.setPrompt(newSessionId, contextMessage);
 
       // Wait for SessionChatProvider to mount and register sendMessage for the new session

--- a/packages/kepler/package.json
+++ b/packages/kepler/package.json
@@ -41,6 +41,7 @@
     "@sqlrooms/room-shell": "workspace:*",
     "@sqlrooms/s3-browser": "workspace:*",
     "@sqlrooms/ui": "workspace:*",
+    "@sqlrooms/vega": "workspace:*",
     "apache-arrow": "17.0.0",
     "immer": "^11.0.1",
     "lucide-react": "^0.556.0",

--- a/packages/kepler/src/components/KeplerVegaChartToolResult.tsx
+++ b/packages/kepler/src/components/KeplerVegaChartToolResult.tsx
@@ -10,7 +10,7 @@ import {
   extractTableNameFromSql,
   resolveBrushToRowIndices,
 } from '@sqlrooms/vega';
-import {ReactNode, useCallback, useEffect, useMemo, useRef} from 'react';
+import {ReactNode, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {useStoreWithKepler} from '../KeplerSlice';
 import type {DbSliceState} from '@sqlrooms/room-shell';
 
@@ -56,14 +56,34 @@ export function KeplerVegaChartToolResult(
   const {mapId, ...toolResultProps} = props;
   const sqlQuery = toolResultProps.output?.sqlQuery ?? '';
 
-  const datasetName = useMemo(
-    () => extractTableNameFromSql(sqlQuery),
-    [sqlQuery],
-  );
-
   const getConnector = useStoreWithKepler(
     (state: DbSliceState) => state.db.getConnector,
   );
+
+  // `datasetName` is resolved asynchronously because table-name extraction now
+  // parses the SQL via DuckDB (`json_serialize_sql`) rather than a regex.
+  const [datasetName, setDatasetName] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      if (!sqlQuery) {
+        if (!cancelled) setDatasetName(null);
+        return;
+      }
+      try {
+        const connector = await getConnector();
+        const name = await extractTableNameFromSql(connector, sqlQuery);
+        if (!cancelled) setDatasetName(name);
+      } catch (e) {
+        console.warn('Failed to extract table name from chart SQL:', e);
+        if (!cancelled) setDatasetName(null);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [sqlQuery, getConnector]);
+
   const keplerMap = useStoreWithKepler((state) => state.kepler.map[mapId]);
   const dispatchAction = useStoreWithKepler(
     (state) => state.kepler.dispatchAction,

--- a/packages/kepler/src/components/KeplerVegaChartToolResult.tsx
+++ b/packages/kepler/src/components/KeplerVegaChartToolResult.tsx
@@ -1,0 +1,174 @@
+import {layerSetIsValid} from '@kepler.gl/actions';
+import {Layer} from '@kepler.gl/layers';
+import {Datasets} from '@kepler.gl/table';
+import {
+  BrushFieldMapping,
+  VegaChartToolResult,
+  VegaChartToolResultProps,
+  VegaBrushSelectionRanges,
+  computeBrushMapping,
+  extractTableNameFromSql,
+  resolveBrushToRowIndices,
+} from '@sqlrooms/vega';
+import {ReactNode, useCallback, useEffect, useMemo, useRef} from 'react';
+import {useStoreWithKepler} from '../KeplerSlice';
+import type {DbSliceState} from '@sqlrooms/room-shell';
+
+function highlightRows(
+  datasets: Datasets,
+  layers: Layer[],
+  datasetName: string,
+  selectedRowIndices: number[],
+  dispatchLayerSetIsValid: (layer: Layer, isValid: boolean) => void,
+) {
+  const datasetId = Object.keys(datasets).find(
+    (dataId) => datasets[dataId]?.label === datasetName,
+  );
+  if (!datasetId) return;
+  const dataset = datasets[datasetId];
+  if (!dataset) return;
+  dataset.filteredIndex =
+    selectedRowIndices.length === 0 ? dataset.allIndexes : selectedRowIndices;
+  const affectedLayers = layers.filter(
+    (layer) => layer.config.dataId === dataset.id,
+  );
+  affectedLayers.forEach((layer) => {
+    layer.formatLayerData(datasets);
+    dispatchLayerSetIsValid(layer, true);
+  });
+}
+
+/**
+ * Wraps `VegaChartToolResult` with Kepler.gl brush-to-map highlighting.
+ * When the user brushes data in the chart, matching rows are highlighted
+ * on the Kepler.gl map layers.
+ *
+ * The brush field mapping is computed lazily on the first brush interaction
+ * and cached for subsequent brushes.
+ *
+ * This component reads from the Kepler slice of the room store via
+ * `useStoreWithKepler`, so it must be rendered inside a room that includes
+ * the Kepler slice.
+ */
+export function KeplerVegaChartToolResult(
+  props: VegaChartToolResultProps & {mapId: string},
+): ReactNode {
+  const {mapId, ...toolResultProps} = props;
+  const sqlQuery = toolResultProps.output?.sqlQuery ?? '';
+
+  const datasetName = useMemo(
+    () => extractTableNameFromSql(sqlQuery),
+    [sqlQuery],
+  );
+
+  const getConnector = useStoreWithKepler(
+    (state: DbSliceState) => state.db.getConnector,
+  );
+  const keplerMap = useStoreWithKepler((state) => state.kepler.map[mapId]);
+  const dispatchAction = useStoreWithKepler(
+    (state) => state.kepler.dispatchAction,
+  );
+
+  const hasMatchingLayer = useMemo(() => {
+    if (!keplerMap || !datasetName) return false;
+    const {datasets, layers} = keplerMap.visState;
+    const datasetId = Object.keys(datasets).find(
+      (dataId) => datasets[dataId]?.label === datasetName,
+    );
+    if (!datasetId) return false;
+    return layers.some((layer) => layer.config.dataId === datasetId);
+  }, [keplerMap, datasetName]);
+
+  const dispatchLayerSetIsValid = useCallback(
+    (layer: Layer, isValid: boolean) => {
+      dispatchAction(mapId, layerSetIsValid(layer, isValid));
+    },
+    [dispatchAction, mapId],
+  );
+
+  const keplerMapRef = useRef(keplerMap);
+  useEffect(() => {
+    keplerMapRef.current = keplerMap;
+  }, [keplerMap]);
+
+  // Lazy cache: computed once on first brush, then reused.
+  // `null` = not yet attempted, `undefined` = attempted but unavailable.
+  const brushCacheRef = useRef<{
+    mapping: BrushFieldMapping | undefined;
+    promise: Promise<BrushFieldMapping | null> | null;
+  }>({mapping: undefined, promise: null});
+
+  const sqlQueryRef = useRef(sqlQuery);
+  useEffect(() => {
+    if (sqlQueryRef.current !== sqlQuery) {
+      sqlQueryRef.current = sqlQuery;
+      brushCacheRef.current = {mapping: undefined, promise: null};
+    }
+  }, [sqlQuery]);
+
+  const onBrushSelection = useCallback(
+    async (ranges: VegaBrushSelectionRanges) => {
+      const map = keplerMapRef.current;
+      if (!map || !datasetName || !sqlQuery) return;
+
+      const cache = brushCacheRef.current;
+
+      if (cache.mapping !== undefined) {
+        const hasRanges = Object.keys(ranges).length > 0;
+        const indices = hasRanges
+          ? resolveBrushToRowIndices(cache.mapping, ranges)
+          : [];
+        highlightRows(
+          map.visState.datasets,
+          map.visState.layers,
+          datasetName,
+          indices,
+          dispatchLayerSetIsValid,
+        );
+        return;
+      }
+
+      if (!cache.promise) {
+        cache.promise = (async () => {
+          try {
+            const connector = await getConnector();
+            return await computeBrushMapping(connector, sqlQuery);
+          } catch (e) {
+            console.warn('Failed to compute brush field mapping:', e);
+            return null;
+          }
+        })();
+      }
+
+      const mapping = await cache.promise;
+      if (!mapping) {
+        cache.mapping = {} as BrushFieldMapping;
+        return;
+      }
+      cache.mapping = mapping;
+
+      const freshMap = keplerMapRef.current;
+      if (!freshMap) return;
+      const hasRanges = Object.keys(ranges).length > 0;
+      const indices = hasRanges
+        ? resolveBrushToRowIndices(mapping, ranges)
+        : [];
+      highlightRows(
+        freshMap.visState.datasets,
+        freshMap.visState.layers,
+        datasetName,
+        indices,
+        dispatchLayerSetIsValid,
+      );
+    },
+    [datasetName, sqlQuery, getConnector, dispatchLayerSetIsValid],
+  );
+
+  return (
+    <VegaChartToolResult
+      {...toolResultProps}
+      onBrushSelection={hasMatchingLayer ? onBrushSelection : undefined}
+      brushAvailable={hasMatchingLayer}
+    />
+  );
+}

--- a/packages/kepler/src/index.ts
+++ b/packages/kepler/src/index.ts
@@ -61,3 +61,5 @@ export {
   CustomAddDataButtonFactory,
   CustomPanelTitleFactory,
 } from './components/KeplerInjector';
+
+export {KeplerVegaChartToolResult} from './components/KeplerVegaChartToolResult';

--- a/packages/vega/src/VegaChartTool.tsx
+++ b/packages/vega/src/VegaChartTool.tsx
@@ -51,6 +51,13 @@ export type VegaChartToolOutput = {
 };
 
 /**
+ * Maps field alias → { distinct_value → source_row_indices[] }.
+ * Used to reverse-map brush selections on aggregated/aliased chart fields
+ * back to the original source table rows.
+ */
+export type BrushFieldMapping = Record<string, Record<string, number[]>>;
+
+/**
  * Default description for the VegaChart tool
  */
 export const DEFAULT_VEGA_CHART_DESCRIPTION = `A tool for creating VegaLite charts based on the schema of the SQL query result from the "query" tool.

--- a/packages/vega/src/VegaChartToolResult.tsx
+++ b/packages/vega/src/VegaChartToolResult.tsx
@@ -1,5 +1,12 @@
 import type {ToolRendererProps} from '@sqlrooms/ai-core';
-import {cn} from '@sqlrooms/ui';
+import {
+  cn,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@sqlrooms/ui';
+import {SquareDashedMousePointer} from 'lucide-react';
 import {ReactNode} from 'react';
 import {EmbedOptions, VisualizationSpec} from 'vega-embed';
 import {EditorMode} from './editor/types';
@@ -11,7 +18,10 @@ import type {
 } from './VegaChartTool';
 import {VegaEditAction} from './VegaEditAction';
 import {VegaExportAction} from './VegaExportAction';
-import {VegaLiteArrowChart} from './VegaLiteArrowChart';
+import {
+  VegaLiteArrowChart,
+  VegaBrushSelectionRanges,
+} from './VegaLiteArrowChart';
 
 export type VegaChartToolResultProps = ToolRendererProps<
   VegaChartToolOutput,
@@ -24,11 +34,27 @@ export type VegaChartToolResultProps = ToolRendererProps<
    * @default 'both'
    */
   editorMode?: EditorMode;
+  /**
+   * Callback for brush selection events (opt-in).
+   * When provided, an interval selection param is injected into the spec.
+   */
+  onBrushSelection?: (ranges: VegaBrushSelectionRanges) => void;
+  /**
+   * When true, shows an indicator that brush-to-map highlighting is available.
+   * When explicitly false, shows a muted indicator that brush is not available.
+   * When undefined (default), no indicator is shown.
+   */
+  brushAvailable?: boolean;
 };
 
 /**
  * Renders a chart tool call with visualization using Vega-Lite.
  * Shows read-only editors for inspecting spec and SQL.
+ *
+ * When `onBrushSelection` is provided, an interval selection param is
+ * injected into the Vega-Lite spec and the callback is invoked on brush
+ * events. The caller is responsible for deciding whether to act on the
+ * ranges (e.g. by computing a brush field mapping from the SQL query).
  */
 export function VegaChartToolResult({
   className,
@@ -36,6 +62,8 @@ export function VegaChartToolResult({
   output,
   options,
   editorMode = 'both',
+  onBrushSelection,
+  brushAvailable,
 }: VegaChartToolResultProps): ReactNode {
   const sqlQuery = output?.sqlQuery ?? '';
   const vegaLiteSpec = output?.vegaLiteSpec as VisualizationSpec | null;
@@ -56,10 +84,39 @@ export function VegaChartToolResult({
         sqlQuery={sqlQuery}
         options={options}
         editable={false}
+        onBrushSelection={onBrushSelection}
       >
         <div className="relative max-w-full overflow-x-auto">
           <VegaChartDisplay aspectRatio={16 / 9} className="pt-2">
             <VegaLiteArrowChart.Actions className="right-3">
+              {brushAvailable !== undefined && (
+                <TooltipProvider delayDuration={300}>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <div
+                        className={cn(
+                          'flex h-6 w-6 items-center justify-center rounded-sm',
+                          brushAvailable
+                            ? 'text-primary'
+                            : 'text-muted-foreground/40',
+                        )}
+                        aria-label={
+                          brushAvailable
+                            ? 'Brush to highlight map layers'
+                            : 'No map layer linked'
+                        }
+                      >
+                        <SquareDashedMousePointer className="h-3.5 w-3.5" />
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom" className="text-xs">
+                      {brushAvailable
+                        ? 'Brush to highlight map layers'
+                        : 'No map layer linked'}
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              )}
               <VegaExportAction />
               <VegaEditAction editorMode={editorMode} />
             </VegaLiteArrowChart.Actions>

--- a/packages/vega/src/VegaLiteArrowChart.tsx
+++ b/packages/vega/src/VegaLiteArrowChart.tsx
@@ -18,15 +18,9 @@ import {VegaChartActions} from './VegaChartActions';
 import {VegaChartContextProvider} from './VegaChartContext';
 import {VegaEditAction} from './VegaEditAction';
 import {VegaExportAction} from './VegaExportAction';
+import type {VegaBrushSelectionRanges} from './editor/types';
 
-/**
- * Brush selection ranges emitted by the Vega signal listener.
- * Keys are field names; values are either numeric ranges or categorical arrays.
- */
-export type VegaBrushSelectionRanges = Record<
-  string,
-  [number, number] | string[]
->;
+export type {VegaBrushSelectionRanges};
 
 export type VegaLiteArrowChartProps = {
   className?: string;

--- a/packages/vega/src/VegaLiteArrowChart.tsx
+++ b/packages/vega/src/VegaLiteArrowChart.tsx
@@ -19,6 +19,15 @@ import {VegaChartContextProvider} from './VegaChartContext';
 import {VegaEditAction} from './VegaEditAction';
 import {VegaExportAction} from './VegaExportAction';
 
+/**
+ * Brush selection ranges emitted by the Vega signal listener.
+ * Keys are field names; values are either numeric ranges or categorical arrays.
+ */
+export type VegaBrushSelectionRanges = Record<
+  string,
+  [number, number] | string[]
+>;
+
 export type VegaLiteArrowChartProps = {
   className?: string;
   width?: number | 'auto';
@@ -27,6 +36,14 @@ export type VegaLiteArrowChartProps = {
   spec: string | VisualizationSpec;
   options?: EmbedOptions;
   arrowTable: arrow.Table | undefined;
+  /**
+   * Optional callback invoked when the user interacts with data in the chart.
+   * When provided, a selection param is automatically injected into the
+   * Vega-Lite spec: interval (drag) for continuous axes, point (click) for
+   * nominal/ordinal axes (bar charts, pie charts, heatmaps, etc.).
+   * Pass `undefined`/omit to disable.
+   */
+  onBrushSelection?: (selectedRanges: VegaBrushSelectionRanges) => void;
   /**
    * Children for composing actions and other elements.
    * Use VegaLiteArrowChart.Actions to add action buttons.
@@ -62,6 +79,101 @@ export function makeDefaultVegaLiteOptions(
   };
 }
 
+const BRUSH_PARAM_NAME = 'brush';
+
+type EncodingType = 'quantitative' | 'temporal' | 'nominal' | 'ordinal';
+
+/**
+ * Inspect the top-level encoding of a parsed Vega-Lite spec and return the
+ * types of the x and y channels. Returns `undefined` for missing channels.
+ */
+function getEncodingTypes(spec: Record<string, unknown>): {
+  x?: EncodingType;
+  y?: EncodingType;
+} {
+  const encoding = spec.encoding as Record<string, {type?: string}> | undefined;
+  if (!encoding) return {};
+  return {
+    x: encoding.x?.type as EncodingType | undefined,
+    y: encoding.y?.type as EncodingType | undefined,
+  };
+}
+
+function isContinuousType(t: EncodingType | undefined): boolean {
+  return t === 'quantitative' || t === 'temporal';
+}
+
+type BrushMode = 'interval' | 'point';
+
+/**
+ * Build the brush selection param appropriate for the chart's encoding.
+ * - If both axes are continuous → plain interval selection (2D drag).
+ * - If only one axis is continuous → interval restricted to that encoding.
+ * - If neither axis is continuous (bar w/ nominal, pie, heatmap) → point
+ *   selection (click) so the user can still select marks.
+ * - If there's no encoding at all (layered/concat specs) → `null`.
+ */
+function buildBrushParam(
+  spec: Record<string, unknown>,
+): {name: string; select: unknown; mode: BrushMode} | null {
+  const encoding = spec.encoding as Record<string, unknown> | undefined;
+  if (!encoding) return null;
+
+  const {x, y} = getEncodingTypes(spec);
+  const xCont = isContinuousType(x);
+  const yCont = isContinuousType(y);
+
+  if (xCont && yCont) {
+    return {name: BRUSH_PARAM_NAME, select: 'interval', mode: 'interval'};
+  }
+  if (xCont) {
+    return {
+      name: BRUSH_PARAM_NAME,
+      select: {type: 'interval', encodings: ['x']},
+      mode: 'interval',
+    };
+  }
+  if (yCont) {
+    return {
+      name: BRUSH_PARAM_NAME,
+      select: {type: 'interval', encodings: ['y']},
+      mode: 'interval',
+    };
+  }
+  // No continuous axis — fall back to click-based point selection.
+  // toggle: true allows shift-click to accumulate; clear resets on background.
+  return {
+    name: BRUSH_PARAM_NAME,
+    select: {type: 'point', toggle: true},
+    mode: 'point',
+  };
+}
+
+/**
+ * Normalize a point selection signal value into {@link VegaBrushSelectionRanges}.
+ *
+ * Point selection signals emit individual field values (e.g.
+ * `{risk_category: "Critical"}`) rather than ranges.  We wrap each scalar
+ * value in a single-element array so the downstream pipeline treats it as a
+ * categorical selection.
+ */
+function normalizePointSignal(
+  value: Record<string, unknown>,
+): VegaBrushSelectionRanges {
+  const ranges: VegaBrushSelectionRanges = {};
+  for (const [key, val] of Object.entries(value)) {
+    // Skip internal Vega selection metadata fields
+    if (key.startsWith('vlPoint') || key.startsWith('_vgsid')) continue;
+    if (val == null) continue;
+    if (typeof val === 'number') {
+      ranges[key] = [val, val];
+    } else {
+      ranges[key] = [String(val)];
+    }
+  }
+  return ranges;
+}
+
 const VegaLiteArrowChartBase: React.FC<VegaLiteArrowChartProps> = ({
   className,
   aspectRatio = 16 / 9,
@@ -70,6 +182,7 @@ const VegaLiteArrowChartBase: React.FC<VegaLiteArrowChartProps> = ({
   options: propsOptions,
   width = 'auto',
   height = 'auto',
+  onBrushSelection,
   children,
 }) => {
   const {theme} = useTheme();
@@ -97,12 +210,21 @@ const VegaLiteArrowChartBase: React.FC<VegaLiteArrowChartProps> = ({
     return {values: arrowTableToJson(arrowTable)};
   }, [arrowTable]);
 
+  // Determine the brush mode that was injected into the spec.
+  const brushMode = useMemo((): BrushMode | null => {
+    if (!onBrushSelection) return null;
+    const parsed = typeof spec === 'string' ? safeJsonParse(spec) : spec;
+    if (!parsed) return null;
+    const param = buildBrushParam(parsed as Record<string, unknown>);
+    return param?.mode ?? null;
+  }, [spec, onBrushSelection]);
+
   const specWithData = useMemo(() => {
     const parsed = typeof spec === 'string' ? safeJsonParse(spec) : spec;
     if (!parsed) {
       return null;
     }
-    return {
+    const base = {
       padding: 10,
       background: 'transparent',
       ...parsed,
@@ -111,8 +233,23 @@ const VegaLiteArrowChartBase: React.FC<VegaLiteArrowChartProps> = ({
       width: 'container',
       height: 'container',
       autosize: {contains: 'padding'},
-    } as VisualizationSpec;
-  }, [spec, data]);
+    } as VisualizationSpec & Record<string, unknown>;
+
+    if (onBrushSelection) {
+      const brushParam = buildBrushParam(base as Record<string, unknown>);
+      if (brushParam) {
+        const existingParams = Array.isArray(base.params) ? base.params : [];
+        const hasBrush = existingParams.some(
+          (p: {name?: string}) => p.name === BRUSH_PARAM_NAME,
+        );
+        if (!hasBrush) {
+          base.params = [...existingParams, brushParam];
+        }
+      }
+    }
+
+    return base as VisualizationSpec;
+  }, [spec, data, onBrushSelection]);
   const specError = specWithData
     ? null
     : new Error('Invalid Vega-Lite specification');
@@ -147,6 +284,70 @@ const VegaLiteArrowChartBase: React.FC<VegaLiteArrowChartProps> = ({
   useEffect(() => {
     changeDimensions(dimensions.width, dimensions.height);
   }, [changeDimensions, dimensions.width, dimensions.height]);
+
+  // Attach brush signal listener when onBrushSelection is provided.
+  // The handler is debounced so that rapid brush drags only trigger a single
+  // downstream update (e.g. Kepler map re-render) once the user settles.
+  useEffect(() => {
+    if (!embed?.view || !onBrushSelection || !brushMode) return;
+
+    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+    const DEBOUNCE_MS = 150;
+
+    const debouncedCallback = (ranges: VegaBrushSelectionRanges) => {
+      if (debounceTimer) clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(() => onBrushSelection(ranges), DEBOUNCE_MS);
+    };
+
+    if (brushMode === 'interval') {
+      const handler = (_name: string, value: unknown) => {
+        debouncedCallback(
+          (value && typeof value === 'object'
+            ? value
+            : {}) as VegaBrushSelectionRanges,
+        );
+      };
+      try {
+        embed.view.addSignalListener(BRUSH_PARAM_NAME, handler);
+      } catch {
+        return;
+      }
+      return () => {
+        if (debounceTimer) clearTimeout(debounceTimer);
+        try {
+          embed.view.removeSignalListener(BRUSH_PARAM_NAME, handler);
+        } catch {
+          // View may already be finalized
+        }
+      };
+    }
+
+    // Point selection: the signal value contains field values of the clicked
+    // mark.  We normalize it into the VegaBrushSelectionRanges shape so the
+    // downstream map-highlighting logic works unchanged.
+    const handler = (_name: string, value: unknown) => {
+      if (value && typeof value === 'object') {
+        const raw = value as Record<string, unknown>;
+        const ranges = normalizePointSignal(raw);
+        debouncedCallback(ranges);
+      } else {
+        debouncedCallback({});
+      }
+    };
+    try {
+      embed.view.addSignalListener(BRUSH_PARAM_NAME, handler);
+    } catch {
+      return;
+    }
+    return () => {
+      if (debounceTimer) clearTimeout(debounceTimer);
+      try {
+        embed.view.removeSignalListener(BRUSH_PARAM_NAME, handler);
+      } catch {
+        // View may already be finalized
+      }
+    };
+  }, [embed, onBrushSelection, brushMode]);
 
   return (
     <VegaChartContextProvider value={{embed}}>

--- a/packages/vega/src/brushMappingUtils.ts
+++ b/packages/vega/src/brushMappingUtils.ts
@@ -3,123 +3,194 @@ import type {BrushFieldMapping} from './VegaChartTool';
 import type {VegaBrushSelectionRanges} from './VegaLiteArrowChart';
 
 // ---------------------------------------------------------------------------
-// SQL parsing helpers
+// SQL parsing helpers (DuckDB AST via json_serialize_sql)
 // ---------------------------------------------------------------------------
 
-const AGGREGATE_PATTERN =
-  /^(?:COUNT|SUM|AVG|MIN|MAX|STDDEV|VARIANCE|MEDIAN|APPROX_COUNT_DISTINCT|LIST|ARRAY_AGG|STRING_AGG|GROUP_CONCAT|FIRST|LAST|ANY_VALUE)\s*\(/i;
-
 /**
- * Extract the first table name referenced in a SQL query.
- * Handles `FROM table`, `FROM "quoted"`, and `FROM schema.table`.
+ * Minimal shape of a parsed expression node from DuckDB's
+ * `json_serialize_sql`. Only the fields we rely on are typed; the full node
+ * carries many more properties that we pass through opaquely.
  */
-export function extractTableNameFromSql(sql: string): string | null {
-  const match = sql.match(/\bFROM\s+(?:"([^"]+)"|`([^`]+)`|(\w+(?:\.\w+)?))/i);
-  if (!match) return null;
-  const raw = match[1] ?? match[2] ?? match[3] ?? null;
-  if (!raw) return null;
-  const parts = raw.split('.');
-  return parts[parts.length - 1] ?? null;
+type ParsedExpr = {
+  class?: string;
+  type?: string;
+  alias?: string;
+  function_name?: string;
+  column_names?: string[];
+  children?: ParsedExpr[];
+  [key: string]: unknown;
+};
+
+/** Minimal shape of a parsed table reference from `json_serialize_sql`. */
+type ParsedTableRef = {
+  type?: string;
+  table_name?: string;
+  left?: ParsedTableRef;
+  right?: ParsedTableRef;
+  [key: string]: unknown;
+};
+
+/** Minimal shape of a parsed SELECT statement from `json_serialize_sql`. */
+type ParsedSelectStatement = {
+  node: {
+    type?: string;
+    from_table?: ParsedTableRef;
+    select_list?: ParsedExpr[];
+    where_clause?: unknown;
+    group_expressions?: unknown;
+    group_sets?: unknown;
+    qualify?: unknown;
+    having?: unknown;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+};
+
+type ParsedSql =
+  | {error: true; [key: string]: unknown}
+  | {error: false; statements: ParsedSelectStatement[]};
+
+function escapeSqlLiteral(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
 }
 
 /**
- * Extract the body between `SELECT` and the top-level `FROM`, respecting
- * nesting of parenthesized subqueries and CASE expressions.
+ * Parse a single SQL SELECT statement into DuckDB's JSON AST. Returns `null`
+ * when the SQL is invalid or does not contain a SELECT statement.
  */
-function extractTopLevelSelectBody(sql: string): string | null {
-  const upper = sql.toUpperCase();
-  const selectIdx = upper.search(/\bSELECT\b/);
-  if (selectIdx < 0) return null;
-
-  let start = selectIdx + 'SELECT'.length;
-  if (upper.substring(start).match(/^\s+DISTINCT\b/i)) {
-    start += upper.substring(start).indexOf('DISTINCT') + 'DISTINCT'.length;
+async function parseSelectStatement(
+  connector: DuckDbConnector,
+  sql: string,
+): Promise<ParsedSelectStatement | null> {
+  let parsed: ParsedSql;
+  try {
+    const result = await connector.query(
+      `SELECT json_serialize_sql(${escapeSqlLiteral(sql)}) AS ast`,
+    );
+    const raw = result?.getChildAt(0)?.get(0);
+    if (raw == null) return null;
+    parsed = JSON.parse(String(raw)) as ParsedSql;
+  } catch {
+    return null;
   }
+  if (parsed.error) return null;
+  const statement = parsed.statements?.[0];
+  if (!statement || statement.node?.type !== 'SELECT_NODE') return null;
+  return statement;
+}
 
-  let depth = 0;
-  let caseDepth = 0;
-  for (let i = start; i < sql.length; i++) {
-    const ch = sql[i];
-    if (ch === '(' || ch === '[') {
-      depth++;
-    } else if (ch === ')' || ch === ']') {
-      depth--;
-    } else if (depth === 0) {
-      const remaining = upper.substring(i);
-      if (remaining.startsWith('CASE') && /^CASE\b/.test(remaining)) {
-        caseDepth++;
-      } else if (remaining.startsWith('END') && /^END\b/.test(remaining)) {
-        caseDepth = Math.max(0, caseDepth - 1);
-      } else if (
-        caseDepth === 0 &&
-        remaining.startsWith('FROM') &&
-        /^FROM\b/.test(remaining)
-      ) {
-        return sql.substring(start, i);
+/**
+ * Descend a (possibly joined/subqueried) table reference to the leftmost
+ * base table and return its unqualified name.
+ */
+function findBaseTableName(ref: ParsedTableRef | undefined): string | null {
+  if (!ref) return null;
+  if (ref.type === 'BASE_TABLE' && typeof ref.table_name === 'string') {
+    return ref.table_name;
+  }
+  // JOIN nodes nest into left/right; follow the left side first.
+  return findBaseTableName(ref.left) ?? findBaseTableName(ref.right);
+}
+
+/**
+ * Load the set of aggregate function names known to the connected DuckDB
+ * instance (lowercased). Cached per connector since the catalog is stable.
+ */
+const aggregateNameCache = new WeakMap<DuckDbConnector, Promise<Set<string>>>();
+
+function getAggregateFunctionNames(
+  connector: DuckDbConnector,
+): Promise<Set<string>> {
+  let cached = aggregateNameCache.get(connector);
+  if (!cached) {
+    cached = (async () => {
+      try {
+        const result = await connector.query(
+          `SELECT DISTINCT lower(function_name) AS n
+             FROM duckdb_functions()
+            WHERE function_type = 'aggregate'`,
+        );
+        const rows = arrowTableToJson(result);
+        return new Set(rows.map((r) => String(r['n'])));
+      } catch {
+        return new Set<string>();
       }
-    }
+    })();
+    aggregateNameCache.set(connector, cached);
+  }
+  return cached;
+}
+
+/**
+ * Whether a parsed expression contains an aggregate anywhere in its tree
+ * (e.g. `SUM(x)`, `COUNT(*)`, or `SUM(x) + 1`).
+ */
+function exprContainsAggregate(
+  expr: ParsedExpr,
+  aggregateNames: Set<string>,
+): boolean {
+  if (
+    expr.class === 'FUNCTION' &&
+    typeof expr.function_name === 'string' &&
+    aggregateNames.has(expr.function_name.toLowerCase())
+  ) {
+    return true;
+  }
+  if (Array.isArray(expr.children)) {
+    return expr.children.some((child) =>
+      exprContainsAggregate(child, aggregateNames),
+    );
+  }
+  return false;
+}
+
+/**
+ * Derive the output field name for a select-list item: its explicit alias,
+ * or the (unqualified) column name for a bare column reference.
+ */
+function selectItemFieldName(expr: ParsedExpr): string | null {
+  if (typeof expr.alias === 'string' && expr.alias.length > 0) {
+    return expr.alias;
+  }
+  if (expr.class === 'COLUMN_REF' && Array.isArray(expr.column_names)) {
+    const last = expr.column_names[expr.column_names.length - 1];
+    return last ?? null;
   }
   return null;
 }
 
 /**
- * Split a SELECT clause into individual items, respecting nested parens
- * and function calls.
+ * Build an AST for `row_number() OVER () - 1 AS __row_idx` by parsing it
+ * through the connector, so it matches the connected DuckDB version exactly.
  */
-function splitSelectItems(selectBody: string): string[] {
-  const items: string[] = [];
-  let depth = 0;
-  let current = '';
-  for (const ch of selectBody) {
-    if (ch === '(' || ch === '[') depth++;
-    else if (ch === ')' || ch === ']') depth--;
-    else if (ch === ',' && depth === 0) {
-      items.push(current);
-      current = '';
-      continue;
-    }
-    current += ch;
-  }
-  if (current.trim()) items.push(current);
-  return items;
+async function buildRowIndexExpr(
+  connector: DuckDbConnector,
+): Promise<ParsedExpr | null> {
+  const statement = await parseSelectStatement(
+    connector,
+    'SELECT row_number() OVER () - 1 AS __row_idx',
+  );
+  return statement?.node.select_list?.[0] ?? null;
 }
 
+// ---------------------------------------------------------------------------
+// Public helpers
+// ---------------------------------------------------------------------------
+
 /**
- * Extract alias -> expression mappings from a SQL SELECT clause.
- * Returns only non-aggregate expressions (skips COUNT, SUM, etc.).
+ * Extract the primary base table referenced by a SQL SELECT query by parsing
+ * it through DuckDB (`json_serialize_sql`). For joins, returns the leftmost
+ * base table; for subqueries/CTEs without a base table, returns `null`.
  *
- * Handles three forms:
- *   - `expr AS alias`        → alias maps to expr
- *   - `column_name`          → column_name maps to itself
- *   - `table.column_name`    → column_name maps to itself (qualified)
- *   - `*` or aggregates      → skipped
+ * This is async because it relies on the DuckDB parser via {@link connector}.
  */
-function parseNonAggregateAliases(sql: string): Map<string, string> {
-  const result = new Map<string, string>();
-  const selectBody = extractTopLevelSelectBody(sql);
-  if (!selectBody) return result;
-
-  for (const item of splitSelectItems(selectBody)) {
-    const trimmed = item.trim();
-    if (trimmed === '*') continue;
-
-    const asMatch = trimmed.match(/^([\s\S]+?)\s+AS\s+(\w+)\s*$/i);
-    if (asMatch) {
-      const expr = asMatch[1]!.trim();
-      const alias = asMatch[2]!;
-      if (AGGREGATE_PATTERN.test(expr)) continue;
-      result.set(alias, expr);
-      continue;
-    }
-
-    // Bare column: `col` or `table.col` or `"quoted_col"`
-    const bareMatch = trimmed.match(/^(?:\w+\.)?(?:"([^"]+)"|(\w+))$/);
-    if (bareMatch) {
-      const colName = bareMatch[1] ?? bareMatch[2]!;
-      result.set(colName, trimmed);
-    }
-  }
-  return result;
+export async function extractTableNameFromSql(
+  connector: DuckDbConnector,
+  sql: string,
+): Promise<string | null> {
+  const statement = await parseSelectStatement(connector, sql);
+  if (!statement) return null;
+  return findBaseTableName(statement.node.from_table);
 }
 
 // ---------------------------------------------------------------------------
@@ -131,39 +202,78 @@ const MAX_BRUSH_MAPPING_ROWS = 100_000;
 /**
  * Computes a {@link BrushFieldMapping} for the given chart SQL by querying
  * the source table. Evaluates non-aggregate field expressions against every
- * row and groups source row indices by each expression's value.
+ * source row and groups source row indices by each expression's value.
+ *
+ * The chart SQL is parsed via DuckDB's AST (`json_serialize_sql`) to identify
+ * the source table and the non-aggregate select-list expressions. The query
+ * used to build the mapping reuses the original `FROM` clause exactly (joins,
+ * subqueries, schema-qualified names) but drops `WHERE`/`GROUP BY`/`HAVING`/
+ * `QUALIFY` so that every source row is evaluated.
  *
  * Returns `null` when the source table exceeds
- * {@link MAX_BRUSH_MAPPING_ROWS} rows to avoid expensive scans.
+ * {@link MAX_BRUSH_MAPPING_ROWS} rows to avoid expensive scans, when the SQL
+ * cannot be parsed, or when there are no non-aggregate fields to map.
  */
 export async function computeBrushMapping(
   connector: DuckDbConnector,
   chartSql: string,
 ): Promise<BrushFieldMapping | null> {
-  const tableName = extractTableNameFromSql(chartSql);
+  const statement = await parseSelectStatement(connector, chartSql);
+  if (!statement) return null;
+
+  const tableName = findBaseTableName(statement.node.from_table);
   if (!tableName) return null;
 
-  const aliasToExpr = parseNonAggregateAliases(chartSql);
-  if (aliasToExpr.size === 0) return null;
+  const aggregateNames = await getAggregateFunctionNames(connector);
+  const selectList = statement.node.select_list ?? [];
+
+  const fieldItems: ParsedExpr[] = [];
+  const aliases: string[] = [];
+  const seen = new Set<string>();
+  for (const item of selectList) {
+    if (item.class === 'STAR') continue;
+    if (exprContainsAggregate(item, aggregateNames)) continue;
+    const field = selectItemFieldName(item);
+    if (!field || seen.has(field)) continue;
+    seen.add(field);
+    // Force the output field name to a deterministic alias so we can read it
+    // back regardless of how DuckDB would auto-name the column.
+    fieldItems.push({...item, alias: field});
+    aliases.push(field);
+  }
+  if (fieldItems.length === 0) return null;
 
   const escapedTable = `"${tableName.replace(/"/g, '""')}"`;
-
   const countResult = await connector.query(
     `SELECT COUNT(*) AS cnt FROM ${escapedTable}`,
   );
   const rowCount = Number(countResult?.getChildAt(0)?.get(0) ?? 0);
   if (rowCount > MAX_BRUSH_MAPPING_ROWS) return null;
 
-  const selectParts = [`row_number() OVER () - 1 AS __row_idx`];
-  const aliases: string[] = [];
-  for (const [alias, expr] of aliasToExpr) {
-    const escapedAlias = `"${alias.replace(/"/g, '""')}"`;
-    selectParts.push(`(${expr}) AS ${escapedAlias}`);
-    aliases.push(alias);
-  }
+  const rowIndexExpr = await buildRowIndexExpr(connector);
+  if (!rowIndexExpr) return null;
 
-  const sql = `SELECT ${selectParts.join(', ')} FROM ${escapedTable}`;
-  const result = await connector.query(sql);
+  // Mutate the parsed statement: keep only the row index + non-aggregate
+  // fields, and strip clauses that would filter/reduce rows. Deserializing
+  // back to SQL lets DuckDB regenerate a correct query (quoting, joins, etc.).
+  const projectStatement = JSON.parse(
+    JSON.stringify(statement),
+  ) as ParsedSelectStatement;
+  projectStatement.node.select_list = [rowIndexExpr, ...fieldItems];
+  projectStatement.node.where_clause = null;
+  projectStatement.node.group_expressions = [];
+  projectStatement.node.group_sets = [];
+  projectStatement.node.having = null;
+  projectStatement.node.qualify = null;
+
+  const serialized = JSON.stringify({error: false, statements: [projectStatement]});
+  const deserializeResult = await connector.query(
+    `SELECT json_deserialize_sql(${escapeSqlLiteral(serialized)}) AS sql`,
+  );
+  const projectionSql = deserializeResult?.getChildAt(0)?.get(0);
+  if (projectionSql == null) return null;
+
+  const result = await connector.query(String(projectionSql));
   if (!result || result.numRows === 0) return null;
 
   const rows = arrowTableToJson(result);

--- a/packages/vega/src/brushMappingUtils.ts
+++ b/packages/vega/src/brushMappingUtils.ts
@@ -1,0 +1,242 @@
+import {arrowTableToJson, DuckDbConnector} from '@sqlrooms/duckdb';
+import type {BrushFieldMapping} from './VegaChartTool';
+import type {VegaBrushSelectionRanges} from './VegaLiteArrowChart';
+
+// ---------------------------------------------------------------------------
+// SQL parsing helpers
+// ---------------------------------------------------------------------------
+
+const AGGREGATE_PATTERN =
+  /^(?:COUNT|SUM|AVG|MIN|MAX|STDDEV|VARIANCE|MEDIAN|APPROX_COUNT_DISTINCT|LIST|ARRAY_AGG|STRING_AGG|GROUP_CONCAT|FIRST|LAST|ANY_VALUE)\s*\(/i;
+
+/**
+ * Extract the first table name referenced in a SQL query.
+ * Handles `FROM table`, `FROM "quoted"`, and `FROM schema.table`.
+ */
+export function extractTableNameFromSql(sql: string): string | null {
+  const match = sql.match(/\bFROM\s+(?:"([^"]+)"|`([^`]+)`|(\w+(?:\.\w+)?))/i);
+  if (!match) return null;
+  const raw = match[1] ?? match[2] ?? match[3] ?? null;
+  if (!raw) return null;
+  const parts = raw.split('.');
+  return parts[parts.length - 1] ?? null;
+}
+
+/**
+ * Extract the body between `SELECT` and the top-level `FROM`, respecting
+ * nesting of parenthesized subqueries and CASE expressions.
+ */
+function extractTopLevelSelectBody(sql: string): string | null {
+  const upper = sql.toUpperCase();
+  const selectIdx = upper.search(/\bSELECT\b/);
+  if (selectIdx < 0) return null;
+
+  let start = selectIdx + 'SELECT'.length;
+  if (upper.substring(start).match(/^\s+DISTINCT\b/i)) {
+    start += upper.substring(start).indexOf('DISTINCT') + 'DISTINCT'.length;
+  }
+
+  let depth = 0;
+  let caseDepth = 0;
+  for (let i = start; i < sql.length; i++) {
+    const ch = sql[i];
+    if (ch === '(' || ch === '[') {
+      depth++;
+    } else if (ch === ')' || ch === ']') {
+      depth--;
+    } else if (depth === 0) {
+      const remaining = upper.substring(i);
+      if (remaining.startsWith('CASE') && /^CASE\b/.test(remaining)) {
+        caseDepth++;
+      } else if (remaining.startsWith('END') && /^END\b/.test(remaining)) {
+        caseDepth = Math.max(0, caseDepth - 1);
+      } else if (
+        caseDepth === 0 &&
+        remaining.startsWith('FROM') &&
+        /^FROM\b/.test(remaining)
+      ) {
+        return sql.substring(start, i);
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Split a SELECT clause into individual items, respecting nested parens
+ * and function calls.
+ */
+function splitSelectItems(selectBody: string): string[] {
+  const items: string[] = [];
+  let depth = 0;
+  let current = '';
+  for (const ch of selectBody) {
+    if (ch === '(' || ch === '[') depth++;
+    else if (ch === ')' || ch === ']') depth--;
+    else if (ch === ',' && depth === 0) {
+      items.push(current);
+      current = '';
+      continue;
+    }
+    current += ch;
+  }
+  if (current.trim()) items.push(current);
+  return items;
+}
+
+/**
+ * Extract alias -> expression mappings from a SQL SELECT clause.
+ * Returns only non-aggregate expressions (skips COUNT, SUM, etc.).
+ *
+ * Handles three forms:
+ *   - `expr AS alias`        → alias maps to expr
+ *   - `column_name`          → column_name maps to itself
+ *   - `table.column_name`    → column_name maps to itself (qualified)
+ *   - `*` or aggregates      → skipped
+ */
+function parseNonAggregateAliases(sql: string): Map<string, string> {
+  const result = new Map<string, string>();
+  const selectBody = extractTopLevelSelectBody(sql);
+  if (!selectBody) return result;
+
+  for (const item of splitSelectItems(selectBody)) {
+    const trimmed = item.trim();
+    if (trimmed === '*') continue;
+
+    const asMatch = trimmed.match(/^([\s\S]+?)\s+AS\s+(\w+)\s*$/i);
+    if (asMatch) {
+      const expr = asMatch[1]!.trim();
+      const alias = asMatch[2]!;
+      if (AGGREGATE_PATTERN.test(expr)) continue;
+      result.set(alias, expr);
+      continue;
+    }
+
+    // Bare column: `col` or `table.col` or `"quoted_col"`
+    const bareMatch = trimmed.match(/^(?:\w+\.)?(?:"([^"]+)"|(\w+))$/);
+    if (bareMatch) {
+      const colName = bareMatch[1] ?? bareMatch[2]!;
+      result.set(colName, trimmed);
+    }
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Lazy brush mapping computation
+// ---------------------------------------------------------------------------
+
+const MAX_BRUSH_MAPPING_ROWS = 100_000;
+
+/**
+ * Computes a {@link BrushFieldMapping} for the given chart SQL by querying
+ * the source table. Evaluates non-aggregate field expressions against every
+ * row and groups source row indices by each expression's value.
+ *
+ * Returns `null` when the source table exceeds
+ * {@link MAX_BRUSH_MAPPING_ROWS} rows to avoid expensive scans.
+ */
+export async function computeBrushMapping(
+  connector: DuckDbConnector,
+  chartSql: string,
+): Promise<BrushFieldMapping | null> {
+  const tableName = extractTableNameFromSql(chartSql);
+  if (!tableName) return null;
+
+  const aliasToExpr = parseNonAggregateAliases(chartSql);
+  if (aliasToExpr.size === 0) return null;
+
+  const escapedTable = `"${tableName.replace(/"/g, '""')}"`;
+
+  const countResult = await connector.query(
+    `SELECT COUNT(*) AS cnt FROM ${escapedTable}`,
+  );
+  const rowCount = Number(countResult?.getChildAt(0)?.get(0) ?? 0);
+  if (rowCount > MAX_BRUSH_MAPPING_ROWS) return null;
+
+  const selectParts = [`row_number() OVER () - 1 AS __row_idx`];
+  const aliases: string[] = [];
+  for (const [alias, expr] of aliasToExpr) {
+    const escapedAlias = `"${alias.replace(/"/g, '""')}"`;
+    selectParts.push(`(${expr}) AS ${escapedAlias}`);
+    aliases.push(alias);
+  }
+
+  const sql = `SELECT ${selectParts.join(', ')} FROM ${escapedTable}`;
+  const result = await connector.query(sql);
+  if (!result || result.numRows === 0) return null;
+
+  const rows = arrowTableToJson(result);
+  const mapping: BrushFieldMapping = {};
+  for (const alias of aliases) {
+    mapping[alias] = {};
+  }
+  for (const row of rows) {
+    const rowIdx = Number(row['__row_idx']);
+    for (const alias of aliases) {
+      const val = row[alias];
+      const key = val == null ? '__null__' : String(val);
+      const bucket = mapping[alias]!;
+      if (!bucket[key]) bucket[key] = [];
+      bucket[key]!.push(rowIdx);
+    }
+  }
+  return mapping;
+}
+
+// ---------------------------------------------------------------------------
+// Brush-to-map row resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Given a {@link BrushFieldMapping} and the current brush selection ranges,
+ * resolves the set of source-table row indices that match all selected fields
+ * (intersection across fields).
+ */
+export function resolveBrushToRowIndices(
+  mapping: BrushFieldMapping,
+  ranges: VegaBrushSelectionRanges,
+): number[] {
+  const fieldResults: number[][] = [];
+
+  for (const [field, range] of Object.entries(ranges)) {
+    const fieldMap = mapping[field];
+    if (!fieldMap) continue;
+
+    if (
+      Array.isArray(range) &&
+      range.length === 2 &&
+      typeof range[0] === 'number' &&
+      typeof range[1] === 'number'
+    ) {
+      const min = range[0];
+      const max = range[1];
+      const indices: number[] = [];
+      for (const [key, rowIndices] of Object.entries(fieldMap)) {
+        const numVal = Number(key);
+        if (!isNaN(numVal) && numVal >= min && numVal <= max) {
+          indices.push(...rowIndices);
+        }
+      }
+      fieldResults.push(indices);
+    } else if (Array.isArray(range)) {
+      const indices: number[] = [];
+      for (const val of range) {
+        const key = String(val);
+        const rowIndices = fieldMap[key];
+        if (rowIndices) indices.push(...rowIndices);
+      }
+      fieldResults.push(indices);
+    }
+  }
+
+  if (fieldResults.length === 0) return [];
+  if (fieldResults.length === 1) return fieldResults[0]!;
+
+  let intersection = new Set(fieldResults[0]!);
+  for (let i = 1; i < fieldResults.length; i++) {
+    const next = new Set(fieldResults[i]!);
+    intersection = new Set([...intersection].filter((x) => next.has(x)));
+  }
+  return [...intersection];
+}

--- a/packages/vega/src/editor/VegaChartContainer.tsx
+++ b/packages/vega/src/editor/VegaChartContainer.tsx
@@ -2,9 +2,13 @@ import * as arrow from 'apache-arrow';
 import React from 'react';
 import {EmbedOptions, VisualizationSpec} from 'vega-embed';
 import {cn} from '@sqlrooms/ui';
-import type {VegaBrushSelectionRanges} from '../VegaLiteArrowChart';
 import {VegaEditorContext} from './VegaEditorContext';
-import {OnSpecChange, OnSqlChange, VegaEditorContextValue} from './types';
+import {
+  OnSpecChange,
+  OnSqlChange,
+  VegaBrushSelectionRanges,
+  VegaEditorContextValue,
+} from './types';
 import {useVegaChartEditor} from './useVegaChartEditor';
 
 export interface VegaChartContainerProps {

--- a/packages/vega/src/editor/VegaChartContainer.tsx
+++ b/packages/vega/src/editor/VegaChartContainer.tsx
@@ -2,6 +2,7 @@ import * as arrow from 'apache-arrow';
 import React from 'react';
 import {EmbedOptions, VisualizationSpec} from 'vega-embed';
 import {cn} from '@sqlrooms/ui';
+import type {VegaBrushSelectionRanges} from '../VegaLiteArrowChart';
 import {VegaEditorContext} from './VegaEditorContext';
 import {OnSpecChange, OnSqlChange, VegaEditorContextValue} from './types';
 import {useVegaChartEditor} from './useVegaChartEditor';
@@ -44,6 +45,11 @@ export interface VegaChartContainerProps {
    * Custom class name for the container
    */
   className?: string;
+  /**
+   * Callback for brush selection events (opt-in).
+   * When provided, an interval selection param is injected into the spec.
+   */
+  onBrushSelection?: (ranges: VegaBrushSelectionRanges) => void;
 }
 
 /**
@@ -74,6 +80,7 @@ export const VegaChartContainer: React.FC<VegaChartContainerProps> = ({
   editable = true,
   onSpecChange,
   onSqlChange,
+  onBrushSelection,
   children,
   className,
 }) => {
@@ -93,6 +100,7 @@ export const VegaChartContainer: React.FC<VegaChartContainerProps> = ({
     sqlQuery,
     arrowTable,
     options,
+    onBrushSelection,
     canApply,
     hasChanges,
   };

--- a/packages/vega/src/editor/VegaChartDisplay.tsx
+++ b/packages/vega/src/editor/VegaChartDisplay.tsx
@@ -41,7 +41,7 @@ export const VegaChartDisplay: React.FC<VegaChartDisplayProps> = ({
   aspectRatio = 16 / 9,
   children,
 }) => {
-  const {state, arrowTable, options} = useVegaEditorContext();
+  const {state, arrowTable, options, onBrushSelection} = useVegaEditorContext();
 
   // Use the applied SQL for chart rendering (updates when Apply is clicked)
   const sqlQuery = state.appliedSql;
@@ -97,6 +97,7 @@ export const VegaChartDisplay: React.FC<VegaChartDisplayProps> = ({
         arrowTable={chartData}
         aspectRatio={aspectRatio}
         options={options}
+        onBrushSelection={onBrushSelection}
       >
         {children}
       </VegaLiteArrowChart>

--- a/packages/vega/src/editor/types.ts
+++ b/packages/vega/src/editor/types.ts
@@ -1,5 +1,6 @@
 import * as arrow from 'apache-arrow';
 import {EmbedOptions, VisualizationSpec} from 'vega-embed';
+import type {VegaBrushSelectionRanges} from '../VegaLiteArrowChart';
 
 /**
  * Editor mode determines which editors are shown
@@ -71,6 +72,8 @@ export interface VegaEditorContextValue {
   arrowTable: arrow.Table | undefined;
   /** Vega embed options */
   options: EmbedOptions | undefined;
+  /** Callback for brush selection events (opt-in) */
+  onBrushSelection: ((ranges: VegaBrushSelectionRanges) => void) | undefined;
 
   // Derived
   /** Whether apply is possible (no errors, has changes) */

--- a/packages/vega/src/editor/types.ts
+++ b/packages/vega/src/editor/types.ts
@@ -1,6 +1,14 @@
 import * as arrow from 'apache-arrow';
 import {EmbedOptions, VisualizationSpec} from 'vega-embed';
-import type {VegaBrushSelectionRanges} from '../VegaLiteArrowChart';
+
+/**
+ * Brush selection ranges emitted by the Vega signal listener.
+ * Keys are field names; values are either numeric ranges or categorical arrays.
+ */
+export type VegaBrushSelectionRanges = Record<
+  string,
+  [number, number] | string[]
+>;
 
 /**
  * Editor mode determines which editors are shown

--- a/packages/vega/src/index.ts
+++ b/packages/vega/src/index.ts
@@ -11,8 +11,10 @@ import {VegaSpecEditorPanel} from './editor/VegaSpecEditorPanel';
 import {VegaSqlEditorPanel} from './editor/VegaSqlEditorPanel';
 import {VegaChartEditorActions} from './editor/VegaChartEditorActions';
 export {VegaChartToolResult as VegaChartToolResult} from './VegaChartToolResult';
+export type {VegaChartToolResultProps} from './VegaChartToolResult';
 export type {VisualizationSpec} from 'vega-embed';
 export type {SignalListenerHandler, SignalValue} from 'vega';
+export type {VegaBrushSelectionRanges} from './VegaLiteArrowChart';
 
 export {
   createVegaChartTool,
@@ -21,7 +23,11 @@ export {
   DEFAULT_VEGA_CHART_DESCRIPTION,
 } from './VegaChartTool';
 
-export type {VegaChartToolOptions, VegaChartToolOutput} from './VegaChartTool';
+export type {
+  VegaChartToolOptions,
+  VegaChartToolOutput,
+  BrushFieldMapping,
+} from './VegaChartTool';
 export {
   createChartImageForMarkdownTool,
   ChartImageForMarkdownToolParameters,
@@ -30,6 +36,12 @@ export type {
   ChartImageForMarkdownToolOutput,
   ChartImageForMarkdownToolParameters as ChartImageForMarkdownToolParametersType,
 } from './ChartImageForMarkdownTool';
+
+export {
+  extractTableNameFromSql,
+  computeBrushMapping,
+  resolveBrushToRowIndices,
+} from './brushMappingUtils';
 
 /**
  * Composable Vega-Lite chart component with editing capabilities.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,9 @@ overrides:
   zod: 4.1.13
 
 patchedDependencies:
-  sigstore@4.1.0: 72ba6f3df587a050af679bdcd9c835c92bb45b80b91bd9f33351d2d92f69eb29
+  sigstore@4.1.0:
+    hash: 72ba6f3df587a050af679bdcd9c835c92bb45b80b91bd9f33351d2d92f69eb29
+    path: patches/sigstore@4.1.0.patch
 
 importers:
 
@@ -3342,31 +3344,31 @@ importers:
         version: 6.3.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@kepler.gl/actions':
         specifier: 3.3.0-alpha.0
-        version: 3.3.0-alpha.0(8243121f28788ee63b9a710c20d87294)
+        version: 3.3.0-alpha.0(27f6bea79e462b0c06f3f326abc4dad4)
       '@kepler.gl/components':
         specifier: 3.3.0-alpha.0
-        version: 3.3.0-alpha.0(bf6a6415e277dbf1f025be2f1e5cc337)
+        version: 3.3.0-alpha.0(04446f8574f759b1c230deb3058d287c)
       '@kepler.gl/constants':
         specifier: 3.3.0-alpha.0
         version: 3.3.0-alpha.0
       '@kepler.gl/duckdb':
         specifier: 3.3.0-alpha.0
-        version: 3.3.0-alpha.0(2372bcb5acf6a43eae651a5b34753934)
+        version: 3.3.0-alpha.0(d64a432f344103278a494e252d030190)
       '@kepler.gl/layers':
         specifier: 3.3.0-alpha.0
-        version: 3.3.0-alpha.0(7b43554b893d9babf66f4a2b08327d8b)
+        version: 3.3.0-alpha.0(a7ca2d0805e8a8b1c1523893fc9cd744)
       '@kepler.gl/localization':
         specifier: 3.3.0-alpha.0
         version: 3.3.0-alpha.0(typescript@5.9.3)
       '@kepler.gl/processors':
         specifier: 3.3.0-alpha.0
-        version: 3.3.0-alpha.0(4092ca5836587fba49e9e83ead97bb24)
+        version: 3.3.0-alpha.0(8c18bdeb82bbadc69f6d1ef78da84304)
       '@kepler.gl/reducers':
         specifier: 3.3.0-alpha.0
-        version: 3.3.0-alpha.0(2372bcb5acf6a43eae651a5b34753934)
+        version: 3.3.0-alpha.0(d64a432f344103278a494e252d030190)
       '@kepler.gl/schemas':
         specifier: 3.3.0-alpha.0
-        version: 3.3.0-alpha.0(c5e44002554f34aa35129559cab4db52)
+        version: 3.3.0-alpha.0(22538a62726209ff405746cf1525302d)
       '@kepler.gl/styles':
         specifier: 3.3.0-alpha.0
         version: 3.3.0-alpha.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -3394,6 +3396,9 @@ importers:
       '@sqlrooms/ui':
         specifier: workspace:*
         version: link:../ui
+      '@sqlrooms/vega':
+        specifier: workspace:*
+        version: link:../vega
       apache-arrow:
         specifier: 17.0.0
         version: 17.0.0
@@ -6353,105 +6358,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -7291,28 +7280,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.6':
     resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.6':
     resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.6':
     resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.6':
     resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
@@ -7515,49 +7500,41 @@ packages:
     resolution: {integrity: sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.19.1':
     resolution: {integrity: sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.19.1':
     resolution: {integrity: sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.19.1':
     resolution: {integrity: sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.19.1':
     resolution: {integrity: sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.19.1':
     resolution: {integrity: sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.19.1':
     resolution: {integrity: sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.19.1':
     resolution: {integrity: sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.19.1':
     resolution: {integrity: sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==}
@@ -8255,42 +8232,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0':
     resolution: {integrity: sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0':
     resolution: {integrity: sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0':
     resolution: {integrity: sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0':
     resolution: {integrity: sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0':
     resolution: {integrity: sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0':
     resolution: {integrity: sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==}
@@ -8416,79 +8387,66 @@ packages:
     resolution: {integrity: sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.3':
     resolution: {integrity: sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.3':
     resolution: {integrity: sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.3':
     resolution: {integrity: sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.3':
     resolution: {integrity: sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.3':
     resolution: {integrity: sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.3':
     resolution: {integrity: sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.3':
     resolution: {integrity: sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.3':
     resolution: {integrity: sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.3':
     resolution: {integrity: sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.3':
     resolution: {integrity: sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.3':
     resolution: {integrity: sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.3':
     resolution: {integrity: sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.3':
     resolution: {integrity: sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==}
@@ -8813,42 +8771,36 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.33':
     resolution: {integrity: sha512-il7tYM+CpUNzieQbwAjFT1P8zqAhmGWNAGhQZBnxurXZ0aNn+5nqYFTEUKNZl7QibtT0uQXzTZrNGHCIj6Y1Og==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-ppc64-gnu@1.15.33':
     resolution: {integrity: sha512-ZtNBwN0Z7CFj9Il0FcPaKdjgP7URyKu/3RfH46vq+0paOBqLj4NYldD6Qo//Duif/7IOtAraUfDOmp0PLAufog==}
     engines: {node: '>=10'}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-s390x-gnu@1.15.33':
     resolution: {integrity: sha512-De1IyajoOmhOYYjw/lx66bKlyDpHZTueqwpDrWgf5O7T6d1ODeJJO9/OqMBmrBQc5C+dNnlmIufHsp4QVCWufA==}
     engines: {node: '>=10'}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-gnu@1.15.33':
     resolution: {integrity: sha512-mGTH0YxmUN+x6vRN/I6NOk5X0ogNktkwPnJ94IMvR7QjhRDwL0O8RXEDhyUM0YtwWrryBOqaJQBX4zruxEPRGw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.33':
     resolution: {integrity: sha512-hj628ZkSEJf6zMf5VMbYrG2O6QqyTIp2qwY6VlCjvIa9lAEZ5c2lfPblCLVGYubTeLJDxadLB/CxqQYOQABeEQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.33':
     resolution: {integrity: sha512-GV2oohtN2/5+KSccl86VULu3aT+LrISC8uzgSq0FRnikpD+Zwc+sBlXmoKQ+Db6jI57ITUOIB8jRkdGMABC29g==}
@@ -8934,28 +8886,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -9979,49 +9927,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -13077,28 +13017,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -19665,13 +19601,13 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@kepler.gl/actions@3.3.0-alpha.0(8243121f28788ee63b9a710c20d87294)':
+  '@kepler.gl/actions@3.3.0-alpha.0(27f6bea79e462b0c06f3f326abc4dad4)':
     dependencies:
       '@deck.gl/core': 9.3.2
       '@kepler.gl/cloud-providers': 3.3.0-alpha.0
       '@kepler.gl/constants': 3.3.0-alpha.0
-      '@kepler.gl/layers': 3.3.0-alpha.0(7b43554b893d9babf66f4a2b08327d8b)
-      '@kepler.gl/processors': 3.3.0-alpha.0(4092ca5836587fba49e9e83ead97bb24)
+      '@kepler.gl/layers': 3.3.0-alpha.0(a7ca2d0805e8a8b1c1523893fc9cd744)
+      '@kepler.gl/processors': 3.3.0-alpha.0(8c18bdeb82bbadc69f6d1ef78da84304)
       '@kepler.gl/table': 3.3.0-alpha.0(@loaders.gl/core@4.4.1)(enzyme-adapter-utils@1.14.2(react@19.2.1))(enzyme@3.11.0)(react-dom@19.2.1(react@19.2.1))(react-test-renderer@16.14.0(react@19.2.1))(react@19.2.1)
       '@kepler.gl/types': 3.3.0-alpha.0
       '@kepler.gl/utils': 3.3.0-alpha.0(@loaders.gl/core@4.4.1)(react-dom@19.2.1(react@19.2.1))
@@ -19727,7 +19663,7 @@ snapshots:
       h3-js: 3.7.2
       type-analyzer: 0.4.0
 
-  '@kepler.gl/components@3.3.0-alpha.0(bf6a6415e277dbf1f025be2f1e5cc337)':
+  '@kepler.gl/components@3.3.0-alpha.0(04446f8574f759b1c230deb3058d287c)':
     dependencies:
       '@deck.gl-community/editable-layers': 9.2.8(35750d7589353ace1a30b3b15c99d31b)
       '@deck.gl/core': 9.3.2
@@ -19739,16 +19675,16 @@ snapshots:
       '@dnd-kit/utilities': 3.2.2(react@19.2.1)
       '@emotion/is-prop-valid': 1.4.0
       '@floating-ui/react': 0.25.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      '@kepler.gl/actions': 3.3.0-alpha.0(8243121f28788ee63b9a710c20d87294)
+      '@kepler.gl/actions': 3.3.0-alpha.0(27f6bea79e462b0c06f3f326abc4dad4)
       '@kepler.gl/cloud-providers': 3.3.0-alpha.0
       '@kepler.gl/common-utils': 3.3.0-alpha.0
       '@kepler.gl/constants': 3.3.0-alpha.0
       '@kepler.gl/effects': 3.3.0-alpha.0(@loaders.gl/core@4.4.1)(react-dom@19.2.1(react@19.2.1))
-      '@kepler.gl/layers': 3.3.0-alpha.0(7b43554b893d9babf66f4a2b08327d8b)
+      '@kepler.gl/layers': 3.3.0-alpha.0(a7ca2d0805e8a8b1c1523893fc9cd744)
       '@kepler.gl/localization': 3.3.0-alpha.0(typescript@5.9.3)
-      '@kepler.gl/processors': 3.3.0-alpha.0(4092ca5836587fba49e9e83ead97bb24)
-      '@kepler.gl/reducers': 3.3.0-alpha.0(2372bcb5acf6a43eae651a5b34753934)
-      '@kepler.gl/schemas': 3.3.0-alpha.0(c5e44002554f34aa35129559cab4db52)
+      '@kepler.gl/processors': 3.3.0-alpha.0(8c18bdeb82bbadc69f6d1ef78da84304)
+      '@kepler.gl/reducers': 3.3.0-alpha.0(d64a432f344103278a494e252d030190)
+      '@kepler.gl/schemas': 3.3.0-alpha.0(22538a62726209ff405746cf1525302d)
       '@kepler.gl/styles': 3.3.0-alpha.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@kepler.gl/table': 3.3.0-alpha.0(@loaders.gl/core@4.4.1)(enzyme-adapter-utils@1.14.2(react@19.2.1))(enzyme@3.11.0)(react-dom@19.2.1(react@19.2.1))(react-test-renderer@16.14.0(react@19.2.1))(react@19.2.1)
       '@kepler.gl/types': 3.3.0-alpha.0
@@ -19909,12 +19845,12 @@ snapshots:
       - '@luma.gl/shadertools'
       - react-dom
 
-  '@kepler.gl/duckdb@3.3.0-alpha.0(2372bcb5acf6a43eae651a5b34753934)':
+  '@kepler.gl/duckdb@3.3.0-alpha.0(d64a432f344103278a494e252d030190)':
     dependencies:
       '@duckdb/duckdb-wasm': 1.32.0
       '@kepler.gl/common-utils': 3.3.0-alpha.0
       '@kepler.gl/constants': 3.3.0-alpha.0
-      '@kepler.gl/processors': 3.3.0-alpha.0(4092ca5836587fba49e9e83ead97bb24)
+      '@kepler.gl/processors': 3.3.0-alpha.0(8c18bdeb82bbadc69f6d1ef78da84304)
       '@kepler.gl/table': 3.3.0-alpha.0(@loaders.gl/core@4.4.1)(enzyme-adapter-utils@1.14.2(react@19.2.1))(enzyme@3.11.0)(react-dom@19.2.1(react@19.2.1))(react-test-renderer@16.14.0(react@19.2.1))(react@19.2.1)
       '@kepler.gl/types': 3.3.0-alpha.0
       '@kepler.gl/utils': 3.3.0-alpha.0(@loaders.gl/core@4.4.1)(react-dom@19.2.1(react@19.2.1))
@@ -19969,7 +19905,7 @@ snapshots:
       - '@loaders.gl/core'
       - react-dom
 
-  '@kepler.gl/layers@3.3.0-alpha.0(7b43554b893d9babf66f4a2b08327d8b)':
+  '@kepler.gl/layers@3.3.0-alpha.0(a7ca2d0805e8a8b1c1523893fc9cd744)':
     dependencies:
       '@deck.gl-community/editable-layers': 9.2.8(35750d7589353ace1a30b3b15c99d31b)
       '@deck.gl/core': 9.3.2
@@ -19992,7 +19928,7 @@ snapshots:
       '@loaders.gl/gltf': 4.4.1(@loaders.gl/core@4.4.1)
       '@loaders.gl/i3s': 4.3.4(@loaders.gl/core@4.4.1)
       '@loaders.gl/mvt': 4.4.1(@loaders.gl/core@4.4.1)
-      '@loaders.gl/parquet': 4.4.1(@loaders.gl/core@4.4.1)(apache-arrow@17.0.0)(ws@8.20.1)
+      '@loaders.gl/parquet': 4.4.1(@loaders.gl/core@4.4.1)(apache-arrow@17.0.0)(ws@5.2.4)
       '@loaders.gl/pmtiles': 4.4.1(@loaders.gl/core@4.4.1)
       '@loaders.gl/schema': 4.4.1
       '@loaders.gl/wkt': 4.4.1(@loaders.gl/core@4.4.1)
@@ -20050,12 +19986,12 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@kepler.gl/processors@3.3.0-alpha.0(4092ca5836587fba49e9e83ead97bb24)':
+  '@kepler.gl/processors@3.3.0-alpha.0(8c18bdeb82bbadc69f6d1ef78da84304)':
     dependencies:
       '@deck.gl-community/editable-layers': 9.2.8(35750d7589353ace1a30b3b15c99d31b)
       '@kepler.gl/common-utils': 3.3.0-alpha.0
       '@kepler.gl/constants': 3.3.0-alpha.0
-      '@kepler.gl/schemas': 3.3.0-alpha.0(c5e44002554f34aa35129559cab4db52)
+      '@kepler.gl/schemas': 3.3.0-alpha.0(22538a62726209ff405746cf1525302d)
       '@kepler.gl/table': 3.3.0-alpha.0(@loaders.gl/core@4.4.1)(enzyme-adapter-utils@1.14.2(react@19.2.1))(enzyme@3.11.0)(react-dom@19.2.1(react@19.2.1))(react-test-renderer@16.14.0(react@19.2.1))(react@19.2.1)
       '@kepler.gl/types': 3.3.0-alpha.0
       '@kepler.gl/utils': 3.3.0-alpha.0(@loaders.gl/core@4.4.1)(react-dom@19.2.1(react@19.2.1))
@@ -20065,7 +20001,7 @@ snapshots:
       '@loaders.gl/gis': 4.4.1(@loaders.gl/core@4.4.1)
       '@loaders.gl/json': 4.4.1(@loaders.gl/core@4.4.1)
       '@loaders.gl/loader-utils': 4.4.1(@loaders.gl/core@4.4.1)
-      '@loaders.gl/parquet': 4.4.1(@loaders.gl/core@4.4.1)(apache-arrow@17.0.0)(ws@8.20.1)
+      '@loaders.gl/parquet': 4.4.1(@loaders.gl/core@4.4.1)(apache-arrow@17.0.0)(ws@5.2.4)
       '@loaders.gl/schema': 4.4.1
       '@loaders.gl/wkt': 4.4.1(@loaders.gl/core@4.4.1)
       '@mapbox/geojson-normalize': 0.0.1
@@ -20099,21 +20035,21 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@kepler.gl/reducers@3.3.0-alpha.0(2372bcb5acf6a43eae651a5b34753934)':
+  '@kepler.gl/reducers@3.3.0-alpha.0(d64a432f344103278a494e252d030190)':
     dependencies:
-      '@kepler.gl/actions': 3.3.0-alpha.0(8243121f28788ee63b9a710c20d87294)
+      '@kepler.gl/actions': 3.3.0-alpha.0(27f6bea79e462b0c06f3f326abc4dad4)
       '@kepler.gl/cloud-providers': 3.3.0-alpha.0
       '@kepler.gl/common-utils': 3.3.0-alpha.0
       '@kepler.gl/constants': 3.3.0-alpha.0
       '@kepler.gl/deckgl-arrow-layers': 3.3.0-alpha.0(ce384245f5c9fb6d7ff5e96cffd57511)
       '@kepler.gl/deckgl-layers': 3.3.0-alpha.0(@deck.gl/extensions@9.3.2(@deck.gl/core@9.3.2)(@luma.gl/core@9.3.3)(@luma.gl/engine@9.3.3(@luma.gl/core@9.3.3)(@luma.gl/shadertools@9.3.3(@luma.gl/core@9.3.3))))(@deck.gl/mesh-layers@9.3.2(@deck.gl/core@9.3.2)(@loaders.gl/core@4.4.1)(@luma.gl/core@9.3.3)(@luma.gl/engine@9.3.3(@luma.gl/core@9.3.3)(@luma.gl/shadertools@9.3.3(@luma.gl/core@9.3.3)))(@luma.gl/gltf@9.3.3(@luma.gl/core@9.3.3)(@luma.gl/engine@9.3.3(@luma.gl/core@9.3.3)(@luma.gl/shadertools@9.3.3(@luma.gl/core@9.3.3)))(@luma.gl/shadertools@9.3.3(@luma.gl/core@9.3.3)))(@luma.gl/shadertools@9.3.3(@luma.gl/core@9.3.3)))(@loaders.gl/core@4.4.1)(@luma.gl/shadertools@9.3.3(@luma.gl/core@9.3.3))(react-dom@19.2.1(react@19.2.1))
       '@kepler.gl/effects': 3.3.0-alpha.0(@loaders.gl/core@4.4.1)(react-dom@19.2.1(react@19.2.1))
-      '@kepler.gl/layers': 3.3.0-alpha.0(7b43554b893d9babf66f4a2b08327d8b)
+      '@kepler.gl/layers': 3.3.0-alpha.0(a7ca2d0805e8a8b1c1523893fc9cd744)
       '@kepler.gl/localization': 3.3.0-alpha.0(typescript@5.9.3)
-      '@kepler.gl/processors': 3.3.0-alpha.0(4092ca5836587fba49e9e83ead97bb24)
-      '@kepler.gl/schemas': 3.3.0-alpha.0(c5e44002554f34aa35129559cab4db52)
+      '@kepler.gl/processors': 3.3.0-alpha.0(8c18bdeb82bbadc69f6d1ef78da84304)
+      '@kepler.gl/schemas': 3.3.0-alpha.0(22538a62726209ff405746cf1525302d)
       '@kepler.gl/table': 3.3.0-alpha.0(@loaders.gl/core@4.4.1)(enzyme-adapter-utils@1.14.2(react@19.2.1))(enzyme@3.11.0)(react-dom@19.2.1(react@19.2.1))(react-test-renderer@16.14.0(react@19.2.1))(react@19.2.1)
-      '@kepler.gl/tasks': 3.3.0-alpha.0(4092ca5836587fba49e9e83ead97bb24)
+      '@kepler.gl/tasks': 3.3.0-alpha.0(8c18bdeb82bbadc69f6d1ef78da84304)
       '@kepler.gl/types': 3.3.0-alpha.0
       '@kepler.gl/utils': 3.3.0-alpha.0(@loaders.gl/core@4.4.1)(react-dom@19.2.1(react@19.2.1))
       '@loaders.gl/loader-utils': 4.4.1(@loaders.gl/core@4.4.1)
@@ -20164,11 +20100,11 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@kepler.gl/schemas@3.3.0-alpha.0(c5e44002554f34aa35129559cab4db52)':
+  '@kepler.gl/schemas@3.3.0-alpha.0(22538a62726209ff405746cf1525302d)':
     dependencies:
       '@kepler.gl/common-utils': 3.3.0-alpha.0
       '@kepler.gl/constants': 3.3.0-alpha.0
-      '@kepler.gl/layers': 3.3.0-alpha.0(7b43554b893d9babf66f4a2b08327d8b)
+      '@kepler.gl/layers': 3.3.0-alpha.0(a7ca2d0805e8a8b1c1523893fc9cd744)
       '@kepler.gl/table': 3.3.0-alpha.0(@loaders.gl/core@4.4.1)(enzyme-adapter-utils@1.14.2(react@19.2.1))(enzyme@3.11.0)(react-dom@19.2.1(react@19.2.1))(react-test-renderer@16.14.0(react@19.2.1))(react@19.2.1)
       '@kepler.gl/types': 3.3.0-alpha.0
       '@kepler.gl/utils': 3.3.0-alpha.0(@loaders.gl/core@4.4.1)(react-dom@19.2.1(react@19.2.1))
@@ -20233,9 +20169,9 @@ snapshots:
       - react-dom
       - react-test-renderer
 
-  '@kepler.gl/tasks@3.3.0-alpha.0(4092ca5836587fba49e9e83ead97bb24)':
+  '@kepler.gl/tasks@3.3.0-alpha.0(8c18bdeb82bbadc69f6d1ef78da84304)':
     dependencies:
-      '@kepler.gl/processors': 3.3.0-alpha.0(4092ca5836587fba49e9e83ead97bb24)
+      '@kepler.gl/processors': 3.3.0-alpha.0(8c18bdeb82bbadc69f6d1ef78da84304)
       react-palm: 3.3.11(enzyme-adapter-utils@1.14.2(react@19.2.1))(enzyme@3.11.0)(react-test-renderer@16.14.0(react@19.2.1))(react@19.2.1)
     transitivePeerDependencies:
       - '@deck.gl-community/layers'
@@ -20767,7 +20703,7 @@ snapshots:
       '@probe.gl/stats': 4.1.1
       pbf: 3.3.0
 
-  '@loaders.gl/parquet@4.4.1(@loaders.gl/core@4.4.1)(apache-arrow@17.0.0)(ws@8.20.1)':
+  '@loaders.gl/parquet@4.4.1(@loaders.gl/core@4.4.1)(apache-arrow@17.0.0)(ws@5.2.4)':
     dependencies:
       '@loaders.gl/arrow': 4.4.1(@loaders.gl/core@4.4.1)
       '@loaders.gl/bson': 4.4.1(@loaders.gl/core@4.4.1)
@@ -20785,7 +20721,7 @@ snapshots:
       brotli: 1.3.3
       ieee754: 1.2.1
       int53: 0.2.4
-      isomorphic-ws: 5.0.0(ws@8.20.1)
+      isomorphic-ws: 5.0.0(ws@5.2.4)
       lz4js: 0.2.0
       node-int64: 0.4.0
       object-stream: 0.0.1
@@ -27308,9 +27244,9 @@ snapshots:
     dependencies:
       ws: 5.2.4
 
-  isomorphic-ws@5.0.0(ws@8.20.1):
+  isomorphic-ws@5.0.0(ws@5.2.4):
     dependencies:
-      ws: 8.20.1
+      ws: 5.2.4
 
   istanbul-lib-coverage@3.2.2: {}
 


### PR DESCRIPTION
## Summary

Add brush selection functionality to Vega-Lite chart components and integrate with map context.

Cherry-picked from commit `ef42ab5dc964c084f6791e62e052fbc4fca971e4`.

1. AI creates a chart with e.g.:
     sqlQuery:  "SELECT city, AVG(price) AS avg_price FROM sales GROUP BY city"
     vegaLiteSpec: bar chart with x=city (nominal), y=avg_price (quantitative)

```
│ city     │ avg_price │
│ NYC      │ 35        │
│ LA       │ 22        │
│ SF       │ 45        │
│ Chicago  │ 18        │
```

**Note: if there are more than 1 table involved in vega-chart, then brush disabled. We can instruct AI to always save the complex query to one table for charting.**

2. VegaLiteArrowChart detects:
     x is nominal, y is quantitative
     → injects interval brush on y-axis only

3. User drags a brush on the y-axis selecting avg_price range [20, 40]
     → Vega emits signal: { avg_price: [20, 40] }

**Note: for e.g. pie chart without x, y encoding, it will fall back to `point selection` and normalizePointSignal() will be used to return all matching source row indices**

4. KeplerVegaChartToolResult receives the signal:
     First time → calls `computeBrushMapping(sqlQuery)`
       - Extracts table: "sales"
       - Extracts non-aggregate aliases: { city → "city" }
         (avg_price is skipped — it's an aggregate)
       - Queries: SELECT row_number()-1 AS __row_idx, city FROM sales
       - Builds mapping: { city: { "NYC": [0,3,7], "LA": [1,4], ... } }
       
**Note: if there is no matching map layer: A dimmed/muted mouse-pointer icon with tooltip "No map layer linked". No brush interaction is possible on the chart.**

5. `resolveBrushToRowIndices`(mapping, { avg_price: [20, 40] }, chartData)

  Step A — avg_price is NOT in the mapping → aggregate bridge kicks in
  Step B — Scan the chart's Arrow table for rows where avg_price ∈ [20, 40]:
```
       NYC     → 35 ✓
       LA      → 22 ✓
       SF      → 45 ✗
       Chicago → 18 ✗
```
  Step C — Collect the group-by keys (fields that ARE in the mapping):
```
       Matching groups: ["NYC", "LA"]
```
  Step D — Look up group keys in the existing mapping:
```
       city.NYC     → source rows [0, 3, 7]
       city.LA      → source rows [1, 4]
```
  Step E — Union: [0, 1, 3, 4, 7]

6. highlightRows() sets dataset.filteredIndex = [0, 1, 3, 4, 7]
     → Kepler re-renders showing only the matching points on the map

7. User clears the brush (clicks background)
     → Vega emits signal: {}
     → resolveBrushToRowIndices returns []
     → highlightRows resets filteredIndex to allIndexes
     → Map shows all points again

## Changes

- Add brush selection support to `VegaLiteArrowChart` and `VegaChartDisplay` components
- Add `brushMappingUtils` for mapping brush ranges to data fields
- Add `KeplerVegaChartToolResult` component for Kepler-Vega integration
- Expose `onBrushSelection` and `brushAvailable` props in `VegaChartToolResult`
- Update exports in kepler and vega packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added interactive chart brush selection with visual indicator showing map integration availability
  * Chart selections now automatically synchronize and highlight corresponding dataset rows in Kepler.gl map layers

* **Improvements**
  * Enhanced context message formatting in summarization workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->