### PR TITLE
fix: Normalize Mosaic table references to omit DuckDB catalogs

### DIFF
--- a/packages/ai/__tests__/tableTools.test.ts
+++ b/packages/ai/__tests__/tableTools.test.ts
@@ -1,4 +1,5 @@
-import type {DataTable, QualifiedTableName} from '@sqlrooms/duckdb';
+import type {DataTable} from '@sqlrooms/duckdb';
+import {makeQualifiedTableName} from '../../duckdb-core/src/duckdb-utils';
 import {
   createTableIdentitySummary,
   formatAmbiguousTableMessage,
@@ -27,27 +28,6 @@ function makeTable(
     schema: options.schema ?? 'main',
     tableName,
     columns: options.columns ?? [{name: 'id', type: 'INTEGER'}],
-  };
-}
-
-function quoteIdentifier(id: string): string {
-  return `"${id.replace(/"/g, '""')}"`;
-}
-
-function makeQualifiedTableName({
-  database,
-  schema,
-  table,
-}: QualifiedTableName): QualifiedTableName {
-  const tableId = [database, schema, table]
-    .filter((id) => id !== undefined && id !== null)
-    .map((id) => quoteIdentifier(id))
-    .join('.');
-  return {
-    database,
-    schema,
-    table,
-    toString: () => tableId,
   };
 }
 

--- a/packages/ai/src/tools/tableSchemaContext.ts
+++ b/packages/ai/src/tools/tableSchemaContext.ts
@@ -1,7 +1,8 @@
-import type {
-  DataTable,
-  QualifiedTableName,
-  TableColumn,
+import {
+  makeQualifiedTableName,
+  type DataTable,
+  type QualifiedTableName,
+  type TableColumn,
 } from '@sqlrooms/duckdb';
 
 /**
@@ -115,29 +116,6 @@ export function getTableNameForAi(table: DataTable): string {
   return table.table?.table || table.tableName;
 }
 
-function escapeTableIdPart(id: string): string {
-  const str = String(id);
-  if (str.startsWith('"') && str.endsWith('"')) return str;
-  return `"${str.replace(/"/g, '""')}"`;
-}
-
-function makeQualifiedTableNameForAi({
-  database,
-  schema,
-  table,
-}: QualifiedTableName): QualifiedTableName {
-  const tableId = [database, schema, table]
-    .filter((id) => id !== undefined && id !== null)
-    .map((id) => escapeTableIdPart(id))
-    .join('.');
-  return {
-    database,
-    schema,
-    table,
-    toString: () => tableId,
-  };
-}
-
 /**
  * Builds the canonical qualified identity for an AI-visible table.
  *
@@ -149,7 +127,7 @@ export function getQualifiedTableNameForAi(
   table: DataTable,
 ): QualifiedTableName {
   const tableName = table.table?.table || table.tableName;
-  return makeQualifiedTableNameForAi({
+  return makeQualifiedTableName({
     database: table.table?.database || table.database,
     schema: table.table?.schema || table.schema,
     table: tableName,

--- a/packages/ai/src/tools/tableSchemaContext.ts
+++ b/packages/ai/src/tools/tableSchemaContext.ts
@@ -1,8 +1,7 @@
-import {
-  makeQualifiedTableName,
-  type DataTable,
-  type QualifiedTableName,
-  type TableColumn,
+import type {
+  DataTable,
+  QualifiedTableName,
+  TableColumn,
 } from '@sqlrooms/duckdb';
 
 /**
@@ -116,6 +115,44 @@ export function getTableNameForAi(table: DataTable): string {
   return table.table?.table || table.tableName;
 }
 
+function escapeTableIdPart(id: string): string {
+  const str = String(id);
+  if (str.startsWith('"') && str.endsWith('"')) return str;
+  return `"${str.replace(/"/g, '""')}"`;
+}
+
+function makeQualifiedTableNameForAi({
+  database,
+  schema,
+  table,
+}: Pick<
+  QualifiedTableName,
+  'database' | 'schema' | 'table'
+>): QualifiedTableName {
+  const tableId = [database, schema, table]
+    .filter((id) => id !== undefined && id !== null)
+    .map((id) => escapeTableIdPart(id))
+    .join('.');
+  return {
+    database,
+    schema,
+    table,
+    toArray: ({
+      includeDatabase = true,
+      includeSchema = true,
+    }: {
+      includeDatabase?: boolean;
+      includeSchema?: boolean;
+    } = {}) =>
+      [
+        includeDatabase ? database : undefined,
+        includeSchema ? schema : undefined,
+        table,
+      ].filter((id): id is string => id !== undefined && id !== null),
+    toString: () => tableId,
+  };
+}
+
 /**
  * Builds the canonical qualified identity for an AI-visible table.
  *
@@ -127,7 +164,7 @@ export function getQualifiedTableNameForAi(
   table: DataTable,
 ): QualifiedTableName {
   const tableName = table.table?.table || table.tableName;
-  return makeQualifiedTableName({
+  return makeQualifiedTableNameForAi({
     database: table.table?.database || table.database,
     schema: table.table?.schema || table.schema,
     table: tableName,

--- a/packages/duckdb-core/__tests__/getUnqualifiedSqlIdentifier.test.ts
+++ b/packages/duckdb-core/__tests__/getUnqualifiedSqlIdentifier.test.ts
@@ -1,8 +1,85 @@
 import {
   getUnqualifiedSqlIdentifier,
+  makeQualifiedTableName,
   parseQualifiedSqlIdentifier,
   quoteTableReference,
 } from '../src/duckdb-utils';
+
+describe('makeQualifiedTableName', () => {
+  it('returns database, schema, and table parts by default', () => {
+    const table = makeQualifiedTableName({
+      database: 'local',
+      schema: 'main',
+      table: 'earthquakes',
+    });
+
+    expect(table.toArray()).toEqual(['local', 'main', 'earthquakes']);
+  });
+
+  it('returns schema and table when no database is present', () => {
+    const table = makeQualifiedTableName({
+      schema: 'main',
+      table: 'earthquakes',
+    });
+
+    expect(table.toArray()).toEqual(['main', 'earthquakes']);
+  });
+
+  it('returns table only when no database or schema is present', () => {
+    const table = makeQualifiedTableName({table: 'earthquakes'});
+
+    expect(table.toArray()).toEqual(['earthquakes']);
+  });
+
+  it('can omit the database part', () => {
+    const table = makeQualifiedTableName({
+      database: 'local',
+      schema: 'main',
+      table: 'earthquakes',
+    });
+
+    expect(table.toArray({includeDatabase: false})).toEqual([
+      'main',
+      'earthquakes',
+    ]);
+  });
+
+  it('can omit the schema part', () => {
+    const table = makeQualifiedTableName({
+      database: 'local',
+      schema: 'main',
+      table: 'earthquakes',
+    });
+
+    expect(table.toArray({includeSchema: false})).toEqual([
+      'local',
+      'earthquakes',
+    ]);
+  });
+
+  it('can omit database and schema together', () => {
+    const table = makeQualifiedTableName({
+      database: 'local',
+      schema: 'main',
+      table: 'earthquakes',
+    });
+
+    expect(
+      table.toArray({includeDatabase: false, includeSchema: false}),
+    ).toEqual(['earthquakes']);
+  });
+
+  it('keeps raw dotted and quoted identifier parts in arrays', () => {
+    const table = makeQualifiedTableName({
+      database: 'local.db',
+      schema: 'ma"in',
+      table: 'events.2026',
+    });
+
+    expect(table.toArray()).toEqual(['local.db', 'ma"in', 'events.2026']);
+    expect(table.toString()).toBe('"local.db"."ma""in"."events.2026"');
+  });
+});
 
 describe('parseQualifiedSqlIdentifier', () => {
   it('returns undefined for empty input', () => {

--- a/packages/duckdb-core/src/duckdb-utils.ts
+++ b/packages/duckdb-core/src/duckdb-utils.ts
@@ -4,8 +4,21 @@ export type QualifiedTableName = {
   database?: string;
   schema?: string;
   table: string;
+  /**
+   * Returns raw, unescaped identifier parts in `[database, schema, table]`
+   * order after applying any requested omissions.
+   */
+  toArray: (options?: {
+    includeDatabase?: boolean;
+    includeSchema?: boolean;
+  }) => string[];
   toString: () => string;
 };
+
+type QualifiedTableNameParts = Pick<
+  QualifiedTableName,
+  'database' | 'schema' | 'table'
+>;
 
 export type ResolveTableReferenceResult<T> = {
   table?: T;
@@ -33,7 +46,7 @@ export function makeQualifiedTableName({
   database,
   schema,
   table,
-}: QualifiedTableName) {
+}: QualifiedTableNameParts): QualifiedTableName {
   const qualifiedTableName = [database, schema, table]
     .filter((id) => id !== undefined && id !== null)
     .map((id) => escapeId(id))
@@ -42,6 +55,18 @@ export function makeQualifiedTableName({
     database,
     schema,
     table,
+    toArray: ({
+      includeDatabase = true,
+      includeSchema = true,
+    }: {
+      includeDatabase?: boolean;
+      includeSchema?: boolean;
+    } = {}) =>
+      [
+        includeDatabase ? database : undefined,
+        includeSchema ? schema : undefined,
+        table,
+      ].filter((id): id is string => id !== undefined && id !== null),
     toString: () => qualifiedTableName,
   };
 }

--- a/packages/duckdb-core/src/schema-tree/__tests__/schemaTree.test.ts
+++ b/packages/duckdb-core/src/schema-tree/__tests__/schemaTree.test.ts
@@ -1,4 +1,5 @@
 import {createDbSchemaTrees} from '../schemaTree';
+import {makeQualifiedTableName} from '../../duckdb-utils';
 import type {SchemaWithTables} from '../types';
 
 describe('schemaTree', () => {
@@ -11,12 +12,11 @@ describe('schemaTree', () => {
             schema: 'schema1',
             tables: [
               {
-                table: {
+                table: makeQualifiedTableName({
                   database: 'db1',
                   schema: 'schema1',
                   table: 'table1',
-                  toString: () => 'db1.schema1.table1',
-                },
+                }),
                 isView: false,
                 database: 'db1',
                 schema: 'schema1',

--- a/packages/duckdb/src/DuckDbSlice.ts
+++ b/packages/duckdb/src/DuckDbSlice.ts
@@ -578,7 +578,9 @@ export function createDuckDbSlice({
            * @deprecated Use .loadTableRowCount() instead
            */
           async getTableRowCount(table, schema = 'main') {
-            return get().db.loadTableRowCount({table, schema});
+            return get().db.loadTableRowCount(
+              makeQualifiedTableName({table, schema}),
+            );
           },
 
           async loadTableRowCount(tableName: string | QualifiedTableName) {

--- a/packages/mosaic/__tests__/BoxPlotClient.test.ts
+++ b/packages/mosaic/__tests__/BoxPlotClient.test.ts
@@ -35,6 +35,17 @@ describe('BoxPlotClient', () => {
     expect(sql).not.toContain('"""local"""');
   });
 
+  it('preserves dotted table-name parts in quoted table references', () => {
+    const sql = buildBoxPlotQuery({
+      tableName: '"main"."events.2026"',
+      x: 'region',
+      y: 'magnitude',
+    });
+
+    expect(sql).toContain('FROM "main"."events.2026"');
+    expect(sql).not.toContain('FROM "main"."events"."2026"');
+  });
+
   it('applies external selection predicates to the box plot query', () => {
     const selection = Selection.crossfilter();
     selection.update(clausePoint('status', 'active', {source: {}}));

--- a/packages/mosaic/__tests__/chart-types/line-chart-spec.test.ts
+++ b/packages/mosaic/__tests__/chart-types/line-chart-spec.test.ts
@@ -51,7 +51,10 @@ describe('createLineChartSpec', () => {
       selectionName: 'test_selection',
     }) as any;
 
-    expect(spec.plot[0].data.from.toString()).toBe('"main"."test_table"');
+    expect(spec.plot[0].data.from).toBe('"main"."test_table"');
+    expect(JSON.parse(JSON.stringify(spec)).plot[0].data.from).toBe(
+      '"main"."test_table"',
+    );
   });
 
   it('preserves dotted table-name parts in generated data sources', () => {
@@ -74,7 +77,10 @@ describe('createLineChartSpec', () => {
       selectionName: 'test_selection',
     }) as any;
 
-    expect(spec.plot[0].data.from.toString()).toBe('"main"."events.2026"');
+    expect(spec.plot[0].data.from).toBe('"main"."events.2026"');
+    expect(JSON.parse(JSON.stringify(spec)).plot[0].data.from).toBe(
+      '"main"."events.2026"',
+    );
   });
 
   it('generates spec with legend when showLegend is true', () => {

--- a/packages/mosaic/__tests__/chart-types/line-chart-spec.test.ts
+++ b/packages/mosaic/__tests__/chart-types/line-chart-spec.test.ts
@@ -1,16 +1,14 @@
 import {createLineChartSpec} from '../../src/charts/chart-types/line-chart/spec';
 import {LineChartSettings} from '../../src/charts/chart-types/line-chart/schema';
-import type {DataTable} from '@sqlrooms/duckdb';
+import {makeQualifiedTableName, type DataTable} from '@sqlrooms/duckdb';
 
 describe('createLineChartSpec', () => {
-  const tableId = '"attached"."main"."test_table"';
   const mockDataTable: DataTable = {
-    table: {
+    table: makeQualifiedTableName({
       database: 'attached',
       schema: 'main',
       table: 'test_table',
-      toString: () => tableId,
-    },
+    }),
     tableName: 'test_table',
     schema: 'main',
     isView: false,

--- a/packages/mosaic/__tests__/chart-types/line-chart-spec.test.ts
+++ b/packages/mosaic/__tests__/chart-types/line-chart-spec.test.ts
@@ -51,7 +51,30 @@ describe('createLineChartSpec', () => {
       selectionName: 'test_selection',
     }) as any;
 
-    expect(spec.plot[0].data.from).toBe('main.test_table');
+    expect(spec.plot[0].data.from.toString()).toBe('"main"."test_table"');
+  });
+
+  it('preserves dotted table-name parts in generated data sources', () => {
+    const settings: LineChartSettings = {
+      x: 'date',
+      yFields: [{field: 'sales'}],
+      showLegend: false,
+    };
+
+    const spec = createLineChartSpec({
+      dataTable: {
+        ...mockDataTable,
+        table: makeQualifiedTableName({
+          database: 'attached',
+          schema: 'main',
+          table: 'events.2026',
+        }),
+      },
+      settings,
+      selectionName: 'test_selection',
+    }) as any;
+
+    expect(spec.plot[0].data.from.toString()).toBe('"main"."events.2026"');
   });
 
   it('generates spec with legend when showLegend is true', () => {

--- a/packages/mosaic/__tests__/chart-types/line-chart-spec.test.ts
+++ b/packages/mosaic/__tests__/chart-types/line-chart-spec.test.ts
@@ -40,7 +40,7 @@ describe('createLineChartSpec', () => {
     expect(hasLegend).toBe(false);
   });
 
-  it('uses the qualified table reference in generated data sources', () => {
+  it('uses the Mosaic query table reference in generated data sources', () => {
     const settings: LineChartSettings = {
       x: 'date',
       yFields: [{field: 'sales'}],
@@ -53,7 +53,7 @@ describe('createLineChartSpec', () => {
       selectionName: 'test_selection',
     }) as any;
 
-    expect(spec.plot[0].data.from).toBe(tableId);
+    expect(spec.plot[0].data.from).toBe('main.test_table');
   });
 
   it('generates spec with legend when showLegend is true', () => {

--- a/packages/mosaic/__tests__/data-table-explorer.utils.test.ts
+++ b/packages/mosaic/__tests__/data-table-explorer.utils.test.ts
@@ -1,4 +1,5 @@
 import {sql} from '@uwdata/mosaic-sql';
+import {getMosaicSqlTableReference} from '../src/mosaicTableReference';
 import {
   buildCategoryBuckets,
   buildCategorySummaryQuery,
@@ -31,6 +32,18 @@ describe('dataTableExplorer utils', () => {
     });
     expect(page.toString()).toContain('LIMIT 25');
     expect(page.toString()).toContain('OFFSET 50');
+  });
+
+  it('builds SQL from parsed Mosaic table references without the catalog', () => {
+    const query = buildDataTableExplorerBaseQuery({
+      columns: ['Magnitude'],
+      tableName: getMosaicSqlTableReference(
+        '"sqlrooms-cli"."main"."earthquakes"',
+      ),
+    });
+
+    expect(query.toString()).toContain('FROM "main"."earthquakes"');
+    expect(query.toString()).not.toContain('sqlrooms-cli');
   });
 
   it('sanitizes invalid pagination values before generating LIMIT/OFFSET', () => {

--- a/packages/mosaic/__tests__/mosaicTableReference.test.ts
+++ b/packages/mosaic/__tests__/mosaicTableReference.test.ts
@@ -1,0 +1,26 @@
+import {makeQualifiedTableName} from '@sqlrooms/db';
+import {
+  getMosaicSqlTableReference,
+  getMosaicTableReferenceString,
+} from '../src/mosaicTableReference';
+
+describe('mosaic table references', () => {
+  it('drops the catalog and keeps schema/table for Mosaic string APIs', () => {
+    const table = makeQualifiedTableName({
+      database: 'sqlrooms-cli',
+      schema: 'main',
+      table: 'earthquakes',
+    });
+
+    expect(getMosaicTableReferenceString(table)).toBe('main.earthquakes');
+  });
+
+  it('parses quoted qualified strings before building Mosaic SQL refs', () => {
+    const tableRef = getMosaicSqlTableReference(
+      '"sqlrooms-cli"."main"."earthquakes"',
+    );
+
+    expect(tableRef.toString()).toContain('"main"."earthquakes"');
+    expect(tableRef.toString()).not.toContain('sqlrooms-cli');
+  });
+});

--- a/packages/mosaic/__tests__/mosaicTableReference.test.ts
+++ b/packages/mosaic/__tests__/mosaicTableReference.test.ts
@@ -22,14 +22,31 @@ describe('mosaic table references', () => {
     expect(getMosaicTableIdentity(second)).toBe('"db2"."main"."orders"');
   });
 
-  it('drops the catalog and keeps schema/table for Mosaic string APIs', () => {
+  it('drops the catalog and quotes schema/table for Mosaic string APIs', () => {
     const table = makeQualifiedTableName({
       database: 'sqlrooms-cli',
       schema: 'main',
       table: 'earthquakes',
     });
 
-    expect(getMosaicTableReferenceString(table)).toBe('main.earthquakes');
+    expect(getMosaicTableReferenceString(table)).toBe(
+      '"main"."earthquakes"',
+    );
+  });
+
+  it('preserves dotted and quoted identifier boundaries', () => {
+    const table = makeQualifiedTableName({
+      database: 'db',
+      schema: 'ma.in',
+      table: 'events"2026',
+    });
+
+    expect(getMosaicTableReferenceString(table)).toBe(
+      '"ma.in"."events""2026"',
+    );
+    expect(getMosaicSqlTableReference(table).toString()).toContain(
+      '"ma.in"."events""2026"',
+    );
   });
 
   it('parses quoted qualified strings before building Mosaic SQL refs', () => {

--- a/packages/mosaic/__tests__/mosaicTableReference.test.ts
+++ b/packages/mosaic/__tests__/mosaicTableReference.test.ts
@@ -1,10 +1,27 @@
 import {makeQualifiedTableName} from '@sqlrooms/db';
 import {
   getMosaicSqlTableReference,
+  getMosaicTableIdentity,
   getMosaicTableReferenceString,
 } from '../src/mosaicTableReference';
 
 describe('mosaic table references', () => {
+  it('keeps the catalog in SQLRooms identity strings', () => {
+    const first = makeQualifiedTableName({
+      database: 'db1',
+      schema: 'main',
+      table: 'orders',
+    });
+    const second = makeQualifiedTableName({
+      database: 'db2',
+      schema: 'main',
+      table: 'orders',
+    });
+
+    expect(getMosaicTableIdentity(first)).toBe('"db1"."main"."orders"');
+    expect(getMosaicTableIdentity(second)).toBe('"db2"."main"."orders"');
+  });
+
   it('drops the catalog and keeps schema/table for Mosaic string APIs', () => {
     const table = makeQualifiedTableName({
       database: 'sqlrooms-cli',

--- a/packages/mosaic/src/charts/MosaicChartView.tsx
+++ b/packages/mosaic/src/charts/MosaicChartView.tsx
@@ -14,7 +14,7 @@ import {useChartRetainerByKey} from './useChartRetainer';
 import {useMosaicChartRenderContext} from './useMosaicChartRenderContext';
 import {useRuntimeIssueReporter} from './useRuntimeIssueReporter';
 import {DataTable} from '@sqlrooms/db';
-import {getChartTableReference} from './chart-types/base-types';
+import {getChartTableReferenceString} from './chart-types/base-types';
 
 export type MosaicChartViewProps = {
   dataTable?: DataTable;
@@ -131,7 +131,7 @@ export const MosaicChartView: FC<MosaicChartViewProps> = ({
     return (
       <div className={cn('h-full w-full', className)}>
         {createElement(renderContext.renderer, {
-          tableName: getChartTableReference(renderContext.dataTable),
+          tableName: getChartTableReferenceString(renderContext.dataTable),
           config,
           coordinator: connection.coordinator,
           params,

--- a/packages/mosaic/src/charts/chart-types/base-types.ts
+++ b/packages/mosaic/src/charts/chart-types/base-types.ts
@@ -6,6 +6,7 @@
 import type {Spec} from '@uwdata/mosaic-spec';
 import {type Tool} from 'ai';
 import type {Coordinator} from '@uwdata/mosaic-core';
+import type {TableRefNode} from '@uwdata/mosaic-sql';
 import type {ComponentType} from 'react';
 import type * as z from 'zod';
 import {ChartConfig, ChartSettings, ChartType} from './chart-config';
@@ -21,7 +22,10 @@ import type {
   ChartRuntimeIssueReporter,
 } from '../../chart-runtime';
 import {DataTable, type QualifiedTableName} from '@sqlrooms/duckdb';
-import {getMosaicTableReferenceString} from '../../mosaicTableReference';
+import {
+  getMosaicSqlTableReference,
+  getMosaicTableReferenceString,
+} from '../../mosaicTableReference';
 
 export type {ChartType};
 
@@ -200,7 +204,11 @@ export type CreateSpecOptions<TSettings = ChartSettings> = {
   selectionName?: string;
 };
 
-export function getChartTableReference(dataTable: DataTable): string {
+export function getChartTableReference(dataTable: DataTable): TableRefNode {
+  return getMosaicSqlTableReference(dataTable.table);
+}
+
+export function getChartTableReferenceString(dataTable: DataTable): string {
   return getMosaicTableReferenceString(dataTable.table);
 }
 

--- a/packages/mosaic/src/charts/chart-types/base-types.ts
+++ b/packages/mosaic/src/charts/chart-types/base-types.ts
@@ -21,6 +21,7 @@ import type {
   ChartRuntimeIssueReporter,
 } from '../../chart-runtime';
 import {DataTable, type QualifiedTableName} from '@sqlrooms/duckdb';
+import {getMosaicTableReferenceString} from '../../mosaicTableReference';
 
 export type {ChartType};
 
@@ -200,7 +201,7 @@ export type CreateSpecOptions<TSettings = ChartSettings> = {
 };
 
 export function getChartTableReference(dataTable: DataTable): string {
-  return dataTable.table.toString();
+  return getMosaicTableReferenceString(dataTable.table);
 }
 
 export type SpecChartTypeDefinition<TConfig extends ChartConfig = ChartConfig> =

--- a/packages/mosaic/src/charts/chart-types/base-types.ts
+++ b/packages/mosaic/src/charts/chart-types/base-types.ts
@@ -6,7 +6,6 @@
 import type {Spec} from '@uwdata/mosaic-spec';
 import {type Tool} from 'ai';
 import type {Coordinator} from '@uwdata/mosaic-core';
-import type {TableRefNode} from '@uwdata/mosaic-sql';
 import type {ComponentType} from 'react';
 import type * as z from 'zod';
 import {ChartConfig, ChartSettings, ChartType} from './chart-config';
@@ -22,10 +21,7 @@ import type {
   ChartRuntimeIssueReporter,
 } from '../../chart-runtime';
 import {DataTable, type QualifiedTableName} from '@sqlrooms/duckdb';
-import {
-  getMosaicSqlTableReference,
-  getMosaicTableReferenceString,
-} from '../../mosaicTableReference';
+import {getMosaicTableReferenceString} from '../../mosaicTableReference';
 
 export type {ChartType};
 
@@ -204,13 +200,11 @@ export type CreateSpecOptions<TSettings = ChartSettings> = {
   selectionName?: string;
 };
 
-export function getChartTableReference(dataTable: DataTable): TableRefNode {
-  return getMosaicSqlTableReference(dataTable.table);
-}
-
-export function getChartTableReferenceString(dataTable: DataTable): string {
+export function getChartTableReference(dataTable: DataTable): string {
   return getMosaicTableReferenceString(dataTable.table);
 }
+
+export const getChartTableReferenceString = getChartTableReference;
 
 export type SpecChartTypeDefinition<TConfig extends ChartConfig = ChartConfig> =
   BaseChartTypeDefinition<TConfig> & {

--- a/packages/mosaic/src/charts/useChartDataPolicy.tsx
+++ b/packages/mosaic/src/charts/useChartDataPolicy.tsx
@@ -2,7 +2,7 @@ import {useMemo} from 'react';
 import type {ChartDataPolicy} from '../chart-runtime';
 import {resolveChartDataPolicy} from '../chart-runtime';
 import type {ChartConfig} from './chart-types/chart-config';
-import {getChartTableReference} from './chart-types/base-types';
+import {getChartTableReferenceString} from './chart-types/base-types';
 import {useChartTypeDefinition} from './useChartTypeDefinition';
 import {DataTable} from '@sqlrooms/db';
 
@@ -19,7 +19,7 @@ export function useChartDataPolicy(
 
     const defaultPolicy =
       chartTypeDefinition.getDataPolicy({
-        tableName: getChartTableReference(dataTable),
+        tableName: getChartTableReferenceString(dataTable),
         config,
       }) ?? null;
 

--- a/packages/mosaic/src/data-table-explorer/DataTableExplorerCategoryClient.ts
+++ b/packages/mosaic/src/data-table-explorer/DataTableExplorerCategoryClient.ts
@@ -1,7 +1,10 @@
 import {MosaicClient, clausePoint, type Selection} from '@uwdata/mosaic-core';
 import {type ExprNode, Query} from '@uwdata/mosaic-sql';
 import type * as arrow from 'apache-arrow';
-import type {DataTableExplorerCategorySummary} from './types';
+import type {
+  DataTableExplorerCategorySummary,
+  DataTableExplorerSqlTableReference,
+} from './types';
 import {
   buildCategoryBuckets,
   buildCategorySummaryQuery,
@@ -17,6 +20,7 @@ type CategoryClientOptions = {
   onStateChange: (summary: DataTableExplorerCategorySummary) => void;
   selection: Selection;
   tableName: string;
+  tableReference?: DataTableExplorerSqlTableReference;
 };
 
 export class DataTableExplorerCategoryClient extends MosaicClient {
@@ -29,7 +33,7 @@ export class DataTableExplorerCategoryClient extends MosaicClient {
   ) => void;
   private selectedKey?: string;
   private filteredRows?: CategoryCountRow[];
-  private readonly tableName: string;
+  private readonly tableReference: DataTableExplorerSqlTableReference;
   private totalError?: Error;
   private totalLoading = true;
   private totalRows?: CategoryCountRow[];
@@ -39,7 +43,7 @@ export class DataTableExplorerCategoryClient extends MosaicClient {
     this.categoryLimit = options.categoryLimit;
     this.field = options.field;
     this.onStateChange = options.onStateChange;
-    this.tableName = options.tableName;
+    this.tableReference = options.tableReference ?? options.tableName;
   }
 
   override get filterStable(): boolean {
@@ -104,7 +108,11 @@ export class DataTableExplorerCategoryClient extends MosaicClient {
   }
 
   override query(filter: Array<ExprNode> = []): Query {
-    return buildCategorySummaryQuery(this.tableName, this.field.name, filter);
+    return buildCategorySummaryQuery(
+      this.tableReference,
+      this.field.name,
+      filter,
+    );
   }
 
   override queryResult(data: unknown): this {

--- a/packages/mosaic/src/data-table-explorer/DataTableExplorerCountClient.ts
+++ b/packages/mosaic/src/data-table-explorer/DataTableExplorerCountClient.ts
@@ -1,5 +1,6 @@
 import {MosaicClient, type Selection} from '@uwdata/mosaic-core';
 import {type ExprNode, type Query} from '@uwdata/mosaic-sql';
+import type {DataTableExplorerSqlTableReference} from './types';
 import {buildCountQuery, readCountData} from './utils';
 
 export type DataTableExplorerCountState = {
@@ -13,6 +14,7 @@ type DataTableExplorerCountClientOptions = {
   onStateChange: (state: DataTableExplorerCountState) => void;
   selection?: Selection;
   tableName: string;
+  tableReference?: DataTableExplorerSqlTableReference;
 };
 
 export class DataTableExplorerCountClient extends MosaicClient {
@@ -20,13 +22,13 @@ export class DataTableExplorerCountClient extends MosaicClient {
   private error?: Error;
   private readonly isFilterStable: boolean;
   private readonly onStateChange: (state: DataTableExplorerCountState) => void;
-  private readonly tableName: string;
+  private readonly tableReference: DataTableExplorerSqlTableReference;
 
   constructor(options: DataTableExplorerCountClientOptions) {
     super(options.selection);
     this.isFilterStable = options.filterStable ?? false;
     this.onStateChange = options.onStateChange;
-    this.tableName = options.tableName;
+    this.tableReference = options.tableReference ?? options.tableName;
   }
 
   override get filterStable(): boolean {
@@ -45,7 +47,7 @@ export class DataTableExplorerCountClient extends MosaicClient {
   override query(filter: Array<ExprNode> = []): Query {
     return buildCountQuery({
       filter,
-      tableName: this.tableName,
+      tableName: this.tableReference,
     });
   }
 

--- a/packages/mosaic/src/data-table-explorer/DataTableExplorerHistogramClient.ts
+++ b/packages/mosaic/src/data-table-explorer/DataTableExplorerHistogramClient.ts
@@ -7,7 +7,10 @@ import {
 import {Interval1D, bin} from '@uwdata/mosaic-plot';
 import {count, type ExprNode, Query} from '@uwdata/mosaic-sql';
 import type * as arrow from 'apache-arrow';
-import type {DataTableExplorerHistogramSummary} from './types';
+import type {
+  DataTableExplorerHistogramSummary,
+  DataTableExplorerSqlTableReference,
+} from './types';
 import {rowsFromQueryResult, splitHistogramBins} from './utils';
 
 type HistogramStateChange = (
@@ -20,6 +23,7 @@ type HistogramClientOptions = {
   selection: Selection;
   steps: number;
   tableName: string;
+  tableReference?: DataTableExplorerSqlTableReference;
   valueType: 'date' | 'number';
 };
 
@@ -46,6 +50,7 @@ export class DataTableExplorerHistogramClient extends MosaicClient {
     y: ExprNode;
   };
   private readonly tableName: string;
+  private readonly tableReference: DataTableExplorerSqlTableReference;
   private totalBins?: HistogramRow[];
   private totalError?: Error;
   private totalLoading = true;
@@ -57,6 +62,7 @@ export class DataTableExplorerHistogramClient extends MosaicClient {
     this.field = options.field;
     this.onStateChange = options.onStateChange;
     this.tableName = options.tableName;
+    this.tableReference = options.tableReference ?? options.tableName;
     this.valueType = options.valueType;
 
     const binned = bin(options.field.name, {steps: options.steps})(
@@ -166,7 +172,7 @@ export class DataTableExplorerHistogramClient extends MosaicClient {
   }
 
   override query(filter: Array<ExprNode> = []): Query {
-    return Query.from({source: this.tableName})
+    return Query.from({source: this.tableReference})
       .select(this.select)
       .groupby([this.select.x1, this.select.x2])
       .where(filter);

--- a/packages/mosaic/src/data-table-explorer/DataTableExplorerHistogramClient.ts
+++ b/packages/mosaic/src/data-table-explorer/DataTableExplorerHistogramClient.ts
@@ -49,7 +49,6 @@ export class DataTableExplorerHistogramClient extends MosaicClient {
     x2: ExprNode;
     y: ExprNode;
   };
-  private readonly tableName: string;
   private readonly tableReference: DataTableExplorerSqlTableReference;
   private totalBins?: HistogramRow[];
   private totalError?: Error;
@@ -61,7 +60,6 @@ export class DataTableExplorerHistogramClient extends MosaicClient {
     super(options.selection);
     this.field = options.field;
     this.onStateChange = options.onStateChange;
-    this.tableName = options.tableName;
     this.tableReference = options.tableReference ?? options.tableName;
     this.valueType = options.valueType;
 
@@ -119,7 +117,7 @@ export class DataTableExplorerHistogramClient extends MosaicClient {
     if (!this.fieldInfoPromise) {
       this.fieldInfoPromise = queryFieldInfo(this.coordinator!, [
         {
-          table: this.tableName,
+          table: this.tableReference as unknown as string,
           column: this.field.name,
           stats: ['min', 'max'],
         },

--- a/packages/mosaic/src/data-table-explorer/DataTableExplorerPageClient.ts
+++ b/packages/mosaic/src/data-table-explorer/DataTableExplorerPageClient.ts
@@ -3,6 +3,7 @@ import {type ExprNode, type Query} from '@uwdata/mosaic-sql';
 import type {Table} from 'apache-arrow';
 import type {
   DataTableExplorerPaginationState,
+  DataTableExplorerSqlTableReference,
   DataTableExplorerSorting,
 } from './types';
 import {
@@ -24,6 +25,7 @@ type DataTableExplorerPageClientOptions = {
   pagination: DataTableExplorerPaginationState;
   sorting: DataTableExplorerSorting;
   tableName: string;
+  tableReference?: DataTableExplorerSqlTableReference;
 };
 
 export class DataTableExplorerPageClient extends MosaicClient {
@@ -36,6 +38,7 @@ export class DataTableExplorerPageClient extends MosaicClient {
   private pageTable?: Table;
   private readonly sorting: DataTableExplorerSorting;
   private readonly tableName: string;
+  private readonly tableReference: DataTableExplorerSqlTableReference;
 
   constructor(options: DataTableExplorerPageClientOptions) {
     super();
@@ -46,6 +49,7 @@ export class DataTableExplorerPageClient extends MosaicClient {
     this.pagination = options.pagination;
     this.sorting = options.sorting;
     this.tableName = options.tableName;
+    this.tableReference = options.tableReference ?? options.tableName;
   }
 
   override get filterStable(): boolean {
@@ -69,7 +73,7 @@ export class DataTableExplorerPageClient extends MosaicClient {
         columns: this.columns,
         filter: resolvedFilter,
         sorting: this.sorting,
-        tableName: this.tableName,
+        tableName: this.tableReference,
       }),
       this.pagination,
     );

--- a/packages/mosaic/src/data-table-explorer/DataTableExplorerUnsupportedSummaryClient.ts
+++ b/packages/mosaic/src/data-table-explorer/DataTableExplorerUnsupportedSummaryClient.ts
@@ -1,7 +1,10 @@
 import {MosaicClient, type Selection} from '@uwdata/mosaic-core';
 import {type ExprNode, type Query} from '@uwdata/mosaic-sql';
 import type * as arrow from 'apache-arrow';
-import type {DataTableExplorerUnsupportedSummary} from './types';
+import type {
+  DataTableExplorerSqlTableReference,
+  DataTableExplorerUnsupportedSummary,
+} from './types';
 import {buildDistinctCountQuery, readCountData} from './utils';
 
 type UnsupportedSummaryClientOptions = {
@@ -9,6 +12,7 @@ type UnsupportedSummaryClientOptions = {
   onStateChange: (summary: DataTableExplorerUnsupportedSummary) => void;
   selection: Selection;
   tableName: string;
+  tableReference?: DataTableExplorerSqlTableReference;
 };
 
 export class DataTableExplorerUnsupportedSummaryClient extends MosaicClient {
@@ -17,13 +21,13 @@ export class DataTableExplorerUnsupportedSummaryClient extends MosaicClient {
   private readonly onStateChange: (
     summary: DataTableExplorerUnsupportedSummary,
   ) => void;
-  private readonly tableName: string;
+  private readonly tableReference: DataTableExplorerSqlTableReference;
 
   constructor(options: UnsupportedSummaryClientOptions) {
     super(options.selection);
     this.field = options.field;
     this.onStateChange = options.onStateChange;
-    this.tableName = options.tableName;
+    this.tableReference = options.tableReference ?? options.tableName;
   }
 
   override get filterStable(): boolean {
@@ -43,7 +47,7 @@ export class DataTableExplorerUnsupportedSummaryClient extends MosaicClient {
     return buildDistinctCountQuery({
       fieldName: this.field.name,
       filter,
-      tableName: this.tableName,
+      tableName: this.tableReference,
     });
   }
 

--- a/packages/mosaic/src/data-table-explorer/dataTableExplorerController.ts
+++ b/packages/mosaic/src/data-table-explorer/dataTableExplorerController.ts
@@ -32,23 +32,37 @@ function toError(error: unknown): Error {
 /**
  * Loads field metadata for the dataTableExplorer table and writes the normalized field
  * definitions into the dataTableExplorer store.
+ *
+ * @param options.columns Optional subset of column names to load. When omitted,
+ * metadata is loaded for every column in the table.
+ * @param options.coordinator Mosaic coordinator used to run the field-info query.
+ * @param options.store Instance store that receives schema loading, success, and
+ * error state.
+ * @param options.tableIdentity Stable SQLRooms table identity used for store keys.
+ * This should preserve catalog/database identity when available.
+ * @param options.tableReference Mosaic SQL table reference used to query the table.
+ * Prefer a TableRefNode for qualified table names so dotted identifier parts are
+ * not reparsed as separate identifiers.
  */
 export async function loadDataTableExplorerSchema(options: {
   columns?: string[];
   coordinator: Parameters<typeof queryFieldInfo>[0];
   store: DataTableExplorerStore;
   tableIdentity: string;
-  tableName: string;
+  tableReference: DataTableExplorerSqlTableReference;
 }) {
-  const {columns, coordinator, store, tableIdentity, tableName} = options;
+  const {columns, coordinator, store, tableIdentity, tableReference} = options;
   store.getState().setSchemaLoading(true, tableIdentity);
 
   try {
+    // queryFieldInfo is typed as string-only, but Mosaic's runtime accepts
+    // TableRefNode values and preserves identifier boundaries for dotted names.
+    const fieldInfoTable = tableReference as unknown as string;
     const fieldInfo = await queryFieldInfo(
       coordinator,
       columns?.length
-        ? columns.map((column) => ({column, table: tableName}))
-        : [{column: '*', table: tableName}],
+        ? columns.map((column) => ({column, table: fieldInfoTable}))
+        : [{column: '*', table: fieldInfoTable}],
     );
     store
       .getState()
@@ -72,6 +86,20 @@ type ReadyConnection = {
 /**
  * Connects the paged row client for the current dataTableExplorer page and disconnects
  * it when the caller tears down the lifecycle.
+ *
+ * @param options.connection Ready Mosaic connection that owns client
+ * registration.
+ * @param options.fieldNames Ordered fields to include in the page query and page
+ * dataset identity.
+ * @param options.filter Optional row filter applied to the page query.
+ * @param options.pagination Current page index and page size.
+ * @param options.sorting Current sort descriptors.
+ * @param options.store Instance store that receives page loading, data, and error
+ * state.
+ * @param options.tableName Stable SQLRooms table identity used for page dataset
+ * keys.
+ * @param options.tableReference Mosaic SQL table reference used in generated page
+ * queries.
  */
 export function connectDataTableExplorerPageClient(options: {
   connection: ReadyConnection;
@@ -103,6 +131,20 @@ export function connectDataTableExplorerPageClient(options: {
 /**
  * Connects either the filtered or total count client and routes updates into
  * the corresponding store slice.
+ *
+ * @param options.connection Ready Mosaic connection that owns client
+ * registration.
+ * @param options.filterStable Whether Mosaic can treat this count query as
+ * stable under filter changes.
+ * @param options.selection Optional Mosaic selection that supplies cross-filter
+ * predicates.
+ * @param options.store Instance store that receives filtered or total count
+ * state.
+ * @param options.tableName Stable SQLRooms table identity used for client state.
+ * @param options.tableReference Mosaic SQL table reference used in generated count
+ * queries.
+ * @param options.target Selects whether updates go to the filtered or total count
+ * store slice.
  */
 export function connectDataTableExplorerCountClient(options: {
   connection: ReadyConnection;
@@ -139,6 +181,19 @@ export function connectDataTableExplorerCountClient(options: {
 /**
  * Connects all per-column summary clients for the active schema and initializes
  * matching empty summary state in the dataTableExplorer store.
+ *
+ * @param options.categoryLimit Maximum number of category buckets to expose before
+ * grouping the remainder into an overflow bucket.
+ * @param options.connection Ready Mosaic connection that owns summary client
+ * registration.
+ * @param options.fields Active Arrow fields to summarize.
+ * @param options.selection Mosaic selection shared by summary clients.
+ * @param options.store Instance store that receives summary state.
+ * @param options.summaryBins Requested bin count for histogram summaries.
+ * @param options.tableName Human-readable or string table reference kept for
+ * summary clients that still accept string identities.
+ * @param options.tableReference Mosaic SQL table reference used in generated
+ * summary queries.
  */
 export function connectDataTableExplorerSummaryClients(options: {
   categoryLimit: number;

--- a/packages/mosaic/src/data-table-explorer/dataTableExplorerController.ts
+++ b/packages/mosaic/src/data-table-explorer/dataTableExplorerController.ts
@@ -37,10 +37,11 @@ export async function loadDataTableExplorerSchema(options: {
   columns?: string[];
   coordinator: Parameters<typeof queryFieldInfo>[0];
   store: DataTableExplorerStore;
+  tableIdentity: string;
   tableName: string;
 }) {
-  const {columns, coordinator, store, tableName} = options;
-  store.getState().setSchemaLoading(true, tableName);
+  const {columns, coordinator, store, tableIdentity, tableName} = options;
+  store.getState().setSchemaLoading(true, tableIdentity);
 
   try {
     const fieldInfo = await queryFieldInfo(
@@ -53,11 +54,11 @@ export async function loadDataTableExplorerSchema(options: {
       .getState()
       .setSchemaSuccess(
         fieldInfo.map(fieldInfoToDataTableExplorerField),
-        tableName,
+        tableIdentity,
       );
   } catch (error: unknown) {
-    store.getState().setSchemaSuccess([], tableName);
-    store.getState().setSchemaError(toError(error), tableName);
+    store.getState().setSchemaSuccess([], tableIdentity);
+    store.getState().setSchemaError(toError(error), tableIdentity);
   }
 }
 

--- a/packages/mosaic/src/data-table-explorer/dataTableExplorerController.ts
+++ b/packages/mosaic/src/data-table-explorer/dataTableExplorerController.ts
@@ -14,6 +14,7 @@ import {DataTableExplorerPageClient} from './DataTableExplorerPageClient';
 import {DataTableExplorerUnsupportedSummaryClient} from './DataTableExplorerUnsupportedSummaryClient';
 import type {
   DataTableExplorerSummaryState,
+  DataTableExplorerSqlTableReference,
   DataTableExplorerSorting,
 } from './types';
 import type {DataTableExplorerStore} from './createDataTableExplorerStore';
@@ -79,6 +80,7 @@ export function connectDataTableExplorerPageClient(options: {
   sorting: DataTableExplorerSorting;
   store: DataTableExplorerStore;
   tableName: string;
+  tableReference: DataTableExplorerSqlTableReference;
 }) {
   const client = new DataTableExplorerPageClient({
     columns: options.fieldNames,
@@ -87,6 +89,7 @@ export function connectDataTableExplorerPageClient(options: {
     pagination: options.pagination,
     sorting: options.sorting,
     tableName: options.tableName,
+    tableReference: options.tableReference,
   });
 
   options.connection.coordinator.connect(client);
@@ -106,6 +109,7 @@ export function connectDataTableExplorerCountClient(options: {
   selection?: Selection;
   store: DataTableExplorerStore;
   tableName: string;
+  tableReference: DataTableExplorerSqlTableReference;
   target: 'filtered' | 'total';
 }) {
   const setCountState =
@@ -118,6 +122,7 @@ export function connectDataTableExplorerCountClient(options: {
     onStateChange: setCountState,
     selection: options.selection,
     tableName: options.tableName,
+    tableReference: options.tableReference,
   });
 
   options.connection.coordinator.connect(client);
@@ -142,6 +147,7 @@ export function connectDataTableExplorerSummaryClients(options: {
   store: DataTableExplorerStore;
   summaryBins: number;
   tableName: string;
+  tableReference: DataTableExplorerSqlTableReference;
 }) {
   const {
     categoryLimit,
@@ -151,6 +157,7 @@ export function connectDataTableExplorerSummaryClients(options: {
     store,
     summaryBins,
     tableName,
+    tableReference,
   } = options;
 
   store.getState().initializeSummaries(fields);
@@ -167,6 +174,7 @@ export function connectDataTableExplorerSummaryClients(options: {
           onStateChange: update,
           selection,
           tableName,
+          tableReference,
         }),
       ];
     }
@@ -178,6 +186,7 @@ export function connectDataTableExplorerSummaryClients(options: {
         selection,
         steps: summaryBins,
         tableName,
+        tableReference,
         valueType:
           getDataTableExplorerValueType(field.type) === 'date'
             ? 'date'
@@ -198,6 +207,7 @@ export function connectDataTableExplorerSummaryClients(options: {
       onStateChange: update,
       selection,
       tableName,
+      tableReference,
     });
 
     return [

--- a/packages/mosaic/src/data-table-explorer/hooks/useDataTableExplorerLifecycles.ts
+++ b/packages/mosaic/src/data-table-explorer/hooks/useDataTableExplorerLifecycles.ts
@@ -15,6 +15,10 @@ import {
   loadDataTableExplorerSchema,
 } from '../dataTableExplorerController';
 
+/**
+ * Inputs required to synchronize a dataTableExplorer instance with Mosaic
+ * connection, selection, schema, row, count, and summary lifecycles.
+ */
 export type UseDataTableExplorerLifecyclesOptions = {
   categoryLimit: number;
   columns?: string[];
@@ -29,8 +33,20 @@ export type UseDataTableExplorerLifecyclesOptions = {
   selectionVersion: number;
   sorting: DataTableExplorerSorting;
   summaryBins: number;
+  /**
+   * Stable SQLRooms table identity used for store keys, selection resets, and
+   * dataset IDs. This should keep catalog/database identity when available.
+   */
   tableIdentity: string;
+  /**
+   * String table reference used for readiness checks and legacy client inputs.
+   */
   tableName: string;
+  /**
+   * Mosaic SQL table reference used by generated queries. Use a TableRefNode for
+   * qualified names to preserve identifier boundaries such as dots inside table
+   * names.
+   */
   tableReference: DataTableExplorerSqlTableReference;
 };
 
@@ -41,6 +57,10 @@ export type UseDataTableExplorerLifecyclesReturn = {
 /**
  * Owns the coordinator-backed schema, row, count, and summary client
  * lifecycles for a dataTableExplorer instance.
+ *
+ * The hook keeps SQLRooms identity state separate from Mosaic SQL references:
+ * tableIdentity drives local store keys, while tableReference is used at query
+ * boundaries.
  */
 export function useDataTableExplorerLifecycles(
   options: UseDataTableExplorerLifecyclesOptions,
@@ -94,9 +114,16 @@ export function useDataTableExplorerLifecycles(
       coordinator: connection.coordinator,
       store: dataTableExplorerStore,
       tableIdentity,
-      tableName,
+      tableReference,
     });
-  }, [columns, connection, dataTableExplorerStore, tableIdentity, tableName]);
+  }, [
+    columns,
+    connection,
+    dataTableExplorerStore,
+    tableIdentity,
+    tableName,
+    tableReference,
+  ]);
 
   useEffect(() => {
     if (connection.status !== 'ready' || !tableName || !fieldNames.length) {

--- a/packages/mosaic/src/data-table-explorer/hooks/useDataTableExplorerLifecycles.ts
+++ b/packages/mosaic/src/data-table-explorer/hooks/useDataTableExplorerLifecycles.ts
@@ -29,6 +29,7 @@ export type UseDataTableExplorerLifecyclesOptions = {
   selectionVersion: number;
   sorting: DataTableExplorerSorting;
   summaryBins: number;
+  tableIdentity: string;
   tableName: string;
   tableReference: DataTableExplorerSqlTableReference;
 };
@@ -58,24 +59,25 @@ export function useDataTableExplorerLifecycles(
     selectionVersion,
     sorting,
     summaryBins,
+    tableIdentity,
     tableName,
     tableReference,
   } = options;
-  const previousTableNameRef = useRef(tableName);
+  const previousTableNameRef = useRef(tableIdentity);
 
   useEffect(() => {
     dataTableExplorerStore.getState().syncPageSize(pageSize);
   }, [pageSize, dataTableExplorerStore]);
 
   useEffect(() => {
-    if (previousTableNameRef.current === tableName) return;
+    if (previousTableNameRef.current === tableIdentity) return;
     selection.reset();
-    previousTableNameRef.current = tableName;
-  }, [selection, tableName]);
+    previousTableNameRef.current = tableIdentity;
+  }, [selection, tableIdentity]);
 
   useEffect(() => {
     dataTableExplorerStore.getState().resetPageIndex();
-  }, [dataTableExplorerStore, selectionVersion, tableName]);
+  }, [dataTableExplorerStore, selectionVersion, tableIdentity]);
 
   useEffect(() => {
     if (connection.status !== 'ready' || !tableName) {
@@ -91,9 +93,10 @@ export function useDataTableExplorerLifecycles(
       columns,
       coordinator: connection.coordinator,
       store: dataTableExplorerStore,
+      tableIdentity,
       tableName,
     });
-  }, [columns, connection, dataTableExplorerStore, tableName]);
+  }, [columns, connection, dataTableExplorerStore, tableIdentity, tableName]);
 
   useEffect(() => {
     if (connection.status !== 'ready' || !tableName || !fieldNames.length) {
@@ -108,7 +111,7 @@ export function useDataTableExplorerLifecycles(
       pagination,
       sorting,
       store: dataTableExplorerStore,
-      tableName,
+      tableName: tableIdentity,
       tableReference,
     });
   }, [
@@ -118,6 +121,7 @@ export function useDataTableExplorerLifecycles(
     dataTableExplorerStore,
     rowFilter,
     sorting,
+    tableIdentity,
     tableName,
     tableReference,
   ]);
@@ -134,7 +138,7 @@ export function useDataTableExplorerLifecycles(
       filterStable: true,
       selection,
       store: dataTableExplorerStore,
-      tableName,
+      tableName: tableIdentity,
       tableReference,
       target: 'filtered',
     });
@@ -144,7 +148,14 @@ export function useDataTableExplorerLifecycles(
       cleanup();
       dataTableExplorerStore.getState().setClient(null);
     };
-  }, [connection, dataTableExplorerStore, selection, tableName, tableReference]);
+  }, [
+    connection,
+    dataTableExplorerStore,
+    selection,
+    tableIdentity,
+    tableName,
+    tableReference,
+  ]);
 
   useEffect(() => {
     if (connection.status !== 'ready' || !tableName) {
@@ -155,13 +166,19 @@ export function useDataTableExplorerLifecycles(
     const {cleanup} = connectDataTableExplorerCountClient({
       connection,
       store: dataTableExplorerStore,
-      tableName,
+      tableName: tableIdentity,
       tableReference,
       target: 'total',
     });
 
     return cleanup;
-  }, [connection, dataTableExplorerStore, tableName, tableReference]);
+  }, [
+    connection,
+    dataTableExplorerStore,
+    tableIdentity,
+    tableName,
+    tableReference,
+  ]);
 
   useEffect(() => {
     if (connection.status !== 'ready' || !fields.length) {
@@ -186,6 +203,7 @@ export function useDataTableExplorerLifecycles(
     dataTableExplorerStore,
     selection,
     summaryBins,
+    tableIdentity,
     tableName,
     tableReference,
   ]);

--- a/packages/mosaic/src/data-table-explorer/hooks/useDataTableExplorerLifecycles.ts
+++ b/packages/mosaic/src/data-table-explorer/hooks/useDataTableExplorerLifecycles.ts
@@ -4,6 +4,7 @@ import type {MosaicSliceState} from '../../MosaicSlice';
 import type {DataTableExplorerStore} from '../createDataTableExplorerStore';
 import type {
   DataTableExplorerPaginationState,
+  DataTableExplorerSqlTableReference,
   DataTableExplorerSorting,
 } from '../types';
 import type {DataTableExplorerStoreState} from '../createDataTableExplorerStore';
@@ -29,6 +30,7 @@ export type UseDataTableExplorerLifecyclesOptions = {
   sorting: DataTableExplorerSorting;
   summaryBins: number;
   tableName: string;
+  tableReference: DataTableExplorerSqlTableReference;
 };
 
 export type UseDataTableExplorerLifecyclesReturn = {
@@ -57,6 +59,7 @@ export function useDataTableExplorerLifecycles(
     sorting,
     summaryBins,
     tableName,
+    tableReference,
   } = options;
   const previousTableNameRef = useRef(tableName);
 
@@ -106,6 +109,7 @@ export function useDataTableExplorerLifecycles(
       sorting,
       store: dataTableExplorerStore,
       tableName,
+      tableReference,
     });
   }, [
     connection,
@@ -115,6 +119,7 @@ export function useDataTableExplorerLifecycles(
     rowFilter,
     sorting,
     tableName,
+    tableReference,
   ]);
 
   useEffect(() => {
@@ -130,6 +135,7 @@ export function useDataTableExplorerLifecycles(
       selection,
       store: dataTableExplorerStore,
       tableName,
+      tableReference,
       target: 'filtered',
     });
     dataTableExplorerStore.getState().setClient(newClient);
@@ -138,7 +144,7 @@ export function useDataTableExplorerLifecycles(
       cleanup();
       dataTableExplorerStore.getState().setClient(null);
     };
-  }, [connection, dataTableExplorerStore, selection, tableName]);
+  }, [connection, dataTableExplorerStore, selection, tableName, tableReference]);
 
   useEffect(() => {
     if (connection.status !== 'ready' || !tableName) {
@@ -150,11 +156,12 @@ export function useDataTableExplorerLifecycles(
       connection,
       store: dataTableExplorerStore,
       tableName,
+      tableReference,
       target: 'total',
     });
 
     return cleanup;
-  }, [connection, dataTableExplorerStore, tableName]);
+  }, [connection, dataTableExplorerStore, tableName, tableReference]);
 
   useEffect(() => {
     if (connection.status !== 'ready' || !fields.length) {
@@ -170,6 +177,7 @@ export function useDataTableExplorerLifecycles(
       store: dataTableExplorerStore,
       summaryBins,
       tableName,
+      tableReference,
     });
   }, [
     categoryLimit,
@@ -179,6 +187,7 @@ export function useDataTableExplorerLifecycles(
     selection,
     summaryBins,
     tableName,
+    tableReference,
   ]);
 
   // Client is not returned - it's stored in the dataTableExplorerStore

--- a/packages/mosaic/src/data-table-explorer/hooks/useDataTableExplorerQueryState.ts
+++ b/packages/mosaic/src/data-table-explorer/hooks/useDataTableExplorerQueryState.ts
@@ -3,6 +3,7 @@ import type {Selection} from '@uwdata/mosaic-core';
 import type {DataTableExplorerStoreState} from '../createDataTableExplorerStore';
 import type {
   DataTableExplorerPaginationState,
+  DataTableExplorerSqlTableReference,
   DataTableExplorerSorting,
 } from '../types';
 import {
@@ -18,6 +19,7 @@ export type UseDataTableExplorerQueryStateOptions = {
   selectionVersion: number;
   sorting: DataTableExplorerSorting;
   tableName: string;
+  tableReference: DataTableExplorerSqlTableReference;
 };
 
 export type UseDataTableExplorerQueryStateReturn = {
@@ -42,6 +44,7 @@ export function useDataTableExplorerQueryState({
   selectionVersion,
   sorting,
   tableName,
+  tableReference,
 }: UseDataTableExplorerQueryStateOptions): UseDataTableExplorerQueryStateReturn {
   const fields = schema.fields;
   const fieldNames = useMemo(() => fields.map((field) => field.name), [fields]);
@@ -59,9 +62,9 @@ export function useDataTableExplorerQueryState({
         columns: fieldNames,
         filter,
         sorting,
-        tableName,
+        tableName: tableReference,
       }),
-    [fieldNames, filter, sorting, tableName],
+    [fieldNames, filter, sorting, tableReference],
   );
   const pageBaseQuery = useMemo(
     () =>
@@ -69,9 +72,9 @@ export function useDataTableExplorerQueryState({
         columns: fieldNames,
         filter: rowFilter,
         sorting,
-        tableName,
+        tableName: tableReference,
       }),
-    [fieldNames, rowFilter, sorting, tableName],
+    [fieldNames, rowFilter, sorting, tableReference],
   );
 
   return {

--- a/packages/mosaic/src/data-table-explorer/hooks/useDataTableExplorerQueryState.ts
+++ b/packages/mosaic/src/data-table-explorer/hooks/useDataTableExplorerQueryState.ts
@@ -18,7 +18,7 @@ export type UseDataTableExplorerQueryStateOptions = {
   selection: Selection;
   selectionVersion: number;
   sorting: DataTableExplorerSorting;
-  tableName: string;
+  tableIdentity: string;
   tableReference: DataTableExplorerSqlTableReference;
 };
 
@@ -43,7 +43,7 @@ export function useDataTableExplorerQueryState({
   selection,
   selectionVersion,
   sorting,
-  tableName,
+  tableIdentity,
   tableReference,
 }: UseDataTableExplorerQueryStateOptions): UseDataTableExplorerQueryStateReturn {
   const fields = schema.fields;
@@ -79,7 +79,7 @@ export function useDataTableExplorerQueryState({
 
   return {
     baseQuery,
-    datasetId: [tableName, ...fieldNames].join(''),
+    datasetId: [tableIdentity, ...fieldNames].join(''),
     fieldNames,
     fields,
     hasFilters: Array.isArray(filter) ? filter.length > 0 : Boolean(filter),

--- a/packages/mosaic/src/data-table-explorer/hooks/useDataTableExplorerQueryState.ts
+++ b/packages/mosaic/src/data-table-explorer/hooks/useDataTableExplorerQueryState.ts
@@ -11,6 +11,9 @@ import {
   buildDataTableExplorerPageQuery,
 } from '../utils';
 
+/**
+ * Inputs used to derive memoized query state for a dataTableExplorer instance.
+ */
 export type UseDataTableExplorerQueryStateOptions = {
   pagination: DataTableExplorerPaginationState;
   rowSelectionVersion: number;
@@ -18,7 +21,14 @@ export type UseDataTableExplorerQueryStateOptions = {
   selection: Selection;
   selectionVersion: number;
   sorting: DataTableExplorerSorting;
+  /**
+   * Stable SQLRooms table identity used to build dataset IDs and distinguish
+   * tables that share schema/table names across catalogs.
+   */
   tableIdentity: string;
+  /**
+   * Mosaic SQL table reference used in generated queries.
+   */
   tableReference: DataTableExplorerSqlTableReference;
 };
 
@@ -35,6 +45,9 @@ export type UseDataTableExplorerQueryStateReturn = {
 /**
  * Derives the dataTableExplorer's field and SQL state from the current schema,
  * selection, sorting, and pagination state.
+ *
+ * @param options Current schema, selection, pagination, sorting, and table
+ * reference inputs for query generation.
  */
 export function useDataTableExplorerQueryState({
   pagination,

--- a/packages/mosaic/src/data-table-explorer/types.ts
+++ b/packages/mosaic/src/data-table-explorer/types.ts
@@ -80,6 +80,14 @@ export type DataTableExplorerColumnState = {
 
 export type DataTableExplorerTableReference = string | QualifiedTableName;
 
+/**
+ * Table reference accepted by dataTableExplorer query builders.
+ *
+ * Use a string for simple unqualified table names or for call sites that already
+ * require a string SQL boundary. Use a TableRefNode for qualified names,
+ * especially when schema or table identifier parts may contain dots or quotes,
+ * so Mosaic does not reparse those parts from a flattened string.
+ */
 export type DataTableExplorerSqlTableReference = string | TableRefNode;
 
 export type DataTableExplorerOptions = {

--- a/packages/mosaic/src/data-table-explorer/types.ts
+++ b/packages/mosaic/src/data-table-explorer/types.ts
@@ -1,5 +1,6 @@
 import type {QualifiedTableName} from '@sqlrooms/db';
 import type {MosaicClient, Selection} from '@uwdata/mosaic-core';
+import type {TableRefNode} from '@uwdata/mosaic-sql';
 import type {Interval1D} from '@uwdata/mosaic-plot';
 import type {Field, Table} from 'apache-arrow';
 import type {Dispatch, SetStateAction} from 'react';
@@ -78,6 +79,8 @@ export type DataTableExplorerColumnState = {
 };
 
 export type DataTableExplorerTableReference = string | QualifiedTableName;
+
+export type DataTableExplorerSqlTableReference = string | TableRefNode;
 
 export type DataTableExplorerOptions = {
   categoryLimit?: number;

--- a/packages/mosaic/src/data-table-explorer/useDataTableExplorer.ts
+++ b/packages/mosaic/src/data-table-explorer/useDataTableExplorer.ts
@@ -14,6 +14,7 @@ import {useDataTableExplorerStatus} from './hooks/useDataTableExplorerStatus';
 import {useDataTableExplorerVisiblePage} from './hooks/useDataTableExplorerVisiblePage';
 import {
   getMosaicSqlTableReference,
+  getMosaicTableIdentity,
   getMosaicTableReferenceString,
 } from '../mosaicTableReference';
 
@@ -35,6 +36,7 @@ export function useDataTableExplorer(
     tableName: table,
   } = options;
 
+  const tableIdentity = useMemo(() => getMosaicTableIdentity(table), [table]);
   const tableName = useMemo(
     () => getMosaicTableReferenceString(table),
     [table],
@@ -68,7 +70,7 @@ export function useDataTableExplorer(
     pageSize,
   });
   const schema =
-    rawSchema.tableName === tableName
+    rawSchema.tableName === tableIdentity
       ? rawSchema
       : {...rawSchema, fields: [], isLoading: true};
   const {
@@ -86,7 +88,7 @@ export function useDataTableExplorer(
     selection,
     selectionVersion,
     sorting,
-    tableName,
+    tableIdentity,
     tableReference,
   });
   useDataTableExplorerLifecycles({
@@ -103,6 +105,7 @@ export function useDataTableExplorer(
     selectionVersion,
     sorting,
     summaryBins,
+    tableIdentity,
     tableName,
     tableReference,
   });

--- a/packages/mosaic/src/data-table-explorer/useDataTableExplorer.ts
+++ b/packages/mosaic/src/data-table-explorer/useDataTableExplorer.ts
@@ -1,4 +1,5 @@
 import {useDebounce} from '@sqlrooms/ui';
+import {useMemo} from 'react';
 import {useStoreWithMosaic} from '../MosaicSlice';
 import type {
   DataTableExplorerOptions,
@@ -11,12 +12,10 @@ import {useDataTableExplorerLifecycles} from './hooks/useDataTableExplorerLifecy
 import {useDataTableExplorerColumns} from './hooks/useDataTableExplorerColumns';
 import {useDataTableExplorerStatus} from './hooks/useDataTableExplorerStatus';
 import {useDataTableExplorerVisiblePage} from './hooks/useDataTableExplorerVisiblePage';
-
-function getTableReference(
-  tableName: DataTableExplorerOptions['tableName'],
-): string {
-  return typeof tableName === 'string' ? tableName : tableName.toString();
-}
+import {
+  getMosaicSqlTableReference,
+  getMosaicTableReferenceString,
+} from '../mosaicTableReference';
 
 /**
  * Aggregates Mosaic-backed schema, rows, counts, and summaries into the stable
@@ -36,7 +35,14 @@ export function useDataTableExplorer(
     tableName: table,
   } = options;
 
-  const tableName = getTableReference(table);
+  const tableName = useMemo(
+    () => getMosaicTableReferenceString(table),
+    [table],
+  );
+  const tableReference = useMemo(
+    () => getMosaicSqlTableReference(table),
+    [table],
+  );
 
   const connection = useStoreWithMosaic((state) => state.mosaic.connection);
   const {selection, selectionVersion} = useDataTableExplorerSelection({
@@ -81,6 +87,7 @@ export function useDataTableExplorer(
     selectionVersion,
     sorting,
     tableName,
+    tableReference,
   });
   useDataTableExplorerLifecycles({
     categoryLimit,
@@ -97,6 +104,7 @@ export function useDataTableExplorer(
     sorting,
     summaryBins,
     tableName,
+    tableReference,
   });
   const dataTableExplorerColumns = useDataTableExplorerColumns({
     fields,

--- a/packages/mosaic/src/data-table-explorer/useDataTableExplorer.ts
+++ b/packages/mosaic/src/data-table-explorer/useDataTableExplorer.ts
@@ -42,8 +42,8 @@ export function useDataTableExplorer(
     [table],
   );
   const tableReference = useMemo(
-    () => getMosaicSqlTableReference(table),
-    [table],
+    () => getMosaicSqlTableReference(tableName),
+    [tableName],
   );
 
   const connection = useStoreWithMosaic((state) => state.mosaic.connection);

--- a/packages/mosaic/src/data-table-explorer/utils.ts
+++ b/packages/mosaic/src/data-table-explorer/utils.ts
@@ -5,6 +5,7 @@ import type {
   DataTableExplorerBin,
   DataTableExplorerCategoryBucket,
   DataTableExplorerPaginationState,
+  DataTableExplorerSqlTableReference,
   DataTableExplorerSorting,
   DataTableExplorerSummaryState,
 } from './types';
@@ -55,7 +56,7 @@ export function getDataTableExplorerValueType(
 }
 
 export function buildSchemaQuery(
-  tableName: string,
+  tableName: DataTableExplorerSqlTableReference,
   columns?: string[],
 ): ReturnType<typeof Query.from> {
   return Query.from(tableName)
@@ -123,7 +124,7 @@ export function buildDataTableExplorerBaseQuery(args: {
   columns?: string[];
   filter?: QueryWhereInput;
   sorting?: DataTableExplorerSorting;
-  tableName: string;
+  tableName: DataTableExplorerSqlTableReference;
 }) {
   const {columns, filter, sorting, tableName} = args;
   const query = Query.from(tableName)
@@ -166,7 +167,7 @@ export function normalizeDataTableExplorerPagination(
 
 export function buildCountQuery(args: {
   filter?: QueryWhereInput;
-  tableName: string;
+  tableName: DataTableExplorerSqlTableReference;
 }) {
   return Query.from(args.tableName)
     .select({count: count()})
@@ -176,7 +177,7 @@ export function buildCountQuery(args: {
 export function buildDistinctCountQuery(args: {
   filter?: QueryWhereInput;
   fieldName: string;
-  tableName: string;
+  tableName: DataTableExplorerSqlTableReference;
 }) {
   return Query.from(args.tableName)
     .select({
@@ -215,7 +216,7 @@ export function rowsFromQueryResult<T>(data: unknown): T[] {
 }
 
 export function buildCategorySummaryQuery(
-  tableName: string,
+  tableName: DataTableExplorerSqlTableReference,
   fieldName: string,
   filter?: QueryWhereInput,
 ) {

--- a/packages/mosaic/src/data-table-explorer/utils.ts
+++ b/packages/mosaic/src/data-table-explorer/utils.ts
@@ -55,6 +55,15 @@ export function getDataTableExplorerValueType(
   return 'string';
 }
 
+/**
+ * Builds a one-row schema probe query for a dataTableExplorer table.
+ *
+ * @param tableName Table reference to query. Pass a TableRefNode when the table
+ * reference is qualified or contains dotted identifier parts.
+ * @param columns Optional list of columns to include; when omitted, the query
+ * selects all columns.
+ * @returns Mosaic query used to infer Arrow field metadata from the table.
+ */
 export function buildSchemaQuery(
   tableName: DataTableExplorerSqlTableReference,
   columns?: string[],
@@ -120,6 +129,18 @@ export function fieldInfoToDataTableExplorerField(
   );
 }
 
+/**
+ * Builds the base dataTableExplorer query before pagination is applied.
+ *
+ * @param args.columns Optional selected column names; when omitted, all columns
+ * are selected.
+ * @param args.filter Optional Mosaic where clause or clause array.
+ * @param args.sorting Optional sort descriptors applied in order.
+ * @param args.tableName Table reference to query. This accepts
+ * DataTableExplorerSqlTableReference so callers can pass TableRefNode values
+ * that preserve qualified identifier boundaries.
+ * @returns Mosaic query with projection, filtering, and sorting applied.
+ */
 export function buildDataTableExplorerBaseQuery(args: {
   columns?: string[];
   filter?: QueryWhereInput;
@@ -140,6 +161,13 @@ export function buildDataTableExplorerBaseQuery(args: {
   return query;
 }
 
+/**
+ * Applies normalized dataTableExplorer pagination to a base query.
+ *
+ * @param baseQuery Query returned by buildDataTableExplorerBaseQuery.
+ * @param pagination Requested page index and page size.
+ * @returns A cloned Mosaic query with limit and offset applied.
+ */
 export function buildDataTableExplorerPageQuery(
   baseQuery: ReturnType<typeof buildDataTableExplorerBaseQuery>,
   pagination: DataTableExplorerPaginationState,
@@ -165,6 +193,14 @@ export function normalizeDataTableExplorerPagination(
   return {pageIndex, pageSize};
 }
 
+/**
+ * Builds a row-count query for a dataTableExplorer table.
+ *
+ * @param args.filter Optional Mosaic where clause or clause array.
+ * @param args.tableName Table reference to query. Pass a TableRefNode for
+ * qualified references that should not be reparsed from a string.
+ * @returns Mosaic query that returns a single count column.
+ */
 export function buildCountQuery(args: {
   filter?: QueryWhereInput;
   tableName: DataTableExplorerSqlTableReference;
@@ -174,6 +210,15 @@ export function buildCountQuery(args: {
     .where(args.filter ?? []);
 }
 
+/**
+ * Builds a distinct-value count query for one dataTableExplorer field.
+ *
+ * @param args.filter Optional Mosaic where clause or clause array.
+ * @param args.fieldName Field whose distinct non-null values should be counted.
+ * @param args.tableName Table reference to query. Pass a TableRefNode for
+ * qualified references that should not be reparsed from a string.
+ * @returns Mosaic query that returns a single distinct count column.
+ */
 export function buildDistinctCountQuery(args: {
   filter?: QueryWhereInput;
   fieldName: string;
@@ -215,6 +260,19 @@ export function rowsFromQueryResult<T>(data: unknown): T[] {
   return Array.from((data as {toArray(): T[]}).toArray());
 }
 
+/**
+ * Builds the category summary query used by dataTableExplorer categorical
+ * columns.
+ *
+ * @param tableName Table reference to query. This accepts
+ * DataTableExplorerSqlTableReference so callers can use TableRefNode when
+ * identifier boundaries must be preserved.
+ * @param fieldName Field to summarize into value, null, unique, and overflow
+ * buckets.
+ * @param filter Optional Mosaic where clause or clause array.
+ * @returns Mosaic query that produces bucket kind, typed value, and total count
+ * rows for category summaries.
+ */
 export function buildCategorySummaryQuery(
   tableName: DataTableExplorerSqlTableReference,
   fieldName: string,

--- a/packages/mosaic/src/mosaicTableReference.ts
+++ b/packages/mosaic/src/mosaicTableReference.ts
@@ -1,0 +1,49 @@
+import {
+  parseQualifiedSqlIdentifier,
+  type QualifiedTableName,
+} from '@sqlrooms/db';
+import {asTableRef, type TableRefNode} from '@uwdata/mosaic-sql';
+
+export type MosaicTableReferenceInput = string | QualifiedTableName;
+
+/**
+ * Converts SQLRooms table identity into a Mosaic query table reference.
+ *
+ * SQLRooms keeps the DuckDB catalog/database in QualifiedTableName for stable
+ * identity, but Mosaic queries execute against the active connector. Including
+ * that catalog in generated SQL can target a catalog that is not attached in
+ * the query connection. Mosaic also is not quote-aware when parsing table
+ * strings, so return a TableRefNode for generated SQL.
+ */
+export function getMosaicSqlTableReference(
+  tableName: MosaicTableReferenceInput,
+): TableRefNode {
+  return asTableRef(getMosaicTableReferenceParts(tableName))!;
+}
+
+/**
+ * Converts SQLRooms table identity into the plain schema/table string expected
+ * by Mosaic metadata and spec APIs.
+ */
+export function getMosaicTableReferenceString(
+  tableName: MosaicTableReferenceInput,
+): string {
+  return getMosaicTableReferenceParts(tableName).join('.');
+}
+
+function getMosaicTableReferenceParts(
+  tableName: MosaicTableReferenceInput,
+): string[] {
+  const parsed =
+    typeof tableName === 'string'
+      ? parseQualifiedSqlIdentifier(tableName)
+      : tableName;
+
+  if (parsed?.table) {
+    return [parsed.schema, parsed.table].filter(
+      (part): part is string => Boolean(part),
+    );
+  }
+
+  return [String(tableName).trim()];
+}

--- a/packages/mosaic/src/mosaicTableReference.ts
+++ b/packages/mosaic/src/mosaicTableReference.ts
@@ -31,13 +31,15 @@ export function getMosaicTableIdentity(
 }
 
 /**
- * Converts SQLRooms table identity into the plain schema/table string expected
- * by Mosaic metadata and spec APIs.
+ * Converts SQLRooms table identity into a schema/table SQL string for APIs that
+ * only accept string table references.
  */
 export function getMosaicTableReferenceString(
   tableName: MosaicTableReferenceInput,
 ): string {
-  return getMosaicTableReferenceParts(tableName).join('.');
+  return getMosaicTableReferenceParts(tableName)
+    .map(quoteMosaicTableReferencePart)
+    .join('.');
 }
 
 function getMosaicTableReferenceParts(
@@ -56,4 +58,8 @@ function getMosaicTableReferenceParts(
   }
 
   return [String(tableName).trim()];
+}
+
+function quoteMosaicTableReferencePart(part: string): string {
+  return `"${part.replaceAll('"', '""')}"`;
 }

--- a/packages/mosaic/src/mosaicTableReference.ts
+++ b/packages/mosaic/src/mosaicTableReference.ts
@@ -34,10 +34,11 @@ export function getMosaicTableReferenceString(
 function getMosaicTableReferenceParts(
   tableName: MosaicTableReferenceInput,
 ): string[] {
-  const parsed =
-    typeof tableName === 'string'
-      ? parseQualifiedSqlIdentifier(tableName)
-      : tableName;
+  if (typeof tableName !== 'string') {
+    return tableName.toArray({includeDatabase: false});
+  }
+
+  const parsed = parseQualifiedSqlIdentifier(tableName);
 
   if (parsed?.table) {
     return [parsed.schema, parsed.table].filter(

--- a/packages/mosaic/src/mosaicTableReference.ts
+++ b/packages/mosaic/src/mosaicTableReference.ts
@@ -22,6 +22,15 @@ export function getMosaicSqlTableReference(
 }
 
 /**
+ * Returns the full SQLRooms table identity for React/store keys.
+ */
+export function getMosaicTableIdentity(
+  tableName: MosaicTableReferenceInput,
+): string {
+  return typeof tableName === 'string' ? tableName.trim() : tableName.toString();
+}
+
+/**
  * Converts SQLRooms table identity into the plain schema/table string expected
  * by Mosaic metadata and spec APIs.
  */

--- a/packages/mosaic/src/useVgPlotChartRender.ts
+++ b/packages/mosaic/src/useVgPlotChartRender.ts
@@ -10,6 +10,7 @@ import {
   type ChartRuntimeIssueContext,
   type ChartRuntimeIssueReporter,
 } from './chart-runtime';
+import {getMosaicSqlTableReference} from './mosaicTableReference';
 
 type PlotDomElement = HTMLElement | SVGSVGElement;
 
@@ -24,6 +25,38 @@ type PlotInstance = {
   render?: () => Promise<unknown> | unknown;
   setAttribute?: (name: string, value: unknown) => boolean;
 };
+
+function normalizeSpecTableReferences(value: unknown, key?: string): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeSpecTableReferences(item));
+  }
+
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    return value;
+  }
+
+  const entries = Object.entries(value).map(([entryKey, entryValue]) => [
+    entryKey,
+    normalizeSpecTableReferences(entryValue, entryKey),
+  ]);
+  const normalized = Object.fromEntries(entries) as Record<string, unknown>;
+
+  if (
+    key === 'data' &&
+    typeof normalized.from === 'string' &&
+    normalized.from.trim() &&
+    !normalized.from.trim().startsWith('$')
+  ) {
+    normalized.from = getMosaicSqlTableReference(normalized.from);
+  }
+
+  return normalized;
+}
 
 /**
  * Symbols used to store original mark handlers before wrapping.
@@ -81,7 +114,7 @@ async function createSpecChartElement(
     height: size.height,
   } as Spec;
 
-  const ast = await parseSpec(sizedSpec);
+  const ast = await parseSpec(normalizeSpecTableReferences(sizedSpec) as Spec);
   const options = params
     ? {params: params as unknown as Map<string, Param<any>>}
     : undefined;

--- a/packages/mosaic/src/useVgPlotChartRender.ts
+++ b/packages/mosaic/src/useVgPlotChartRender.ts
@@ -28,7 +28,7 @@ type PlotInstance = {
 
 function normalizeSpecTableReferences(value: unknown, key?: string): unknown {
   if (Array.isArray(value)) {
-    return value.map((item) => normalizeSpecTableReferences(item));
+    return value.map((item) => normalizeSpecTableReferences(item, key));
   }
 
   if (!value || typeof value !== 'object') {
@@ -52,7 +52,7 @@ function normalizeSpecTableReferences(value: unknown, key?: string): unknown {
     normalized.from.trim() &&
     !normalized.from.trim().startsWith('$')
   ) {
-    normalized.from = getMosaicSqlTableReference(normalized.from);
+    normalized.from = getMosaicSqlTableReference(normalized.from.trim());
   }
 
   return normalized;


### PR DESCRIPTION
## Summary
- Add helpers to convert SQLRooms table identities into Mosaic-friendly schema/table references
- Use parsed `TableRefNode` values for Mosaic SQL generation so generated queries do not include the DuckDB catalog
- Update data table explorer and chart specs to use the new reference shape consistently
- Add tests covering string conversion, SQL parsing, and chart data source references

## Testing
- Added unit coverage for Mosaic table reference conversion and data table explorer query generation
- Updated chart spec expectations to reflect the normalized table reference behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added utilities to convert/format SQLRooms table identifiers into Mosaic-compatible table references and strings.

* **Refactor**
  * Updated the data table explorer to use structured table references and identity-based schema loading.
  * Updated chart rendering and data policies to rely on Mosaic-formatted table-name strings.

* **Bug Fixes**
  * Preserved quoted, dotted schema/table components in generated `FROM` clauses and ensured catalog prefixes are omitted where appropriate.

* **Tests**
  * Expanded coverage for qualified/unqualified identifier handling and data explorer SQL generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->