### PR TITLE
feat: Add chat history

### DIFF
--- a/apps/sqlrooms-cli-ui/src/components/AssistantChatContainer.tsx
+++ b/apps/sqlrooms-cli-ui/src/components/AssistantChatContainer.tsx
@@ -28,50 +28,55 @@ export const AssistantChatContainer: React.FC<AssistantChatContainerProps> = ({
   return (
     <Chat.Root>
       <div className="flex min-h-0 flex-1 flex-col gap-0 overflow-hidden">
-        {currentSessionId && !showHistory && (
-          <Chat.Header
-            onHistoryClick={() => setShowHistory(true)}
-            className="mb-4"
-          />
-        )}
-        {showHistory ? (
-          <Chat.History
-            onBack={() => setShowHistory(false)}
-            onSelectChat={(sessionId) => {
-              const switchSession = useRoomStore.getState().ai.switchSession;
-              switchSession(sessionId);
-              setShowHistory(false);
-            }}
-            className="flex-1"
-          />
+        {!currentSessionId ? (
+          <div className="flex h-full w-full items-center justify-center">
+            <Button
+              type="button"
+              variant="outline"
+              className="h-12 gap-2 px-4"
+              onClick={() => createSession()}
+            >
+              <PlusIcon className="h-4 w-4" />
+              New session
+            </Button>
+          </div>
         ) : (
-          <div className="print-container grow overflow-auto">
-            {!currentSessionId ? (
-              <div className="flex h-full w-full items-center justify-center">
-                <Button
-                  type="button"
-                  variant="outline"
-                  className="h-12 gap-2 px-4"
-                  onClick={() => createSession()}
-                >
-                  <PlusIcon className="h-4 w-4" />
-                  New session
-                </Button>
-              </div>
-            ) : isDataAvailable ? (
-              <Chat.Messages
-                key={currentSessionId}
-                hoistedRenderers={['chart']}
+          <>
+            {!showHistory && (
+              <Chat.Header
+                onHistoryClick={() => setShowHistory(true)}
+                className="mb-4"
+              />
+            )}
+            {showHistory ? (
+              <Chat.History
+                onBack={() => setShowHistory(false)}
+                onSelectChat={(sessionId) => {
+                  const switchSession =
+                    useRoomStore.getState().ai.switchSession;
+                  switchSession(sessionId);
+                  setShowHistory(false);
+                }}
+                className="flex-1"
               />
             ) : (
-              <div className="flex h-full w-full flex-col items-center justify-center">
-                <SkeletonPane className="p-4" />
-                <p className="text-muted-foreground mt-4">
-                  Loading database...
-                </p>
+              <div className="print-container grow overflow-auto">
+                {isDataAvailable ? (
+                  <Chat.Messages
+                    key={currentSessionId}
+                    hoistedRenderers={['chart']}
+                  />
+                ) : (
+                  <div className="flex h-full w-full flex-col items-center justify-center">
+                    <SkeletonPane className="p-4" />
+                    <p className="text-muted-foreground mt-4">
+                      Loading database...
+                    </p>
+                  </div>
+                )}
               </div>
             )}
-          </div>
+          </>
         )}
         {currentSessionId && !showHistory && (
           <>

--- a/apps/sqlrooms-cli-ui/src/components/AssistantChatContainer.tsx
+++ b/apps/sqlrooms-cli-ui/src/components/AssistantChatContainer.tsx
@@ -1,7 +1,7 @@
 import {Chat} from '@sqlrooms/ai';
 import {Button, SkeletonPane} from '@sqlrooms/ui';
 import {PlusIcon} from 'lucide-react';
-import React from 'react';
+import React, {useState} from 'react';
 import {useRoomStore} from '../store';
 import {AssistantContextSelector} from './AssistantContextSelector';
 
@@ -23,40 +23,57 @@ export const AssistantChatContainer: React.FC<AssistantChatContainerProps> = ({
   const updateProvider = useRoomStore((s) => s.aiSettings.updateProvider);
   const createSession = useRoomStore((s) => s.ai.createSession);
 
+  const [showHistory, setShowHistory] = useState(false);
+
   return (
     <Chat.Root>
       <div className="flex min-h-0 flex-1 flex-col gap-0 overflow-hidden">
-        {currentSessionId && (
-          <div className="mb-4 flex items-center justify-between gap-2">
-            <Chat.Sessions className="w-full" />
+        {currentSessionId && !showHistory && (
+          <Chat.Header
+            onHistoryClick={() => setShowHistory(true)}
+            className="mb-4"
+          />
+        )}
+        {showHistory ? (
+          <Chat.History
+            onBack={() => setShowHistory(false)}
+            onSelectChat={(sessionId) => {
+              const switchSession = useRoomStore.getState().ai.switchSession;
+              switchSession(sessionId);
+              setShowHistory(false);
+            }}
+            className="flex-1"
+          />
+        ) : (
+          <div className="print-container grow overflow-auto">
+            {!currentSessionId ? (
+              <div className="flex h-full w-full items-center justify-center">
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="h-12 gap-2 px-4"
+                  onClick={() => createSession()}
+                >
+                  <PlusIcon className="h-4 w-4" />
+                  New session
+                </Button>
+              </div>
+            ) : isDataAvailable ? (
+              <Chat.Messages
+                key={currentSessionId}
+                hoistedRenderers={['chart']}
+              />
+            ) : (
+              <div className="flex h-full w-full flex-col items-center justify-center">
+                <SkeletonPane className="p-4" />
+                <p className="text-muted-foreground mt-4">
+                  Loading database...
+                </p>
+              </div>
+            )}
           </div>
         )}
-        <div className="print-container grow overflow-auto">
-          {!currentSessionId ? (
-            <div className="flex h-full w-full items-center justify-center">
-              <Button
-                type="button"
-                variant="outline"
-                className="h-12 gap-2 px-4"
-                onClick={() => createSession()}
-              >
-                <PlusIcon className="h-4 w-4" />
-                New session
-              </Button>
-            </div>
-          ) : isDataAvailable ? (
-            <Chat.Messages
-              key={currentSessionId}
-              hoistedRenderers={['chart']}
-            />
-          ) : (
-            <div className="flex h-full w-full flex-col items-center justify-center">
-              <SkeletonPane className="p-4" />
-              <p className="text-muted-foreground mt-4">Loading database...</p>
-            </div>
-          )}
-        </div>
-        {currentSessionId && (
+        {currentSessionId && !showHistory && (
           <>
             <Chat.PromptSuggestions>
               <Chat.PromptSuggestions.Item text="What questions can I ask to get insights from my data?" />

--- a/packages/ai-core/src/components/Chat.tsx
+++ b/packages/ai-core/src/components/Chat.tsx
@@ -25,6 +25,8 @@ import {SessionChatManager} from './SessionChatManager';
 import {SessionControls} from './SessionControls';
 import {ChatSearch, ChatSearchProvider} from './ChatSearch';
 import {ContextSelector} from './context/ContextSelector';
+import {ChatHeader} from './ChatHeader';
+import {ChatHistoryView} from './ChatHistoryView';
 
 type RootProps = PropsWithChildren<{
   toolRenderBehavior?: ToolRenderBehavior;
@@ -34,6 +36,8 @@ type ChatComponent = FC<RootProps> & {
   Root: FC<RootProps>;
   LocalAgentRoot: FC<LocalAgentChatRootProps>;
   Sessions: typeof SessionControls;
+  Header: typeof ChatHeader;
+  History: typeof ChatHistoryView;
   Messages: FC<ComponentProps<typeof AnalysisResultsContainer>>;
   Composer: FC<ComponentProps<typeof QueryControls>>;
   InlineApiKeyInput: typeof InlineApiKeyInput;
@@ -129,6 +133,8 @@ export const Chat: ChatComponent = Object.assign(Root, {
   Root,
   LocalAgentRoot,
   Sessions: SessionControls,
+  Header: ChatHeader,
+  History: ChatHistoryView,
   Messages,
   Composer,
   InlineApiKeyInput: InlineApiKeyInput,

--- a/packages/ai-core/src/components/ChatHeader.tsx
+++ b/packages/ai-core/src/components/ChatHeader.tsx
@@ -1,4 +1,10 @@
-import {Button, cn} from '@sqlrooms/ui';
+import {
+  Button,
+  cn,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@sqlrooms/ui';
 import {HistoryIcon, PlusIcon} from 'lucide-react';
 import {useCallback, useState} from 'react';
 import {useStoreWithAi} from '../AiSlice';
@@ -100,9 +106,19 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
 
       {/* Right section */}
       <div className="flex items-center gap-2">
-        <Button variant="ghost" size="sm" onClick={handleCreateSession}>
-          <PlusIcon className="h-4 w-4" />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleCreateSession}
+              aria-label="New session"
+            >
+              <PlusIcon className="h-4 w-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>New session</TooltipContent>
+        </Tooltip>
       </div>
 
       <RenameSessionDialog

--- a/packages/ai-core/src/components/ChatHeader.tsx
+++ b/packages/ai-core/src/components/ChatHeader.tsx
@@ -1,0 +1,121 @@
+import {Button, cn} from '@sqlrooms/ui';
+import {HistoryIcon, PlusIcon} from 'lucide-react';
+import {useCallback, useState} from 'react';
+import {useStoreWithAi} from '../AiSlice';
+import {DeleteSessionDialog, RenameSessionDialog} from './session';
+import {SessionActionsMenu} from './SessionActionsMenu';
+import type {AnalysisSessionSchema} from '@sqlrooms/ai-config';
+
+interface ChatHeaderProps {
+  onHistoryClick: () => void;
+  className?: string;
+}
+
+export const ChatHeader: React.FC<ChatHeaderProps> = ({
+  onHistoryClick,
+  className,
+}) => {
+  const currentSession = useStoreWithAi((s) => s.ai.getCurrentSession());
+  const createSession = useStoreWithAi((s) => s.ai.createSession);
+  const renameSession = useStoreWithAi((s) => s.ai.renameSession);
+  const deleteSession = useStoreWithAi((s) => s.ai.deleteSession);
+
+  const [sessionToRename, setSessionToRename] =
+    useState<AnalysisSessionSchema | null>(null);
+  const [sessionToDelete, setSessionToDelete] =
+    useState<AnalysisSessionSchema | null>(null);
+
+  const handleRename = useCallback(() => {
+    if (currentSession) {
+      setSessionToRename(currentSession);
+    }
+  }, [currentSession]);
+
+  const handleDelete = useCallback(() => {
+    if (currentSession) {
+      // If no messages, delete immediately; otherwise show confirmation
+      if (!currentSession.uiMessages?.length) {
+        deleteSession(currentSession.id);
+      } else {
+        setSessionToDelete(currentSession);
+      }
+    }
+  }, [currentSession, deleteSession]);
+
+  const handleRenameConfirm = useCallback(
+    (newName: string) => {
+      if (sessionToRename) {
+        renameSession(sessionToRename.id, newName);
+      }
+      setSessionToRename(null);
+    },
+    [sessionToRename, renameSession],
+  );
+
+  const handleDeleteConfirm = useCallback(() => {
+    if (sessionToDelete) {
+      deleteSession(sessionToDelete.id);
+    }
+    setSessionToDelete(null);
+  }, [sessionToDelete, deleteSession]);
+
+  const handleCloseRenameDialog = useCallback(() => {
+    setSessionToRename(null);
+  }, []);
+
+  const handleCloseDeleteDialog = useCallback(() => {
+    setSessionToDelete(null);
+  }, []);
+
+  const handleCreateSession = useCallback(() => {
+    createSession();
+  }, [createSession]);
+
+  return (
+    <div
+      className={cn(
+        'flex items-center justify-between gap-3 border-b pb-3',
+        className,
+      )}
+    >
+      {/* Left section */}
+      <div className="flex min-w-0 flex-1 items-center gap-2 text-sm">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onHistoryClick}
+          className="gap-2"
+        >
+          <HistoryIcon className="h-3.5 w-3.5" />
+          History
+        </Button>
+        <span className="text-muted-foreground">/</span>
+        <span className="truncate font-semibold">
+          {currentSession?.name || 'New Chat'}
+        </span>
+        {currentSession && (
+          <SessionActionsMenu onRename={handleRename} onDelete={handleDelete} />
+        )}
+      </div>
+
+      {/* Right section */}
+      <div className="flex items-center gap-2">
+        <Button variant="ghost" size="sm" onClick={handleCreateSession}>
+          <PlusIcon className="h-4 w-4" />
+        </Button>
+      </div>
+
+      <RenameSessionDialog
+        isOpen={sessionToRename !== null}
+        onClose={handleCloseRenameDialog}
+        initialName={sessionToRename?.name ?? ''}
+        onRename={handleRenameConfirm}
+      />
+      <DeleteSessionDialog
+        isOpen={sessionToDelete !== null}
+        onClose={handleCloseDeleteDialog}
+        onDelete={handleDeleteConfirm}
+      />
+    </div>
+  );
+};

--- a/packages/ai-core/src/components/ChatHistoryItem.tsx
+++ b/packages/ai-core/src/components/ChatHistoryItem.tsx
@@ -1,0 +1,102 @@
+import {Button, cn} from '@sqlrooms/ui';
+import {PencilIcon, TrashIcon} from 'lucide-react';
+import {FC, useState} from 'react';
+import {formatTimeRelative} from '@sqlrooms/utils';
+import type {AnalysisSessionSchema} from '@sqlrooms/ai-config';
+
+type ChatHistoryItemProps = {
+  session: AnalysisSessionSchema;
+  isActive: boolean;
+  onClick: () => void;
+  onRename: () => void;
+  onDelete: () => void;
+};
+
+export const ChatHistoryItem: FC<ChatHistoryItemProps> = ({
+  session,
+  isActive,
+  onClick,
+  onRename,
+  onDelete,
+}) => {
+  const [isHovered, setIsHovered] = useState(false);
+
+  const messageCount = session.uiMessages?.length ?? 0;
+  const lastMessage = session.uiMessages?.[session.uiMessages.length - 1];
+
+  // Extract text from message parts
+  const preview =
+    lastMessage?.parts
+      ?.filter(
+        (part): part is {type: 'text'; text: string} => part.type === 'text',
+      )
+      .map((part) => part.text)
+      .join(' ') ?? '';
+
+  const relativeTime = session.lastOpenedAt
+    ? formatTimeRelative(session.lastOpenedAt)
+    : '';
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        'group relative w-full cursor-pointer rounded-md border p-3 text-left transition-colors',
+        isActive
+          ? 'border-l-primary bg-primary/5 border-l-4'
+          : 'border-border hover:bg-muted',
+      )}
+      onClick={onClick}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <div className="flex items-start gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="mb-1 text-sm font-medium">{session.name}</div>
+          <div className="text-muted-foreground mb-2 text-xs">
+            {messageCount} {messageCount === 1 ? 'message' : 'messages'}
+            {relativeTime && ` · ${relativeTime}`}
+          </div>
+          {preview && (
+            <div className="text-muted-foreground truncate text-xs">
+              {preview}
+            </div>
+          )}
+        </div>
+
+        {/* Action buttons - visible on hover */}
+        <div
+          className={cn(
+            'flex gap-1 transition-opacity',
+            isHovered ? 'opacity-100' : 'opacity-0',
+          )}
+        >
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 w-8 p-0"
+            onClick={(e) => {
+              e.stopPropagation();
+              onRename();
+            }}
+            aria-label="Rename chat"
+          >
+            <PencilIcon className="h-3 w-3" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-destructive hover:text-destructive h-8 w-8 p-0"
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete();
+            }}
+            aria-label="Delete chat"
+          >
+            <TrashIcon className="h-3 w-3" />
+          </Button>
+        </div>
+      </div>
+    </button>
+  );
+};

--- a/packages/ai-core/src/components/ChatHistoryItem.tsx
+++ b/packages/ai-core/src/components/ChatHistoryItem.tsx
@@ -38,8 +38,9 @@ export const ChatHistoryItem: FC<ChatHistoryItemProps> = ({
     : '';
 
   return (
-    <button
-      type="button"
+    <div
+      role="button"
+      tabIndex={0}
       className={cn(
         'group relative w-full cursor-pointer rounded-md border p-3 text-left transition-colors',
         isActive
@@ -47,6 +48,12 @@ export const ChatHistoryItem: FC<ChatHistoryItemProps> = ({
           : 'border-border hover:bg-muted',
       )}
       onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick();
+        }
+      }}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
@@ -97,6 +104,6 @@ export const ChatHistoryItem: FC<ChatHistoryItemProps> = ({
           </Button>
         </div>
       </div>
-    </button>
+    </div>
   );
 };

--- a/packages/ai-core/src/components/ChatHistoryView.tsx
+++ b/packages/ai-core/src/components/ChatHistoryView.tsx
@@ -1,0 +1,208 @@
+import {Button, cn} from '@sqlrooms/ui';
+import {ArrowLeft, PencilIcon, PlusIcon, TrashIcon} from 'lucide-react';
+import {useMemo, useState} from 'react';
+import {formatTimeRelative} from '@sqlrooms/utils';
+import {useStoreWithAi} from '../AiSlice';
+import {DeleteSessionDialog, RenameSessionDialog} from './session';
+import type {AnalysisSessionSchema} from '@sqlrooms/ai-config';
+
+interface ChatHistoryViewProps {
+  onBack: () => void;
+  onSelectChat: (sessionId: string) => void;
+  className?: string;
+}
+
+interface SessionListItemProps {
+  session: AnalysisSessionSchema;
+  isActive: boolean;
+  onClick: () => void;
+  onRename: () => void;
+  onDelete: () => void;
+}
+
+const SessionListItem: React.FC<SessionListItemProps> = ({
+  session,
+  isActive,
+  onClick,
+  onRename,
+  onDelete,
+}) => {
+  const [isHovered, setIsHovered] = useState(false);
+
+  const messageCount = session.uiMessages?.length ?? 0;
+  const lastMessage = session.uiMessages?.[session.uiMessages.length - 1];
+
+  // Extract text from message parts
+  const preview =
+    lastMessage?.parts
+      ?.filter(
+        (part): part is {type: 'text'; text: string} => part.type === 'text',
+      )
+      .map((part) => part.text)
+      .join(' ') ?? '';
+
+  const relativeTime = session.lastOpenedAt
+    ? formatTimeRelative(session.lastOpenedAt)
+    : '';
+
+  return (
+    <div
+      className={cn(
+        'group relative cursor-pointer rounded-md border p-3 transition-colors',
+        isActive
+          ? 'border-l-primary bg-primary/5 border-l-4'
+          : 'border-border hover:bg-muted',
+      )}
+      onClick={onClick}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <div className="flex items-start gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="mb-1 text-sm font-medium">{session.name}</div>
+          <div className="text-muted-foreground mb-2 text-xs">
+            {messageCount} {messageCount === 1 ? 'message' : 'messages'}
+            {relativeTime && ` · ${relativeTime}`}
+          </div>
+          {preview && (
+            <div className="text-muted-foreground truncate text-xs">
+              {preview}
+            </div>
+          )}
+        </div>
+
+        {/* Action buttons - visible on hover */}
+        <div
+          className={cn(
+            'flex gap-1 transition-opacity',
+            isHovered ? 'opacity-100' : 'opacity-0',
+          )}
+        >
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 w-8 p-0"
+            onClick={(e) => {
+              e.stopPropagation();
+              onRename();
+            }}
+          >
+            <PencilIcon className="h-3 w-3" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-destructive hover:text-destructive h-8 w-8 p-0"
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete();
+            }}
+          >
+            <TrashIcon className="h-3 w-3" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const ChatHistoryView: React.FC<ChatHistoryViewProps> = ({
+  onBack,
+  onSelectChat,
+  className,
+}) => {
+  const sessions = useStoreWithAi((s) => s.ai.config.sessions);
+  const currentSessionId = useStoreWithAi((s) => s.ai.config.currentSessionId);
+  const createSession = useStoreWithAi((s) => s.ai.createSession);
+  const renameSession = useStoreWithAi((s) => s.ai.renameSession);
+  const deleteSession = useStoreWithAi((s) => s.ai.deleteSession);
+
+  const [sessionToRename, setSessionToRename] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
+  const [sessionToDelete, setSessionToDelete] = useState<string | null>(null);
+
+  // Sort sessions by lastOpenedAt (most recent first)
+  const sortedSessions = useMemo(() => {
+    return [...sessions].sort((a, b) => {
+      const aTime = a.lastOpenedAt ?? 0;
+      const bTime = b.lastOpenedAt ?? 0;
+      return bTime - aTime;
+    });
+  }, [sessions]);
+
+  return (
+    <div className={cn('flex flex-col gap-4', className)}>
+      {/* Header */}
+      <div className="flex items-center gap-3 border-b pb-3 text-sm">
+        <Button variant="ghost" size="sm" onClick={onBack} className="gap-2">
+          <ArrowLeft className="h-4 w-4" />
+        </Button>
+        <span className="font-semibold">History</span>
+      </div>
+
+      {/* Session list */}
+      {sortedSessions.length > 0 ? (
+        <div className="flex flex-col gap-2">
+          {sortedSessions.map((session) => (
+            <SessionListItem
+              key={session.id}
+              session={session}
+              isActive={session.id === currentSessionId}
+              onClick={() => onSelectChat(session.id)}
+              onRename={() =>
+                setSessionToRename({id: session.id, name: session.name})
+              }
+              onDelete={() => {
+                // If no messages, delete immediately; otherwise show confirmation
+                if (!session.uiMessages?.length) {
+                  deleteSession(session.id);
+                } else {
+                  setSessionToDelete(session.id);
+                }
+              }}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="flex flex-col items-center justify-center gap-4 py-12">
+          <p className="text-muted-foreground text-sm">No chats yet</p>
+          <Button
+            variant="outline"
+            onClick={() => {
+              createSession();
+              onBack();
+            }}
+            className="gap-2"
+          >
+            <PlusIcon className="h-4 w-4" />
+            Create your first chat
+          </Button>
+        </div>
+      )}
+
+      <RenameSessionDialog
+        isOpen={sessionToRename !== null}
+        onClose={() => setSessionToRename(null)}
+        initialName={sessionToRename?.name ?? ''}
+        onRename={(newName) => {
+          if (sessionToRename) {
+            renameSession(sessionToRename.id, newName);
+          }
+          setSessionToRename(null);
+        }}
+      />
+      <DeleteSessionDialog
+        isOpen={sessionToDelete !== null}
+        onClose={() => setSessionToDelete(null)}
+        onDelete={() => {
+          if (sessionToDelete) {
+            deleteSession(sessionToDelete);
+          }
+          setSessionToDelete(null);
+        }}
+      />
+    </div>
+  );
+};

--- a/packages/ai-core/src/components/ChatHistoryView.tsx
+++ b/packages/ai-core/src/components/ChatHistoryView.tsx
@@ -1,112 +1,18 @@
 import {Button, cn} from '@sqlrooms/ui';
-import {ArrowLeft, PencilIcon, PlusIcon, TrashIcon} from 'lucide-react';
-import {useMemo, useState} from 'react';
-import {formatTimeRelative} from '@sqlrooms/utils';
+import {ArrowLeft, PlusIcon} from 'lucide-react';
+import {FC, useCallback, useMemo, useState} from 'react';
 import {useStoreWithAi} from '../AiSlice';
 import {DeleteSessionDialog, RenameSessionDialog} from './session';
-import type {AnalysisSessionSchema} from '@sqlrooms/ai-config';
+import {ChatHistoryItem} from './ChatHistoryItem';
+import {AnalysisSessionSchema} from '@sqlrooms/ai-config';
 
-interface ChatHistoryViewProps {
+type ChatHistoryViewProps = {
   onBack: () => void;
   onSelectChat: (sessionId: string) => void;
   className?: string;
-}
-
-interface SessionListItemProps {
-  session: AnalysisSessionSchema;
-  isActive: boolean;
-  onClick: () => void;
-  onRename: () => void;
-  onDelete: () => void;
-}
-
-const SessionListItem: React.FC<SessionListItemProps> = ({
-  session,
-  isActive,
-  onClick,
-  onRename,
-  onDelete,
-}) => {
-  const [isHovered, setIsHovered] = useState(false);
-
-  const messageCount = session.uiMessages?.length ?? 0;
-  const lastMessage = session.uiMessages?.[session.uiMessages.length - 1];
-
-  // Extract text from message parts
-  const preview =
-    lastMessage?.parts
-      ?.filter(
-        (part): part is {type: 'text'; text: string} => part.type === 'text',
-      )
-      .map((part) => part.text)
-      .join(' ') ?? '';
-
-  const relativeTime = session.lastOpenedAt
-    ? formatTimeRelative(session.lastOpenedAt)
-    : '';
-
-  return (
-    <div
-      className={cn(
-        'group relative cursor-pointer rounded-md border p-3 transition-colors',
-        isActive
-          ? 'border-l-primary bg-primary/5 border-l-4'
-          : 'border-border hover:bg-muted',
-      )}
-      onClick={onClick}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
-    >
-      <div className="flex items-start gap-3">
-        <div className="min-w-0 flex-1">
-          <div className="mb-1 text-sm font-medium">{session.name}</div>
-          <div className="text-muted-foreground mb-2 text-xs">
-            {messageCount} {messageCount === 1 ? 'message' : 'messages'}
-            {relativeTime && ` · ${relativeTime}`}
-          </div>
-          {preview && (
-            <div className="text-muted-foreground truncate text-xs">
-              {preview}
-            </div>
-          )}
-        </div>
-
-        {/* Action buttons - visible on hover */}
-        <div
-          className={cn(
-            'flex gap-1 transition-opacity',
-            isHovered ? 'opacity-100' : 'opacity-0',
-          )}
-        >
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-8 w-8 p-0"
-            onClick={(e) => {
-              e.stopPropagation();
-              onRename();
-            }}
-          >
-            <PencilIcon className="h-3 w-3" />
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="text-destructive hover:text-destructive h-8 w-8 p-0"
-            onClick={(e) => {
-              e.stopPropagation();
-              onDelete();
-            }}
-          >
-            <TrashIcon className="h-3 w-3" />
-          </Button>
-        </div>
-      </div>
-    </div>
-  );
 };
 
-export const ChatHistoryView: React.FC<ChatHistoryViewProps> = ({
+export const ChatHistoryView: FC<ChatHistoryViewProps> = ({
   onBack,
   onSelectChat,
   className,
@@ -117,11 +23,10 @@ export const ChatHistoryView: React.FC<ChatHistoryViewProps> = ({
   const renameSession = useStoreWithAi((s) => s.ai.renameSession);
   const deleteSession = useStoreWithAi((s) => s.ai.deleteSession);
 
-  const [sessionToRename, setSessionToRename] = useState<{
-    id: string;
-    name: string;
-  } | null>(null);
-  const [sessionToDelete, setSessionToDelete] = useState<string | null>(null);
+  const [sessionToRename, setSessionToRename] =
+    useState<AnalysisSessionSchema | null>(null);
+  const [sessionToDelete, setSessionToDelete] =
+    useState<AnalysisSessionSchema | null>(null);
 
   // Sort sessions by lastOpenedAt (most recent first)
   const sortedSessions = useMemo(() => {
@@ -132,11 +37,70 @@ export const ChatHistoryView: React.FC<ChatHistoryViewProps> = ({
     });
   }, [sessions]);
 
+  const handleSelectChat = useCallback(
+    (sessionId: string) => {
+      onSelectChat(sessionId);
+    },
+    [onSelectChat],
+  );
+
+  const handleRenameSession = useCallback((session: AnalysisSessionSchema) => {
+    setSessionToRename(session);
+  }, []);
+
+  const handleDeleteSession = useCallback(
+    (session: AnalysisSessionSchema) => {
+      // If no messages, delete immediately; otherwise show confirmation
+      if (!session.uiMessages?.length) {
+        deleteSession(session.id);
+      } else {
+        setSessionToDelete(session);
+      }
+    },
+    [deleteSession],
+  );
+
+  const handleCreateAndBack = useCallback(() => {
+    createSession();
+    onBack();
+  }, [createSession, onBack]);
+
+  const handleCloseRenameDialog = useCallback(() => {
+    setSessionToRename(null);
+  }, []);
+
+  const handleConfirmRename = useCallback(
+    (newName: string) => {
+      if (sessionToRename) {
+        renameSession(sessionToRename.id, newName);
+      }
+      setSessionToRename(null);
+    },
+    [sessionToRename, renameSession],
+  );
+
+  const handleCloseDeleteDialog = useCallback(() => {
+    setSessionToDelete(null);
+  }, []);
+
+  const handleConfirmDelete = useCallback(() => {
+    if (sessionToDelete) {
+      deleteSession(sessionToDelete.id);
+    }
+    setSessionToDelete(null);
+  }, [sessionToDelete, deleteSession]);
+
   return (
     <div className={cn('flex flex-col gap-4', className)}>
       {/* Header */}
       <div className="flex items-center gap-3 border-b pb-3 text-sm">
-        <Button variant="ghost" size="sm" onClick={onBack} className="gap-2">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onBack}
+          className="gap-2"
+          aria-label="Back"
+        >
           <ArrowLeft className="h-4 w-4" />
         </Button>
         <span className="font-semibold">History</span>
@@ -146,22 +110,13 @@ export const ChatHistoryView: React.FC<ChatHistoryViewProps> = ({
       {sortedSessions.length > 0 ? (
         <div className="flex flex-col gap-2">
           {sortedSessions.map((session) => (
-            <SessionListItem
+            <ChatHistoryItem
               key={session.id}
               session={session}
               isActive={session.id === currentSessionId}
-              onClick={() => onSelectChat(session.id)}
-              onRename={() =>
-                setSessionToRename({id: session.id, name: session.name})
-              }
-              onDelete={() => {
-                // If no messages, delete immediately; otherwise show confirmation
-                if (!session.uiMessages?.length) {
-                  deleteSession(session.id);
-                } else {
-                  setSessionToDelete(session.id);
-                }
-              }}
+              onClick={() => handleSelectChat(session.id)}
+              onRename={() => handleRenameSession(session)}
+              onDelete={() => handleDeleteSession(session)}
             />
           ))}
         </div>
@@ -170,10 +125,7 @@ export const ChatHistoryView: React.FC<ChatHistoryViewProps> = ({
           <p className="text-muted-foreground text-sm">No chats yet</p>
           <Button
             variant="outline"
-            onClick={() => {
-              createSession();
-              onBack();
-            }}
+            onClick={handleCreateAndBack}
             className="gap-2"
           >
             <PlusIcon className="h-4 w-4" />
@@ -184,24 +136,14 @@ export const ChatHistoryView: React.FC<ChatHistoryViewProps> = ({
 
       <RenameSessionDialog
         isOpen={sessionToRename !== null}
-        onClose={() => setSessionToRename(null)}
+        onClose={handleCloseRenameDialog}
         initialName={sessionToRename?.name ?? ''}
-        onRename={(newName) => {
-          if (sessionToRename) {
-            renameSession(sessionToRename.id, newName);
-          }
-          setSessionToRename(null);
-        }}
+        onRename={handleConfirmRename}
       />
       <DeleteSessionDialog
         isOpen={sessionToDelete !== null}
-        onClose={() => setSessionToDelete(null)}
-        onDelete={() => {
-          if (sessionToDelete) {
-            deleteSession(sessionToDelete);
-          }
-          setSessionToDelete(null);
-        }}
+        onClose={handleCloseDeleteDialog}
+        onDelete={handleConfirmDelete}
       />
     </div>
   );

--- a/packages/ai-core/src/components/SessionActionsMenu.tsx
+++ b/packages/ai-core/src/components/SessionActionsMenu.tsx
@@ -1,0 +1,43 @@
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@sqlrooms/ui';
+import {MoreVertical, PencilIcon, TrashIcon} from 'lucide-react';
+
+type SessionActionsMenuProps = {
+  onRename: () => void;
+  onDelete: () => void;
+};
+
+export const SessionActionsMenu: React.FC<SessionActionsMenuProps> = ({
+  onRename,
+  onDelete,
+}) => {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon" className="h-6 w-6">
+          <MoreVertical className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={onRename}>
+          <PencilIcon className="mr-2 h-4 w-4" />
+          Rename
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          className="text-destructive focus:text-destructive"
+          onClick={onDelete}
+        >
+          <TrashIcon className="mr-2 h-4 w-4" />
+          Delete
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/packages/ai-core/src/components/SessionActionsMenu.tsx
+++ b/packages/ai-core/src/components/SessionActionsMenu.tsx
@@ -5,6 +5,9 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from '@sqlrooms/ui';
 import {MoreVertical, PencilIcon, TrashIcon} from 'lucide-react';
 
@@ -19,11 +22,21 @@ export const SessionActionsMenu: React.FC<SessionActionsMenuProps> = ({
 }) => {
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon" className="h-6 w-6">
-          <MoreVertical className="h-4 w-4" />
-        </Button>
-      </DropdownMenuTrigger>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6"
+              aria-label="Open session actions"
+            >
+              <MoreVertical className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Session actions</TooltipContent>
+      </Tooltip>
       <DropdownMenuContent align="end">
         <DropdownMenuItem onClick={onRename}>
           <PencilIcon className="mr-2 h-4 w-4" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browse a Chat History view to see, select, and switch between past sessions.
  * Header includes a History button and displays the current session name; “New session” remains available when none.
  * Rename and delete sessions (inline or via dialogs), with contextual confirmation and immediate delete for empty sessions.
  * Session list shows message counts, last-opened times, and message previews; empty state offers a CTA to create the first chat.
  * Loading skeleton shown while chat data is being fetched.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->