### PR TITLE
feat: Add createKeplerTheme

### DIFF
--- a/packages/kepler/README.md
+++ b/packages/kepler/README.md
@@ -146,13 +146,26 @@ dataset-id override remain clear at the call site.
 Pass options to `createKeplerSlice()`:
 
 ```ts
+import {createKeplerTheme, type KeplerThemeOverrides} from '@sqlrooms/kepler';
+
 createKeplerSlice({
   basicKeplerProps: {
     mapboxApiAccessToken: import.meta.env.VITE_MAPBOX_TOKEN,
   },
+  keplerTheme: createKeplerTheme({
+    modalOverLayZ: 40,
+  } satisfies KeplerThemeOverrides),
+  modalPortalTarget: 'body',
   actionLogging: false,
 });
 ```
+
+Notes:
+
+- `basicKeplerProps` is for base Kepler registration/component props.
+- `keplerTheme` (optional) sets the theme passed to Kepler `ThemeProvider`.
+- `modalPortalTarget` controls modal portal placement: `'container'` (default)
+  or `'body'`.
 
 ### Table selection and dataset ids
 

--- a/packages/kepler/src/KeplerSlice.ts
+++ b/packages/kepler/src/KeplerSlice.ts
@@ -87,6 +87,19 @@ class DesktopKeplerTable extends KeplerTable {
 
 export type KeplerGLBasicProps = {
   mapboxApiAccessToken?: string;
+  /**
+   * Where the Kepler modal (Add Map Style, Export, etc.) should be portaled.
+   * - `'body'`: portals to `document.body` (escapes stacking contexts)
+   * - `'container'`: portals inside the kepler map container element
+   * @default 'container'
+   */
+  modalPortalTarget?: 'body' | 'container';
+  /**
+   * z-index for the Kepler modal overlay. Use this to coordinate layering
+   * with app-level dialogs (e.g., Radix Dialog at z-50).
+   * When undefined, falls back to the styled-components theme value.
+   */
+  modalOverlayZIndex?: number;
 };
 
 export type CreateInitialMapKeplerStateContext = {

--- a/packages/kepler/src/KeplerSlice.ts
+++ b/packages/kepler/src/KeplerSlice.ts
@@ -65,6 +65,7 @@ import type {
 } from 'redux';
 import {compose, Dispatch, Middleware} from 'redux';
 import {createLogger, ReduxLoggerOptions} from 'redux-logger';
+import type {DefaultTheme} from 'styled-components';
 import {getUnqualifiedSqlIdentifier} from '@sqlrooms/duckdb-core';
 import {
   findKeplerTableForDatasetId,
@@ -87,20 +88,9 @@ class DesktopKeplerTable extends KeplerTable {
 
 export type KeplerGLBasicProps = {
   mapboxApiAccessToken?: string;
-  /**
-   * Where the Kepler modal (Add Map Style, Export, etc.) should be portaled.
-   * - `'body'`: portals to `document.body` (escapes stacking contexts)
-   * - `'container'`: portals inside the kepler map container element
-   * @default 'container'
-   */
-  modalPortalTarget?: 'body' | 'container';
-  /**
-   * z-index for the Kepler modal overlay. Use this to coordinate layering
-   * with app-level dialogs (e.g., Radix Dialog at z-50).
-   * When undefined, falls back to the styled-components theme value.
-   */
-  modalOverlayZIndex?: number;
 };
+
+export type KeplerModalPortalTarget = 'body' | 'container';
 
 export type CreateInitialMapKeplerStateContext = {
   reason:
@@ -120,6 +110,18 @@ export type CreateKeplerSliceOptions = {
     context: CreateInitialMapKeplerStateContext,
   ) => Partial<KeplerGlState>;
   basicKeplerProps?: Partial<KeplerGLBasicProps>;
+  /**
+   * Theme passed to Kepler's ThemeProvider.
+   * Use createKeplerTheme() to merge app-level overrides into the default theme.
+   */
+  keplerTheme?: DefaultTheme;
+  /**
+   * Where the Kepler modal (Add Map Style, Export, etc.) should be portaled.
+   * - 'body': portals to document.body (escapes stacking contexts)
+   * - 'container': portals inside the kepler map container element
+   * @default 'container'
+   */
+  modalPortalTarget?: KeplerModalPortalTarget;
   actionLogging?: boolean | ReduxLoggerOptions;
   middlewares?: Middleware[];
   applicationConfig?: KeplerApplicationConfig;
@@ -278,6 +280,8 @@ export type KeplerSliceState = {
     config: KeplerSliceConfig;
     map: KeplerGlReduxState;
     basicKeplerProps?: Partial<KeplerGLBasicProps>;
+    keplerTheme?: DefaultTheme;
+    modalPortalTarget: KeplerModalPortalTarget;
     tableSelection: KeplerTableSelectionOptions;
     forwardDispatch: {
       [mapId: string]: Dispatch;
@@ -377,6 +381,8 @@ const SKIP_AUTO_SAVE_ACTIONS: string[] = [
 
 export function createKeplerSlice({
   basicKeplerProps = {},
+  keplerTheme,
+  modalPortalTarget = 'container',
   config: initialConfigProps,
   createInitialMapKeplerState,
   actionLogging = false,
@@ -501,6 +507,8 @@ export function createKeplerSlice({
       kepler: {
         config: initialConfig,
         basicKeplerProps,
+        keplerTheme,
+        modalPortalTarget,
         tableSelection: resolvedTableSelection,
         map: {},
         isRestoringConfig: false,

--- a/packages/kepler/src/components/KeplerMapContainer.tsx
+++ b/packages/kepler/src/components/KeplerMapContainer.tsx
@@ -155,8 +155,12 @@ const KeplerGl: FC<{
     };
   }, [hasFilters, hasAnimatableLayers, mergedKeplerProps, theme]);
 
-  const modalPortalNode =
-    modalPortalTarget === 'body' ? document.body : containerNode;
+  const modalPortalNode = useMemo(() => {
+    if (modalPortalTarget === 'body') {
+      return typeof document !== 'undefined' ? document.body : null;
+    }
+    return containerNode;
+  }, [modalPortalTarget, containerNode]);
 
   const modalContainerFields = keplerState?.visState
     ? modalContainerSelector(mergedKeplerProps, modalPortalNode)

--- a/packages/kepler/src/components/KeplerMapContainer.tsx
+++ b/packages/kepler/src/components/KeplerMapContainer.tsx
@@ -71,6 +71,9 @@ const KeplerGl: FC<{
   const basicKeplerProps = useStoreWithKepler(
     (state) => state.kepler.basicKeplerProps,
   );
+  const modalPortalTarget = useStoreWithKepler(
+    (state) => state.kepler.modalPortalTarget,
+  );
 
   const {keplerActions, keplerState} = useKeplerStateActions({mapId});
   const interactionConfig = keplerState?.visState?.interactionConfig;
@@ -153,9 +156,7 @@ const KeplerGl: FC<{
   }, [hasFilters, hasAnimatableLayers, mergedKeplerProps, theme]);
 
   const modalPortalNode =
-    basicKeplerProps?.modalPortalTarget === 'body'
-      ? document.body
-      : containerNode;
+    modalPortalTarget === 'body' ? document.body : containerNode;
 
   const modalContainerFields = keplerState?.visState
     ? modalContainerSelector(mergedKeplerProps, modalPortalNode)

--- a/packages/kepler/src/components/KeplerMapContainer.tsx
+++ b/packages/kepler/src/components/KeplerMapContainer.tsx
@@ -75,7 +75,7 @@ const KeplerGl: FC<{
   const {keplerActions, keplerState} = useKeplerStateActions({mapId});
   const interactionConfig = keplerState?.visState?.interactionConfig;
 
-  // Capture the current container DOM node outside of render logic
+  // Capture container DOM node outside of render for portal use
   useEffect(() => {
     setContainerNode(containerRef.current);
   }, [containerRef]);
@@ -152,8 +152,13 @@ const KeplerGl: FC<{
     };
   }, [hasFilters, hasAnimatableLayers, mergedKeplerProps, theme]);
 
+  const modalPortalNode =
+    basicKeplerProps?.modalPortalTarget === 'body'
+      ? document.body
+      : containerNode;
+
   const modalContainerFields = keplerState?.visState
-    ? modalContainerSelector(mergedKeplerProps, containerNode)
+    ? modalContainerSelector(mergedKeplerProps, modalPortalNode)
     : null;
 
   const mapboxApiAccessToken =

--- a/packages/kepler/src/components/KeplerProvider.tsx
+++ b/packages/kepler/src/components/KeplerProvider.tsx
@@ -20,16 +20,8 @@ export const KeplerProvider: React.FC<KeplerProviderProps> = ({
   const reduxProviderStore = useStoreWithKepler(
     (state) => state.kepler.__reduxProviderStore,
   );
-  const basicKeplerProps = useStoreWithKepler(
-    (state) => state.kepler.basicKeplerProps,
-  );
-
-  // Merge modal z-index override into the kepler theme so react-modal picks it up
-  const modalOverlayZIndex = basicKeplerProps?.modalOverlayZIndex;
-  const resolvedTheme = useMemo(() => {
-    if (modalOverlayZIndex == null) return darkTheme;
-    return {...darkTheme, modalOverLayZ: modalOverlayZIndex};
-  }, [modalOverlayZIndex]);
+  const keplerTheme = useStoreWithKepler((state) => state.kepler.keplerTheme);
+  const resolvedTheme = useMemo(() => keplerTheme ?? darkTheme, [keplerTheme]);
 
   const keplerContext = useMemo(
     () => ({

--- a/packages/kepler/src/components/KeplerProvider.tsx
+++ b/packages/kepler/src/components/KeplerProvider.tsx
@@ -20,6 +20,16 @@ export const KeplerProvider: React.FC<KeplerProviderProps> = ({
   const reduxProviderStore = useStoreWithKepler(
     (state) => state.kepler.__reduxProviderStore,
   );
+  const basicKeplerProps = useStoreWithKepler(
+    (state) => state.kepler.basicKeplerProps,
+  );
+
+  // Merge modal z-index override into the kepler theme so react-modal picks it up
+  const modalOverlayZIndex = basicKeplerProps?.modalOverlayZIndex;
+  const resolvedTheme = useMemo(() => {
+    if (modalOverlayZIndex == null) return darkTheme;
+    return {...darkTheme, modalOverLayZ: modalOverlayZIndex};
+  }, [modalOverlayZIndex]);
 
   const keplerContext = useMemo(
     () => ({
@@ -35,7 +45,7 @@ export const KeplerProvider: React.FC<KeplerProviderProps> = ({
     <IntlProvider locale="en" messages={messages['en']}>
       <Provider store={reduxProviderStore}>
         <StyleSheetManager shouldForwardProp={shouldForwardProp}>
-          <ThemeProvider theme={darkTheme}>
+          <ThemeProvider theme={resolvedTheme}>
             <KeplerGlContext.Provider value={keplerContext}>
               <>{children}</>
             </KeplerGlContext.Provider>

--- a/packages/kepler/src/index.ts
+++ b/packages/kepler/src/index.ts
@@ -14,6 +14,7 @@ export type {
   AddTableToMapParams,
   CreateInitialMapKeplerStateContext,
   CreateKeplerSliceOptions,
+  KeplerModalPortalTarget,
   KeplerSliceState,
 } from './KeplerSlice';
 export {
@@ -78,4 +79,5 @@ export {
 } from './components/KeplerInjector';
 
 export {createKeplerTheme, darkTheme} from './styles/theme';
+export type {KeplerThemeOverrides} from './styles/theme';
 export type {KeplerGLBasicProps} from './KeplerSlice';

--- a/packages/kepler/src/index.ts
+++ b/packages/kepler/src/index.ts
@@ -76,3 +76,6 @@ export {
   CustomAddDataButtonFactory,
   CustomPanelTitleFactory,
 } from './components/KeplerInjector';
+
+export {createKeplerTheme, darkTheme} from './styles/theme';
+export type {KeplerGLBasicProps} from './KeplerSlice';

--- a/packages/kepler/src/styles/theme.ts
+++ b/packages/kepler/src/styles/theme.ts
@@ -87,6 +87,9 @@ export const darkTheme: DefaultTheme = {
   panelHeaderBorderRadius: '4px',
 };
 
+export type KeplerThemeOverrides = Partial<typeof theme> &
+  Partial<DefaultTheme>;
+
 /**
  * Create a custom Kepler theme by merging overrides into the base dark theme.
  * Use this to set modal z-indices, colors, or other theme values from the app level.
@@ -97,7 +100,7 @@ export const darkTheme: DefaultTheme = {
  * ```
  */
 export function createKeplerTheme(
-  overrides?: Partial<DefaultTheme>,
+  overrides?: KeplerThemeOverrides,
 ): DefaultTheme {
   return {...darkTheme, ...overrides};
 }

--- a/packages/kepler/src/styles/theme.ts
+++ b/packages/kepler/src/styles/theme.ts
@@ -86,3 +86,18 @@ export const darkTheme: DefaultTheme = {
   bottomWidgetPaddingLeft: 0,
   panelHeaderBorderRadius: '4px',
 };
+
+/**
+ * Create a custom Kepler theme by merging overrides into the base dark theme.
+ * Use this to set modal z-indices, colors, or other theme values from the app level.
+ *
+ * @example
+ * ```ts
+ * const myTheme = createKeplerTheme({ modalOverLayZ: 49 });
+ * ```
+ */
+export function createKeplerTheme(
+  overrides?: Partial<DefaultTheme>,
+): DefaultTheme {
+  return {...darkTheme, ...overrides};
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * **Theme customization**: Added `createKeplerTheme()` with `KeplerThemeOverrides`, and exposed `darkTheme` for consistent theming.
  * **Modal portal targeting**: Added `modalPortalTarget` (supports rendering modals in the container or at `document.body`).
  * **Enhanced public API**: Exported `KeplerModalPortalTarget`, `KeplerThemeOverrides`, `KeplerGLBasicProps`, plus theme utilities for easier configuration.
* **Bug Fixes**
  * **Configured theming applied**: The provider now uses the Kepler store theme when provided (fallback remains `darkTheme`).
* **Documentation**
  * Updated the `createKeplerSlice()` customization example and notes to reflect the new options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->