### PR TITLE
feat: Add rename and delete actions to CLI artifact sidebar

### DIFF
--- a/apps/sqlrooms-cli-ui/src/workspace/sidebar/CliArtifactsSidebarSection.tsx
+++ b/apps/sqlrooms-cli-ui/src/workspace/sidebar/CliArtifactsSidebarSection.tsx
@@ -7,18 +7,37 @@ import {
   CommandItem,
   CommandList,
   CommandSeparator,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Input,
   Popover,
   PopoverContent,
   PopoverTrigger,
   SidebarMenu,
+  SidebarMenuAction,
   SidebarMenuButton,
   SidebarMenuItem,
   ScrollArea,
   ScrollBar,
   useSidebar,
 } from '@sqlrooms/ui';
-import {FileStackIcon, LoaderCircleIcon, Plus} from 'lucide-react';
-import {useState} from 'react';
+import {
+  EllipsisVerticalIcon,
+  FileStackIcon,
+  LoaderCircleIcon,
+  PencilIcon,
+  Plus,
+  Trash2Icon,
+} from 'lucide-react';
+import {FormEvent, useEffect, useRef, useState} from 'react';
 import {useRoomStore} from '../../store';
 import {useCliArtifactSidebarTabs} from './useCliArtifactSidebarTabs';
 
@@ -29,6 +48,27 @@ export function CliArtifactsSidebarSection() {
   );
   const {state} = useSidebar();
   const [popoverOpen, setPopoverOpen] = useState(false);
+  const [renameArtifact, setRenameArtifact] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
+  const [deleteConfirm, setDeleteConfirm] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
+
+  const handleRenameArtifact = (artifactId: string, name: string) => {
+    const trimmedName = name.trim();
+    if (!trimmedName) return;
+    artifactTabs.renameArtifact(artifactId, trimmedName);
+    setRenameArtifact(null);
+  };
+
+  const handleDeleteArtifact = () => {
+    if (!deleteConfirm) return;
+    artifactTabs.deleteArtifact(deleteConfirm.id);
+    setDeleteConfirm(null);
+  };
 
   if (state === 'expanded') {
     return (
@@ -84,6 +124,21 @@ export function CliArtifactsSidebarSection() {
                         <LoaderCircleIcon className="text-primary h-3.5 w-3.5 shrink-0 animate-spin" />
                       ) : null}
                     </SidebarMenuButton>
+                    <ArtifactSidebarItemMenu
+                      artifactName={artifact.name}
+                      onDelete={() =>
+                        setDeleteConfirm({
+                          id: artifact.id,
+                          name: artifact.name,
+                        })
+                      }
+                      onRename={() =>
+                        setRenameArtifact({
+                          id: artifact.id,
+                          name: artifact.name,
+                        })
+                      }
+                    />
                   </SidebarMenuItem>
                 );
               })}
@@ -91,6 +146,20 @@ export function CliArtifactsSidebarSection() {
           </div>
           <ScrollBar orientation="vertical" />
         </ScrollArea>
+        <RenameArtifactDialog
+          artifact={renameArtifact}
+          onOpenChange={(open) => {
+            if (!open) setRenameArtifact(null);
+          }}
+          onRename={handleRenameArtifact}
+        />
+        <DeleteArtifactDialog
+          artifact={deleteConfirm}
+          onOpenChange={(open) => {
+            if (!open) setDeleteConfirm(null);
+          }}
+          onConfirm={handleDeleteArtifact}
+        />
       </div>
     );
   }
@@ -160,5 +229,142 @@ export function CliArtifactsSidebarSection() {
         </Command>
       </PopoverContent>
     </Popover>
+  );
+}
+
+function ArtifactSidebarItemMenu({
+  artifactName,
+  onDelete,
+  onRename,
+}: {
+  artifactName: string;
+  onDelete: () => void;
+  onRename: () => void;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <SidebarMenuAction
+          type="button"
+          showOnHover
+          aria-label={`More actions for ${artifactName}`}
+          onClick={(event) => event.stopPropagation()}
+        >
+          <EllipsisVerticalIcon className="h-4 w-4" aria-hidden />
+        </SidebarMenuAction>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" side="right">
+        <DropdownMenuItem onSelect={onRename}>
+          <PencilIcon className="h-4 w-4" aria-hidden />
+          Rename
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          className="text-destructive focus:text-destructive"
+          onSelect={onDelete}
+        >
+          <Trash2Icon className="h-4 w-4" aria-hidden />
+          Delete
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function RenameArtifactDialog({
+  artifact,
+  onOpenChange,
+  onRename,
+}: {
+  artifact: {id: string; name: string} | null;
+  onOpenChange: (open: boolean) => void;
+  onRename: (artifactId: string, name: string) => void;
+}) {
+  const [name, setName] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    setName(artifact?.name ?? '');
+  }, [artifact]);
+
+  useEffect(() => {
+    if (!artifact) return;
+    const timeoutId = window.setTimeout(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }, 100);
+    return () => window.clearTimeout(timeoutId);
+  }, [artifact]);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!artifact) return;
+    onRename(artifact.id, name);
+  };
+
+  return (
+    <Dialog open={artifact !== null} onOpenChange={onOpenChange}>
+      <DialogContent showCloseButton={false}>
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>Rename artifact</DialogTitle>
+            <DialogDescription>
+              Choose a new name for this workspace artifact.
+            </DialogDescription>
+          </DialogHeader>
+          <Input
+            ref={inputRef}
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            className="my-4"
+            aria-label="Artifact name"
+          />
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!name.trim()}>
+              Rename
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function DeleteArtifactDialog({
+  artifact,
+  onOpenChange,
+  onConfirm,
+}: {
+  artifact: {id: string; name: string} | null;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <Dialog open={artifact !== null} onOpenChange={onOpenChange}>
+      <DialogContent showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>Delete artifact</DialogTitle>
+          <DialogDescription>
+            Are you sure you want to delete &ldquo;
+            {artifact?.name ?? 'this artifact'}&rdquo;? This action cannot be
+            undone.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={onConfirm}>
+            Delete
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/sqlrooms-cli-ui/src/workspace/sidebar/CliArtifactsSidebarSection.tsx
+++ b/apps/sqlrooms-cli-ui/src/workspace/sidebar/CliArtifactsSidebarSection.tsx
@@ -247,6 +247,7 @@ function ArtifactSidebarItemMenu({
         <SidebarMenuAction
           type="button"
           showOnHover
+          className="top-1/2 right-1 size-6 w-6 -translate-y-1/2"
           aria-label={`More actions for ${artifactName}`}
           onClick={(event) => event.stopPropagation()}
         >

--- a/apps/sqlrooms-cli-ui/src/workspace/sidebar/useCliArtifactSidebarTabs.ts
+++ b/apps/sqlrooms-cli-ui/src/workspace/sidebar/useCliArtifactSidebarTabs.ts
@@ -16,8 +16,15 @@ export function useCliArtifactSidebarTabs() {
   );
   const addTab = useRoomStore((state) => state.layout.addTab);
   const setActiveTab = useRoomStore((state) => state.layout.setActiveTab);
+  const deleteTab = useRoomStore((state) => state.layout.deleteTab);
   const setCurrentArtifact = useRoomStore(
     (state) => state.artifacts.setCurrentArtifact,
+  );
+  const deleteArtifactFromStore = useRoomStore(
+    (state) => state.artifacts.deleteArtifact,
+  );
+  const renameArtifactInStore = useRoomStore(
+    (state) => state.artifacts.renameArtifact,
   );
   const setShowArtifactChooser = useRoomStore(
     (state) => state.workspaceUi.setShowArtifactChooser,
@@ -65,5 +72,27 @@ export function useCliArtifactSidebarTabs() {
     [addTab, setActiveTab, setCurrentArtifact, setShowArtifactChooser],
   );
 
-  return {artifactTypes, selectedTabId, selectArtifact, tabs};
+  const renameArtifact = useCallback(
+    (artifactId: string, title: string) => {
+      renameArtifactInStore(artifactId, title);
+    },
+    [renameArtifactInStore],
+  );
+
+  const deleteArtifact = useCallback(
+    (artifactId: string) => {
+      deleteArtifactFromStore(artifactId);
+      deleteTab('workspace', artifactId);
+    },
+    [deleteArtifactFromStore, deleteTab],
+  );
+
+  return {
+    artifactTypes,
+    deleteArtifact,
+    renameArtifact,
+    selectedTabId,
+    selectArtifact,
+    tabs,
+  };
 }

--- a/apps/sqlrooms-cli-ui/src/workspace/sidebar/useCliArtifactSidebarTabs.ts
+++ b/apps/sqlrooms-cli-ui/src/workspace/sidebar/useCliArtifactSidebarTabs.ts
@@ -81,10 +81,14 @@ export function useCliArtifactSidebarTabs() {
 
   const deleteArtifact = useCallback(
     (artifactId: string) => {
+      const activeArtifactId = selectedTabId;
       deleteArtifactFromStore(artifactId);
       deleteTab('workspace', artifactId);
+      if (activeArtifactId && activeArtifactId !== artifactId) {
+        setActiveTab('workspace', activeArtifactId);
+      }
     },
-    [deleteArtifactFromStore, deleteTab],
+    [deleteArtifactFromStore, deleteTab, selectedTabId, setActiveTab],
   );
 
   return {


### PR DESCRIPTION
## Summary
- Add a per-artifact overflow menu in the CLI sidebar
- Support renaming artifacts through a focused dialog
- Support deleting artifacts with confirmation and tab cleanup

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-artifact actions via a dropdown menu for renaming and deleting
  * Rename now opens a dedicated dialog to update the artifact title
  * Delete now opens a confirmation dialog to prevent accidental removal
* **Bug Fixes**
  * Improved tab behavior after deletion to ensure the appropriate artifact remains active when possible
<!-- end of auto-generated comment: release notes by coderabbit.ai -->