### PR TITLE
refactor: Use state.db.tables for assistant and run context

### DIFF
--- a/apps/sqlrooms-cli-ui/src/components/useAssistantContextItems.ts
+++ b/apps/sqlrooms-cli-ui/src/components/useAssistantContextItems.ts
@@ -3,11 +3,7 @@ import {
   getVisibleSessionContextItemIds,
   type ContextSelectorItem,
 } from '@sqlrooms/ai';
-import {
-  getAllTablesFromSchemaTrees,
-  makeQualifiedTableName,
-  type TableNodeObject,
-} from '@sqlrooms/duckdb';
+import {type DataTable} from '@sqlrooms/duckdb';
 import {useMemo} from 'react';
 import type {ArtifactMetadata} from '@sqlrooms/artifacts';
 import {useRoomStore} from '../store';
@@ -35,9 +31,8 @@ export function useContextArtifacts(): ArtifactMetadata[] {
 /**
  * Hook to get context-eligible tables from the store
  */
-export function useContextTables(): TableNodeObject[] {
-  const schemaTrees = useRoomStore((s) => s.db.schemaTrees);
-  return useMemo(() => getAllTablesFromSchemaTrees(schemaTrees), [schemaTrees]);
+export function useContextTables(): DataTable[] {
+  return useRoomStore((s) => s.db.tables);
 }
 
 /**
@@ -67,13 +62,8 @@ export function useContextSelectorItems(): ContextSelectorItem[] {
       }));
 
     const tableItems = tables.map((table) => {
-      const qualifiedName = makeQualifiedTableName({
-        database: table.table.database,
-        schema: table.table.schema,
-        table: table.table.table,
-      });
       return {
-        id: qualifiedName.toString(),
+        id: table.table.toString(),
         kind: 'table',
         title: table.table.table,
         type: table.isView ? 'view' : 'table',
@@ -133,9 +123,7 @@ export function useValidatedSelectedIds(): string[] {
 
   return useMemo(() => {
     const contextItemIds = getVisibleSessionContextItemIds(currentSession);
-    const tableIdSet = new Set(
-      tables.map((table) => makeQualifiedTableName(table.table).toString()),
-    );
+    const tableIdSet = new Set(tables.map((table) => table.table.toString()));
 
     return contextItemIds.filter((id) => {
       if (id === owningArtifactId) {

--- a/apps/sqlrooms-cli-ui/src/context/formatRunContextInstructions.ts
+++ b/apps/sqlrooms-cli-ui/src/context/formatRunContextInstructions.ts
@@ -3,7 +3,6 @@ import {
   type AiRunContext,
   type AiRunContextItem,
 } from '@sqlrooms/ai';
-import {findTableInSchemaTrees, makeQualifiedTableName} from '@sqlrooms/duckdb';
 import type {RoomState} from '../store-types';
 import type {StoreApi} from 'zustand';
 
@@ -53,14 +52,9 @@ function formatTableContextInstructions(
   }
 
   const state = store.getState();
-  const {schemaTrees} = state.db;
 
   const tableDetails = tableItems.map((item) => {
-    const tableObj = findTableInSchemaTrees(
-      schemaTrees,
-      item.id,
-      makeQualifiedTableName,
-    );
+    const tableObj = state.db.findTable(item.id);
 
     const columnCount = tableObj?.columns.length ?? 0;
     const rowCount = tableObj?.rowCount;

--- a/apps/sqlrooms-cli-ui/src/context/getRunContext.ts
+++ b/apps/sqlrooms-cli-ui/src/context/getRunContext.ts
@@ -1,8 +1,4 @@
-import {
-  getAllTablesFromSchemaTrees,
-  makeQualifiedTableName,
-  type DbSchemaNode,
-} from '@sqlrooms/duckdb';
+import {type DataTable} from '@sqlrooms/duckdb';
 import {
   getRunContextItemIds,
   type AiRunContext,
@@ -24,20 +20,12 @@ type TableInfo = {
 };
 
 function buildTablesMap(
-  schemaTrees: DbSchemaNode[] | undefined,
+  tables: DataTable[] | undefined,
 ): Map<string, TableInfo> {
-  if (!schemaTrees) return new Map();
-
   const tablesByQualifiedName = new Map<string, TableInfo>();
 
-  const allTables = getAllTablesFromSchemaTrees(schemaTrees);
-  for (const tableObj of allTables) {
-    const qualifiedName = makeQualifiedTableName({
-      database: tableObj.table.database,
-      schema: tableObj.table.schema,
-      table: tableObj.table.table,
-    }).toString();
-    tablesByQualifiedName.set(qualifiedName, {
+  for (const tableObj of tables ?? []) {
+    tablesByQualifiedName.set(tableObj.table.toString(), {
       database: tableObj.table.database,
       schema: tableObj.table.schema,
       table: tableObj.table.table,
@@ -98,11 +86,11 @@ export function getRunContext(
 ): AiRunContext | undefined {
   const state = store.getState();
   const {artifactsById} = state.artifacts.config;
-  const {schemaTrees} = state.db;
+  const {tables} = state.db;
   const session = state.ai.config.sessions.find(
     (candidate) => candidate.id === sessionId,
   );
-  const tablesByQualifiedName = buildTablesMap(schemaTrees);
+  const tablesByQualifiedName = buildTablesMap(tables);
 
   if (
     session?.draftContextItemIds === undefined &&

--- a/apps/sqlrooms-cli-ui/src/workspace/sidebar/CliDataSidebarSection.tsx
+++ b/apps/sqlrooms-cli-ui/src/workspace/sidebar/CliDataSidebarSection.tsx
@@ -1,8 +1,4 @@
-import {
-  getAllTablesFromSchemaTrees,
-  makeQualifiedTableName,
-  type TableNodeObject,
-} from '@sqlrooms/duckdb';
+import {type DataTable} from '@sqlrooms/duckdb';
 import {SchemaExplorer} from '@sqlrooms/sql-editor';
 import {
   DropdownMenu,
@@ -17,7 +13,7 @@ import {
   useSidebar,
 } from '@sqlrooms/ui';
 import {ArrowUpFromLine, Database, Table2} from 'lucide-react';
-import {useCallback, useMemo, useRef, type ChangeEvent} from 'react';
+import {useCallback, useRef, type ChangeEvent} from 'react';
 import {useRoomStore} from '../../store';
 import {
   LOCAL_DATA_ACCEPTED_FORMATS,
@@ -31,12 +27,8 @@ const acceptedDataFileExtensions = Object.values(LOCAL_DATA_ACCEPTED_FORMATS)
 export function CliDataSidebarSection() {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const loadLocalFiles = useLocalFileLoader();
-  const schemaTrees = useRoomStore((state) => state.db.schemaTrees);
   const selectTable = useRoomStore((state) => state.sqlEditor.selectTable);
-  const tables = useMemo(
-    () => getAllTablesFromSchemaTrees(schemaTrees),
-    [schemaTrees],
-  );
+  const tables = useRoomStore((state) => state.db.tables);
   const {state} = useSidebar();
 
   const addData = useCallback(() => {
@@ -55,13 +47,8 @@ export function CliDataSidebarSection() {
   );
 
   const handleSelectTable = useCallback(
-    (table: TableNodeObject) => {
-      const qualifiedTableName = makeQualifiedTableName({
-        database: table.table.database,
-        schema: table.table.schema,
-        table: table.table.table,
-      }).toString();
-      selectTable(qualifiedTableName);
+    (table: DataTable) => {
+      selectTable(table.table.toString());
     },
     [selectTable],
   );
@@ -115,7 +102,7 @@ export function CliDataSidebarSection() {
               >
                 <Table2 className="h-4 w-4" aria-hidden />
                 <div className="grid min-w-0 gap-px">
-                  <span className="truncate">{table.name}</span>
+                  <span className="truncate">{table.table.table}</span>
                   <small className="text-muted-foreground truncate text-xs">
                     {formatTableMeta(table)}
                   </small>
@@ -146,7 +133,7 @@ export function CliDataSidebarSection() {
   );
 }
 
-function formatTableMeta(table: TableNodeObject) {
+function formatTableMeta(table: DataTable) {
   const columnCount = table.columns.length;
   const columnLabel = `${columnCount} ${columnCount === 1 ? 'column' : 'columns'}`;
   if (table.rowCount === undefined) return columnLabel;

--- a/packages/duckdb-core/src/schema-tree/schemaTreeUtils.ts
+++ b/packages/duckdb-core/src/schema-tree/schemaTreeUtils.ts
@@ -4,6 +4,7 @@ import type {DbSchemaNode, TableNodeObject} from './types';
  * Flattens a schema tree and extracts all table nodes.
  * @param schemaTrees - Array of database schema tree nodes
  * @returns Array of all table objects found in the tree
+ * @deprecated Use state.db.tables
  */
 export function getAllTablesFromSchemaTrees(
   schemaTrees: DbSchemaNode[] | undefined,


### PR DESCRIPTION
## Summary
- Switch assistant context, run-context formatting, and CLI sidebar data surfaces to read from `state.db.tables`
- Use each table’s qualified `toString()` identifier consistently for selection and lookup
- Mark `getAllTablesFromSchemaTrees` as deprecated in duckdb-core

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized table data access patterns for improved consistency and performance.
  * Enhanced internal data retrieval and table selection handling.
  * Updated table context management for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->