### PR TITLE
chore: Hide prompt suggestions in assistant chat

### DIFF
--- a/apps/sqlrooms-cli-ui/src/components/AssistantChatContainer.tsx
+++ b/apps/sqlrooms-cli-ui/src/components/AssistantChatContainer.tsx
@@ -180,12 +180,6 @@ export const AssistantChatContainer: React.FC<AssistantChatContainerProps> = ({
         )}
         {currentSessionId && !showHistory && (
           <>
-            <Chat.PromptSuggestions>
-              <Chat.PromptSuggestions.Item text="What questions can I ask to get insights from my data?" />
-              <Chat.PromptSuggestions.Item text="Show me a summary of the data" />
-              <Chat.PromptSuggestions.Item text="What are the key trends?" />
-              <Chat.PromptSuggestions.Item text="Help me understand the data structure" />
-            </Chat.PromptSuggestions>
             <Chat.Composer
               placeholder="What would you like to learn about the data?"
               contextDropTarget={contextDropTarget}
@@ -197,7 +191,6 @@ export const AssistantChatContainer: React.FC<AssistantChatContainerProps> = ({
               />
               <AssistantContextSelector />
               <div className="flex items-center justify-end gap-2">
-                <Chat.PromptSuggestions.VisibilityToggle />
                 <Chat.ModelSelector />
               </div>
             </Chat.Composer>


### PR DESCRIPTION
## Summary
- Remove the default prompt suggestions block from the assistant chat composer
- Remove the prompt suggestions visibility toggle from the composer actions
- Keep the chat entry area focused on the model selector and context controls

## Testing
- Not run (not requested)