### PR TITLE
fix: handle output-error parts to prevent session poisoning

### DIFF
--- a/packages/ai-core/__tests__/fixIncompleteToolCalls.test.ts
+++ b/packages/ai-core/__tests__/fixIncompleteToolCalls.test.ts
@@ -1,0 +1,133 @@
+import type {UIMessage} from 'ai';
+import {fixIncompleteToolCalls} from '../src/utils';
+import {TOOL_CALL_CANCELLED} from '../src/constants';
+
+type AnyPart = Record<string, unknown>;
+
+function assistantMessage(parts: AnyPart[]): UIMessage {
+  return {
+    id: 'assistant-1',
+    role: 'assistant',
+    parts: parts as UIMessage['parts'],
+  };
+}
+
+describe('fixIncompleteToolCalls', () => {
+  it('clears partial input on a cancelled output-error tool part', () => {
+    // Reproduces the real-world bug: a `query` tool call cancelled while its
+    // input was still streaming, so only the partial `reasoning` field arrived
+    // and the required `sqlQuery` was never emitted.
+    const messages = [
+      assistantMessage([
+        {type: 'step-start'},
+        {
+          type: 'tool-query',
+          toolCallId: 'tooluse_partial',
+          state: 'output-error',
+          input: {reasoning: 'Analyze the distribution of land use types'},
+          errorText: TOOL_CALL_CANCELLED,
+          providerExecuted: false,
+        },
+      ]),
+    ];
+
+    const [fixed] = fixIncompleteToolCalls(messages);
+    const part = fixed.parts[1] as AnyPart;
+
+    expect(part.state).toBe('output-error');
+    // input must be undefined so the AI SDK skips schema validation
+    expect(part.input).toBeUndefined();
+    // the partial input is preserved under rawInput
+    expect(part.rawInput).toEqual({
+      reasoning: 'Analyze the distribution of land use types',
+    });
+    expect(part.errorText).toBe(TOOL_CALL_CANCELLED);
+  });
+
+  it('preserves existing rawInput when present', () => {
+    const messages = [
+      assistantMessage([
+        {
+          type: 'tool-query',
+          toolCallId: 'tooluse_raw',
+          state: 'output-error',
+          input: undefined,
+          rawInput: 'not valid json {',
+          errorText: 'bad input',
+        },
+      ]),
+    ];
+
+    const [fixed] = fixIncompleteToolCalls(messages);
+    const part = fixed.parts[0] as AnyPart;
+
+    // input was already undefined, so it stays undefined and rawInput is kept
+    expect(part.input).toBeUndefined();
+    expect(part.rawInput).toBe('not valid json {');
+  });
+
+  it('synthesizes an output-error result for an in-flight (input-streaming) tool call', () => {
+    const messages = [
+      assistantMessage([
+        {
+          type: 'tool-query',
+          toolCallId: 'tooluse_inflight',
+          state: 'input-streaming',
+          input: {reasoning: 'partial only'},
+        },
+      ]),
+    ];
+
+    const [fixed] = fixIncompleteToolCalls(messages);
+    const part = fixed.parts[0] as AnyPart;
+
+    expect(part.state).toBe('output-error');
+    expect(part.input).toBeUndefined();
+    expect(part.rawInput).toEqual({reasoning: 'partial only'});
+    expect(part.errorText).toBe(TOOL_CALL_CANCELLED);
+  });
+
+  it('leaves completed (output-available) tool parts untouched', () => {
+    const messages = [
+      assistantMessage([
+        {
+          type: 'tool-query',
+          toolCallId: 'tooluse_ok',
+          state: 'output-available',
+          input: {sqlQuery: 'SELECT 1'},
+          output: {success: true},
+        },
+      ]),
+    ];
+
+    const [fixed] = fixIncompleteToolCalls(messages);
+    const part = fixed.parts[0] as AnyPart;
+
+    expect(part.state).toBe('output-available');
+    expect(part.input).toEqual({sqlQuery: 'SELECT 1'});
+    expect(part.output).toEqual({success: true});
+  });
+
+  it('handles dynamic-tool parts the same way', () => {
+    const messages = [
+      assistantMessage([
+        {
+          type: 'dynamic-tool',
+          toolName: 'agent-h3-hub-analysis',
+          toolCallId: 'tooluse_dyn',
+          state: 'input-streaming',
+          input: {prompt: 'partial'},
+        },
+      ]),
+    ];
+
+    const [fixed] = fixIncompleteToolCalls(messages);
+    const part = fixed.parts[0] as AnyPart;
+
+    expect(part.type).toBe('dynamic-tool');
+    expect(part.toolName).toBe('agent-h3-hub-analysis');
+    expect(part.state).toBe('output-error');
+    expect(part.input).toBeUndefined();
+    expect(part.rawInput).toEqual({prompt: 'partial'});
+  });
+});

--- a/packages/ai-core/src/utils.ts
+++ b/packages/ai-core/src/utils.ts
@@ -458,6 +458,12 @@ export function shouldEndAnalysis(messages: UIMessage[]): boolean {
  * This is important when canceling with AbortController, which may leave incomplete tool-calls.
  * Assumes sequential tool execution (only one tool runs at a time).
  *
+ * For any `output-error` tool part (cancelled or failed), the partial/invalid
+ * `input` is moved to `rawInput` and `input` is set to `undefined`. The AI SDK
+ * only validates `output-error` input when it is defined, so this prevents
+ * "Type validation failed ... parts[n].input" errors from poisoning a session
+ * after the user stops a tool call mid-stream.
+ *
  * @param messages - The messages to validate and complete
  * @returns Cleaned messages with completed tool-call/result pairs
  */
@@ -514,26 +520,43 @@ export function fixIncompleteToolCalls(messages: UIMessage[]): UIMessage[] {
         toolPart.state === 'approval-requested' ||
         toolPart.state === 'approval-responded';
       if (isCompleted) {
-        // An `output-error` part produced from a failed tool-input parse (e.g.
-        // schema validation failure or hallucinated tool name) carries only
-        // `rawInput`, not `input`. The AI SDK's `validateUIMessages` requires
-        // `input` to be defined, so backfill it from `rawInput` to avoid
-        // "Type validation failed ... input: Value: undefined" on later sends.
-        if (toolPart.state === 'output-error' && toolPart.input === undefined) {
+        // `output-error` parts can carry an `input` that does NOT satisfy the
+        // tool's schema. This happens when a tool call is cancelled while its
+        // input is still streaming (e.g. only the partial `reasoning` field
+        // arrived before "Stop"), or when the model produced an invalid tool
+        // input. The AI SDK validates `output-error` input whenever it is
+        // `!== undefined` (see `validateUIMessages`), so an incomplete input
+        // like `{reasoning: "..."}` for a tool that requires `sqlQuery` throws
+        // "Type validation failed ... messages[i].parts[j].input" on every
+        // subsequent send, permanently poisoning the session.
+        //
+        // Since `output-error` parts only convey `errorText` to the model (the
+        // input is never re-executed), we preserve the original value under
+        // `rawInput` and clear `input` so the SDK skips schema validation.
+        // `convertToModelMessages` already falls back to `rawInput`/undefined
+        // for error parts, so no model context is lost.
+        if (toolPart.state === 'output-error' && toolPart.input !== undefined) {
           updatedParts[i] = {
             ...updatedParts[i],
-            input: toolPart.rawInput ?? {},
+            input: undefined,
+            rawInput: toolPart.rawInput ?? toolPart.input,
           } as (typeof message.parts)[number];
         }
         // Completed tool; continue checking earlier parts just in case
         continue;
       }
 
-      // Synthesize a completed error result for the incomplete tool call
+      // Synthesize a completed error result for the incomplete tool call.
+      // Keep `input` undefined (stashing any partial streamed input under
+      // `rawInput`) so the AI SDK skips schema validation for this
+      // `output-error` part on subsequent sends. A partial input such as
+      // `{reasoning: "..."}` — or `{}` for a tool with required fields —
+      // would otherwise fail validation and poison the session.
       const base = {
         toolCallId: toolPart.toolCallId,
         state: 'output-error' as const,
-        input: toolPart.input ?? {},
+        input: undefined,
+        rawInput: toolPart.rawInput ?? toolPart.input,
         errorText: TOOL_CALL_CANCELLED,
         providerExecuted: false,
       };


### PR DESCRIPTION
sqlrooms/ai-core: Updated the handling of `output-error` tool parts to ensure that incomplete or invalid inputs are cleared, preventing schema validation errors in subsequent sends. The original input is preserved under `rawInput`, allowing the AI SDK to skip validation and maintain session integrity.

This will avoid "stop" and then continue prompting throws incomplete message parts error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling for incomplete tool calls to prevent malformed error states from contaminating message validation pipelines and ensure system stability.

* **Tests**
  * Added comprehensive test suite covering tool call error handling across multiple scenarios, including partial data streams and error state edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->