### PR TITLE
fix: Inconsistent agent chat height

### DIFF
--- a/packages/ui/src/components/textarea.tsx
+++ b/packages/ui/src/components/textarea.tsx
@@ -7,7 +7,15 @@ type TextareaProps = React.ComponentProps<'textarea'> & {
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   (
-    {className, autoResize = false, onInput, value, defaultValue, ...props},
+    {
+      className,
+      autoResize = false,
+      onInput,
+      value,
+      defaultValue,
+      rows,
+      ...props
+    },
     ref,
   ) => {
     const localRef = React.useRef<HTMLTextAreaElement>(null);
@@ -57,6 +65,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
             : undefined,
           className,
         )}
+        rows={rows ?? (autoResize ? 1 : undefined)}
         ref={localRef}
         onInput={handleInput}
         value={value}


### PR DESCRIPTION
Issue: The AI prompt textarea appeared too tall when empty because HTML textareas default to `rows="2"` causing `scrollHeight` (used by `autoResize` to report a 2-row height even with no content — then shrinking to 1 row once typing begins.

Fix: Default `rows` to 1 when `autoResize` is enabled, so the empty-state intrinsic height matches a single line and grows naturally as content is added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed textarea row height handling to correctly apply defaults when auto-resize is enabled or disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->