### PR TITLE
fix: Accept artifact config input shape in artifacts slice

### DIFF
--- a/packages/artifacts/src/ArtifactsSlice.ts
+++ b/packages/artifacts/src/ArtifactsSlice.ts
@@ -7,6 +7,7 @@ import {
   useBaseRoomStore,
 } from '@sqlrooms/room-store';
 import {produce} from 'immer';
+import type {z} from 'zod';
 import type {StoreApi} from 'zustand';
 import type {ArtifactTypeDefinitions} from './ArtifactTypes';
 import type {
@@ -16,8 +17,10 @@ import type {
 import {ArtifactMetadata, ArtifactsSliceConfig} from './ArtifactsSliceConfig';
 import {normalizeOrder} from './helpers';
 
+type ArtifactsSliceConfigInput = z.input<typeof ArtifactsSliceConfig>;
+
 function createDefaultArtifactsConfig(
-  overrides?: Partial<ArtifactsSliceConfigType>,
+  overrides?: ArtifactsSliceConfigInput,
 ): ArtifactsSliceConfigType {
   return ArtifactsSliceConfig.parse(overrides ?? {});
 }
@@ -65,7 +68,7 @@ export type ArtifactsSliceState = {
 export type CreateArtifactsSliceProps<
   TRoomState extends BaseRoomStoreState = BaseRoomStoreState,
 > = {
-  config?: Partial<ArtifactsSliceConfigType>;
+  config?: ArtifactsSliceConfigInput;
   artifactTypes?: ArtifactTypeDefinitions<TRoomState>;
 };
 


### PR DESCRIPTION
## Summary
- Update `createArtifactsSlice` to accept the Zod input shape for artifact config
- Keep normalized artifact metadata stored as the parsed output shape
- Fix the Kepler example build error without requiring callers to pass defaulted fields

## Testing
- Unit tests for `@sqlrooms/artifacts` passed
- `kepler-example` built successfully locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety for artifact configuration handling through enhanced type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->