### PR TITLE
feat: TabStrip TabDescriptor and RoomPanelInfo custom className prop

### DIFF
--- a/packages/layout/src/node-renderers/tabs-node-renderer/useTabDescriptors.ts
+++ b/packages/layout/src/node-renderers/tabs-node-renderer/useTabDescriptors.ts
@@ -36,6 +36,7 @@ export function useTabDescriptors(): TabDescriptor[] {
         id,
         name: panelInfo?.title ?? panelId,
         icon: panelInfo?.icon,
+        className: panelInfo?.className,
       });
     }
 

--- a/packages/layout/src/types.ts
+++ b/packages/layout/src/types.ts
@@ -20,6 +20,8 @@ export type RoomPanelInfo = {
   placement?: string;
   component?: RoomPanelComponent;
   dragOverlay?: ComponentType<{node: LayoutNode}>;
+  /** Optional className appended to this panel's tab wrapper inside a tabs node. */
+  className?: string;
 };
 
 /**

--- a/packages/ui/src/components/tab-strip.tsx
+++ b/packages/ui/src/components/tab-strip.tsx
@@ -65,6 +65,8 @@ import {
 export interface TabDescriptor {
   id: string;
   name: string;
+  /** Optional className appended to the outer wrapper of this tab. */
+  className?: string;
   [key: string]: unknown;
 }
 
@@ -248,6 +250,7 @@ function SortableTab({
           'items-center justify-between gap-1 overflow-hidden rounded-b-none',
           'py-0 pr-1 font-normal data-[state=active]:shadow-none',
           tabClassName,
+          tab.className,
           isEditing && 'focus-visible:ring-0',
         )}
       >


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tabs now support optional custom CSS classes for per-tab styling customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->