### PR TITLE
fix: Switch component fallback

### DIFF
--- a/packages/ui/src/components/switch.tsx
+++ b/packages/ui/src/components/switch.tsx
@@ -5,25 +5,6 @@ import * as SwitchPrimitives from '@radix-ui/react-switch';
 
 import {cn} from '../lib/utils';
 
-const SwitchRoot = React.forwardRef<
-  React.ComponentRef<typeof SwitchPrimitives.Root>,
-  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root> & {
-    children?: React.ReactNode;
-  }
->(({className, children, ...props}, ref) => (
-  <SwitchPrimitives.Root
-    className={cn(
-      'focus-visible:ring-ring focus-visible:ring-offset-background data-[state=checked]:bg-primary data-[state=unchecked]:bg-input peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
-      className,
-    )}
-    {...props}
-    ref={ref}
-  >
-    {children ?? <SwitchPrimitives.Thumb />}
-  </SwitchPrimitives.Root>
-));
-SwitchRoot.displayName = SwitchPrimitives.Root.displayName;
-
 const SwitchThumb = React.forwardRef<
   React.ComponentRef<typeof SwitchPrimitives.Thumb>,
   React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Thumb>
@@ -38,6 +19,25 @@ const SwitchThumb = React.forwardRef<
   />
 ));
 SwitchThumb.displayName = SwitchPrimitives.Thumb.displayName;
+
+const SwitchRoot = React.forwardRef<
+  React.ComponentRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root> & {
+    children?: React.ReactNode;
+  }
+>(({className, children, ...props}, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      'focus-visible:ring-ring focus-visible:ring-offset-background data-[state=checked]:bg-primary data-[state=unchecked]:bg-input peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
+      className,
+    )}
+    {...props}
+    ref={ref}
+  >
+    {children ?? <SwitchThumb />}
+  </SwitchPrimitives.Root>
+));
+SwitchRoot.displayName = SwitchPrimitives.Root.displayName;
 
 const Switch = Object.assign(SwitchRoot, {
   Thumb: SwitchThumb,


### PR DESCRIPTION
Issue: The `Switch` component's default fallback when no children are passed renders the raw unstyled `<SwitchPrimitives.Thumb />` instead of the styled `<SwitchThumb />`. This causes all `<Switch />` usages without explicit children (e.g., in `CustomInteractionManager` `KeplerImageExport` to appear as solid blue pills with no visible knob/toggle circle.

Fix: Move the `SwitchThumb` declaration above `SwitchRoot` and change the default fallback from `<SwitchPrimitives.Thumb />` to `<SwitchThumb />` so the styled thumb with bg-background, rounded corners, shadow, and translate transitions is always rendered by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal Switch component structure with no breaking changes. The exported `Switch` API remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->