### PR TITLE
fix: Replace table explorer overflow with ScrollArea and horizontal scrollbar

### DIFF
--- a/packages/mosaic/src/data-table-explorer/dashboard/MosaicDashboardDataTableExplorerPanelRenderer.tsx
+++ b/packages/mosaic/src/data-table-explorer/dashboard/MosaicDashboardDataTableExplorerPanelRenderer.tsx
@@ -1,4 +1,4 @@
-import {SpinnerPane} from '@sqlrooms/ui';
+import {ScrollArea, ScrollBar, SpinnerPane} from '@sqlrooms/ui';
 import {TablePropertiesIcon} from 'lucide-react';
 import {DataTableExplorer} from '../DataTableExplorer';
 import type {DataTableExplorerPanel} from '../../dashboard/dashboard-types';
@@ -61,12 +61,13 @@ const MosaicDashboardDataTableExplorerRendererInner: FC<
   return (
     <DataTableExplorer.Root explorer={explorer}>
       <div className="flex h-full min-h-0 flex-col">
-        <div className="min-h-0 flex-1 overflow-auto">
+        <ScrollArea className="min-h-0 flex-1">
           <DataTableExplorer.Table>
             <DataTableExplorer.Header />
             <DataTableExplorer.Rows />
           </DataTableExplorer.Table>
-        </div>
+          <ScrollBar orientation="horizontal" />
+        </ScrollArea>
         <DataTableExplorer.StatusBar />
       </div>
     </DataTableExplorer.Root>

--- a/packages/mosaic/src/data-table-explorer/worksheet/DataTableBlockRenderer.tsx
+++ b/packages/mosaic/src/data-table-explorer/worksheet/DataTableBlockRenderer.tsx
@@ -1,6 +1,6 @@
 import type {DataTable} from '@sqlrooms/db';
 import type {BlockDocumentStatefulBlockRendererProps} from '@sqlrooms/documents';
-import {SpinnerPane} from '@sqlrooms/ui';
+import {ScrollArea, ScrollBar, SpinnerPane} from '@sqlrooms/ui';
 import {FC, useCallback} from 'react';
 import {useStoreWithMosaic} from '../../MosaicSlice';
 import {DataTableSelectorEmptyState} from '../../components/DataTableSelector';
@@ -91,12 +91,13 @@ export const DataTableBlockRenderer: FC<
           tables={tables}
           onTableChange={handleTableChange}
         />
-        <div className="min-h-0 flex-1 overflow-auto">
+        <ScrollArea className="min-h-0 flex-1">
           <DataTableExplorer.Table>
             <DataTableExplorer.Header />
             <DataTableExplorer.Rows />
           </DataTableExplorer.Table>
-        </div>
+          <ScrollBar orientation="horizontal" />
+        </ScrollArea>
         <DataTableExplorer.StatusBar />
       </div>
     </DataTableExplorer>


### PR DESCRIPTION
## Summary
- Swap the data table explorer wrappers from plain `overflow-auto` containers to `ScrollArea`
- Add a horizontal `ScrollBar` to both the dashboard panel and worksheet block renderers
- Keep the existing table, status bar, and loading behavior unchanged

## Testing
- Not run (not requested)