### PR TITLE
fix: Standardize table name qualification across SQLRooms

### DIFF
--- a/examples/code-editor/src/SqlEditor.tsx
+++ b/examples/code-editor/src/SqlEditor.tsx
@@ -21,6 +21,7 @@ const tableSchemas: DataTable[] = [
   {
     table: {
       table: 'users',
+      toFullString: () => 'users',
       toString: () => 'users',
     },
     isView: false,
@@ -38,6 +39,7 @@ const tableSchemas: DataTable[] = [
   {
     table: {
       table: 'orders',
+      toFullString: () => 'orders',
       toString: () => 'orders',
     },
     isView: false,

--- a/packages/ai/__tests__/tableSchemaContext.test.ts
+++ b/packages/ai/__tests__/tableSchemaContext.test.ts
@@ -9,6 +9,7 @@ function makeTable(
   tableName: string,
   options: {
     database?: string;
+    defaultDatabase?: string;
     schema?: string;
     columns?: {name: string; type?: string}[];
     rowCount?: number;
@@ -21,6 +22,7 @@ function makeTable(
       database: options.database,
       schema: options.schema ?? 'main',
       table: tableName,
+      defaultDatabase: options.defaultDatabase ?? 'local',
     }),
     isView: false,
     database: options.database,
@@ -86,9 +88,9 @@ describe('table schema context formatting', () => {
       {fullSchemaThreshold: 1, namesOnlyThreshold: 2},
     );
 
-    expect(output).toContain('tableId: "local"."main"."events"');
+    expect(output).toContain('tableId: "main"."events"');
     expect(output).toContain('magnitude DOUBLE');
-    expect(output).toContain('tableId: "local"."main"."stations"');
+    expect(output).toContain('tableId: "main"."stations"');
     expect(output).toContain('forward the canonical tableId');
     expect(output).toContain(
       '1 more tables are available via list_tables and read_table_schema.',

--- a/packages/ai/__tests__/tableSchemaContext.test.ts
+++ b/packages/ai/__tests__/tableSchemaContext.test.ts
@@ -86,9 +86,8 @@ describe('table schema context formatting', () => {
       {fullSchemaThreshold: 1, namesOnlyThreshold: 2},
     );
 
-    expect(output).toContain('events (tableId: "local"."main"."events")');
+    expect(output).toContain('tableId: "local"."main"."events"');
     expect(output).toContain('magnitude DOUBLE');
-    expect(output).toContain('- stations');
     expect(output).toContain('tableId: "local"."main"."stations"');
     expect(output).toContain('forward the canonical tableId');
     expect(output).toContain(

--- a/packages/ai/__tests__/tableSchemaContext.test.ts
+++ b/packages/ai/__tests__/tableSchemaContext.test.ts
@@ -1,4 +1,5 @@
 import type {DataTable} from '@sqlrooms/duckdb';
+import {makeQualifiedTableName} from '../../duckdb-core/src/duckdb-utils';
 import {
   formatTablesForLLM,
   getTablesForAiScope,
@@ -16,11 +17,12 @@ function makeTable(
 ): DataTable {
   return {
     tableName,
-    table: {
+    table: makeQualifiedTableName({
       database: options.database,
       schema: options.schema ?? 'main',
       table: tableName,
-    },
+    }),
+    isView: false,
     database: options.database,
     schema: options.schema ?? 'main',
     columns: options.columns ?? [{name: 'id', type: 'INTEGER'}],

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -47,11 +47,7 @@ export {
   formatTableSummaryForAi,
   getAiTableScopeSummary,
   getAiTableSchemaContextLimits,
-  getDatabaseNameForAi,
-  getFullTableNameForAi,
-  getSchemaNameForAi,
   getTablesForAiScope,
-  getTableNameForAi,
 } from './tools/tableSchemaContext';
 export type {
   AiTableScope,

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -50,7 +50,6 @@ export {
   getDatabaseNameForAi,
   getFullTableNameForAi,
   getSchemaNameForAi,
-  getTableIdForAi,
   getTablesForAiScope,
   getTableNameForAi,
 } from './tools/tableSchemaContext';

--- a/packages/ai/src/tools/defaultInstructions.ts
+++ b/packages/ai/src/tools/defaultInstructions.ts
@@ -36,7 +36,7 @@ Instructions for analysis:
 - Break down complex problems into smaller steps
 - Use "SUMMARIZE table_name"for quick overview of the table
 - Before writing SQL against a table whose columns are not shown, call read_table_schema.
-- Users may refer to tables by bare names such as "events"; after selecting or resolving a concrete table from the candidates, forward its canonical identity. When a tool accepts only a string, pass the exact tableId shown in table context or list_tables. tableId is the fully quoted SQL identifier string from QualifiedTableName.toString(), for example "db"."schema"."events"; do not forward only the bare/display table name once a table is known.
+- Users may refer to tables by bare names such as "events"; after selecting or resolving a concrete table from the candidates, forward its canonical identity. When a tool accepts only a string, pass the exact tableId shown in table context or list_tables. tableId is the quoted SQLRooms table reference from QualifiedTableName.toString(); it may omit the default database, for example "schema"."events", and includes a database for non-default attached databases. Do not forward only the bare/display table name once a table is known.
 - Use list_tables to search or page through available tables when the prompt mentions a table that is not shown below, including other visible schemas or databases when relevant. Use its database, schema, and pattern filters when needed.
 - Please don't modify data
 - IMPORTANT: When you receive an error response from a tool call (where success: false):

--- a/packages/ai/src/tools/tableSchemaContext.ts
+++ b/packages/ai/src/tools/tableSchemaContext.ts
@@ -125,11 +125,20 @@ function makeQualifiedTableNameForAi({
   database,
   schema,
   table,
+  defaultDatabase,
 }: Pick<
   QualifiedTableName,
-  'database' | 'schema' | 'table'
+  'database' | 'schema' | 'table' | 'defaultDatabase'
 >): QualifiedTableName {
-  const tableId = [database, schema, table]
+  const fullTableId = [database, schema, table]
+    .filter((id) => id !== undefined && id !== null)
+    .map((id) => escapeTableIdPart(id))
+    .join('.');
+  const tableId = [
+    database && database !== defaultDatabase ? database : undefined,
+    schema,
+    table,
+  ]
     .filter((id) => id !== undefined && id !== null)
     .map((id) => escapeTableIdPart(id))
     .join('.');
@@ -137,6 +146,7 @@ function makeQualifiedTableNameForAi({
     database,
     schema,
     table,
+    defaultDatabase,
     toArray: ({
       includeDatabase = true,
       includeSchema = true,
@@ -149,6 +159,7 @@ function makeQualifiedTableNameForAi({
         includeSchema ? schema : undefined,
         table,
       ].filter((id): id is string => id !== undefined && id !== null),
+    toFullString: () => fullTableId,
     toString: () => tableId,
   };
 }
@@ -157,8 +168,8 @@ function makeQualifiedTableNameForAi({
  * Builds the canonical qualified identity for an AI-visible table.
  *
  * @param table - Data table metadata from the DuckDB catalog.
- * @returns A `QualifiedTableName` whose `toString()` is the fully quoted table
- *   identifier expected at string-only tool boundaries.
+ * @returns A `QualifiedTableName` whose `toString()` is the canonical quoted
+ *   table reference expected at string-only tool boundaries.
  */
 export function getQualifiedTableNameForAi(
   table: DataTable,
@@ -168,14 +179,15 @@ export function getQualifiedTableNameForAi(
     database: table.table?.database || table.database,
     schema: table.table?.schema || table.schema,
     table: tableName,
+    defaultDatabase: table.table?.defaultDatabase,
   });
 }
 
 /**
- * Gets the fully quoted canonical table identifier for AI tools.
+ * Gets the canonical quoted table identifier for AI tools.
  *
  * @param table - Data table metadata from the DuckDB catalog.
- * @returns Fully quoted table ID derived from the table's qualified identity.
+ * @returns Canonical table ID derived from the table's qualified identity.
  */
 export function getTableIdForAi(table: DataTable): string {
   return getQualifiedTableNameForAi(table).toString();
@@ -356,7 +368,7 @@ export function formatOtherTableScopesForAi(
 
   return [
     `${summary.outsideCurrentDatabaseMainSchemaCount.toLocaleString()} additional visible tables/views exist outside the current local main schema.`,
-    `Use list_tables with database, schema, or pattern filters to inspect them, then forward the resolved fully quoted tableId rather than only a bare table name.`,
+    `Use list_tables with database, schema, or pattern filters to inspect them, then forward the resolved canonical tableId rather than only a bare table name.`,
     locationSummary
       ? `Outside-main locations: ${locationSummary}${hiddenLocationCount}.`
       : '',
@@ -440,7 +452,7 @@ function formatBudgetedTableContextForAi(
   maxChars: number,
 ): string {
   const sections = [
-    'Schema context trimmed. Users may say bare names; after resolving, forward tableId, the fully quoted QualifiedTableName.toString() string. Use list_tables and read_table_schema with tableId before SQL.',
+    'Schema context trimmed. Users may say bare names; after resolving, forward tableId, the canonical QualifiedTableName.toString() string. It may omit the default database. Use list_tables and read_table_schema with tableId before SQL.',
   ];
 
   addSectionWithinBudget(
@@ -548,7 +560,7 @@ export function formatTablesForLLM(
     summaryTables.length;
 
   const hybridContext = joinSections([
-    'Users may say bare table names. After choosing a concrete table, forward the canonical tableId shown here, which is the fully quoted SQL identifier string from QualifiedTableName.toString(), rather than only the bare/display name.',
+    'Users may say bare table names. After choosing a concrete table, forward the canonical tableId shown here, which is the quoted SQLRooms table reference from QualifiedTableName.toString(), rather than only the bare/display name.',
     `Full schemas shown for the first ${fullSchemaTables.length} of ${currentMainSchemaTables.length} available tables:`,
     fullSchemaTables.map(formatTableSchemaForAi).join('\n\n'),
     summaryTables.length > 0

--- a/packages/ai/src/tools/tableSchemaContext.ts
+++ b/packages/ai/src/tools/tableSchemaContext.ts
@@ -1,8 +1,4 @@
-import type {
-  DataTable,
-  QualifiedTableName,
-  TableColumn,
-} from '@sqlrooms/duckdb';
+import type {DataTable, TableColumn} from '@sqlrooms/duckdb';
 
 /**
  * Prompt-size limits used when formatting table schema context for an AI model.
@@ -113,84 +109,6 @@ export function getAiTableSchemaContextLimits(
  */
 export function getTableNameForAi(table: DataTable): string {
   return table.table?.table || table.tableName;
-}
-
-function escapeTableIdPart(id: string): string {
-  const str = String(id);
-  if (str.startsWith('"') && str.endsWith('"')) return str;
-  return `"${str.replace(/"/g, '""')}"`;
-}
-
-function makeQualifiedTableNameForAi({
-  database,
-  schema,
-  table,
-  defaultDatabase,
-}: Pick<
-  QualifiedTableName,
-  'database' | 'schema' | 'table' | 'defaultDatabase'
->): QualifiedTableName {
-  const fullTableId = [database, schema, table]
-    .filter((id) => id !== undefined && id !== null)
-    .map((id) => escapeTableIdPart(id))
-    .join('.');
-  const tableId = [
-    database && database !== defaultDatabase ? database : undefined,
-    schema,
-    table,
-  ]
-    .filter((id) => id !== undefined && id !== null)
-    .map((id) => escapeTableIdPart(id))
-    .join('.');
-  return {
-    database,
-    schema,
-    table,
-    defaultDatabase,
-    toArray: ({
-      includeDatabase = true,
-      includeSchema = true,
-    }: {
-      includeDatabase?: boolean;
-      includeSchema?: boolean;
-    } = {}) =>
-      [
-        includeDatabase ? database : undefined,
-        includeSchema ? schema : undefined,
-        table,
-      ].filter((id): id is string => id !== undefined && id !== null),
-    toFullString: () => fullTableId,
-    toString: () => tableId,
-  };
-}
-
-/**
- * Builds the canonical qualified identity for an AI-visible table.
- *
- * @param table - Data table metadata from the DuckDB catalog.
- * @returns A `QualifiedTableName` whose `toString()` is the canonical quoted
- *   table reference expected at string-only tool boundaries.
- */
-export function getQualifiedTableNameForAi(
-  table: DataTable,
-): QualifiedTableName {
-  const tableName = table.table?.table || table.tableName;
-  return makeQualifiedTableNameForAi({
-    database: table.table?.database || table.database,
-    schema: table.table?.schema || table.schema,
-    table: tableName,
-    defaultDatabase: table.table?.defaultDatabase,
-  });
-}
-
-/**
- * Gets the canonical quoted table identifier for AI tools.
- *
- * @param table - Data table metadata from the DuckDB catalog.
- * @returns Canonical table ID derived from the table's qualified identity.
- */
-export function getTableIdForAi(table: DataTable): string {
-  return getQualifiedTableNameForAi(table).toString();
 }
 
 /**
@@ -396,7 +314,7 @@ function formatColumnForAi(column: TableColumn): string {
  */
 export function formatTableSchemaForAi(table: DataTable): string {
   const header = [
-    `${getFullTableNameForAi(table)} (tableId: ${getTableIdForAi(table)})`,
+    `${getFullTableNameForAi(table)} (tableId: ${table.table.toString()})`,
   ];
   const rowCount = formatRowCount(table.rowCount);
   if (rowCount) header.push(`[${rowCount}]`);
@@ -420,9 +338,9 @@ export function formatTableSchemaForAi(table: DataTable): string {
  */
 export function formatTableSummaryForAi(table: DataTable): string {
   const rowCount = formatRowCount(table.rowCount);
-  return `- ${getFullTableNameForAi(table)} (tableId: ${getTableIdForAi(
+  return `- ${getFullTableNameForAi(
     table,
-  )})${rowCount ? ` [${rowCount}]` : ''}`;
+  )} (tableId: ${table.table.toString()})${rowCount ? ` [${rowCount}]` : ''}`;
 }
 
 function fitTextToMaxChars(text: string, maxChars?: number): string {

--- a/packages/ai/src/tools/tableSchemaContext.ts
+++ b/packages/ai/src/tools/tableSchemaContext.ts
@@ -101,58 +101,14 @@ export function getAiTableSchemaContextLimits(
   };
 }
 
-/**
- * Gets the display table name for AI-facing context.
- *
- * @param table - Data table metadata from the DuckDB catalog.
- * @returns The bare table name when available, falling back to `tableName`.
- */
-export function getTableNameForAi(table: DataTable): string {
-  return table.table?.table || table.tableName;
-}
-
-/**
- * Gets the schema name for an AI-visible table.
- *
- * @param table - Data table metadata from the DuckDB catalog.
- * @returns Schema name when known.
- */
-export function getSchemaNameForAi(table: DataTable): string | undefined {
-  return table.table?.schema || table.schema;
-}
-
-/**
- * Gets the database name for an AI-visible table.
- *
- * @param table - Data table metadata from the DuckDB catalog.
- * @returns Database name when known.
- */
-export function getDatabaseNameForAi(table: DataTable): string | undefined {
-  return table.table?.database || table.database;
-}
-
-/**
- * Gets a compact display name for a table in AI-facing summaries.
- *
- * @param table - Data table metadata from the DuckDB catalog.
- * @returns `schema.table` for non-main schemas, otherwise the bare table name.
- */
-export function getFullTableNameForAi(table: DataTable): string {
-  const tableName = getTableNameForAi(table);
-  const schemaName = getSchemaNameForAi(table);
-  return schemaName && schemaName !== 'main'
-    ? `${schemaName}.${tableName}`
-    : tableName;
-}
-
 function isTableInAiScope(
   table: DataTable,
   currentDatabase?: string,
   options: AiTableScopeOptions = {},
 ): boolean {
   const {scope = 'main', schema, database} = options;
-  const tableSchema = getSchemaNameForAi(table);
-  const tableDatabase = getDatabaseNameForAi(table);
+  const tableSchema = table.table.schema;
+  const tableDatabase = table.table.database;
 
   if (database && tableDatabase !== database) return false;
   if (schema && tableSchema !== schema) return false;
@@ -210,8 +166,8 @@ export function getAiTableScopeSummary(
   >();
 
   for (const table of outsideCurrentDatabaseMainSchemaTables) {
-    const database = getDatabaseNameForAi(table);
-    const schema = getSchemaNameForAi(table);
+    const database = table.table.database;
+    const schema = table.table.schema;
     const key = `${database ?? ''}\x00${schema ?? ''}`;
     const existing = byLocation.get(key);
     if (existing) {
@@ -227,12 +183,12 @@ export function getAiTableScopeSummary(
       outsideCurrentDatabaseMainSchemaTables.length,
     otherCurrentDatabaseSchemaCount:
       outsideCurrentDatabaseMainSchemaTables.filter((table) => {
-        const database = getDatabaseNameForAi(table);
+        const database = table.table.database;
         return !database || database === currentDatabase;
       }).length,
     otherDatabaseCount: outsideCurrentDatabaseMainSchemaTables.filter(
       (table) => {
-        const database = getDatabaseNameForAi(table);
+        const database = table.table.database;
         return database && database !== currentDatabase;
       },
     ).length,
@@ -309,13 +265,11 @@ function formatColumnForAi(column: TableColumn): string {
  * Formats a table with full column schema for AI context.
  *
  * @param table - Data table metadata to format.
- * @returns Multi-line schema text including display name, canonical table ID,
- *   optional row count, columns, and optional comment.
+ * @returns Multi-line schema text including canonical table ID, optional row
+ *   count, columns, and optional comment.
  */
 export function formatTableSchemaForAi(table: DataTable): string {
-  const header = [
-    `${getFullTableNameForAi(table)} (tableId: ${table.table.toString()})`,
-  ];
+  const header = [`tableId: ${table.table.toString()}`];
   const rowCount = formatRowCount(table.rowCount);
   if (rowCount) header.push(`[${rowCount}]`);
 
@@ -333,14 +287,13 @@ export function formatTableSchemaForAi(table: DataTable): string {
  * Formats a one-line table summary for AI context.
  *
  * @param table - Data table metadata to summarize.
- * @returns Summary line containing display name, canonical table ID, and
- *   optional row count.
+ * @returns Summary line containing canonical table ID and optional row count.
  */
 export function formatTableSummaryForAi(table: DataTable): string {
   const rowCount = formatRowCount(table.rowCount);
-  return `- ${getFullTableNameForAi(
-    table,
-  )} (tableId: ${table.table.toString()})${rowCount ? ` [${rowCount}]` : ''}`;
+  return `- tableId: ${table.table.toString()}${
+    rowCount ? ` [${rowCount}]` : ''
+  }`;
 }
 
 function fitTextToMaxChars(text: string, maxChars?: number): string {

--- a/packages/ai/src/tools/tables/listTables.ts
+++ b/packages/ai/src/tools/tables/listTables.ts
@@ -70,7 +70,7 @@ function likePatternToRegex(pattern: string): RegExp {
 export function createListTablesTool(store: StoreApi<DuckDbSliceState>) {
   return tool({
     description:
-      'List available tables and views in the database. Supports filtering by database, schema, and table name pattern. Use this to discover what tables exist before reading their schemas. Results include tableId, the fully quoted SQL identifier string from QualifiedTableName.toString() to pass to string-only table tools after choosing a table. Lists tables and views visible in the SQLRooms table catalog. Internal SQLRooms schemas/tables may be hidden; use this for user-facing data discovery, not exhaustive DuckDB catalog inspection.',
+      'List available tables and views in the database. Supports filtering by database, schema, and table name pattern. Use this to discover what tables exist before reading their schemas. Results include tableId, the canonical quoted SQLRooms table reference from QualifiedTableName.toString() to pass to string-only table tools after choosing a table. The tableId may omit the default database and includes a database for non-default attached databases. Lists tables and views visible in the SQLRooms table catalog. Internal SQLRooms schemas/tables may be hidden; use this for user-facing data discovery, not exhaustive DuckDB catalog inspection.',
     inputSchema: ListTablesInput,
     execute: async (input) => {
       const state = store.getState();

--- a/packages/ai/src/tools/tables/readTableSchema.ts
+++ b/packages/ai/src/tools/tables/readTableSchema.ts
@@ -14,7 +14,7 @@ const ReadTableSchemaInput = z.object({
     .string()
     .optional()
     .describe(
-      'Fully quoted tableId from table context/list_tables, produced by QualifiedTableName.toString() (for example "db"."schema"."table"). A bare table name is accepted only when it uniquely identifies one visible table. Defaults to the primary context table if not specified.',
+      'Canonical quoted tableId from table context/list_tables, produced by QualifiedTableName.toString() (for example "schema"."table" for the default database or "db"."schema"."table" for an attached database). A bare table name is accepted only when it uniquely identifies one visible table. Defaults to the primary context table if not specified.',
     ),
 });
 

--- a/packages/ai/src/tools/tables/tableIdentity.ts
+++ b/packages/ai/src/tools/tables/tableIdentity.ts
@@ -9,8 +9,8 @@ import {resolveTableReference, type DataTable} from '@sqlrooms/duckdb-core';
  */
 export type TableIdentitySummary = {
   /**
-   * Fully quoted SQL identifier from QualifiedTableName.toString(), used at
-   * string-only tool boundaries.
+   * Canonical quoted SQLRooms table reference from
+   * QualifiedTableName.toString(), used at string-only tool boundaries.
    */
   tableId: string;
   database?: string;
@@ -25,7 +25,7 @@ export type TableIdentitySummary = {
  * Returns the canonical string identity for a visible table.
  *
  * @param table - DataTable to identify.
- * @returns Fully quoted table id from the table's QualifiedTableName.
+ * @returns Canonical quoted table id from the table's QualifiedTableName.
  */
 export function getCanonicalTableId(table: DataTable): string {
   return table.table.toString();

--- a/packages/cells/src/defaultCellRegistry.tsx
+++ b/packages/cells/src/defaultCellRegistry.tsx
@@ -1,4 +1,3 @@
-import {makeQualifiedTableName} from '@sqlrooms/duckdb';
 import {convertToValidColumnOrTableName} from '@sqlrooms/utils';
 import {produce} from 'immer';
 import {InputCellContent} from './components/InputCellContent';
@@ -137,11 +136,13 @@ export function createDefaultCellRegistry(): CellRegistry {
           cell.data as SqlCellData,
           convertToValidColumnOrTableName,
         );
-        const newTableName = makeQualifiedTableName({
-          table: effectiveResultName,
-          schema: schemaName,
-          database: state.db.currentDatabase,
-        }).toString();
+        const newTableName = state.db
+          .qualifyTableName({
+            table: effectiveResultName,
+            schema: schemaName,
+            database: state.db.currentDatabase,
+          })
+          .toString();
 
         if (newTableName === oldResultView) {
           return;

--- a/packages/cells/src/execution.ts
+++ b/packages/cells/src/execution.ts
@@ -1,4 +1,4 @@
-import {escapeId, makeQualifiedTableName} from '@sqlrooms/duckdb';
+import {escapeId} from '@sqlrooms/duckdb';
 import {convertToValidColumnOrTableName} from '@sqlrooms/utils';
 import {produce} from 'immer';
 import {
@@ -162,11 +162,13 @@ export async function executeSqlCell(
         {signal},
       );
 
-      tableName = makeQualifiedTableName({
-        table: effectiveResultName,
-        schema: finalSchemaName,
-        database: db.currentDatabase,
-      }).toString();
+      tableName = db
+        .qualifyTableName({
+          table: effectiveResultName,
+          schema: finalSchemaName,
+          database: db.currentDatabase,
+        })
+        .toString();
       // Adaptive policy:
       // - first run: choose table when there are downstream dependents,
       //   otherwise keep a lightweight view.

--- a/packages/db/src/DbSlice.ts
+++ b/packages/db/src/DbSlice.ts
@@ -1,5 +1,5 @@
 import {createDuckDbSlice, CreateDuckDbSliceProps} from '@sqlrooms/duckdb';
-import {escapeId, makeQualifiedTableName} from '@sqlrooms/duckdb-core';
+import {escapeId} from '@sqlrooms/duckdb-core';
 import {createSlice, useBaseRoomStore} from '@sqlrooms/room-store';
 import * as arrow from 'apache-arrow';
 import {produce} from 'immer';
@@ -112,11 +112,13 @@ export function createDbSlice(props?: CreateDbSliceProps) {
         const schemaName =
           schema ?? get().db.config.coreMaterialization.schemaName;
         await ensureSchemaExists({core, schema: schemaName, database});
-        return makeQualifiedTableName({
-          database,
-          schema: schemaName,
-          table: relationName,
-        }).toString();
+        return get()
+          .db.qualifyTableName({
+            database,
+            schema: schemaName,
+            table: relationName,
+          })
+          .toString();
       }
 
       const attachedName =
@@ -130,11 +132,13 @@ export function createDbSlice(props?: CreateDbSliceProps) {
         schema: schemaName,
         database: attachedName,
       });
-      return makeQualifiedTableName({
-        database: attachedName,
-        schema: schemaName,
-        table: relationName,
-      }).toString();
+      return get()
+        .db.qualifyTableName({
+          database: attachedName,
+          schema: schemaName,
+          table: relationName,
+        })
+        .toString();
     };
     const materializeArrowResult = async (args: {
       table: arrow.Table;

--- a/packages/deck/__tests__/dashboard-ai-map.test.ts
+++ b/packages/deck/__tests__/dashboard-ai-map.test.ts
@@ -1,4 +1,5 @@
 import {MAP_TOOL_KEY, type DashboardToolDeps} from '@sqlrooms/mosaic';
+import {makeQualifiedTableName} from '@sqlrooms/duckdb';
 import {
   createDashboardWithDeckMapAiTools,
   createDeckMapConfigTool,
@@ -122,9 +123,16 @@ function createDeps(): DashboardToolDeps & {
 }
 
 describe('createDeckMapBoundsQuery', () => {
-  it('builds fit-to-data bounds queries without double-quoting table ids', () => {
+  it('builds fit-to-data bounds queries from structured table ids', () => {
     const query = createDeckMapBoundsQuery({
-      source: {tableName: '"local"."main"."events"'},
+      source: {
+        table: makeQualifiedTableName({
+          database: 'local',
+          schema: 'main',
+          table: 'events',
+          defaultDatabase: 'local',
+        }),
+      },
       fitToData: {
         dataset: 'events',
         longitudeColumn: 'longitude',
@@ -132,8 +140,8 @@ describe('createDeckMapBoundsQuery', () => {
       },
     });
 
-    expect(query).toContain('SELECT * FROM "local"."main"."events"');
-    expect(query).not.toContain('"""local"""');
+    expect(query).toContain('SELECT * FROM "main"."events"');
+    expect(query).not.toContain('SELECT * FROM "local"."main"."events"');
   });
 });
 

--- a/packages/deck/src/dashboard.tsx
+++ b/packages/deck/src/dashboard.tsx
@@ -189,6 +189,16 @@ type DeckMapBoundsQuerySource =
   | {table: QualifiedTableName; sqlQuery?: never}
   | {sqlQuery: string; table?: never};
 
+/**
+ * Builds the SQL query used to compute map bounds for fit-to-data.
+ *
+ * @param options - Bounds query options.
+ * @param options.source - Dataset source to inspect, either a structured table
+ *   identity or a SQL query that will be wrapped as a subquery.
+ * @param options.fitToData - Fit-to-data configuration containing the longitude
+ *   and latitude columns to aggregate.
+ * @returns SQL that returns one row with min/max longitude and latitude bounds.
+ */
 export function createDeckMapBoundsQuery(options: {
   source: DeckMapBoundsQuerySource;
   fitToData: DeckMapDashboardFitToDataConfig;
@@ -403,6 +413,9 @@ function DeckMapDashboardRenderer({
   );
   const executeSql = useStoreWithDuckDb((state) => state.db.executeSql);
   const findTable = useStoreWithDuckDb((state) => state.db.findTable);
+  const qualifyTableName = useStoreWithDuckDb(
+    (state) => state.db.qualifyTableName,
+  );
 
   const isSettingsOpen = Boolean(
     (panel.config as DeckMapDashboardPanelConfig).settingsOpen,
@@ -512,8 +525,10 @@ function DeckMapDashboardRenderer({
       return undefined;
     }
     const table = findTable(fitToDataSource.tableName);
-    return table ? {table: table.table} : undefined;
-  }, [findTable, fitToDataSource]);
+    return {
+      table: table?.table ?? qualifyTableName(fitToDataSource.tableName),
+    };
+  }, [findTable, fitToDataSource, qualifyTableName]);
   const fitToDataKey = useMemo(
     () =>
       fitToData && fitToDataBoundsSource

--- a/packages/deck/src/dashboard.tsx
+++ b/packages/deck/src/dashboard.tsx
@@ -6,7 +6,7 @@ type DeckProps = ComponentProps<typeof DeckGLReact>;
 import {
   escapeId,
   getColValAsNumber,
-  quoteTableReference,
+  type QualifiedTableName,
   useStoreWithDuckDb,
 } from '@sqlrooms/duckdb';
 import {
@@ -185,14 +185,19 @@ function isPickedMapFeature(info: DeckMapInteractionEvent) {
   return Boolean(info.picked || info.object || (info.index ?? -1) >= 0);
 }
 
+type DeckMapBoundsQuerySource =
+  | {table: QualifiedTableName; sqlQuery?: never}
+  | {sqlQuery: string; table?: never};
+
 export function createDeckMapBoundsQuery(options: {
-  source: {tableName?: string; sqlQuery?: string};
+  source: DeckMapBoundsQuerySource;
   fitToData: DeckMapDashboardFitToDataConfig;
 }) {
   const {source, fitToData} = options;
-  const baseSourceSql = source.sqlQuery
-    ? `SELECT * FROM (${source.sqlQuery}) AS "__sqlrooms_dashboard_map_source"`
-    : `SELECT * FROM ${quoteTableReference(source.tableName ?? '')}`;
+  const baseSourceSql =
+    'sqlQuery' in source
+      ? `SELECT * FROM (${source.sqlQuery}) AS "__sqlrooms_dashboard_map_source"`
+      : `SELECT * FROM ${source.table.toString()}`;
   const longitudeColumn = escapeId(fitToData.longitudeColumn);
   const latitudeColumn = escapeId(fitToData.latitudeColumn);
 
@@ -397,6 +402,7 @@ function DeckMapDashboardRenderer({
     (state) => state.mosaicDashboard.clearPanelIssue,
   );
   const executeSql = useStoreWithDuckDb((state) => state.db.executeSql);
+  const findTable = useStoreWithDuckDb((state) => state.db.findTable);
 
   const isSettingsOpen = Boolean(
     (panel.config as DeckMapDashboardPanelConfig).settingsOpen,
@@ -493,15 +499,30 @@ function DeckMapDashboardRenderer({
         : undefined,
     [dashboard, fitToData, mapConfig?.datasets, panel],
   );
+  const fitToDataBoundsSource = useMemo<
+    DeckMapBoundsQuerySource | undefined
+  >(() => {
+    if (!fitToDataSource) {
+      return undefined;
+    }
+    if (fitToDataSource.sqlQuery) {
+      return {sqlQuery: fitToDataSource.sqlQuery};
+    }
+    if (!fitToDataSource.tableName) {
+      return undefined;
+    }
+    const table = findTable(fitToDataSource.tableName);
+    return table ? {table: table.table} : undefined;
+  }, [findTable, fitToDataSource]);
   const fitToDataKey = useMemo(
     () =>
-      fitToData && fitToDataSource
+      fitToData && fitToDataBoundsSource
         ? JSON.stringify({
-            source: fitToDataSource,
+            source: fitToDataBoundsSource,
             fitToData,
           })
         : null,
-    [fitToData, fitToDataSource],
+    [fitToData, fitToDataBoundsSource],
   );
   const fitStateKey = useMemo(
     () => JSON.stringify({panelId: panel.id, fitToDataKey}),
@@ -550,7 +571,7 @@ function DeckMapDashboardRenderer({
     const hasManualFitRequest = fitRequestVersion > handledFitRequestVersion;
     if (
       !fitToData ||
-      !fitToDataSource ||
+      !fitToDataBoundsSource ||
       containerSize.width <= 0 ||
       containerSize.height <= 0 ||
       (!hasManualFitRequest && didAutoFit)
@@ -564,7 +585,7 @@ function DeckMapDashboardRenderer({
       try {
         const handle = await executeSql(
           createDeckMapBoundsQuery({
-            source: fitToDataSource,
+            source: fitToDataBoundsSource,
             fitToData,
           }),
         );
@@ -638,7 +659,7 @@ function DeckMapDashboardRenderer({
     fitRequestVersion,
     fitStateKey,
     fitToData,
-    fitToDataSource,
+    fitToDataBoundsSource,
     handledFitRequestVersion,
   ]);
 

--- a/packages/duckdb-core/README.md
+++ b/packages/duckdb-core/README.md
@@ -215,15 +215,18 @@ import {
 // Support for database.schema.table naming
 const qualifiedTable = makeQualifiedTableName({
   database: 'mydb',
+  defaultDatabase: 'mydb',
   schema: 'public',
   table: 'users',
 });
+// qualifiedTable.toString(): '"public"."users"'
+// qualifiedTable.toFullString(): '"mydb"."public"."users"'
 
 const tableSql = quoteTableReference('"mydb"."public"."users"');
 // tableSql: '"mydb"."public"."users"'
 
 const resolved = resolveTableReference([{table: qualifiedTable}], 'users');
-// resolved.table?.table.toString(): '"mydb"."public"."users"'
+// resolved.table?.table.toString(): '"public"."users"'
 
 // Use with table operations
 await createTableFromQuery(qualifiedTable, 'SELECT * FROM source_table');

--- a/packages/duckdb-core/__tests__/getUnqualifiedSqlIdentifier.test.ts
+++ b/packages/duckdb-core/__tests__/getUnqualifiedSqlIdentifier.test.ts
@@ -79,6 +79,30 @@ describe('makeQualifiedTableName', () => {
     expect(table.toArray()).toEqual(['local.db', 'ma"in', 'events.2026']);
     expect(table.toString()).toBe('"local.db"."ma""in"."events.2026"');
   });
+
+  it('omits the default database from the canonical string', () => {
+    const table = makeQualifiedTableName({
+      database: 'local',
+      defaultDatabase: 'local',
+      schema: 'main',
+      table: 'earthquakes',
+    });
+
+    expect(table.toString()).toBe('"main"."earthquakes"');
+    expect(table.toFullString()).toBe('"local"."main"."earthquakes"');
+  });
+
+  it('keeps non-default databases in the canonical string', () => {
+    const table = makeQualifiedTableName({
+      database: 'remote',
+      defaultDatabase: 'local',
+      schema: 'main',
+      table: 'earthquakes',
+    });
+
+    expect(table.toString()).toBe('"remote"."main"."earthquakes"');
+    expect(table.toFullString()).toBe('"remote"."main"."earthquakes"');
+  });
 });
 
 describe('parseQualifiedSqlIdentifier', () => {

--- a/packages/duckdb-core/__tests__/schemaTreeUtils.test.ts
+++ b/packages/duckdb-core/__tests__/schemaTreeUtils.test.ts
@@ -103,7 +103,6 @@ describe('schema tree table lookup utilities', () => {
     const result = findTableInSchemaTrees(
       schemaTrees,
       '"local"."main"."earthquakes"',
-      makeQualifiedTableName,
     );
 
     expect(result?.table.table).toBe('earthquakes');
@@ -117,11 +116,7 @@ describe('schema tree table lookup utilities', () => {
       {database: 'remote', schema: 'main', tables: [remote]},
     ]);
 
-    const result = findTableInSchemaTrees(
-      schemaTrees,
-      'earthquakes',
-      makeQualifiedTableName,
-    );
+    const result = findTableInSchemaTrees(schemaTrees, 'earthquakes');
 
     expect(result).toBeUndefined();
   });

--- a/packages/duckdb-core/src/duckdb-utils.ts
+++ b/packages/duckdb-core/src/duckdb-utils.ts
@@ -52,11 +52,17 @@ function qualifiedTableNameToFullString(tableName: QualifiedTableName): string {
 }
 
 /**
- * Get a qualified table name from a table name, schema, and database.
+ * Builds a pure QualifiedTableName value from explicit identifier parts.
  * @param table - The name of the table.
  * @param schema - The schema of the table.
  * @param database - The database of the table.
  * @returns The qualified table name.
+ *
+ * @remarks
+ * Prefer `state.db.qualifyTableName()` when a table reference should use the
+ * current/default database context, and prefer `state.db.findTable()` when resolving
+ * an existing table reference from user input or persisted table IDs.
+ * Use this helper only when all qualification context is already known.
  */
 export function makeQualifiedTableName({
   database,

--- a/packages/duckdb-core/src/duckdb-utils.ts
+++ b/packages/duckdb-core/src/duckdb-utils.ts
@@ -5,6 +5,10 @@ export type QualifiedTableName = {
   schema?: string;
   table: string;
   /**
+   * Database/catalog that can be omitted from the canonical table reference.
+   */
+  defaultDatabase?: string;
+  /**
    * Returns raw, unescaped identifier parts in `[database, schema, table]`
    * order after applying any requested omissions.
    */
@@ -12,12 +16,17 @@ export type QualifiedTableName = {
     includeDatabase?: boolean;
     includeSchema?: boolean;
   }) => string[];
+  /**
+   * Returns a fully-qualified SQL table reference, including the database when
+   * this object carries one.
+   */
+  toFullString: () => string;
   toString: () => string;
 };
 
 type QualifiedTableNameParts = Pick<
   QualifiedTableName,
-  'database' | 'schema' | 'table'
+  'database' | 'schema' | 'table' | 'defaultDatabase'
 >;
 
 export type ResolveTableReferenceResult<T> = {
@@ -35,6 +44,13 @@ export function isQualifiedTableName(
   return typeof tableName === 'object' && 'toString' in tableName;
 }
 
+function qualifiedTableNameToFullString(tableName: QualifiedTableName): string {
+  return (
+    (tableName as {toFullString?: () => string}).toFullString?.() ??
+    tableName.toString()
+  );
+}
+
 /**
  * Get a qualified table name from a table name, schema, and database.
  * @param table - The name of the table.
@@ -46,8 +62,23 @@ export function makeQualifiedTableName({
   database,
   schema,
   table,
+  defaultDatabase,
 }: QualifiedTableNameParts): QualifiedTableName {
-  const qualifiedTableName = [database, schema, table]
+  const fullyQualifiedTableName = [database, schema, table]
+    .filter((id) => id !== undefined && id !== null)
+    .map((id) => escapeId(id))
+    .join('.');
+  const isDefaultDatabase =
+    database !== undefined &&
+    database !== null &&
+    defaultDatabase !== undefined &&
+    defaultDatabase !== null &&
+    String(database) === String(defaultDatabase);
+  const canonicalTableName = [
+    database && !isDefaultDatabase ? database : undefined,
+    schema,
+    table,
+  ]
     .filter((id) => id !== undefined && id !== null)
     .map((id) => escapeId(id))
     .join('.');
@@ -55,6 +86,7 @@ export function makeQualifiedTableName({
     database,
     schema,
     table,
+    defaultDatabase,
     toArray: ({
       includeDatabase = true,
       includeSchema = true,
@@ -67,7 +99,8 @@ export function makeQualifiedTableName({
         includeSchema ? schema : undefined,
         table,
       ].filter((id): id is string => id !== undefined && id !== null),
-    toString: () => qualifiedTableName,
+    toFullString: () => fullyQualifiedTableName,
+    toString: () => canonicalTableName,
   };
 }
 
@@ -184,8 +217,8 @@ export function getUnqualifiedSqlIdentifier(
  * Quotes a table reference for SQL.
  *
  * Accepts bare names, unquoted qualified names, or already-quoted qualified
- * identifiers. The result is always the fully quoted form produced by
- * QualifiedTableName.toString() when the input parses as a table reference.
+ * identifiers. Without a default database context, the result keeps all parsed
+ * table reference parts and quotes each identifier segment.
  *
  * @example
  * quoteTableReference('events') // '"events"'
@@ -234,14 +267,19 @@ export function resolveTableReference<T extends TableReferenceCandidate>(
   if (typeof tableReference !== 'string') {
     return {
       table: tables.find(
-        (candidate) => candidate.table.toString() === tableReference.toString(),
+        (candidate) =>
+          candidate.table.toString() === tableReference.toString() ||
+          qualifiedTableNameToFullString(candidate.table) ===
+            qualifiedTableNameToFullString(tableReference),
       ),
     };
   }
 
   const trimmedTableReference = tableReference.trim();
   const canonicalMatches = tables.filter(
-    (candidate) => candidate.table.toString() === trimmedTableReference,
+    (candidate) =>
+      candidate.table.toString() === trimmedTableReference ||
+      qualifiedTableNameToFullString(candidate.table) === trimmedTableReference,
   );
   if (canonicalMatches.length === 1) return {table: canonicalMatches[0]};
   if (canonicalMatches.length > 1) {

--- a/packages/duckdb-core/src/schema-tree/schemaTreeUtils.ts
+++ b/packages/duckdb-core/src/schema-tree/schemaTreeUtils.ts
@@ -34,17 +34,11 @@ export function getAllTablesFromSchemaTrees(
  * Finds a specific table by its qualified name in the schema tree.
  * @param schemaTrees - Array of database schema tree nodes
  * @param qualifiedName - Qualified table name (e.g., "database.schema.table")
- * @param makeQualifiedTableName - Function to create qualified table names for comparison
  * @returns The table object if found, undefined otherwise
  */
 export function findTableInSchemaTrees(
   schemaTrees: DbSchemaNode[] | undefined,
   qualifiedName: string,
-  makeQualifiedTableName: (parts: {
-    database?: string;
-    schema?: string;
-    table: string;
-  }) => {toString: () => string},
 ): TableNodeObject | undefined {
   if (!schemaTrees) return undefined;
 
@@ -55,13 +49,7 @@ export function findTableInSchemaTrees(
           for (const tableNode of schemaNode.children) {
             if (tableNode.object.type === 'table') {
               const tableObj = tableNode.object as TableNodeObject;
-              const tableName = makeQualifiedTableName({
-                database: tableObj.table.database,
-                schema: tableObj.table.schema,
-                table: tableObj.table.table,
-              }).toString();
-
-              if (tableName === qualifiedName) {
+              if (tableObj.table.toString() === qualifiedName) {
                 return tableObj;
               }
             }

--- a/packages/duckdb/README.md
+++ b/packages/duckdb/README.md
@@ -229,15 +229,12 @@ function DatabaseManager() {
 ### Working with Qualified Table Names
 
 ```tsx
-import {
-  makeQualifiedTableName,
-  quoteTableReference,
-  resolveTableReference,
-} from '@sqlrooms/duckdb';
+import {quoteTableReference, resolveTableReference} from '@sqlrooms/duckdb';
 import {useRoomStore} from './store';
 import {Button} from '@sqlrooms/ui';
 
 function QualifiedTableOps() {
+  const qualifyTableName = useRoomStore((state) => state.db.qualifyTableName);
   const createTableFromQuery = useRoomStore(
     (state) => state.db.createTableFromQuery,
   );
@@ -245,17 +242,20 @@ function QualifiedTableOps() {
   const checkTableExists = useRoomStore((state) => state.db.checkTableExists);
 
   const run = async () => {
-    // Support for database.schema.table naming
-    const qualifiedTable = makeQualifiedTableName({
+    // Store-aware qualification knows which database is the default.
+    const qualifiedTable = qualifyTableName({
       database: 'mydb',
       schema: 'public',
       table: 'users',
     });
+    // toString() is the canonical portable table ID; toFullString() includes
+    // the database when explicit catalog qualification is needed.
     const tableSql = quoteTableReference(qualifiedTable.toString());
     const resolved = resolveTableReference([{table: qualifiedTable}], 'users');
 
     await createTableFromQuery(qualifiedTable, 'SELECT * FROM source_table');
     console.log('Quoted table reference:', tableSql);
+    console.log('Fully qualified reference:', qualifiedTable.toFullString());
     console.log('Resolved table:', resolved.table?.table.toString());
     const tableExists = await checkTableExists(qualifiedTable);
     console.log('Table exists after create:', tableExists);

--- a/packages/duckdb/__tests__/DuckDbSlice.test.ts
+++ b/packages/duckdb/__tests__/DuckDbSlice.test.ts
@@ -191,12 +191,34 @@ describe('DuckDbSlice', () => {
       );
 
       expect(table).toBeDefined();
+      expect(table!.table.toString()).toBe('"analytics.2026"."daily events"');
+      expect(table!.table.toFullString()).toBe(
+        `"${store.getState().db.currentDatabase}"."analytics.2026"."daily events"`,
+      );
       expect(
         store.getState().db.findTable('"analytics.2026"."daily events"'),
       ).toBe(table);
       expect(store.getState().db.findTable(table!.table.toString())).toBe(
         table,
       );
+    });
+
+    it('resolves stale fully-qualified default database ids by unique schema/table', async () => {
+      const connector = await store.getState().db.getConnector();
+      await connector.query('CREATE TABLE stale_default_db_lookup (id INT)');
+      const tables = await store.getState().db.refreshTableSchemas();
+      const table = tables.find(
+        (candidate) =>
+          candidate.table.table === 'stale_default_db_lookup' &&
+          candidate.table.schema === 'main',
+      );
+
+      expect(table).toBeDefined();
+      expect(
+        store
+          .getState()
+          .db.findTable('"renamed-file"."main"."stale_default_db_lookup"'),
+      ).toBe(table);
     });
 
     it('parses dotted strings as qualified references and quoted dots as literal names', async () => {

--- a/packages/duckdb/__tests__/DuckDbSlice.test.ts
+++ b/packages/duckdb/__tests__/DuckDbSlice.test.ts
@@ -7,7 +7,7 @@ import {
 } from '../src/DuckDbSlice';
 import {createBaseRoomSlice, BaseRoomStoreState} from '@sqlrooms/room-store';
 import * as arrow from 'apache-arrow';
-import {DuckDbConnector} from '@sqlrooms/duckdb-core';
+import {DuckDbConnector, makeQualifiedTableName} from '@sqlrooms/duckdb-core';
 import {loadSchemaCatalog} from '../src/loadTableSchemas';
 
 type TestStoreState = BaseRoomStoreState & DuckDbSliceState;
@@ -203,7 +203,7 @@ describe('DuckDbSlice', () => {
       );
     });
 
-    it('resolves stale fully-qualified default database ids by unique schema/table', async () => {
+    it('resolves stale default database refs by unique schema/table when metadata marks them as default', async () => {
       const connector = await store.getState().db.getConnector();
       await connector.query('CREATE TABLE stale_default_db_lookup (id INT)');
       const tables = await store.getState().db.refreshTableSchemas();
@@ -215,10 +215,27 @@ describe('DuckDbSlice', () => {
 
       expect(table).toBeDefined();
       expect(
+        store.getState().db.findTable(
+          makeQualifiedTableName({
+            database: 'renamed-file',
+            schema: 'main',
+            table: 'stale_default_db_lookup',
+            defaultDatabase: 'renamed-file',
+          }),
+        ),
+      ).toBe(table);
+    });
+
+    it('does not resolve explicit database-qualified misses by schema/table fallback', async () => {
+      const connector = await store.getState().db.getConnector();
+      await connector.query('CREATE TABLE explicit_database_miss (id INT)');
+      await store.getState().db.refreshTableSchemas();
+
+      expect(
         store
           .getState()
-          .db.findTable('"renamed-file"."main"."stale_default_db_lookup"'),
-      ).toBe(table);
+          .db.findTable('"remote"."main"."explicit_database_miss"'),
+      ).toBeUndefined();
     });
 
     it('parses dotted strings as qualified references and quoted dots as literal names', async () => {
@@ -322,6 +339,22 @@ describe('DuckDbSlice', () => {
       await expect(
         store.getState().db.dropTable('view_via_drop_table'),
       ).rejects.toThrow('Use dropRelation() to remove views.');
+    });
+
+    it('does not drop a local table for an explicit database-qualified miss', async () => {
+      await store
+        .getState()
+        .db.createTableFromQuery('drop_database_miss', 'SELECT 1 as id');
+      const connector = await store.getState().db.getConnector();
+
+      await store
+        .getState()
+        .db.dropTable('"remote"."main"."drop_database_miss"')
+        .catch(() => undefined);
+
+      await expect(
+        connector.query('SELECT * FROM drop_database_miss'),
+      ).resolves.toBeTruthy();
     });
   });
 

--- a/packages/duckdb/src/DuckDbSlice.ts
+++ b/packages/duckdb/src/DuckDbSlice.ts
@@ -439,7 +439,34 @@ export function createDuckDbSlice({
           table: qualifiedName.table,
           defaultDatabase: get().db.currentDatabase,
         });
-        return table;
+        return table &&
+          table.table.table === qualifiedName.table &&
+          (!qualifiedName.schema ||
+            table.table.schema === qualifiedName.schema) &&
+          (!qualifiedName.database ||
+            table.table.database === qualifiedName.database)
+          ? table
+          : undefined;
+      };
+
+      const throwIfUnresolvedExplicitDatabaseReference = (
+        tableName: string | QualifiedTableName,
+        table: DataTable | undefined,
+      ) => {
+        if (table) {
+          return;
+        }
+        const database =
+          typeof tableName === 'string'
+            ? parseTableReferenceParts(tableName).database
+            : tableName.database;
+        if (!database) {
+          return;
+        }
+        const qualifiedName = isQualifiedTableName(tableName)
+          ? get().db.qualifyTableName(tableName)
+          : get().db.qualifyTableName(parseTableReferenceParts(tableName));
+        throw new Error(`Relation "${qualifiedName}" not found.`);
       };
 
       return {
@@ -675,6 +702,7 @@ export function createDuckDbSlice({
             const table =
               get().db.findTable(tableName) ??
               (await loadTableSchemaByName(tableName));
+            throwIfUnresolvedExplicitDatabaseReference(tableName, table);
             const qualifiedTable =
               table?.table ??
               (isQualifiedTableName(tableName)
@@ -696,6 +724,7 @@ export function createDuckDbSlice({
             const table =
               get().db.findTable(tableName) ??
               (await loadTableSchemaByName(tableName));
+            throwIfUnresolvedExplicitDatabaseReference(tableName, table);
             const qualifiedTable =
               table?.table ??
               (isQualifiedTableName(tableName)
@@ -780,16 +809,24 @@ export function createDuckDbSlice({
               return matches.length === 1 ? matches[0] : undefined;
             };
 
-            const {table, schema, database} = {
+            const resolvedTableName =
+              typeof tableName === 'string'
+                ? (parseQualifiedSqlIdentifier(tableName) ?? {})
+                : tableName;
+            const {table, schema, database, defaultDatabase} = {
               schema: currentSchema,
               database: currentDatabase,
-              ...(typeof tableName === 'string'
-                ? (parseQualifiedSqlIdentifier(tableName) ?? {})
-                : tableName),
+              ...resolvedTableName,
             };
             const exactMatch = findMatchingTable({table, schema, database});
             if (exactMatch) return exactMatch;
-            if (database && database !== currentDatabase) {
+            const isStaleDefaultDatabaseReference =
+              typeof tableName !== 'string' &&
+              database &&
+              defaultDatabase &&
+              database === defaultDatabase &&
+              database !== currentDatabase;
+            if (isStaleDefaultDatabaseReference) {
               return findUniqueMatchingTable({table, schema});
             }
             return undefined;

--- a/packages/duckdb/src/DuckDbSlice.ts
+++ b/packages/duckdb/src/DuckDbSlice.ts
@@ -50,7 +50,7 @@ export const defaultLoadTableSchemasFilter: LoadTableSchemasFilterFunction = (
   table: QualifiedTableName,
 ): boolean => {
   if (
-    table.table?.startsWith(INTERNAL_SQLROOMS_PREFIX) ||
+    table.table.startsWith(INTERNAL_SQLROOMS_PREFIX) ||
     table.database?.startsWith(INTERNAL_SQLROOMS_PREFIX) ||
     table.schema?.startsWith(INTERNAL_SQLROOMS_PREFIX)
   ) {

--- a/packages/duckdb/src/DuckDbSlice.ts
+++ b/packages/duckdb/src/DuckDbSlice.ts
@@ -147,6 +147,16 @@ export type DuckDbSliceState = {
     currentDatabase: string | undefined;
 
     /**
+     * Create a context-aware qualified table name.
+     *
+     * String inputs are treated as table identifier names, not SQL references;
+     * use findTable() when resolving an existing table reference.
+     */
+    qualifyTableName(
+      tableName: string | QualifiedTableNameInput,
+    ): QualifiedTableName;
+
+    /**
      * Cache of refreshed table schemas
      */
     tables: DataTable[];
@@ -353,6 +363,11 @@ export type DuckDbSliceState = {
   };
 };
 
+type QualifiedTableNameInput = Pick<
+  QualifiedTableName,
+  'database' | 'schema' | 'table' | 'defaultDatabase'
+>;
+
 export type CreateDuckDbSliceProps = {
   connector?: DuckDbConnector;
   /**
@@ -392,6 +407,19 @@ export function createDuckDbSlice({
         }) satisfies LoadSchemaCatalogFilterFunction));
   return createSlice<DuckDbSliceState, BaseRoomStoreState & DuckDbSliceState>(
     (set, get, store) => {
+      const parseTableReferenceParts = (
+        tableName: string,
+      ): QualifiedTableNameInput => {
+        const parsed = parseQualifiedSqlIdentifier(tableName);
+        return parsed?.table
+          ? {
+              database: parsed.database,
+              schema: parsed.schema,
+              table: parsed.table,
+            }
+          : {table: tableName};
+      };
+
       /**
        * Internal helper to load a table schema by exact name, bypassing the visibility filter.
        * Used when performing exact lookups (e.g., checking if a specific table exists).
@@ -399,11 +427,18 @@ export function createDuckDbSlice({
       const loadTableSchemaByName = async (
         tableName: string | QualifiedTableName,
       ): Promise<DataTable | undefined> => {
-        const qualifiedName = isQualifiedTableName(tableName)
-          ? tableName
-          : makeQualifiedTableName({table: tableName});
+        const tableNameParts =
+          typeof tableName === 'string'
+            ? parseTableReferenceParts(tableName)
+            : tableName;
+        const qualifiedName = get().db.qualifyTableName(tableNameParts);
         const connector = await get().db.getConnector();
-        const [table] = await loadTableSchemas(connector, qualifiedName);
+        const [table] = await loadTableSchemas(connector, {
+          database: qualifiedName.database,
+          schema: qualifiedName.schema,
+          table: qualifiedName.table,
+          defaultDatabase: get().db.currentDatabase,
+        });
         return table;
       };
 
@@ -418,6 +453,18 @@ export function createDuckDbSlice({
           tableRowCounts: {},
           schemaTrees: undefined,
           queryCache: {},
+
+          qualifyTableName(tableName) {
+            const {currentDatabase, currentSchema} = get().db;
+            const parts =
+              typeof tableName === 'string' ? {table: tableName} : tableName;
+            return makeQualifiedTableName({
+              database: parts.database ?? currentDatabase,
+              schema: parts.schema ?? currentSchema,
+              table: parts.table,
+              defaultDatabase: parts.defaultDatabase ?? currentDatabase,
+            });
+          },
 
           setConnector: (connector: DuckDbConnector) => {
             set(
@@ -498,15 +545,14 @@ export function createDuckDbSlice({
             } = options || {};
 
             // For temp tables/views, DuckDB requires the "temp" database
-            const baseQualifiedName = isQualifiedTableName(tableName)
-              ? tableName
-              : makeQualifiedTableName({table: tableName});
+            const baseQualifiedName = get().db.qualifyTableName(tableName);
 
             const qualifiedName = temp
               ? makeQualifiedTableName({
                   table: baseQualifiedName.table,
                   schema: baseQualifiedName.schema,
                   database: 'temp',
+                  defaultDatabase: get().db.currentDatabase,
                 })
               : baseQualifiedName;
 
@@ -579,18 +625,18 @@ export function createDuckDbSlice({
            */
           async getTableRowCount(table, schema = 'main') {
             return get().db.loadTableRowCount(
-              makeQualifiedTableName({table, schema}),
+              get().db.qualifyTableName({table, schema}),
             );
           },
 
           async loadTableRowCount(tableName: string | QualifiedTableName) {
             const {schema, database, table} =
               typeof tableName === 'string'
-                ? {table: tableName}
-                : tableName || {};
+                ? get().db.qualifyTableName(parseTableReferenceParts(tableName))
+                : get().db.qualifyTableName(tableName);
             const connector = await get().db.getConnector();
             const result = await connector.query(
-              `SELECT COUNT(*) FROM ${makeQualifiedTableName({
+              `SELECT COUNT(*) FROM ${get().db.qualifyTableName({
                 schema,
                 database,
                 table,
@@ -613,22 +659,29 @@ export function createDuckDbSlice({
             return loadTableSchemas(connector, {
               ...filter,
               filterFunction: loadTableSchemasFilter,
+              defaultDatabase: get().db.currentDatabase,
             });
           },
 
           async checkTableExists(tableName: string | QualifiedTableName) {
-            const table = await loadTableSchemaByName(tableName);
+            const table =
+              get().db.findTable(tableName) ??
+              (await loadTableSchemaByName(tableName));
             return Boolean(table);
           },
 
           async dropRelation(tableName): Promise<void> {
             const connector = await get().db.getConnector();
-            const qualifiedTable = isQualifiedTableName(tableName)
-              ? tableName
-              : makeQualifiedTableName({table: tableName});
             const table =
-              get().db.findTable(qualifiedTable) ??
-              (await loadTableSchemaByName(qualifiedTable));
+              get().db.findTable(tableName) ??
+              (await loadTableSchemaByName(tableName));
+            const qualifiedTable =
+              table?.table ??
+              (isQualifiedTableName(tableName)
+                ? get().db.qualifyTableName(tableName)
+                : get().db.qualifyTableName(
+                    parseTableReferenceParts(tableName),
+                  ));
             const isView = table?.isView;
             if (isView) {
               await connector.query(`DROP VIEW IF EXISTS ${qualifiedTable};`);
@@ -640,12 +693,16 @@ export function createDuckDbSlice({
 
           async dropTable(tableName): Promise<void> {
             const connector = await get().db.getConnector();
-            const qualifiedTable = isQualifiedTableName(tableName)
-              ? tableName
-              : makeQualifiedTableName({table: tableName});
             const table =
-              get().db.findTable(qualifiedTable) ??
-              (await loadTableSchemaByName(qualifiedTable));
+              get().db.findTable(tableName) ??
+              (await loadTableSchemaByName(tableName));
+            const qualifiedTable =
+              table?.table ??
+              (isQualifiedTableName(tableName)
+                ? get().db.qualifyTableName(tableName)
+                : get().db.qualifyTableName(
+                    parseTableReferenceParts(tableName),
+                  ));
 
             if (table?.isView) {
               throw new Error(
@@ -658,9 +715,7 @@ export function createDuckDbSlice({
           },
 
           async addTable(tableName, data) {
-            const qualifiedName = isQualifiedTableName(tableName)
-              ? tableName
-              : makeQualifiedTableName({table: tableName});
+            const qualifiedName = get().db.qualifyTableName(tableName);
 
             const {db} = get();
             if (data instanceof arrow.Table) {
@@ -685,9 +740,7 @@ export function createDuckDbSlice({
           },
 
           async setTableRowCount(tableName, rowCount) {
-            const qualifiedName = isQualifiedTableName(tableName)
-              ? tableName
-              : makeQualifiedTableName({table: tableName});
+            const qualifiedName = get().db.qualifyTableName(tableName);
             set((state) =>
               produce(state, (draft) => {
                 draft.db.tableRowCounts[qualifiedName.toString()] = rowCount;
@@ -714,6 +767,18 @@ export function createDuckDbSlice({
                       (!database || t.table.database === database),
                   )
                 : undefined;
+            const findUniqueMatchingTable = ({
+              table,
+              schema,
+            }: Partial<QualifiedTableName>) => {
+              if (!table) return undefined;
+              const matches = tables.filter(
+                (t) =>
+                  t.table.table === table &&
+                  (!schema || t.table.schema === schema),
+              );
+              return matches.length === 1 ? matches[0] : undefined;
+            };
 
             const {table, schema, database} = {
               schema: currentSchema,
@@ -722,7 +787,12 @@ export function createDuckDbSlice({
                 ? (parseQualifiedSqlIdentifier(tableName) ?? {})
                 : tableName),
             };
-            return findMatchingTable({table, schema, database});
+            const exactMatch = findMatchingTable({table, schema, database});
+            if (exactMatch) return exactMatch;
+            if (database && database !== currentDatabase) {
+              return findUniqueMatchingTable({table, schema});
+            }
+            return undefined;
           },
 
           findTableByName(tableName: string | QualifiedTableName) {
@@ -748,18 +818,27 @@ export function createDuckDbSlice({
                   const result = await connector.query(
                     `SELECT current_schema() AS schema, current_database() AS database`,
                   );
+                  const currentSchemaValue = result.getChild('schema')?.get(0);
+                  const currentDatabaseValue = result
+                    .getChild('database')
+                    ?.get(0);
+                  const currentSchema =
+                    currentSchemaValue == null
+                      ? undefined
+                      : String(currentSchemaValue);
+                  const currentDatabase =
+                    currentDatabaseValue == null
+                      ? undefined
+                      : String(currentDatabaseValue);
                   set((state) =>
                     produce(state, (draft) => {
-                      draft.db.currentSchema = result
-                        .getChild('schema')
-                        ?.get(0);
-                      draft.db.currentDatabase = result
-                        .getChild('database')
-                        ?.get(0);
+                      draft.db.currentSchema = currentSchema;
+                      draft.db.currentDatabase = currentDatabase;
                     }),
                   );
                   schemasWithTables = await loadSchemaCatalog(connector, {
                     filterFunction: effectiveSchemaCatalogFilter,
+                    defaultDatabase: currentDatabase,
                   });
                 } while (pendingSchemaRefresh);
 

--- a/packages/duckdb/src/loadTableSchemas.ts
+++ b/packages/duckdb/src/loadTableSchemas.ts
@@ -20,6 +20,7 @@ export type LoadTableSchemasFilter = {
 
 export type LoadTableSchemasOptions = LoadTableSchemasFilter & {
   filterFunction?: LoadTableSchemasFilterFunction | null;
+  defaultDatabase?: string;
 };
 
 export type SchemaCatalogFilterEntry =
@@ -33,6 +34,7 @@ export type LoadSchemaCatalogFilterFunction = (
 
 export type LoadSchemaCatalogOptions = LoadTableSchemasFilter & {
   filterFunction?: LoadSchemaCatalogFilterFunction | null;
+  defaultDatabase?: string;
 };
 
 /**
@@ -44,14 +46,16 @@ export async function loadTableSchemas(
   connector: DuckDbConnector,
   options: LoadTableSchemasOptions = {},
 ): Promise<DataTable[]> {
-  const {filterFunction, ...filter} = options;
+  const {filterFunction, defaultDatabase, ...filter} = options;
 
   const sql = buildTableSchemasQuery(filter);
   const describeResults = await connector.query(sql);
   const tables: DataTable[] = [];
 
   for (let i = 0; i < describeResults.numRows; i++) {
-    const dataTable = parseTableSchemaRow(describeResults, i);
+    const dataTable = parseTableSchemaRow(describeResults, i, {
+      defaultDatabase,
+    });
 
     // Apply filter (if not provided or null, include all tables)
     if (!filterFunction || filterFunction(dataTable.table)) {
@@ -71,7 +75,7 @@ export async function loadSchemaCatalog(
   connector: DuckDbConnector,
   options: LoadSchemaCatalogOptions = {},
 ): Promise<SchemaWithTables[]> {
-  const {filterFunction, ...filter} = options;
+  const {filterFunction, defaultDatabase, ...filter} = options;
   const result = await connector.query(buildSchemaCatalogQuery(filter));
   const groups = new Map<string, SchemaWithTables>();
   const includedDatabases = new Set<string>();
@@ -103,7 +107,7 @@ export async function loadSchemaCatalog(
       groups.set(key, group);
     }
 
-    const table = parseSchemaCatalogTableRow(result, i);
+    const table = parseSchemaCatalogTableRow(result, i, {defaultDatabase});
     if (
       table &&
       (!filterFunction || filterFunction({type: 'table', table: table.table}))
@@ -122,14 +126,27 @@ function isDuckDbPlaceholderViewColumn(
   return columnName === '__' && columnType.toUpperCase() === 'UNKNOWN';
 }
 
+function getMetadataString(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  return String(value);
+}
+
 /**
  * Parses a single row from the table schema query results into a DataTable object.
  */
-function parseTableSchemaRow(describeResults: any, index: number): DataTable {
+function parseTableSchemaRow(
+  describeResults: any,
+  index: number,
+  options: {defaultDatabase?: string} = {},
+): DataTable {
   const isView = describeResults.getChild('isView')?.get(index);
-  const rowDatabase = describeResults.getChild('database')?.get(index);
-  const rowSchema = describeResults.getChild('schema')?.get(index);
-  const rowTable = describeResults.getChild('name')?.get(index);
+  const rowDatabase = getMetadataString(
+    describeResults.getChild('database')?.get(index),
+  );
+  const rowSchema =
+    getMetadataString(describeResults.getChild('schema')?.get(index)) ?? '';
+  const rowTable =
+    getMetadataString(describeResults.getChild('name')?.get(index)) ?? '';
   const sql = describeResults.getChild('sql')?.get(index);
   const comment = describeResults.getChild('comment')?.get(index);
   const estimatedSize = describeResults.getChild('estimated_size')?.get(index);
@@ -140,6 +157,7 @@ function parseTableSchemaRow(describeResults: any, index: number): DataTable {
     database: rowDatabase,
     schema: rowSchema,
     table: rowTable,
+    defaultDatabase: options.defaultDatabase,
   });
 
   const columns: TableColumn[] = [];
@@ -176,10 +194,11 @@ function parseTableSchemaRow(describeResults: any, index: number): DataTable {
 function parseSchemaCatalogTableRow(
   result: any,
   index: number,
+  options: {defaultDatabase?: string} = {},
 ): DataTable | null {
   const rowTable = result.getChild('name')?.get(index);
   if (rowTable == null) return null;
-  return parseTableSchemaRow(result, index);
+  return parseTableSchemaRow(result, index, options);
 }
 
 function buildMetadataWhereClause(

--- a/packages/mosaic/__tests__/BoxPlotClient.test.ts
+++ b/packages/mosaic/__tests__/BoxPlotClient.test.ts
@@ -1,13 +1,22 @@
 import {Selection, clausePoint} from '@uwdata/mosaic-core';
+import {makeQualifiedTableName} from '@sqlrooms/duckdb';
 import {
   BoxPlotClient,
   buildBoxPlotQuery,
 } from '../src/charts/chart-types/box-plot/renderer/BoxPlotClient';
 
+const table = (name: string, database = 'local') =>
+  makeQualifiedTableName({
+    database,
+    schema: 'main',
+    table: name,
+    defaultDatabase: database,
+  });
+
 describe('BoxPlotClient', () => {
   it('builds grouped box plot SQL with quantiles, whiskers, and outliers', () => {
     const sql = buildBoxPlotQuery({
-      tableName: 'earthquakes',
+      table: table('earthquakes'),
       x: 'region',
       y: 'magnitude',
     });
@@ -24,20 +33,20 @@ describe('BoxPlotClient', () => {
     expect(sql).toContain('UNION ALL');
   });
 
-  it('uses pre-quoted qualified table references without double quoting', () => {
+  it('omits the database from Mosaic SQL table references', () => {
     const sql = buildBoxPlotQuery({
-      tableName: '"local"."main"."earthquakes"',
+      table: table('earthquakes'),
       x: 'region',
       y: 'magnitude',
     });
 
-    expect(sql).toContain('FROM "local"."main"."earthquakes"');
-    expect(sql).not.toContain('"""local"""');
+    expect(sql).toContain('FROM "main"."earthquakes"');
+    expect(sql).not.toContain('FROM "local"."main"."earthquakes"');
   });
 
-  it('preserves dotted table-name parts in quoted table references', () => {
+  it('preserves dotted table-name parts in canonical table references', () => {
     const sql = buildBoxPlotQuery({
-      tableName: '"main"."events.2026"',
+      table: table('events.2026'),
       x: 'region',
       y: 'magnitude',
     });
@@ -52,7 +61,7 @@ describe('BoxPlotClient', () => {
     const client = new BoxPlotClient({
       onStateChange: () => {},
       selection,
-      tableName: 'events',
+      table: table('events'),
       x: 'kind',
       y: 'score',
     });
@@ -72,7 +81,7 @@ describe('BoxPlotClient', () => {
         latestState = state;
       },
       selection,
-      tableName: 'events',
+      table: table('events'),
       x: 'kind',
       y: 'score',
     });
@@ -97,7 +106,7 @@ describe('BoxPlotClient', () => {
         latestState = state;
       },
       selection: Selection.crossfilter(),
-      tableName: 'events',
+      table: table('events'),
       x: 'kind',
       y: 'score',
     });

--- a/packages/mosaic/src/charts/MosaicChartView.tsx
+++ b/packages/mosaic/src/charts/MosaicChartView.tsx
@@ -14,7 +14,6 @@ import {useChartRetainerByKey} from './useChartRetainer';
 import {useMosaicChartRenderContext} from './useMosaicChartRenderContext';
 import {useRuntimeIssueReporter} from './useRuntimeIssueReporter';
 import {DataTable} from '@sqlrooms/db';
-import {getChartTableReferenceString} from './chart-types/base-types';
 
 export type MosaicChartViewProps = {
   dataTable?: DataTable;
@@ -131,7 +130,7 @@ export const MosaicChartView: FC<MosaicChartViewProps> = ({
     return (
       <div className={cn('h-full w-full', className)}>
         {createElement(renderContext.renderer, {
-          tableName: getChartTableReferenceString(renderContext.dataTable),
+          table: renderContext.dataTable.table,
           config,
           coordinator: connection.coordinator,
           params,

--- a/packages/mosaic/src/charts/chart-types/base-types.ts
+++ b/packages/mosaic/src/charts/chart-types/base-types.ts
@@ -151,7 +151,7 @@ export type BrushSelectionParams = Map<string, Selection>;
  * Props passed to chart renderer components.
  */
 export interface ChartRendererProps<TConfig extends ChartConfig = ChartConfig> {
-  tableName: string;
+  table: QualifiedTableName;
   config: TConfig;
   coordinator: Coordinator;
   dataPolicy?: ChartDataPolicy | null;

--- a/packages/mosaic/src/charts/chart-types/base-types.ts
+++ b/packages/mosaic/src/charts/chart-types/base-types.ts
@@ -148,14 +148,26 @@ export type ChartRetainer = {
 export type BrushSelectionParams = Map<string, Selection>;
 
 /**
- * Props passed to chart renderer components.
+ * Props passed to component-based chart renderers.
+ *
+ * Renderers receive the resolved chart configuration, Mosaic coordinator, and
+ * optional runtime services needed to participate in dashboard filtering and
+ * error reporting. The `table` property is the canonical structured SQLRooms
+ * table identity; renderers must convert it through the appropriate SQL dialect
+ * helper instead of reconstructing table references from display names.
  */
 export interface ChartRendererProps<TConfig extends ChartConfig = ChartConfig> {
+  /** Canonical qualified table identity for the chart's data source. */
   table: QualifiedTableName;
+  /** Validated chart configuration for this renderer. */
   config: TConfig;
+  /** Mosaic coordinator used to connect query clients and selections. */
   coordinator: Coordinator;
+  /** Optional row-limit policy applied to renderer-managed queries. */
   dataPolicy?: ChartDataPolicy | null;
+  /** Context attached to runtime issues reported by the renderer. */
   runtimeIssueContext?: ChartRuntimeIssueContext;
+  /** Reporter used to surface renderer query or policy failures. */
   runtimeIssueReporter?: ChartRuntimeIssueReporter;
   /**
    * Pre-defined params/selections to inject when rendering vgplot specs.

--- a/packages/mosaic/src/charts/chart-types/base-types.ts
+++ b/packages/mosaic/src/charts/chart-types/base-types.ts
@@ -53,7 +53,7 @@ export interface ChartBuilderField {
 
 /**
  * Result of table resolution.
- * tableName is the fully quoted string boundary form
+ * tableName is the canonical quoted string boundary form
  * (QualifiedTableName.toString()); qualifiedName is the canonical structured
  * identity when available.
  */

--- a/packages/mosaic/src/charts/chart-types/box-plot/renderer/BoxPlotClient.ts
+++ b/packages/mosaic/src/charts/chart-types/box-plot/renderer/BoxPlotClient.ts
@@ -39,6 +39,20 @@ export type BoxPlotState = {
   yBrush?: [number, number];
 };
 
+/**
+ * Options used to construct a {@link BoxPlotClient}.
+ *
+ * @property dataPolicy - Optional row-limit policy to validate query results.
+ * @property onStateChange - Callback invoked whenever query or brush state changes.
+ * @property runtimeIssueContext - Optional context attached to reported runtime issues.
+ * @property runtimeIssueReporter - Optional reporter used for query and policy failures.
+ * @property selection - Mosaic selection used for external filters and y-axis brushing.
+ * @property table - Canonical SQLRooms table identity. The client converts it
+ *   with `getMosaicSqlTableReference`, so callers should pass the structured
+ *   `QualifiedTableName` instead of a pre-rendered SQL string.
+ * @property x - Category column name.
+ * @property y - Numeric value column name.
+ */
 export type BoxPlotClientOptions = {
   dataPolicy?: ChartDataPolicy | null;
   onStateChange: (state: BoxPlotState) => void;
@@ -129,6 +143,17 @@ type BuildBoxPlotQueryArgs = {
   y: string;
 };
 
+/**
+ * Builds the SQL used by {@link BoxPlotClient} to compute box plot summaries.
+ *
+ * @param args - Query inputs including the source table, selected columns, and
+ *   optional Mosaic filter expression.
+ * @returns SQL that returns summary rows and outlier rows for the box plot.
+ *
+ * The structured `QualifiedTableName` is converted with
+ * `getMosaicSqlTableReference`, which intentionally produces the table
+ * reference shape expected by Mosaic queries.
+ */
 export function buildBoxPlotQuery(args: BuildBoxPlotQueryArgs): string {
   const tableReference = getMosaicSqlTableReference(args.table);
   const x = escapeId(args.x);
@@ -212,6 +237,14 @@ ORDER BY "category", "rowKind", "value"
 `.trim();
 }
 
+/**
+ * Mosaic query client that powers the custom box plot renderer.
+ *
+ * The client owns SQL generation, query-result normalization, runtime issue
+ * reporting, and y-axis brush selection updates. It accepts a structured
+ * `QualifiedTableName` so table identity remains canonical until the query is
+ * rendered for Mosaic SQL.
+ */
 export class BoxPlotClient extends MosaicClient {
   private readonly onStateChange: (state: BoxPlotState) => void;
   private readonly table: QualifiedTableName;

--- a/packages/mosaic/src/charts/chart-types/box-plot/renderer/BoxPlotClient.ts
+++ b/packages/mosaic/src/charts/chart-types/box-plot/renderer/BoxPlotClient.ts
@@ -3,7 +3,7 @@ import {
   clauseInterval,
   type Selection,
 } from '@uwdata/mosaic-core';
-import {escapeId, quoteTableReference} from '@sqlrooms/duckdb';
+import {escapeId, type QualifiedTableName} from '@sqlrooms/duckdb';
 import type {ExprNode, FilterExpr} from '@uwdata/mosaic-sql';
 import {
   assertChartDataPolicy,
@@ -12,6 +12,7 @@ import {
   type ChartRuntimeIssueContext,
   type ChartRuntimeIssueReporter,
 } from '../../../../chart-runtime';
+import {getMosaicSqlTableReference} from '../../../../mosaicTableReference';
 
 export type BoxPlotSummaryRow = {
   category: unknown;
@@ -44,7 +45,7 @@ export type BoxPlotClientOptions = {
   runtimeIssueContext?: ChartRuntimeIssueContext;
   runtimeIssueReporter?: ChartRuntimeIssueReporter;
   selection: Selection;
-  tableName: string;
+  table: QualifiedTableName;
   x: string;
   y: string;
 };
@@ -123,13 +124,13 @@ function numericValue(value: unknown): number | undefined {
 
 type BuildBoxPlotQueryArgs = {
   filter?: FilterExpr | null;
-  tableName: string;
+  table: QualifiedTableName;
   x: string;
   y: string;
 };
 
 export function buildBoxPlotQuery(args: BuildBoxPlotQueryArgs): string {
-  const table = quoteTableReference(args.tableName);
+  const tableReference = getMosaicSqlTableReference(args.table);
   const x = escapeId(args.x);
   const y = escapeId(args.y);
   const filters = normalizeFilter(args.filter).join(' AND ');
@@ -140,7 +141,7 @@ WITH base AS (
   SELECT
     ${x} AS "category",
     TRY_CAST(${y} AS DOUBLE) AS "value"
-  FROM ${table}
+  FROM ${tableReference}
   WHERE ${where}
 ),
 stats AS (
@@ -213,7 +214,7 @@ ORDER BY "category", "rowKind", "value"
 
 export class BoxPlotClient extends MosaicClient {
   private readonly onStateChange: (state: BoxPlotState) => void;
-  private readonly tableName: string;
+  private readonly table: QualifiedTableName;
   private readonly x: string;
   private readonly y: string;
   private readonly selection: Selection;
@@ -233,7 +234,7 @@ export class BoxPlotClient extends MosaicClient {
     this.onStateChange = options.onStateChange;
     this.runtimeIssueContext = options.runtimeIssueContext;
     this.runtimeIssueReporter = options.runtimeIssueReporter;
-    this.tableName = options.tableName;
+    this.table = options.table;
     this.x = options.x;
     this.y = options.y;
     this.selection = options.selection;
@@ -263,7 +264,7 @@ export class BoxPlotClient extends MosaicClient {
   override query(filter?: FilterExpr | null): string {
     return buildBoxPlotQuery({
       filter,
-      tableName: this.tableName,
+      table: this.table,
       x: this.x,
       y: this.y,
     });

--- a/packages/mosaic/src/charts/chart-types/box-plot/renderer/BoxPlotPanelRenderer.tsx
+++ b/packages/mosaic/src/charts/chart-types/box-plot/renderer/BoxPlotPanelRenderer.tsx
@@ -22,7 +22,7 @@ import {BoxPlotErrorBoundary} from './BoxPlotErrorBoundary';
 export const BoxPlotPanelRenderer: FC<
   ChartRendererProps<BoxPlotChartConfig>
 > = ({
-  tableName,
+  table,
   config,
   coordinator,
   params,
@@ -53,7 +53,7 @@ export const BoxPlotPanelRenderer: FC<
     params,
     runtimeIssueContext,
     runtimeIssueReporter,
-    tableName,
+    table,
   });
 
   const summaries = useMemo<PlotSummaryDatum[]>(

--- a/packages/mosaic/src/charts/chart-types/box-plot/renderer/useBoxPlotClient.ts
+++ b/packages/mosaic/src/charts/chart-types/box-plot/renderer/useBoxPlotClient.ts
@@ -2,6 +2,7 @@ import {Coordinator, Selection} from '@uwdata/mosaic-core';
 import {useEffect, useMemo, useRef, useState} from 'react';
 import {BoxPlotClient, type BoxPlotState} from './BoxPlotClient';
 import type {BrushSelectionParams} from '../../base-types';
+import type {QualifiedTableName} from '@sqlrooms/duckdb';
 import type {
   ChartDataPolicy,
   ChartRuntimeIssueContext,
@@ -16,7 +17,7 @@ export function useBoxPlotClient(args: {
   params?: BrushSelectionParams;
   runtimeIssueContext?: ChartRuntimeIssueContext;
   runtimeIssueReporter?: ChartRuntimeIssueReporter;
-  tableName: string;
+  table: QualifiedTableName;
 }) {
   const {
     config,
@@ -25,7 +26,7 @@ export function useBoxPlotClient(args: {
     params,
     runtimeIssueContext,
     runtimeIssueReporter,
-    tableName,
+    table,
   } = args;
   const [state, setState] = useState<BoxPlotState>({
     isLoading: true,
@@ -57,7 +58,7 @@ export function useBoxPlotClient(args: {
       runtimeIssueContext,
       runtimeIssueReporter,
       selection,
-      tableName,
+      table,
       x: config.x,
       y: config.y,
     });
@@ -77,7 +78,7 @@ export function useBoxPlotClient(args: {
     runtimeIssueContext,
     runtimeIssueReporter,
     selection,
-    tableName,
+    table,
   ]);
 
   const effectiveState =

--- a/packages/mosaic/src/charts/chart-types/box-plot/renderer/useBoxPlotClient.ts
+++ b/packages/mosaic/src/charts/chart-types/box-plot/renderer/useBoxPlotClient.ts
@@ -10,6 +10,16 @@ import type {
 } from '../../../../chart-runtime';
 import {BoxPlotChartSettings} from '../schema';
 
+/**
+ * Creates and connects the Mosaic client used by the box plot renderer.
+ *
+ * @param args - Hook inputs including chart settings, Mosaic coordinator,
+ *   optional dashboard services, and the resolved source table.
+ * @param args.table - Canonical `QualifiedTableName` for the source table. The
+ *   hook passes this structured identity through to {@link BoxPlotClient}, where
+ *   it is converted to a Mosaic SQL table reference at query-build time.
+ * @returns The active client ref and normalized renderer state.
+ */
 export function useBoxPlotClient(args: {
   config: BoxPlotChartSettings | null;
   coordinator: Coordinator;

--- a/packages/pivot/__tests__/pivot-sql.test.ts
+++ b/packages/pivot/__tests__/pivot-sql.test.ts
@@ -7,6 +7,7 @@ const table: DataTable = {
   table: {
     table: 'tips',
     schema: 'main',
+    toFullString: () => '"main"."tips"',
     toString: () => '"main"."tips"',
   },
   tableName: 'tips',

--- a/packages/schema-tree/src/nodes/TableTreeNode.tsx
+++ b/packages/schema-tree/src/nodes/TableTreeNode.tsx
@@ -1,7 +1,7 @@
 // Copyright 2022 Foursquare Labs, Inc. All Rights Reserved.
 
 import {DataTableModal} from '@sqlrooms/data-table';
-import {makeQualifiedTableName, TableNodeObject} from '@sqlrooms/duckdb';
+import {TableNodeObject} from '@sqlrooms/duckdb';
 import {cn, useDisclosure} from '@sqlrooms/ui';
 import {formatCount} from '@sqlrooms/utils';
 import {CopyIcon, EyeIcon, TableIcon, ViewIcon} from 'lucide-react';
@@ -16,12 +16,7 @@ export const defaultRenderTableNodeMenuItems = (
   nodeObject: TableNodeObject,
   viewTableModal?: ReturnType<typeof useDisclosure>,
 ) => {
-  const {database, schema, name, sql, isView} = nodeObject;
-  const qualifiedTableName = makeQualifiedTableName({
-    database,
-    schema,
-    table: name,
-  });
+  const {table: qualifiedTableName, sql, isView} = nodeObject;
   return (
     <>
       {viewTableModal && (
@@ -91,12 +86,7 @@ export const TableTreeNode: FC<{
   } = props;
 
   const tableModal = useDisclosure();
-  const {database, schema, name, rowCount, isView} = nodeObject;
-  const qualifiedTableName = makeQualifiedTableName({
-    database,
-    schema,
-    table: name,
-  });
+  const {name, rowCount, isView, table: qualifiedTableName} = nodeObject;
   const sqlQuery = `SELECT * FROM ${qualifiedTableName}`;
 
   return (

--- a/packages/sql-editor/src/components/CreateTableModal.tsx
+++ b/packages/sql-editor/src/components/CreateTableModal.tsx
@@ -1,5 +1,4 @@
 import {zodResolver} from '@hookform/resolvers/zod';
-import {makeQualifiedTableName} from '@sqlrooms/db';
 import {SqlQueryDataSource} from '@sqlrooms/room-shell';
 import {
   Alert,
@@ -262,6 +261,9 @@ const CreateTableForm: FC<CreateTableFormProps> = ({
   const createTableFromQuery = useStoreWithSqlEditor(
     (state) => state.db.createTableFromQuery,
   );
+  const qualifyTableName = useStoreWithSqlEditor(
+    (state) => state.db.qualifyTableName,
+  );
   const refreshTableSchemas = useStoreWithSqlEditor(
     (state) => state.db.refreshTableSchemas,
   );
@@ -345,7 +347,7 @@ const CreateTableForm: FC<CreateTableFormProps> = ({
           // New path: call createTableFromQuery directly
           const qualifiedName =
             schema || database
-              ? makeQualifiedTableName({table: tableName, schema, database})
+              ? qualifyTableName({table: tableName, schema, database})
               : tableName;
 
           await createTableFromQuery(qualifiedName, query, {
@@ -376,6 +378,7 @@ const CreateTableForm: FC<CreateTableFormProps> = ({
       onAddOrUpdateSqlQuery,
       editDataSource?.tableName,
       createTableFromQuery,
+      qualifyTableName,
       allowMultipleStatements,
       refreshTableSchemas,
       onClose,

--- a/packages/sql-editor/src/utils/qualified-name-parser.ts
+++ b/packages/sql-editor/src/utils/qualified-name-parser.ts
@@ -106,7 +106,7 @@ export function findTableAndColumn(
     }
     if (
       tableName &&
-      table.table.table?.localeCompare(tableName, undefined, {
+      table.table.table.localeCompare(tableName, undefined, {
         sensitivity: 'accent',
       }) !== 0
     ) {
@@ -140,7 +140,7 @@ export function findTable(
   return tables.find((table) => {
     // Match table name (case-insensitive)
     if (
-      table.table.table?.localeCompare(tableName, undefined, {
+      table.table.table.localeCompare(tableName, undefined, {
         sensitivity: 'accent',
       }) !== 0
     ) {


### PR DESCRIPTION
## Summary
- Normalize table identity handling so table references are parsed and displayed consistently with schema qualification.
- Update AI table-schema context, DuckDB schema utilities, and table listing/schema loading to use the new qualified-name behavior.
- Propagate the change through SQL editor, execution, dashboard, pivot, cells, and mosaic code paths that inspect or render table names.
- Refresh related tests and docs to cover the new behavior.

## Testing
- Added and updated unit tests for table identity, schema-tree utilities, SQL parsing, and AI table-schema context.
- Updated integration-style coverage for dashboard, DuckDB, pivot, and box plot flows that depend on table naming.
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified qualified table naming across query building, schema/context formatting, and UI components for more consistent handling of databases and schemas.
  * Standardized how charts and table views pass table identity through the app using canonical references.
* **Bug Fixes**
  * Improved table lookup and schema loading behavior for default and attached databases, avoiding incorrect/double-qualification.
* **Documentation**
  * Updated examples and AI guidance to clarify the expected canonical quoted `tableId` format (including when the default database may be omitted).
* **Tests**
  * Expanded test coverage for canonical vs fully-qualified table name behavior and AI context formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->