### PR TITLE
feat: Handle CLI dev port conflicts automatically

### DIFF
--- a/apps/sqlrooms-cli-ui/README.md
+++ b/apps/sqlrooms-cli-ui/README.md
@@ -42,6 +42,10 @@ Terminal B (UI):
 pnpm --filter sqlrooms-cli-app dev -- --host --port 4174
 ```
 
+The Python package dev helper uses API port `4173` by default to match the
+Vite proxy. If you pass a different Python API port, also set
+`SQLROOMS_CLI_API_PROXY_TARGET` when starting Vite.
+
 ## Build the bundled UI (for the Python wheel)
 
 From the repo root:

--- a/apps/sqlrooms-cli-ui/README.md
+++ b/apps/sqlrooms-cli-ui/README.md
@@ -18,16 +18,14 @@ pnpm dev cli
 
 This starts:
 
-- the Python API server on `http://127.0.0.1:4173` without serving static UI
-- the Vite UI on `http://localhost:4174` (proxying `/api` and `/config.json` to 4173)
+- the Python API server on `http://127.0.0.1:4173` without serving static UI, or the next free port
+- the Vite UI on `http://localhost:4174`, or the next free port, proxying `/api` and `/config.json` to the selected Python API port
 
-If you hit `address already in use`, pass different ports to the Python server:
+If you want fixed ports, pass them to the Python server:
 
 ```bash
 pnpm dev cli -- --port 4176 --ws-port 4002
 ```
-
-Then also update the Vite proxy target in `vite.config.ts` (or run Vite with a different proxy setup).
 
 ## Dev mode (separate terminals)
 

--- a/apps/sqlrooms-cli-ui/README.md
+++ b/apps/sqlrooms-cli-ui/README.md
@@ -2,7 +2,7 @@
 
 This package is the **Vite/React UI** that powers the Python `sqlrooms` CLI (`python/sqlrooms-cli`).
 
-In development it runs as a separate dev server (default `http://localhost:4174`) and **proxies API calls** to the Python server (default `http://localhost:4173`).
+In development it runs as a separate dev server (default `http://localhost:4174`) and **proxies API calls** to the Python server.
 
 In production (published `sqlrooms` wheel), the UI is served as **static assets** bundled into the Python package at:
 
@@ -18,8 +18,9 @@ pnpm dev cli
 
 This starts:
 
-- the Python API server on `http://127.0.0.1:4173` without serving static UI, or the next free port
+- the Python API server on `http://127.0.0.1:4273` without serving static UI, or the next free port
 - the Vite UI on `http://localhost:4174`, or the next free port, proxying `/api` and `/config.json` to the selected Python API port
+- a per-session dev database named after the selected UI port, for example `sqlrooms-cli-4174.db`
 
 If you want fixed ports, pass them to the Python server:
 

--- a/apps/sqlrooms-cli-ui/src/cliDatabaseInitialization.ts
+++ b/apps/sqlrooms-cli-ui/src/cliDatabaseInitialization.ts
@@ -131,6 +131,17 @@ async function waitForWebSocketConnection(
   );
 }
 
+/**
+ * Wraps a connector's `initialize` method with CLI database startup diagnostics.
+ *
+ * This mutates `connector.initialize` so startup failures can surface backend
+ * status details and websocket timeout diagnostics to the room shell.
+ *
+ * @param connector - Database connector whose initializer should be wrapped.
+ * @param options - Runtime configuration and websocket URL used for diagnostics.
+ * @param options.runtimeConfig - CLI runtime configuration, including startup status.
+ * @param options.wsUrl - DuckDB websocket URL to probe before initialization.
+ */
 export function addCliDatabaseInitializationDiagnostics(
   connector: DuckDbConnector,
   {

--- a/apps/sqlrooms-cli-ui/src/cliDatabaseInitialization.ts
+++ b/apps/sqlrooms-cli-ui/src/cliDatabaseInitialization.ts
@@ -1,0 +1,105 @@
+import {type DuckDbConnector} from '@sqlrooms/duckdb';
+import {
+  fetchRuntimeStartupStatus,
+  type RuntimeConfig,
+  type RuntimeStartupStatus,
+} from './runtimeConfig';
+
+const DB_INITIALIZATION_TIMEOUT_MS = 12_000;
+
+type ErrorWithDetails = Error & {
+  details?: string;
+};
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  createError: () => Error,
+): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => reject(createError()), timeoutMs);
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
+  });
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  return 'Unknown client-side initialization error.';
+}
+
+function getDuckDbStartupError(status?: RuntimeStartupStatus) {
+  const duckdbStatus = status?.components?.duckdbWebSocket;
+  if (duckdbStatus?.status !== 'error') return undefined;
+  return duckdbStatus;
+}
+
+function createDatabaseStartupError({
+  wsUrl,
+  clientError,
+  startupStatus,
+}: {
+  wsUrl: string;
+  clientError?: unknown;
+  startupStatus?: RuntimeStartupStatus;
+}): ErrorWithDetails {
+  const duckdbError = getDuckDbStartupError(startupStatus);
+  const message =
+    duckdbError?.message ??
+    'Could not connect to the SQLRooms DuckDB websocket backend.';
+  const details = [
+    duckdbError?.error ? `Server error: ${duckdbError.error}` : undefined,
+    duckdbError?.details
+      ? `Server details:\n${duckdbError.details}`
+      : undefined,
+    clientError ? `Client error: ${getErrorMessage(clientError)}` : undefined,
+    `WebSocket URL: ${wsUrl}`,
+    'Check the terminal running `sqlrooms` for startup errors, then reload this page.',
+  ].filter(Boolean);
+
+  const error = new Error(message) as ErrorWithDetails;
+  error.details = details.join('\n\n');
+  return error;
+}
+
+export function addCliDatabaseInitializationDiagnostics(
+  connector: DuckDbConnector,
+  {
+    runtimeConfig,
+    wsUrl,
+  }: {
+    runtimeConfig: RuntimeConfig;
+    wsUrl: string;
+  },
+) {
+  const baseInitialize = connector.initialize.bind(connector);
+  connector.initialize = async () => {
+    const initialStartupError = getDuckDbStartupError(
+      runtimeConfig.startupStatus,
+    );
+    if (initialStartupError) {
+      throw createDatabaseStartupError({
+        wsUrl,
+        startupStatus: runtimeConfig.startupStatus,
+      });
+    }
+
+    try {
+      await withTimeout(baseInitialize(), DB_INITIALIZATION_TIMEOUT_MS, () =>
+        createDatabaseStartupError({wsUrl}),
+      );
+    } catch (error) {
+      const startupStatus = await fetchRuntimeStartupStatus();
+      throw createDatabaseStartupError({
+        wsUrl,
+        clientError: error,
+        startupStatus,
+      });
+    }
+  };
+}

--- a/apps/sqlrooms-cli-ui/src/cliDatabaseInitialization.ts
+++ b/apps/sqlrooms-cli-ui/src/cliDatabaseInitialization.ts
@@ -6,6 +6,8 @@ import {
 } from './runtimeConfig';
 
 const DB_CONNECTION_TIMEOUT_MS = 12_000;
+const DB_CONNECTION_ATTEMPT_TIMEOUT_MS = 1_000;
+const DB_CONNECTION_RETRY_DELAY_MS = 250;
 
 type ErrorWithDetails = Error & {
   details?: string;
@@ -51,7 +53,11 @@ function createDatabaseStartupError({
   return error;
 }
 
-function waitForWebSocketConnection(
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function openWebSocketConnection(
   wsUrl: string,
   timeoutMs: number,
 ): Promise<void> {
@@ -89,6 +95,40 @@ function waitForWebSocketConnection(
     socket.onclose = () =>
       finish(new Error('DuckDB websocket closed before opening.'));
   });
+}
+
+async function waitForWebSocketConnection(
+  wsUrl: string,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    const attemptRemainingMs = deadline - Date.now();
+    try {
+      await openWebSocketConnection(
+        wsUrl,
+        Math.min(DB_CONNECTION_ATTEMPT_TIMEOUT_MS, attemptRemainingMs),
+      );
+      return;
+    } catch (error) {
+      lastError = error;
+      const startupStatus = await fetchRuntimeStartupStatus();
+      if (getDuckDbStartupError(startupStatus)) {
+        throw error;
+      }
+    }
+
+    const retryRemainingMs = deadline - Date.now();
+    if (retryRemainingMs > 0) {
+      await delay(Math.min(DB_CONNECTION_RETRY_DELAY_MS, retryRemainingMs));
+    }
+  }
+
+  throw (
+    lastError ?? new Error('Timed out connecting to DuckDB websocket backend.')
+  );
 }
 
 export function addCliDatabaseInitializationDiagnostics(

--- a/apps/sqlrooms-cli-ui/src/cliDatabaseInitialization.ts
+++ b/apps/sqlrooms-cli-ui/src/cliDatabaseInitialization.ts
@@ -5,27 +5,11 @@ import {
   type RuntimeStartupStatus,
 } from './runtimeConfig';
 
-const DB_INITIALIZATION_TIMEOUT_MS = 12_000;
+const DB_CONNECTION_TIMEOUT_MS = 12_000;
 
 type ErrorWithDetails = Error & {
   details?: string;
 };
-
-function withTimeout<T>(
-  promise: Promise<T>,
-  timeoutMs: number,
-  createError: () => Error,
-): Promise<T> {
-  let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  const timeoutPromise = new Promise<never>((_, reject) => {
-    timeoutId = setTimeout(() => reject(createError()), timeoutMs);
-  });
-  return Promise.race([promise, timeoutPromise]).finally(() => {
-    if (timeoutId !== undefined) {
-      clearTimeout(timeoutId);
-    }
-  });
-}
 
 function getErrorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
@@ -42,16 +26,16 @@ function getDuckDbStartupError(status?: RuntimeStartupStatus) {
 function createDatabaseStartupError({
   wsUrl,
   clientError,
+  fallbackMessage = 'Could not connect to the SQLRooms DuckDB websocket backend.',
   startupStatus,
 }: {
   wsUrl: string;
   clientError?: unknown;
+  fallbackMessage?: string;
   startupStatus?: RuntimeStartupStatus;
 }): ErrorWithDetails {
   const duckdbError = getDuckDbStartupError(startupStatus);
-  const message =
-    duckdbError?.message ??
-    'Could not connect to the SQLRooms DuckDB websocket backend.';
+  const message = duckdbError?.message ?? fallbackMessage;
   const details = [
     duckdbError?.error ? `Server error: ${duckdbError.error}` : undefined,
     duckdbError?.details
@@ -65,6 +49,46 @@ function createDatabaseStartupError({
   const error = new Error(message) as ErrorWithDetails;
   error.details = details.join('\n\n');
   return error;
+}
+
+function waitForWebSocketConnection(
+  wsUrl: string,
+  timeoutMs: number,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocket(wsUrl);
+    let settled = false;
+    let timeoutId: ReturnType<typeof setTimeout>;
+
+    const finish = (error?: Error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutId);
+      socket.onopen = null;
+      socket.onerror = null;
+      socket.onclose = null;
+      try {
+        socket.close();
+      } catch {
+        // Ignore cleanup errors after the connection result is known.
+      }
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    };
+
+    timeoutId = setTimeout(() => {
+      finish(new Error('Timed out connecting to DuckDB websocket backend.'));
+    }, timeoutMs);
+
+    socket.onopen = () => finish();
+    socket.onerror = () =>
+      finish(new Error('DuckDB websocket connection error.'));
+    socket.onclose = () =>
+      finish(new Error('DuckDB websocket closed before opening.'));
+  });
 }
 
 export function addCliDatabaseInitializationDiagnostics(
@@ -90,14 +114,24 @@ export function addCliDatabaseInitializationDiagnostics(
     }
 
     try {
-      await withTimeout(baseInitialize(), DB_INITIALIZATION_TIMEOUT_MS, () =>
-        createDatabaseStartupError({wsUrl}),
-      );
+      await waitForWebSocketConnection(wsUrl, DB_CONNECTION_TIMEOUT_MS);
     } catch (error) {
       const startupStatus = await fetchRuntimeStartupStatus();
       throw createDatabaseStartupError({
         wsUrl,
         clientError: error,
+        startupStatus,
+      });
+    }
+
+    try {
+      await baseInitialize();
+    } catch (error) {
+      const startupStatus = await fetchRuntimeStartupStatus();
+      throw createDatabaseStartupError({
+        wsUrl,
+        clientError: error,
+        fallbackMessage: 'SQLRooms DuckDB initialization failed.',
         startupStatus,
       });
     }

--- a/apps/sqlrooms-cli-ui/src/runtimeConfig.ts
+++ b/apps/sqlrooms-cli-ui/src/runtimeConfig.ts
@@ -117,11 +117,40 @@ async function fetchJson<T>(url: string): Promise<T | undefined> {
   }
 }
 
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchJsonWithRetries<T>({
+  url,
+  attempts,
+  delayMs,
+}: {
+  url: string;
+  attempts: number;
+  delayMs: number;
+}): Promise<T | undefined> {
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const result = await fetchJson<T>(url);
+    if (result) return result;
+    if (attempt < attempts) {
+      await delay(delayMs);
+    }
+  }
+  return undefined;
+}
+
 /**
  * Fetches `/api/config`, returning an empty runtime config if the request fails.
  */
 export async function fetchRuntimeConfig(): Promise<RuntimeConfig> {
-  return (await fetchJson<RuntimeConfig>('/api/config')) ?? {};
+  return (
+    (await fetchJsonWithRetries<RuntimeConfig>({
+      url: '/api/config',
+      attempts: 20,
+      delayMs: 250,
+    })) ?? {}
+  );
 }
 
 /**

--- a/apps/sqlrooms-cli-ui/src/runtimeConfig.ts
+++ b/apps/sqlrooms-cli-ui/src/runtimeConfig.ts
@@ -1,13 +1,26 @@
+/**
+ * Startup state for one runtime component reported by the CLI backend.
+ */
 export type RuntimeComponentStatus = {
+  /** Current startup state for the component. */
   status: 'starting' | 'ready' | 'error';
+  /** Optional human-readable status message. */
   message?: string;
+  /** Optional concise error message when startup failed. */
   error?: string;
+  /** Optional diagnostic detail for startup failures. */
   details?: string;
 };
 
+/**
+ * Aggregate startup status returned by the CLI backend.
+ */
 export type RuntimeStartupStatus = {
+  /** Overall runtime readiness. `degraded` means one or more components are not ready. */
   status: 'ready' | 'degraded';
+  /** Per-component startup status details. */
   components?: {
+    /** DuckDB websocket backend startup status. */
     duckdbWebSocket?: RuntimeComponentStatus;
   };
 };
@@ -104,10 +117,16 @@ async function fetchJson<T>(url: string): Promise<T | undefined> {
   }
 }
 
+/**
+ * Fetches `/api/config`, returning an empty runtime config if the request fails.
+ */
 export async function fetchRuntimeConfig(): Promise<RuntimeConfig> {
   return (await fetchJson<RuntimeConfig>('/api/config')) ?? {};
 }
 
+/**
+ * Fetches `/api/status`, returning `undefined` when the status endpoint fails.
+ */
 export async function fetchRuntimeStartupStatus(): Promise<
   RuntimeStartupStatus | undefined
 > {

--- a/apps/sqlrooms-cli-ui/src/runtimeConfig.ts
+++ b/apps/sqlrooms-cli-ui/src/runtimeConfig.ts
@@ -107,6 +107,13 @@ export type RuntimeConfig = {
   };
 };
 
+const RUNTIME_CONFIG_TIMEOUT_MS = 20_000;
+const RUNTIME_CONFIG_RETRY_DELAY_MS = 250;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 async function fetchJson<T>(url: string): Promise<T | undefined> {
   try {
     const res = await fetch(url);
@@ -117,26 +124,27 @@ async function fetchJson<T>(url: string): Promise<T | undefined> {
   }
 }
 
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
+async function fetchJsonWithRetry<T>(
+  url: string,
+  {
+    timeoutMs = RUNTIME_CONFIG_TIMEOUT_MS,
+    retryDelayMs = RUNTIME_CONFIG_RETRY_DELAY_MS,
+  }: {
+    timeoutMs?: number;
+    retryDelayMs?: number;
+  } = {},
+): Promise<T | undefined> {
+  const deadline = Date.now() + timeoutMs;
 
-async function fetchJsonWithRetries<T>({
-  url,
-  attempts,
-  delayMs,
-}: {
-  url: string;
-  attempts: number;
-  delayMs: number;
-}): Promise<T | undefined> {
-  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+  while (Date.now() <= deadline) {
     const result = await fetchJson<T>(url);
-    if (result) return result;
-    if (attempt < attempts) {
-      await delay(delayMs);
-    }
+    if (result !== undefined) return result;
+
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) break;
+    await delay(Math.min(retryDelayMs, remainingMs));
   }
+
   return undefined;
 }
 
@@ -144,13 +152,7 @@ async function fetchJsonWithRetries<T>({
  * Fetches `/api/config`, returning an empty runtime config if the request fails.
  */
 export async function fetchRuntimeConfig(): Promise<RuntimeConfig> {
-  return (
-    (await fetchJsonWithRetries<RuntimeConfig>({
-      url: '/api/config',
-      attempts: 20,
-      delayMs: 250,
-    })) ?? {}
-  );
+  return (await fetchJsonWithRetry<RuntimeConfig>('/api/config')) ?? {};
 }
 
 /**

--- a/apps/sqlrooms-cli-ui/src/runtimeConfig.ts
+++ b/apps/sqlrooms-cli-ui/src/runtimeConfig.ts
@@ -1,3 +1,17 @@
+export type RuntimeComponentStatus = {
+  status: 'starting' | 'ready' | 'error';
+  message?: string;
+  error?: string;
+  details?: string;
+};
+
+export type RuntimeStartupStatus = {
+  status: 'ready' | 'degraded';
+  components?: {
+    duckdbWebSocket?: RuntimeComponentStatus;
+  };
+};
+
 export type RuntimeConfig = {
   wsUrl?: string;
   wsAuthToken?: string;
@@ -39,6 +53,7 @@ export type RuntimeConfig = {
   };
   dbPath?: string;
   metaNamespace?: string;
+  startupStatus?: RuntimeStartupStatus;
   dbBridge?: {
     id: string;
     connections: Array<{
@@ -79,12 +94,22 @@ export type RuntimeConfig = {
   };
 };
 
-export async function fetchRuntimeConfig(): Promise<RuntimeConfig> {
+async function fetchJson<T>(url: string): Promise<T | undefined> {
   try {
-    const res = await fetch('/api/config');
-    if (!res.ok) return {};
-    return (await res.json()) as RuntimeConfig;
+    const res = await fetch(url);
+    if (!res.ok) return undefined;
+    return (await res.json()) as T;
   } catch {
-    return {};
+    return undefined;
   }
+}
+
+export async function fetchRuntimeConfig(): Promise<RuntimeConfig> {
+  return (await fetchJson<RuntimeConfig>('/api/config')) ?? {};
+}
+
+export async function fetchRuntimeStartupStatus(): Promise<
+  RuntimeStartupStatus | undefined
+> {
+  return fetchJson<RuntimeStartupStatus>('/api/status');
 }

--- a/apps/sqlrooms-cli-ui/src/store.ts
+++ b/apps/sqlrooms-cli-ui/src/store.ts
@@ -24,7 +24,6 @@ import {
   createDefaultLoadTableSchemasFilter,
   createWebSocketDuckDbConnector,
   defaultLoadSchemaCatalogFilter,
-  type DuckDbConnector,
   QualifiedTableName,
   type SchemaCatalogFilterEntry,
 } from '@sqlrooms/duckdb';
@@ -83,6 +82,7 @@ import {
 import {createDocumentsCrdtMirror} from '@sqlrooms/documents/crdt';
 import {toast} from '@sqlrooms/ui';
 import {ARTIFACT_TYPES} from './artifactTypes';
+import {addCliDatabaseInitializationDiagnostics} from './cliDatabaseInitialization';
 import {worksheetAgentTool} from './createWorksheetAgent';
 import {createArtifactContextAiTools} from './context/createArtifactContextAiTools';
 import {formatRunContextInstructions} from './context/formatRunContextInstructions';
@@ -131,41 +131,6 @@ const WORKSHEET_BLOCK_DOCUMENT_OPTIONS = {
   defaultTitle: 'Worksheet',
   blockDocumentAgentToolName: 'worksheet_agent',
 } as const;
-const DB_INITIALIZATION_TIMEOUT_MS = 12_000;
-
-function withTimeout<T>(
-  promise: Promise<T>,
-  timeoutMs: number,
-  createError: () => Error,
-): Promise<T> {
-  let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  const timeoutPromise = new Promise<never>((_, reject) => {
-    timeoutId = setTimeout(() => reject(createError()), timeoutMs);
-  });
-  return Promise.race([promise, timeoutPromise]).finally(() => {
-    if (timeoutId !== undefined) {
-      clearTimeout(timeoutId);
-    }
-  });
-}
-
-function addCliDatabaseInitializationTimeout(
-  connector: DuckDbConnector,
-  wsUrl: string,
-) {
-  const baseInitialize = connector.initialize.bind(connector);
-  connector.initialize = async () => {
-    await withTimeout(baseInitialize(), DB_INITIALIZATION_TIMEOUT_MS, () => {
-      return new Error(
-        [
-          'Could not connect to the SQLRooms DuckDB websocket backend.',
-          `WebSocket URL: ${wsUrl}`,
-          'Check the terminal running `sqlrooms` for startup errors, then reload this page.',
-        ].join('\n'),
-      );
-    });
-  };
-}
 
 export const runtimeConfig = await fetchRuntimeConfig();
 export const aiDevtoolsEnabled =
@@ -263,7 +228,10 @@ const connector = createWebSocketDuckDbConnector({
     `CREATE SCHEMA IF NOT EXISTS ${MOSAIC_PREAGG_SCHEMA_REF}`,
   ].join('; '),
 });
-addCliDatabaseInitializationTimeout(connector, runtimeWsUrl);
+addCliDatabaseInitializationDiagnostics(connector, {
+  runtimeConfig,
+  wsUrl: runtimeWsUrl,
+});
 
 const baseLoadFile = connector.loadFile.bind(connector);
 connector.loadFile = async (file, desiredTableName, options) => {

--- a/apps/sqlrooms-cli-ui/src/store.ts
+++ b/apps/sqlrooms-cli-ui/src/store.ts
@@ -24,6 +24,7 @@ import {
   createDefaultLoadTableSchemasFilter,
   createWebSocketDuckDbConnector,
   defaultLoadSchemaCatalogFilter,
+  type DuckDbConnector,
   QualifiedTableName,
   type SchemaCatalogFilterEntry,
 } from '@sqlrooms/duckdb';
@@ -130,6 +131,41 @@ const WORKSHEET_BLOCK_DOCUMENT_OPTIONS = {
   defaultTitle: 'Worksheet',
   blockDocumentAgentToolName: 'worksheet_agent',
 } as const;
+const DB_INITIALIZATION_TIMEOUT_MS = 12_000;
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  createError: () => Error,
+): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => reject(createError()), timeoutMs);
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
+  });
+}
+
+function addCliDatabaseInitializationTimeout(
+  connector: DuckDbConnector,
+  wsUrl: string,
+) {
+  const baseInitialize = connector.initialize.bind(connector);
+  connector.initialize = async () => {
+    await withTimeout(baseInitialize(), DB_INITIALIZATION_TIMEOUT_MS, () => {
+      return new Error(
+        [
+          'Could not connect to the SQLRooms DuckDB websocket backend.',
+          `WebSocket URL: ${wsUrl}`,
+          'Check the terminal running `sqlrooms` for startup errors, then reload this page.',
+        ].join('\n'),
+      );
+    });
+  };
+}
 
 export const runtimeConfig = await fetchRuntimeConfig();
 export const aiDevtoolsEnabled =
@@ -217,8 +253,9 @@ function createDisabledCrdtState(): CrdtSliceState {
   };
 }
 
+const runtimeWsUrl = runtimeConfig.wsUrl || 'ws://localhost:4000';
 const connector = createWebSocketDuckDbConnector({
-  wsUrl: runtimeConfig.wsUrl || 'ws://localhost:4000',
+  wsUrl: runtimeWsUrl,
   initializationQuery: [
     'INSTALL spatial',
     'LOAD spatial',
@@ -226,6 +263,7 @@ const connector = createWebSocketDuckDbConnector({
     `CREATE SCHEMA IF NOT EXISTS ${MOSAIC_PREAGG_SCHEMA_REF}`,
   ].join('; '),
 });
+addCliDatabaseInitializationTimeout(connector, runtimeWsUrl);
 
 const baseLoadFile = connector.loadFile.bind(connector);
 connector.loadFile = async (file, desiredTableName, options) => {

--- a/apps/sqlrooms-cli-ui/vite.config.ts
+++ b/apps/sqlrooms-cli-ui/vite.config.ts
@@ -9,6 +9,8 @@ import wasm from 'vite-plugin-wasm';
 import scaffoldsPlugin from './plugins/scaffolds';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const apiProxyTarget =
+  process.env.SQLROOMS_CLI_API_PROXY_TARGET ?? 'http://localhost:4173';
 
 type ViteAlias = {find: string | RegExp; replacement: string};
 
@@ -89,8 +91,8 @@ export default defineConfig({
       'Cross-Origin-Resource-Policy': 'cross-origin',
     },
     proxy: {
-      '/api': 'http://localhost:4173',
-      '/config.json': 'http://localhost:4173',
+      '/api': apiProxyTarget,
+      '/config.json': apiProxyTarget,
     },
   },
   preview: {

--- a/packages/room-shell/src/RoomShell.tsx
+++ b/packages/room-shell/src/RoomShell.tsx
@@ -167,8 +167,9 @@ export const LoadingProgress: FC<{className?: string}> = ({className}) => {
     <ProgressModal
       className={className}
       isOpen={loadingProgress !== undefined}
-      title="Loading"
+      title={loadingProgress?.error ? 'Unable to start SQLRooms' : 'Loading'}
       loadingStage={loadingProgress?.message}
+      error={loadingProgress?.error}
       indeterminate={true}
     />
   );

--- a/packages/room-shell/src/RoomShell.tsx
+++ b/packages/room-shell/src/RoomShell.tsx
@@ -170,6 +170,7 @@ export const LoadingProgress: FC<{className?: string}> = ({className}) => {
       title={loadingProgress?.error ? 'Unable to start SQLRooms' : 'Loading'}
       loadingStage={loadingProgress?.message}
       error={loadingProgress?.error}
+      errorDetails={loadingProgress?.errorDetails}
       indeterminate={true}
     />
   );

--- a/packages/room-shell/src/RoomShellSlice.ts
+++ b/packages/room-shell/src/RoomShellSlice.ts
@@ -61,6 +61,7 @@ export type TaskProgress = {
   progress?: number | undefined;
   message: string;
   error?: string | undefined;
+  errorDetails?: string | undefined;
 };
 
 export type RoomShellSliceState = {
@@ -190,6 +191,18 @@ function getErrorMessage(error: unknown): string {
   return 'An unknown error occurred.';
 }
 
+function getErrorDetails(error: unknown): string | undefined {
+  if (
+    error &&
+    typeof error === 'object' &&
+    'details' in error &&
+    typeof error.details === 'string'
+  ) {
+    return error.details;
+  }
+  return undefined;
+}
+
 const RoomSetTitleCommandInput = z.object({
   title: z.string().min(1).describe('Room title.'),
 });
@@ -304,6 +317,7 @@ export function createRoomShellSlice(
               setTaskProgress(INIT_DB_TASK, {
                 message: 'Database connection failed',
                 error: getErrorMessage(error),
+                errorDetails: getErrorDetails(error),
                 progress: undefined,
               });
               throw error;

--- a/packages/room-shell/src/RoomShellSlice.ts
+++ b/packages/room-shell/src/RoomShellSlice.ts
@@ -57,10 +57,17 @@ export type RoomShellSliceConfig = BaseRoomConfig;
 
 export type RoomShellStore = StoreApi<RoomShellSliceState>;
 
+/**
+ * Progress, status, and optional failure details for a room-level task.
+ */
 export type TaskProgress = {
+  /** Optional task completion percentage. */
   progress?: number | undefined;
+  /** Required status message shown while the task is active. */
   message: string;
+  /** Optional concise error message when the task fails. */
   error?: string | undefined;
+  /** Optional detailed diagnostic text for task failures. */
   errorDetails?: string | undefined;
 };
 

--- a/packages/room-shell/src/RoomShellSlice.ts
+++ b/packages/room-shell/src/RoomShellSlice.ts
@@ -60,6 +60,7 @@ export type RoomShellStore = StoreApi<RoomShellSliceState>;
 export type TaskProgress = {
   progress?: number | undefined;
   message: string;
+  error?: string | undefined;
 };
 
 export type RoomShellSliceState = {
@@ -183,6 +184,12 @@ const INIT_DB_TASK = 'init-db';
 const INIT_ROOM_TASK = 'init-room';
 const ROOM_SHELL_COMMAND_OWNER = '@sqlrooms/room-shell';
 
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  return 'An unknown error occurred.';
+}
+
 const RoomSetTitleCommandInput = z.object({
   title: z.string().min(1).describe('Room title.'),
 });
@@ -291,7 +298,16 @@ export function createRoomShellSlice(
               message: 'Establishing database connection…',
               progress: undefined,
             });
-            await get().db.initialize();
+            try {
+              await get().db.initialize();
+            } catch (error) {
+              setTaskProgress(INIT_DB_TASK, {
+                message: 'Database connection failed',
+                error: getErrorMessage(error),
+                progress: undefined,
+              });
+              throw error;
+            }
             setTaskProgress(INIT_DB_TASK, undefined);
 
             setTaskProgress(INIT_ROOM_TASK, {

--- a/packages/ui/src/components/progress-modal.tsx
+++ b/packages/ui/src/components/progress-modal.tsx
@@ -69,7 +69,7 @@ const ProgressModal: FC<{
             />
             <DialogDescription className="text-muted-foreground flex justify-between text-sm">
               <span className="text-sm">{loadingStage ?? ''}</span>
-              {progress ? <span>{progress}%</span> : null}
+              {progress !== undefined ? <span>{progress}%</span> : null}
             </DialogDescription>
           </div>
         )}

--- a/packages/ui/src/components/progress-modal.tsx
+++ b/packages/ui/src/components/progress-modal.tsx
@@ -18,9 +18,17 @@ const ProgressModal: FC<{
   loadingStage?: string;
   progress?: number;
   indeterminate?: boolean;
+  error?: string;
 }> = (props) => {
-  const {className, isOpen, title, loadingStage, progress, indeterminate} =
-    props;
+  const {
+    className,
+    isOpen,
+    title,
+    loadingStage,
+    progress,
+    indeterminate,
+    error,
+  } = props;
   return (
     <Dialog open={isOpen} onOpenChange={() => {}}>
       <DialogContent
@@ -33,17 +41,28 @@ const ProgressModal: FC<{
         <DialogHeader>
           <DialogTitle>{title ?? ''}</DialogTitle>
         </DialogHeader>
-        <div className="flex flex-col gap-2">
-          <Progress
-            value={progress}
-            className="h-2 w-full"
-            indeterminate={indeterminate}
-          />
-          <DialogDescription className="text-muted-foreground flex justify-between text-sm">
-            <span className="text-sm">{loadingStage ?? ''}</span>
-            {progress ? <span>{progress}%</span> : null}
-          </DialogDescription>
-        </div>
+        {error ? (
+          <div className="flex flex-col gap-3">
+            <DialogDescription className="text-destructive text-sm font-medium">
+              {loadingStage ?? 'Initialization failed'}
+            </DialogDescription>
+            <pre className="bg-muted text-muted-foreground max-h-40 overflow-auto rounded-md p-3 text-xs whitespace-pre-wrap">
+              {error}
+            </pre>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-2">
+            <Progress
+              value={progress}
+              className="h-2 w-full"
+              indeterminate={indeterminate}
+            />
+            <DialogDescription className="text-muted-foreground flex justify-between text-sm">
+              <span className="text-sm">{loadingStage ?? ''}</span>
+              {progress ? <span>{progress}%</span> : null}
+            </DialogDescription>
+          </div>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/packages/ui/src/components/progress-modal.tsx
+++ b/packages/ui/src/components/progress-modal.tsx
@@ -19,6 +19,7 @@ const ProgressModal: FC<{
   progress?: number;
   indeterminate?: boolean;
   error?: string;
+  errorDetails?: string;
 }> = (props) => {
   const {
     className,
@@ -28,6 +29,7 @@ const ProgressModal: FC<{
     progress,
     indeterminate,
     error,
+    errorDetails,
   } = props;
   return (
     <Dialog open={isOpen} onOpenChange={() => {}}>
@@ -46,9 +48,17 @@ const ProgressModal: FC<{
             <DialogDescription className="text-destructive text-sm font-medium">
               {loadingStage ?? 'Initialization failed'}
             </DialogDescription>
-            <pre className="bg-muted text-muted-foreground max-h-40 overflow-auto rounded-md p-3 text-xs whitespace-pre-wrap">
-              {error}
-            </pre>
+            <p className="text-muted-foreground text-sm">{error}</p>
+            {errorDetails ? (
+              <details className="text-muted-foreground text-sm">
+                <summary className="hover:text-foreground cursor-pointer font-medium">
+                  Details
+                </summary>
+                <pre className="bg-muted text-muted-foreground mt-2 max-h-40 overflow-auto rounded-md p-3 text-xs whitespace-pre-wrap">
+                  {errorDetails}
+                </pre>
+              </details>
+            ) : null}
           </div>
         ) : (
           <div className="flex flex-col gap-2">

--- a/python/sqlrooms-cli/README.md
+++ b/python/sqlrooms-cli/README.md
@@ -186,10 +186,11 @@ pnpm --filter sqlrooms-cli-app build
 pnpm dev cli
 ```
 
-This starts the Python API server on `http://127.0.0.1:4173` with `--no-ui`
+This starts the Python API server on `http://127.0.0.1:4273` with `--no-ui`
 and the Vite UI on `http://localhost:4174`. If those ports are busy, the dev
-script selects the next free API and UI ports and points the Vite proxy at the
-selected API port.
+script selects the next free API and UI ports from separate ranges and points
+the Vite proxy at the selected API port. The auto-created dev database is named
+after the selected UI port, for example `sqlrooms-cli-4174.db`.
 
 3. Run the Python API server on its own (optional):
 

--- a/python/sqlrooms-cli/README.md
+++ b/python/sqlrooms-cli/README.md
@@ -189,7 +189,9 @@ pnpm dev cli
 ```
 
 This starts the Python API server on `http://127.0.0.1:4173` with `--no-ui`
-and the Vite UI on `http://localhost:4174`.
+and the Vite UI on `http://localhost:4174`. If those ports are busy, the dev
+script selects the next free API and UI ports and points the Vite proxy at the
+selected API port.
 
 3. Run the Python API server on its own (optional):
 

--- a/python/sqlrooms-cli/README.md
+++ b/python/sqlrooms-cli/README.md
@@ -7,15 +7,13 @@ Launch the SQLRooms AI example locally with a DuckDB websocket backend and persi
 ```bash
 # From the repo root
 uvx sqlrooms \
-  ./sqlrooms.db \
-  --ws-port 4000 \
-  --port 4173
+  ./sqlrooms.db
 ```
 
 What happens:
 
-- Starts the DuckDB websocket backend (from `sqlrooms-server`) on `ws://localhost:4000`.
-- Serves the AI example UI on `http://localhost:4173` and opens your browser (disable with `--no-open-browser`).
+- Starts the DuckDB websocket backend (from `sqlrooms-server`) on a free local port.
+- Serves the AI example UI on `http://localhost:4173`, or the next free port, and opens your browser (disable with `--no-open-browser`).
 - Drag-and-drop CSV/Parquet/DuckDB files to load them into DuckDB; files are uploaded to a local `sqlrooms_uploads` folder and referenced by path.
 - UI state is stored in the SQLRooms meta namespace (default `__sqlrooms`) of the selected DuckDB file.
 
@@ -23,7 +21,7 @@ What happens:
 
 - `--db-path` (default `:memory:`): DuckDB file to load/create. The `__sqlrooms` schema is created automatically.
 - `DB_PATH` (positional): Optional positional alternative to `--db-path` (e.g. `sqlrooms ./my.db`).
-- `--host` / `--port`: HTTP host/port for the UI (default `127.0.0.1:4173`).
+- `--host` / `--port`: HTTP host/port for the UI. If `--port` is omitted, `4173` or the next free port is chosen automatically.
 - `--ws-port`: WebSocket port for DuckDB queries. If omitted, a free port is chosen automatically.
 - `--sync`: Enable optional sync (CRDT) over WebSocket (Loro).
 - `--ai-devtools`: Enable the AI session devtools button in the UI, including production-built UI bundles. Can also be set with `SQLROOMS_AI_DEVTOOLS=1`.

--- a/python/sqlrooms-cli/scripts/dev.mjs
+++ b/python/sqlrooms-cli/scripts/dev.mjs
@@ -38,6 +38,8 @@ function readOptionValue(args, name) {
 }
 
 const forwardedArgs = getForwardedArgs();
+// Keep the standalone dev API aligned with the Vite proxy default. Production
+// `sqlrooms` still auto-selects a free port when --port is omitted.
 const portArgs =
   readOptionValue(forwardedArgs, '--port') === null ? ['--port', '4173'] : [];
 

--- a/python/sqlrooms-cli/scripts/dev.mjs
+++ b/python/sqlrooms-cli/scripts/dev.mjs
@@ -1,11 +1,9 @@
 import {spawnSync} from 'node:child_process';
+import {mkdtempSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
 
-const defaultArgs = [
-  'run',
-  'sqlrooms',
-  '--no-open-browser',
-  '--no-ui',
-];
+const defaultArgs = ['run', 'sqlrooms', '--no-open-browser', '--no-ui'];
 
 function getForwardedArgs() {
   const raw = process.env.SQLROOMS_CLI_DEV_ARGS;
@@ -36,6 +34,12 @@ function readOptionValue(args, name) {
 }
 
 const forwardedArgs = getForwardedArgs();
+
+function createDefaultDbPath() {
+  const defaultDbDir = mkdtempSync(path.join(tmpdir(), 'sqlrooms-cli-'));
+  return path.join(defaultDbDir, 'sqlrooms.db');
+}
+
 // Keep the standalone dev API aligned with the Vite proxy default. Production
 // `sqlrooms` still auto-selects a free port when --port is omitted.
 const portArgs =
@@ -43,7 +47,7 @@ const portArgs =
 const dbPathArgs =
   readOptionValue(forwardedArgs, '--db-path') === null &&
   readOptionValue(forwardedArgs, '-d') === null
-    ? ['--db-path', '/tmp/sqlrooms-cli.db']
+    ? ['--db-path', createDefaultDbPath()]
     : [];
 
 const result = spawnSync(

--- a/python/sqlrooms-cli/scripts/dev.mjs
+++ b/python/sqlrooms-cli/scripts/dev.mjs
@@ -5,8 +5,6 @@ const defaultArgs = [
   'sqlrooms',
   '--no-open-browser',
   '--no-ui',
-  '--db-path',
-  '/tmp/sqlrooms-cli.db',
 ];
 
 function getForwardedArgs() {
@@ -42,11 +40,20 @@ const forwardedArgs = getForwardedArgs();
 // `sqlrooms` still auto-selects a free port when --port is omitted.
 const portArgs =
   readOptionValue(forwardedArgs, '--port') === null ? ['--port', '4173'] : [];
+const dbPathArgs =
+  readOptionValue(forwardedArgs, '--db-path') === null &&
+  readOptionValue(forwardedArgs, '-d') === null
+    ? ['--db-path', '/tmp/sqlrooms-cli.db']
+    : [];
 
-const result = spawnSync('uv', [...defaultArgs, ...portArgs, ...forwardedArgs], {
-  stdio: 'inherit',
-  shell: process.platform === 'win32',
-});
+const result = spawnSync(
+  'uv',
+  [...defaultArgs, ...portArgs, ...dbPathArgs, ...forwardedArgs],
+  {
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+  },
+);
 
 if (typeof result.status === 'number') {
   process.exit(result.status);

--- a/python/sqlrooms-cli/scripts/dev.mjs
+++ b/python/sqlrooms-cli/scripts/dev.mjs
@@ -1,5 +1,4 @@
 import {spawnSync} from 'node:child_process';
-import net from 'node:net';
 
 const defaultArgs = [
   'run',
@@ -38,33 +37,9 @@ function readOptionValue(args, name) {
   return null;
 }
 
-async function isPortAvailable(host, port) {
-  return await new Promise((resolve) => {
-    const server = net.createServer();
-    server.once('error', () => resolve(false));
-    server.once('listening', () => {
-      server.close(() => resolve(true));
-    });
-    server.listen(port, host);
-  });
-}
-
-async function findAvailablePort(startPort, host) {
-  let port = startPort;
-  while (port <= 65535) {
-    if (await isPortAvailable(host, port)) return port;
-    console.log(`Port ${port} is in use, trying another one...`);
-    port += 1;
-  }
-  throw new Error(`No available port found starting from ${startPort}.`);
-}
-
 const forwardedArgs = getForwardedArgs();
-const host = readOptionValue(forwardedArgs, '--host') ?? '127.0.0.1';
 const portArgs =
-  readOptionValue(forwardedArgs, '--port') === null
-    ? ['--port', String(await findAvailablePort(4173, host))]
-    : [];
+  readOptionValue(forwardedArgs, '--port') === null ? ['--port', '4173'] : [];
 
 const result = spawnSync('uv', [...defaultArgs, ...portArgs, ...forwardedArgs], {
   stdio: 'inherit',

--- a/python/sqlrooms-cli/scripts/dev.mjs
+++ b/python/sqlrooms-cli/scripts/dev.mjs
@@ -1,12 +1,9 @@
 import {spawnSync} from 'node:child_process';
+import net from 'node:net';
 
 const defaultArgs = [
   'run',
   'sqlrooms',
-  '--ws-port',
-  '4000',
-  '--port',
-  '4173',
   '--no-open-browser',
   '--no-ui',
   '--db-path',
@@ -31,7 +28,45 @@ function unwrapForwardedArgs(args) {
   return args.slice(separatorIndex + 1);
 }
 
-const result = spawnSync('uv', [...defaultArgs, ...getForwardedArgs()], {
+function readOptionValue(args, name) {
+  const prefix = `${name}=`;
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === name) return args[index + 1] ?? null;
+    if (arg.startsWith(prefix)) return arg.slice(prefix.length);
+  }
+  return null;
+}
+
+async function isPortAvailable(host, port) {
+  return await new Promise((resolve) => {
+    const server = net.createServer();
+    server.once('error', () => resolve(false));
+    server.once('listening', () => {
+      server.close(() => resolve(true));
+    });
+    server.listen(port, host);
+  });
+}
+
+async function findAvailablePort(startPort, host) {
+  let port = startPort;
+  while (port <= 65535) {
+    if (await isPortAvailable(host, port)) return port;
+    console.log(`Port ${port} is in use, trying another one...`);
+    port += 1;
+  }
+  throw new Error(`No available port found starting from ${startPort}.`);
+}
+
+const forwardedArgs = getForwardedArgs();
+const host = readOptionValue(forwardedArgs, '--host') ?? '127.0.0.1';
+const portArgs =
+  readOptionValue(forwardedArgs, '--port') === null
+    ? ['--port', String(await findAvailablePort(4173, host))]
+    : [];
+
+const result = spawnSync('uv', [...defaultArgs, ...portArgs, ...forwardedArgs], {
   stdio: 'inherit',
   shell: process.platform === 'win32',
 });

--- a/python/sqlrooms-cli/sqlrooms/cli.py
+++ b/python/sqlrooms-cli/sqlrooms/cli.py
@@ -18,7 +18,7 @@ from .web.db_bridge import (
     PostgresConnectorSettings,
     SnowflakeConnectorSettings,
 )
-from .web.launcher import SqlroomsHttpServer
+from .web.launcher import SqlroomsHttpServer, _pick_free_port
 
 logging.basicConfig(
     level=logging.INFO,
@@ -37,6 +37,20 @@ if sys.platform.startswith("win"):
 else:
     _config_base = Path.home() / ".config" / "sqlrooms"
 DEFAULT_CONFIG_PATH = _config_base / "config.toml"
+DEFAULT_HTTP_PORT = 4173
+
+
+def _resolve_http_port(host: str, port: int | None) -> int:
+    if port is not None:
+        return port
+    selected_port = _pick_free_port(host, DEFAULT_HTTP_PORT)
+    if selected_port != DEFAULT_HTTP_PORT:
+        logger.info(
+            "Port %s is in use, using HTTP port %s instead",
+            DEFAULT_HTTP_PORT,
+            selected_port,
+        )
+    return selected_port
 
 
 def _normalize_config_string(value: Any) -> str | None:
@@ -393,7 +407,11 @@ def main(
         show_default=True,
     ),
     host: str = typer.Option("127.0.0.1", "--host", help="HTTP host for the UI."),
-    port: int = typer.Option(4173, "--port", help="HTTP port for the UI."),
+    port: int | None = typer.Option(
+        None,
+        "--port",
+        help="HTTP port for the UI. If omitted, 4173 or the next free port is chosen automatically.",
+    ),
     ws_port: int | None = typer.Option(
         None,
         "--ws-port",
@@ -471,6 +489,7 @@ def main(
     )
 
     resolved_db_path = db_path if db_path is not None else db_path_option
+    selected_port = _resolve_http_port(host, port)
     selected_api_key = (
         str(ai_providers.get(llm_provider or "", {}).get("apiKey") or "")
         if llm_provider
@@ -479,7 +498,7 @@ def main(
     server = SqlroomsHttpServer(
         db_path=resolved_db_path,
         host=host,
-        port=port,
+        port=selected_port,
         ws_port=ws_port,
         sync_enabled=sync,
         meta_db=meta_db,

--- a/python/sqlrooms-cli/sqlrooms/cli.py
+++ b/python/sqlrooms-cli/sqlrooms/cli.py
@@ -40,10 +40,15 @@ DEFAULT_CONFIG_PATH = _config_base / "config.toml"
 DEFAULT_HTTP_PORT = 4173
 
 
-def _resolve_http_port(host: str, port: int | None) -> int:
+def _resolve_http_port(host: str, port: int | None, ws_port: int | None = None) -> int:
     if port is not None:
         return port
-    selected_port = _pick_free_port(host, DEFAULT_HTTP_PORT)
+    reserved_ports = {ws_port} if ws_port is not None else None
+    selected_port = _pick_free_port(
+        host,
+        DEFAULT_HTTP_PORT,
+        reserved_ports=reserved_ports,
+    )
     if selected_port != DEFAULT_HTTP_PORT:
         logger.info(
             "Port %s is in use, using HTTP port %s instead",
@@ -489,7 +494,7 @@ def main(
     )
 
     resolved_db_path = db_path if db_path is not None else db_path_option
-    selected_port = _resolve_http_port(host, port)
+    selected_port = _resolve_http_port(host, port, ws_port)
     selected_api_key = (
         str(ai_providers.get(llm_provider or "", {}).get("apiKey") or "")
         if llm_provider

--- a/python/sqlrooms-cli/sqlrooms/web/launcher.py
+++ b/python/sqlrooms-cli/sqlrooms/web/launcher.py
@@ -279,7 +279,16 @@ def _sanitize_filename(name: str) -> str:
     return safe or "upload.dat"
 
 
-def _can_bind_port(host: str, port: int) -> bool:
+def _localhost_probe_hosts(host: str) -> tuple[str, ...]:
+    return ("127.0.0.1", "::1") if host == "localhost" else (host,)
+
+
+def _can_bind_single_host_port(
+    host: str,
+    port: int,
+    *,
+    ignore_unavailable: bool = False,
+) -> bool:
     is_ipv6 = ":" in host and host != "0.0.0.0"
     family = socket.AF_INET6 if is_ipv6 else socket.AF_INET
     sock = socket.socket(family, socket.SOCK_STREAM)
@@ -293,9 +302,25 @@ def _can_bind_port(host: str, port: int) -> bool:
     except OSError as exc:
         if exc.errno in {errno.EADDRINUSE, errno.EACCES}:
             return False
+        if ignore_unavailable and exc.errno in {
+            errno.EADDRNOTAVAIL,
+            errno.EAFNOSUPPORT,
+        }:
+            return True
         raise
     finally:
         sock.close()
+
+
+def _can_bind_port(host: str, port: int) -> bool:
+    return all(
+        _can_bind_single_host_port(
+            probe_host,
+            port,
+            ignore_unavailable=host == "localhost",
+        )
+        for probe_host in _localhost_probe_hosts(host)
+    )
 
 
 def _pick_free_port(

--- a/python/sqlrooms-cli/sqlrooms/web/launcher.py
+++ b/python/sqlrooms-cli/sqlrooms/web/launcher.py
@@ -278,15 +278,38 @@ def _sanitize_filename(name: str) -> str:
     return safe or "upload.dat"
 
 
-def _pick_free_port(host: str) -> int:
+def _can_bind_port(host: str, port: int) -> bool:
+    is_ipv6 = ":" in host and host != "0.0.0.0"
+    family = socket.AF_INET6 if is_ipv6 else socket.AF_INET
+    sock = socket.socket(family, socket.SOCK_STREAM)
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        if family == socket.AF_INET6:
+            sock.bind((host, port, 0, 0))
+        else:
+            sock.bind((host, port))
+        return True
+    except OSError:
+        return False
+    finally:
+        sock.close()
+
+
+def _pick_free_port(host: str, start_port: int | None = None) -> int:
     """
     Pick an available TCP port for a local background server.
 
-    This is best-effort: we bind to port 0 to have the OS select a free port,
-    read it back, then close the socket.
+    If ``start_port`` is provided, scan upward from that port. Otherwise bind to
+    port 0 and let the OS select a free port.
     """
     is_ipv6 = ":" in host and host != "0.0.0.0"
     family = socket.AF_INET6 if is_ipv6 else socket.AF_INET
+    if start_port is not None:
+        for port in range(start_port, 65536):
+            if _can_bind_port(host, port):
+                return port
+        raise RuntimeError(f"No available port found starting from {start_port}.")
+
     sock = socket.socket(family, socket.SOCK_STREAM)
     try:
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)

--- a/python/sqlrooms-cli/sqlrooms/web/launcher.py
+++ b/python/sqlrooms-cli/sqlrooms/web/launcher.py
@@ -539,10 +539,9 @@ class SqlroomsHttpServer:
             logger.error("Failed to start DuckDB websocket backend")
             return
         if not self._duckdb_ready.is_set():
-            self._duckdb_start_error = TimeoutError(
-                "Timed out starting DuckDB websocket backend"
+            logger.warning(
+                "DuckDB websocket backend is still starting after 10 seconds"
             )
-            logger.error("Timed out starting DuckDB websocket backend")
             return
         logger.info(
             "Started DuckDB websocket backend at ws://%s:%s",

--- a/python/sqlrooms-cli/sqlrooms/web/launcher.py
+++ b/python/sqlrooms-cli/sqlrooms/web/launcher.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
+import errno
+import json
 import logging
 import os
 import re
+import secrets
 import socket
 import tempfile
 import threading
 import webbrowser
-import json
-import secrets
 from pathlib import Path
 from typing import Any, Dict
 
@@ -289,13 +290,20 @@ def _can_bind_port(host: str, port: int) -> bool:
         else:
             sock.bind((host, port))
         return True
-    except OSError:
-        return False
+    except OSError as exc:
+        if exc.errno in {errno.EADDRINUSE, errno.EACCES}:
+            return False
+        raise
     finally:
         sock.close()
 
 
-def _pick_free_port(host: str, start_port: int | None = None) -> int:
+def _pick_free_port(
+    host: str,
+    start_port: int | None = None,
+    *,
+    reserved_ports: set[int] | None = None,
+) -> int:
     """
     Pick an available TCP port for a local background server.
 
@@ -304,8 +312,11 @@ def _pick_free_port(host: str, start_port: int | None = None) -> int:
     """
     is_ipv6 = ":" in host and host != "0.0.0.0"
     family = socket.AF_INET6 if is_ipv6 else socket.AF_INET
+    reserved = reserved_ports or set()
     if start_port is not None:
         for port in range(start_port, 65536):
+            if port in reserved:
+                continue
             if _can_bind_port(host, port):
                 return port
         raise RuntimeError(f"No available port found starting from {start_port}.")

--- a/python/sqlrooms-cli/sqlrooms/web/launcher.py
+++ b/python/sqlrooms-cli/sqlrooms/web/launcher.py
@@ -457,6 +457,8 @@ class SqlroomsHttpServer:
         self.upload_dir = base_dir / "sqlrooms_uploads"
         self.upload_dir.mkdir(parents=True, exist_ok=True)
         self._duckdb_thread: threading.Thread | None = None
+        self._duckdb_ready = threading.Event()
+        self._duckdb_start_error: BaseException | None = None
 
     async def start(self) -> None:
         logger.info("Starting sqlrooms CLI server")
@@ -498,6 +500,8 @@ class SqlroomsHttpServer:
         return "localhost" if self.host in ("0.0.0.0", "::") else self.host
 
     def _start_duckdb_backend(self) -> None:
+        self._duckdb_ready.clear()
+        self._duckdb_start_error = None
         thread = threading.Thread(
             target=self._run_duckdb_server,
             daemon=True,
@@ -505,6 +509,13 @@ class SqlroomsHttpServer:
         )
         thread.start()
         self._duckdb_thread = thread
+        self._duckdb_ready.wait(timeout=10)
+        if self._duckdb_start_error is not None:
+            raise RuntimeError(
+                "Failed to start DuckDB websocket backend"
+            ) from self._duckdb_start_error
+        if not self._duckdb_ready.is_set():
+            raise RuntimeError("Timed out starting DuckDB websocket backend")
         logger.info(
             "Started DuckDB websocket backend at ws://%s:%s",
             self._public_host(),
@@ -933,6 +944,7 @@ class SqlroomsHttpServer:
         signal.signal = _noop_signal  # type: ignore
         try:
             db_async.init_global_connection(self.duckdb_database, extensions=["httpfs"])
+            self._duckdb_ready.set()
             cache = QueryCache()
             duckdb_ws_server(
                 cache,
@@ -946,5 +958,9 @@ class SqlroomsHttpServer:
                 ),
                 local_only=True,
             )
+        except Exception as exc:
+            self._duckdb_start_error = exc
+            self._duckdb_ready.set()
+            logger.exception("DuckDB websocket backend failed to start")
         finally:
             signal.signal = original_signal  # type: ignore

--- a/python/sqlrooms-cli/sqlrooms/web/launcher.py
+++ b/python/sqlrooms-cli/sqlrooms/web/launcher.py
@@ -511,16 +511,56 @@ class SqlroomsHttpServer:
         self._duckdb_thread = thread
         self._duckdb_ready.wait(timeout=10)
         if self._duckdb_start_error is not None:
-            raise RuntimeError(
-                "Failed to start DuckDB websocket backend"
-            ) from self._duckdb_start_error
+            logger.error("Failed to start DuckDB websocket backend")
+            return
         if not self._duckdb_ready.is_set():
-            raise RuntimeError("Timed out starting DuckDB websocket backend")
+            self._duckdb_start_error = TimeoutError(
+                "Timed out starting DuckDB websocket backend"
+            )
+            logger.error("Timed out starting DuckDB websocket backend")
+            return
         logger.info(
             "Started DuckDB websocket backend at ws://%s:%s",
             self._public_host(),
             self.ws_port,
         )
+
+    def _format_startup_error(self, exc: BaseException) -> Dict[str, str]:
+        details: list[str] = []
+        current: BaseException | None = exc
+        while current is not None:
+            error_type = type(current).__name__
+            message = str(current) or error_type
+            details.append(f"{error_type}: {message}")
+            current = current.__cause__ or current.__context__
+
+        return {
+            "message": str(exc) or type(exc).__name__,
+            "details": "\nCaused by: ".join(details),
+        }
+
+    def _runtime_status(self) -> Dict[str, Any]:
+        duckdb_status: Dict[str, Any]
+        if self._duckdb_start_error is not None:
+            error = self._format_startup_error(self._duckdb_start_error)
+            duckdb_status = {
+                "status": "error",
+                "message": "DuckDB websocket backend failed to start",
+                "error": error["message"],
+                "details": error["details"],
+            }
+        elif self._duckdb_ready.is_set():
+            duckdb_status = {"status": "ready"}
+        else:
+            duckdb_status = {"status": "starting"}
+
+        status = "ready" if duckdb_status["status"] == "ready" else "degraded"
+        return {
+            "status": status,
+            "components": {
+                "duckdbWebSocket": duckdb_status,
+            },
+        }
 
     def _runtime_config(self) -> Dict[str, Any]:
         return {
@@ -545,6 +585,7 @@ class SqlroomsHttpServer:
             },
             "dbPath": self.duckdb_database,
             "metaNamespace": self.meta_namespace,
+            "startupStatus": self._runtime_status(),
             "dbBridge": {
                 "id": self.db_bridge_registry.bridge_id,
                 "connections": self.db_bridge_registry.runtime_connections(),
@@ -601,6 +642,14 @@ class SqlroomsHttpServer:
         @app.get("/config.json")
         async def get_config_json():
             return self._runtime_config()
+
+        @app.get("/api/status")
+        async def get_status():
+            return self._runtime_status()
+
+        @app.get("/status.json")
+        async def get_status_json():
+            return self._runtime_status()
 
         @app.get("/api/db/settings")
         async def get_db_settings():

--- a/python/sqlrooms-cli/sqlrooms/web/launcher.py
+++ b/python/sqlrooms-cli/sqlrooms/web/launcher.py
@@ -1018,6 +1018,7 @@ class SqlroomsHttpServer:
         signal.signal = _noop_signal  # type: ignore
         try:
             db_async.init_global_connection(self.duckdb_database, extensions=["httpfs"])
+            self._duckdb_start_error = None
             self._duckdb_ready.set()
             cache = QueryCache()
             duckdb_ws_server(

--- a/python/sqlrooms-cli/tests/test_cli.py
+++ b/python/sqlrooms-cli/tests/test_cli.py
@@ -37,14 +37,27 @@ def test_resolve_http_port_honors_explicit_port(monkeypatch):
 def test_resolve_http_port_scans_from_default(monkeypatch):
     calls = []
 
-    def fake_pick_free_port(host, start_port=None):
-        calls.append((host, start_port))
+    def fake_pick_free_port(host, start_port=None, *, reserved_ports=None):
+        calls.append((host, start_port, reserved_ports))
         return 4176
 
     monkeypatch.setattr("sqlrooms.cli._pick_free_port", fake_pick_free_port)
 
     assert _resolve_http_port("127.0.0.1", None) == 4176
-    assert calls == [("127.0.0.1", DEFAULT_HTTP_PORT)]
+    assert calls == [("127.0.0.1", DEFAULT_HTTP_PORT, None)]
+
+
+def test_resolve_http_port_reserves_explicit_ws_port(monkeypatch):
+    calls = []
+
+    def fake_pick_free_port(host, start_port=None, *, reserved_ports=None):
+        calls.append((host, start_port, reserved_ports))
+        return 4175
+
+    monkeypatch.setattr("sqlrooms.cli._pick_free_port", fake_pick_free_port)
+
+    assert _resolve_http_port("127.0.0.1", None, ws_port=4174) == 4175
+    assert calls == [("127.0.0.1", DEFAULT_HTTP_PORT, {4174})]
 
 
 def test_cli_export_help():

--- a/python/sqlrooms-cli/tests/test_cli.py
+++ b/python/sqlrooms-cli/tests/test_cli.py
@@ -4,10 +4,12 @@ import click
 from typer.testing import CliRunner
 from sqlrooms.cli import (
     DEFAULT_CONFIG_PATH,
+    DEFAULT_HTTP_PORT,
     _load_ai_runtime_config,
     _load_connector_config,
     _normalize_config_string,
     _resolve_config_path,
+    _resolve_http_port,
     app,
 )
 from sqlrooms.web.db_bridge import PostgresConnectorSettings, SnowflakeConnectorSettings
@@ -21,6 +23,28 @@ def test_cli_help():
     assert result.exit_code == 0
     assert "Start the SQLRooms local experience" in stdout
     assert "--ai-devtools" in stdout
+    assert "next free port" in stdout
+
+
+def test_resolve_http_port_honors_explicit_port(monkeypatch):
+    def fail_pick_free_port(host, start_port=None):
+        raise AssertionError("explicit --port should not scan for a free port")
+
+    monkeypatch.setattr("sqlrooms.cli._pick_free_port", fail_pick_free_port)
+    assert _resolve_http_port("127.0.0.1", 5000) == 5000
+
+
+def test_resolve_http_port_scans_from_default(monkeypatch):
+    calls = []
+
+    def fake_pick_free_port(host, start_port=None):
+        calls.append((host, start_port))
+        return 4176
+
+    monkeypatch.setattr("sqlrooms.cli._pick_free_port", fake_pick_free_port)
+
+    assert _resolve_http_port("127.0.0.1", None) == 4176
+    assert calls == [("127.0.0.1", DEFAULT_HTTP_PORT)]
 
 
 def test_cli_export_help():

--- a/python/sqlrooms-cli/tests/test_launcher.py
+++ b/python/sqlrooms-cli/tests/test_launcher.py
@@ -122,6 +122,24 @@ def test_duckdb_backend_start_failure_is_propagated(server, monkeypatch):
     assert "RuntimeError: duckdb lock held" in duckdb_status["details"]
 
 
+def test_duckdb_backend_slow_start_remains_starting(server, monkeypatch):
+    class FakeThread:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def start(self):
+            pass
+
+    monkeypatch.setattr("sqlrooms.web.launcher.threading.Thread", FakeThread)
+    monkeypatch.setattr(server._duckdb_ready, "wait", lambda timeout=None: False)
+
+    server._start_duckdb_backend()
+
+    duckdb_status = server._runtime_status()["components"]["duckdbWebSocket"]
+    assert server._duckdb_start_error is None
+    assert duckdb_status["status"] == "starting"
+
+
 def test_duckdb_backend_late_success_clears_timeout_status(server, monkeypatch):
     monkeypatch.setattr(
         "sqlrooms.web.launcher.db_async.init_global_connection",

--- a/python/sqlrooms-cli/tests/test_launcher.py
+++ b/python/sqlrooms-cli/tests/test_launcher.py
@@ -41,6 +41,9 @@ def test_api_config(server):
     assert data["dbBridge"]["connections"] == []
     assert data["dbBridge"]["diagnostics"] == []
     assert "wsAuthToken" in data
+    assert (
+        data["startupStatus"]["components"]["duckdbWebSocket"]["status"] == "starting"
+    )
 
 
 def test_pick_free_port_scans_up_from_occupied_port():
@@ -90,8 +93,20 @@ def test_duckdb_backend_start_failure_is_propagated(server, monkeypatch):
         fail_init_global_connection,
     )
 
-    with pytest.raises(RuntimeError, match="Failed to start DuckDB websocket backend"):
-        server._start_duckdb_backend()
+    server._start_duckdb_backend()
+
+    app = server._build_app()
+    client = TestClient(app)
+    response = client.get("/api/status")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "degraded"
+    duckdb_status = data["components"]["duckdbWebSocket"]
+    assert duckdb_status["status"] == "error"
+    assert duckdb_status["message"] == "DuckDB websocket backend failed to start"
+    assert duckdb_status["error"] == "duckdb lock held"
+    assert "RuntimeError: duckdb lock held" in duckdb_status["details"]
 
 
 def test_api_config_with_ai_provider_metadata(tmp_path):

--- a/python/sqlrooms-cli/tests/test_launcher.py
+++ b/python/sqlrooms-cli/tests/test_launcher.py
@@ -1,9 +1,12 @@
+import socket
+
 import pytest
 from fastapi.testclient import TestClient
 from fastapi import UploadFile
 from starlette.requests import Request
 from sqlrooms.web.db_bridge import PostgresConnectorSettings, SnowflakeConnectorSettings
 from sqlrooms.web.launcher import SqlroomsHttpServer
+from sqlrooms.web.launcher import _pick_free_port
 from sqlrooms.web.launcher import _write_ai_settings_to_toml
 from sqlrooms.web.launcher import _write_db_connectors_to_toml
 from sqlrooms.web.launcher import _write_upload_to_path
@@ -38,6 +41,21 @@ def test_api_config(server):
     assert data["dbBridge"]["connections"] == []
     assert data["dbBridge"]["diagnostics"] == []
     assert "wsAuthToken" in data
+
+
+def test_pick_free_port_scans_up_from_occupied_port():
+    host = "127.0.0.1"
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.bind((host, 0))
+        sock.listen()
+        occupied_port = int(sock.getsockname()[1])
+
+        selected_port = _pick_free_port(host, occupied_port)
+
+        assert selected_port > occupied_port
+    finally:
+        sock.close()
 
 
 def test_api_config_with_ai_provider_metadata(tmp_path):

--- a/python/sqlrooms-cli/tests/test_launcher.py
+++ b/python/sqlrooms-cli/tests/test_launcher.py
@@ -58,6 +58,29 @@ def test_pick_free_port_scans_up_from_occupied_port():
         sock.close()
 
 
+def test_pick_free_port_skips_reserved_port():
+    host = "127.0.0.1"
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.bind((host, 0))
+        reserved_port = int(sock.getsockname()[1])
+    finally:
+        sock.close()
+
+    selected_port = _pick_free_port(
+        host,
+        reserved_port,
+        reserved_ports={reserved_port},
+    )
+
+    assert selected_port > reserved_port
+
+
+def test_pick_free_port_fails_fast_for_invalid_host():
+    with pytest.raises(OSError):
+        _pick_free_port("not-a-bindable-host.invalid", 4173)
+
+
 def test_api_config_with_ai_provider_metadata(tmp_path):
     db_path = tmp_path / "test.db"
     server = SqlroomsHttpServer(

--- a/python/sqlrooms-cli/tests/test_launcher.py
+++ b/python/sqlrooms-cli/tests/test_launcher.py
@@ -122,6 +122,23 @@ def test_duckdb_backend_start_failure_is_propagated(server, monkeypatch):
     assert "RuntimeError: duckdb lock held" in duckdb_status["details"]
 
 
+def test_duckdb_backend_late_success_clears_timeout_status(server, monkeypatch):
+    monkeypatch.setattr(
+        "sqlrooms.web.launcher.db_async.init_global_connection",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "sqlrooms.web.launcher.duckdb_ws_server",
+        lambda *_args, **_kwargs: None,
+    )
+    server._duckdb_start_error = TimeoutError("Timed out starting")
+
+    server._run_duckdb_server()
+
+    assert server._duckdb_start_error is None
+    assert server._runtime_status()["status"] == "ready"
+
+
 def test_api_config_with_ai_provider_metadata(tmp_path):
     db_path = tmp_path / "test.db"
     server = SqlroomsHttpServer(

--- a/python/sqlrooms-cli/tests/test_launcher.py
+++ b/python/sqlrooms-cli/tests/test_launcher.py
@@ -6,6 +6,7 @@ from fastapi import UploadFile
 from starlette.requests import Request
 from sqlrooms.web.db_bridge import PostgresConnectorSettings, SnowflakeConnectorSettings
 from sqlrooms.web.launcher import SqlroomsHttpServer
+from sqlrooms.web.launcher import _can_bind_port
 from sqlrooms.web.launcher import _pick_free_port
 from sqlrooms.web.launcher import _write_ai_settings_to_toml
 from sqlrooms.web.launcher import _write_db_connectors_to_toml
@@ -77,6 +78,18 @@ def test_pick_free_port_skips_reserved_port():
     )
 
     assert selected_port > reserved_port
+
+
+def test_localhost_port_probe_checks_ipv4_loopback():
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.bind(("127.0.0.1", 0))
+        sock.listen()
+        occupied_port = int(sock.getsockname()[1])
+
+        assert _can_bind_port("localhost", occupied_port) is False
+    finally:
+        sock.close()
 
 
 def test_pick_free_port_fails_fast_for_invalid_host():

--- a/python/sqlrooms-cli/tests/test_launcher.py
+++ b/python/sqlrooms-cli/tests/test_launcher.py
@@ -81,6 +81,19 @@ def test_pick_free_port_fails_fast_for_invalid_host():
         _pick_free_port("not-a-bindable-host.invalid", 4173)
 
 
+def test_duckdb_backend_start_failure_is_propagated(server, monkeypatch):
+    def fail_init_global_connection(*_args, **_kwargs):
+        raise RuntimeError("duckdb lock held")
+
+    monkeypatch.setattr(
+        "sqlrooms.web.launcher.db_async.init_global_connection",
+        fail_init_global_connection,
+    )
+
+    with pytest.raises(RuntimeError, match="Failed to start DuckDB websocket backend"):
+        server._start_duckdb_backend()
+
+
 def test_api_config_with_ai_provider_metadata(tmp_path):
     db_path = tmp_path / "test.db"
     server = SqlroomsHttpServer(

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -101,6 +101,10 @@ function publicHost(host) {
   return host === '0.0.0.0' || host === '::' ? 'localhost' : host;
 }
 
+function hostForUrl(host) {
+  return host.includes(':') && !host.startsWith('[') ? `[${host}]` : host;
+}
+
 async function isPortAvailable(host, port) {
   return await new Promise((resolve) => {
     const server = net.createServer();
@@ -133,7 +137,7 @@ function parsePortOption(args, name) {
 
 async function getCliDevPorts(args) {
   const host = readOptionValue(args, '--host') ?? '127.0.0.1';
-  const proxyHost = publicHost(host);
+  const proxyHost = hostForUrl(publicHost(host));
   const explicitApiPort = parsePortOption(args, '--port');
   const apiPort =
     explicitApiPort ??

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -139,9 +139,13 @@ async function getCliDevPorts(args) {
   const host = readOptionValue(args, '--host') ?? '127.0.0.1';
   const proxyHost = hostForUrl(publicHost(host));
   const explicitApiPort = parsePortOption(args, '--port');
+  const explicitWsPort = parsePortOption(args, '--ws-port');
+  const reservedPorts = new Set(
+    [4174, explicitWsPort].filter((port) => typeof port === 'number'),
+  );
   const apiPort =
     explicitApiPort ??
-    (await findAvailablePort(4173, host, new Set([4174])));
+    (await findAvailablePort(4173, host, reservedPorts));
   const uiPort = await findAvailablePort(4174, '0.0.0.0', new Set([apiPort]));
   return {apiPort, proxyHost, uiPort};
 }

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -146,7 +146,10 @@ async function getCliDevPorts(args) {
   const apiPort =
     explicitApiPort ??
     (await findAvailablePort(4173, host, reservedPorts));
-  const uiPort = await findAvailablePort(4174, '0.0.0.0', new Set([apiPort]));
+  const uiReservedPorts = new Set(
+    [apiPort, explicitWsPort].filter((port) => typeof port === 'number'),
+  );
+  const uiPort = await findAvailablePort(4174, '0.0.0.0', uiReservedPorts);
   return {apiPort, proxyHost, uiPort};
 }
 

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,5 +1,6 @@
 import {spawn, spawnSync} from 'node:child_process';
 import net from 'node:net';
+import {tmpdir} from 'node:os';
 import path from 'node:path';
 
 /**
@@ -105,12 +106,27 @@ function hostForUrl(host) {
   return host.includes(':') && !host.startsWith('[') ? `[${host}]` : host;
 }
 
-async function isPortAvailable(host, port) {
+function portProbeHosts(host) {
+  return host === 'localhost' ? ['127.0.0.1', '::1'] : [host];
+}
+
+async function isPortAvailableOnHost(
+  host,
+  port,
+  {ignoreUnavailable = false} = {},
+) {
   return await new Promise((resolve, reject) => {
     const server = net.createServer();
     server.once('error', (error) => {
       if (error.code === 'EADDRINUSE' || error.code === 'EACCES') {
         resolve(false);
+        return;
+      }
+      if (
+        ignoreUnavailable &&
+        (error.code === 'EADDRNOTAVAIL' || error.code === 'EAFNOSUPPORT')
+      ) {
+        resolve(true);
         return;
       }
       reject(error);
@@ -120,6 +136,18 @@ async function isPortAvailable(host, port) {
     });
     server.listen(port, host);
   });
+}
+
+async function isPortAvailable(host, port) {
+  const probeHosts = portProbeHosts(host);
+  const results = await Promise.all(
+    probeHosts.map((probeHost) =>
+      isPortAvailableOnHost(probeHost, port, {
+        ignoreUnavailable: host === 'localhost',
+      }),
+    ),
+  );
+  return results.every(Boolean);
 }
 
 async function findAvailablePort(startPort, host, reservedPorts = new Set()) {
@@ -186,8 +214,7 @@ async function getCliDevPorts(args) {
     [4174, explicitWsPort].filter((port) => typeof port === 'number'),
   );
   const apiPort =
-    explicitApiPort ??
-    (await findAvailablePort(4173, host, reservedPorts));
+    explicitApiPort ?? (await findAvailablePort(4173, host, reservedPorts));
   const uiReservedPorts = new Set(
     [apiPort, explicitWsPort].filter((port) => typeof port === 'number'),
   );
@@ -379,14 +406,22 @@ if (target === 'cli') {
     : ['--port', String(apiPort), ...cliArgs];
   const pythonCliArgs = hasDbPathArg(apiPortArgs)
     ? apiPortArgs
-    : ['--db-path', `/tmp/sqlrooms-cli-${apiPort}.db`, ...apiPortArgs];
-  startProcess('sqlrooms CLI UI dev server', ['--host', '--port', String(uiPort)], {
-    command: path.resolve('apps/sqlrooms-cli-ui', 'node_modules/.bin/vite'),
-    cwd: path.resolve('apps/sqlrooms-cli-ui'),
-    env: {
-      SQLROOMS_CLI_API_PROXY_TARGET: `http://${proxyHost}:${apiPort}`,
+    : [
+        '--db-path',
+        path.join(tmpdir(), `sqlrooms-cli-${apiPort}.db`),
+        ...apiPortArgs,
+      ];
+  startProcess(
+    'sqlrooms CLI UI dev server',
+    ['--host', '--port', String(uiPort)],
+    {
+      command: path.resolve('apps/sqlrooms-cli-ui', 'node_modules/.bin/vite'),
+      cwd: path.resolve('apps/sqlrooms-cli-ui'),
+      env: {
+        SQLROOMS_CLI_API_PROXY_TARGET: `http://${proxyHost}:${apiPort}`,
+      },
     },
-  });
+  );
   startProcess('sqlrooms Python CLI dev server', ['scripts/dev.mjs'], {
     command: process.execPath,
     cwd: path.resolve('python/sqlrooms-cli'),

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -106,9 +106,15 @@ function hostForUrl(host) {
 }
 
 async function isPortAvailable(host, port) {
-  return await new Promise((resolve) => {
+  return await new Promise((resolve, reject) => {
     const server = net.createServer();
-    server.once('error', () => resolve(false));
+    server.once('error', (error) => {
+      if (error.code === 'EADDRINUSE' || error.code === 'EACCES') {
+        resolve(false);
+        return;
+      }
+      reject(error);
+    });
     server.once('listening', () => {
       server.close(() => resolve(true));
     });
@@ -133,6 +139,42 @@ function parsePortOption(args, name) {
   if (value === null) return null;
   const port = Number.parseInt(value, 10);
   return Number.isFinite(port) ? port : null;
+}
+
+function hasDbPathArg(args) {
+  if (
+    readOptionValue(args, '--db-path') !== null ||
+    readOptionValue(args, '-d') !== null
+  ) {
+    return true;
+  }
+
+  const optionsWithValue = new Set([
+    '--config',
+    '--db-path',
+    '--host',
+    '--meta-db',
+    '--meta-namespace',
+    '--port',
+    '--ui',
+    '--ws-port',
+    '-d',
+  ]);
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--') {
+      return args.slice(index + 1).some((value) => !value.startsWith('-'));
+    }
+    if (arg.startsWith('--') && arg.includes('=')) continue;
+    if (optionsWithValue.has(arg)) {
+      index += 1;
+      continue;
+    }
+    if (!arg.startsWith('-')) return true;
+  }
+
+  return false;
 }
 
 async function getCliDevPorts(args) {
@@ -335,6 +377,9 @@ if (target === 'cli') {
   const apiPortArgs = hasOption(cliArgs, '--port')
     ? cliArgs
     : ['--port', String(apiPort), ...cliArgs];
+  const pythonCliArgs = hasDbPathArg(apiPortArgs)
+    ? apiPortArgs
+    : ['--db-path', `/tmp/sqlrooms-cli-${apiPort}.db`, ...apiPortArgs];
   startProcess('sqlrooms CLI UI dev server', ['--host', '--port', String(uiPort)], {
     command: path.resolve('apps/sqlrooms-cli-ui', 'node_modules/.bin/vite'),
     cwd: path.resolve('apps/sqlrooms-cli-ui'),
@@ -346,7 +391,7 @@ if (target === 'cli') {
     command: process.execPath,
     cwd: path.resolve('python/sqlrooms-cli'),
     env: {
-      SQLROOMS_CLI_DEV_ARGS: JSON.stringify(apiPortArgs),
+      SQLROOMS_CLI_DEV_ARGS: JSON.stringify(pythonCliArgs),
     },
   });
 } else {

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,4 +1,5 @@
 import {spawn, spawnSync} from 'node:child_process';
+import net from 'node:net';
 import path from 'node:path';
 
 /**
@@ -81,6 +82,65 @@ const childEnv = {
   [pathKey]: childPath,
   SQLROOMS_CLI_DEV_ARGS: JSON.stringify(cliArgs),
 };
+
+function readOptionValue(args, name) {
+  const prefix = `${name}=`;
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === name) return args[index + 1] ?? null;
+    if (arg.startsWith(prefix)) return arg.slice(prefix.length);
+  }
+  return null;
+}
+
+function hasOption(args, name) {
+  return readOptionValue(args, name) !== null;
+}
+
+function publicHost(host) {
+  return host === '0.0.0.0' || host === '::' ? 'localhost' : host;
+}
+
+async function isPortAvailable(host, port) {
+  return await new Promise((resolve) => {
+    const server = net.createServer();
+    server.once('error', () => resolve(false));
+    server.once('listening', () => {
+      server.close(() => resolve(true));
+    });
+    server.listen(port, host);
+  });
+}
+
+async function findAvailablePort(startPort, host, reservedPorts = new Set()) {
+  let port = startPort;
+  while (port <= 65535) {
+    if (!reservedPorts.has(port) && (await isPortAvailable(host, port))) {
+      return port;
+    }
+    console.log(`Port ${port} is in use, trying another one...`);
+    port += 1;
+  }
+  throw new Error(`No available port found starting from ${startPort}.`);
+}
+
+function parsePortOption(args, name) {
+  const value = readOptionValue(args, name);
+  if (value === null) return null;
+  const port = Number.parseInt(value, 10);
+  return Number.isFinite(port) ? port : null;
+}
+
+async function getCliDevPorts(args) {
+  const host = readOptionValue(args, '--host') ?? '127.0.0.1';
+  const proxyHost = publicHost(host);
+  const explicitApiPort = parsePortOption(args, '--port');
+  const apiPort =
+    explicitApiPort ??
+    (await findAvailablePort(4173, host, new Set([4174])));
+  const uiPort = await findAvailablePort(4174, '0.0.0.0', new Set([apiPort]));
+  return {apiPort, proxyHost, uiPort};
+}
 
 function turboRunArgs(task, filters, extraArgs = []) {
   return [
@@ -168,7 +228,7 @@ if (target !== 'cli') {
   }
 } else if (isDryRun) {
   console.log(
-    '(cd apps/sqlrooms-cli-ui && ./node_modules/.bin/vite --host --port 4174)',
+    '(cd apps/sqlrooms-cli-ui && SQLROOMS_CLI_API_PROXY_TARGET=http://localhost:4173 ./node_modules/.bin/vite --host --port 4174)',
   );
   console.log(
     `(cd python/sqlrooms-cli && SQLROOMS_CLI_DEV_ARGS=${JSON.stringify(
@@ -200,12 +260,17 @@ function stopChildren(signal = 'SIGTERM') {
 function startProcess(
   label,
   args,
-  {allowCleanExit = false, command = pnpmCommand, cwd = process.cwd()} = {},
+  {
+    allowCleanExit = false,
+    command = pnpmCommand,
+    cwd = process.cwd(),
+    env = {},
+  } = {},
 ) {
   const child = spawn(command, args, {
     cwd,
     stdio: 'inherit',
-    env: childEnv,
+    env: {...childEnv, ...env},
     detached: process.platform !== 'win32',
     shell: process.platform === 'win32',
   });
@@ -255,13 +320,23 @@ process.on('SIGTERM', () => {
 });
 
 if (target === 'cli') {
-  startProcess('sqlrooms CLI UI dev server', ['--host', '--port', '4174'], {
+  const {apiPort, proxyHost, uiPort} = await getCliDevPorts(cliArgs);
+  const apiPortArgs = hasOption(cliArgs, '--port')
+    ? cliArgs
+    : ['--port', String(apiPort), ...cliArgs];
+  startProcess('sqlrooms CLI UI dev server', ['--host', '--port', String(uiPort)], {
     command: path.resolve('apps/sqlrooms-cli-ui', 'node_modules/.bin/vite'),
     cwd: path.resolve('apps/sqlrooms-cli-ui'),
+    env: {
+      SQLROOMS_CLI_API_PROXY_TARGET: `http://${proxyHost}:${apiPort}`,
+    },
   });
   startProcess('sqlrooms Python CLI dev server', ['scripts/dev.mjs'], {
     command: process.execPath,
     cwd: path.resolve('python/sqlrooms-cli'),
+    env: {
+      SQLROOMS_CLI_DEV_ARGS: JSON.stringify(apiPortArgs),
+    },
   });
 } else {
   startProcess(

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -83,6 +83,8 @@ const childEnv = {
   [pathKey]: childPath,
   SQLROOMS_CLI_DEV_ARGS: JSON.stringify(cliArgs),
 };
+const CLI_DEV_API_DEFAULT_PORT = 4273;
+const CLI_DEV_UI_DEFAULT_PORT = 4174;
 
 function readOptionValue(args, name) {
   const prefix = `${name}=`;
@@ -211,15 +213,35 @@ async function getCliDevPorts(args) {
   const explicitApiPort = parsePortOption(args, '--port');
   const explicitWsPort = parsePortOption(args, '--ws-port');
   const reservedPorts = new Set(
-    [4174, explicitWsPort].filter((port) => typeof port === 'number'),
+    [CLI_DEV_UI_DEFAULT_PORT, explicitWsPort].filter(
+      (port) => typeof port === 'number',
+    ),
   );
   const apiPort =
-    explicitApiPort ?? (await findAvailablePort(4173, host, reservedPorts));
+    explicitApiPort ??
+    (await findAvailablePort(CLI_DEV_API_DEFAULT_PORT, host, reservedPorts));
   const uiReservedPorts = new Set(
     [apiPort, explicitWsPort].filter((port) => typeof port === 'number'),
   );
-  const uiPort = await findAvailablePort(4174, '0.0.0.0', uiReservedPorts);
+  const uiPort = await findAvailablePort(
+    CLI_DEV_UI_DEFAULT_PORT,
+    '0.0.0.0',
+    uiReservedPorts,
+  );
   return {apiPort, proxyHost, uiPort};
+}
+
+function getPythonCliDevArgs(args, apiPort, uiPort) {
+  const apiPortArgs = hasOption(args, '--port')
+    ? args
+    : ['--port', String(apiPort), ...args];
+  return hasDbPathArg(apiPortArgs)
+    ? apiPortArgs
+    : [
+        '--db-path',
+        path.join(tmpdir(), `sqlrooms-cli-${uiPort}.db`),
+        ...apiPortArgs,
+      ];
 }
 
 function turboRunArgs(task, filters, extraArgs = []) {
@@ -307,12 +329,14 @@ if (target !== 'cli') {
     process.exit(1);
   }
 } else if (isDryRun) {
+  const {apiPort, proxyHost, uiPort} = await getCliDevPorts(cliArgs);
+  const pythonCliArgs = getPythonCliDevArgs(cliArgs, apiPort, uiPort);
   console.log(
-    '(cd apps/sqlrooms-cli-ui && SQLROOMS_CLI_API_PROXY_TARGET=http://localhost:4173 ./node_modules/.bin/vite --host --port 4174)',
+    `(cd apps/sqlrooms-cli-ui && SQLROOMS_CLI_API_PROXY_TARGET=http://${proxyHost}:${apiPort} ./node_modules/.bin/vite --host --port ${uiPort})`,
   );
   console.log(
     `(cd python/sqlrooms-cli && SQLROOMS_CLI_DEV_ARGS=${JSON.stringify(
-      cliArgs,
+      pythonCliArgs,
     )} node scripts/dev.mjs)`,
   );
   process.exit(0);
@@ -401,16 +425,7 @@ process.on('SIGTERM', () => {
 
 if (target === 'cli') {
   const {apiPort, proxyHost, uiPort} = await getCliDevPorts(cliArgs);
-  const apiPortArgs = hasOption(cliArgs, '--port')
-    ? cliArgs
-    : ['--port', String(apiPort), ...cliArgs];
-  const pythonCliArgs = hasDbPathArg(apiPortArgs)
-    ? apiPortArgs
-    : [
-        '--db-path',
-        path.join(tmpdir(), `sqlrooms-cli-${apiPort}.db`),
-        ...apiPortArgs,
-      ];
+  const pythonCliArgs = getPythonCliDevArgs(cliArgs, apiPort, uiPort);
   startProcess(
     'sqlrooms CLI UI dev server',
     ['--host', '--port', String(uiPort)],


### PR DESCRIPTION
## Summary
- Detect free ports for the CLI Python API and Vite UI instead of assuming 4173 and 4174
- Pass the selected API port through Vite proxy configuration so the UI stays connected
- Update CLI README notes to explain the new fallback behavior and fixed-port option

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified CLI dev “two-port” startup behavior and updated port-conflict guidance, including proxying to a selected API port.
  * Documented automatic HTTP/UI port selection when defaults are busy.
* **New Features**
  * Added automatic HTTP port selection for the CLI server.
  * Exposed runtime startup status via `/api/status` and `/status.json`, and added UI fetching for it.
* **Bug Fixes**
  * Improved startup failure handling and surfaced clearer error messaging in the UI progress modal.
* **Tests**
  * Added unit tests for HTTP port resolution and free-port selection edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->