### PR TITLE
feat: reuse empty artifact chat sessions

### DIFF
--- a/apps/sqlrooms-cli-ui/src/createDashboardCommands.ts
+++ b/apps/sqlrooms-cli-ui/src/createDashboardCommands.ts
@@ -1,4 +1,7 @@
-import type {RoomCommand} from '@sqlrooms/room-shell';
+import type {
+  RoomCommand,
+  RoomCommandExecutionContext,
+} from '@sqlrooms/room-shell';
 import {generateUniqueName} from '@sqlrooms/utils';
 import {z} from 'zod';
 
@@ -62,6 +65,12 @@ function getUniqueArtifactTitle(state: RoomState, baseTitle: string) {
   );
 }
 
+function shouldCreateInitialArtifactChat(
+  context: RoomCommandExecutionContext<RoomState>,
+) {
+  return !['ai', 'mcp'].includes(context.invocation.surface);
+}
+
 function createArtifactCommand(
   artifactType: CliArtifactType,
   group: string,
@@ -80,7 +89,8 @@ function createArtifactCommand(
       idempotent: false,
       riskLevel: 'low',
     },
-    execute: ({getState}, input) => {
+    execute: (context, input) => {
+      const {getState} = context;
       const {title} = (input as CreateArtifactCommandInput | undefined) ?? {};
       const state = getState();
       const uniqueTitle = getUniqueArtifactTitle(state, title ?? group);
@@ -102,6 +112,9 @@ function createArtifactCommand(
         state.pivot.ensurePivot(artifactId, {title: uniqueTitle});
       }
       state.artifacts.setCurrentArtifact(artifactId);
+      if (shouldCreateInitialArtifactChat(context)) {
+        state.artifactAi.createArtifactScopedSession();
+      }
       return {
         success: true,
         commandId: id,
@@ -131,14 +144,19 @@ function createDashboardCreateArtifactCommand(): RoomCommand<RoomState> {
       idempotent: false,
       riskLevel: 'low',
     },
-    execute: ({getState}, input) => {
-      const {title, layoutType} = input as DashboardCreateArtifactCommandInput;
+    execute: (context, input) => {
+      const {getState} = context;
+      const {title, layoutType} =
+        (input as DashboardCreateArtifactCommandInput | undefined) ?? {};
       const state = getState();
       const artifactId = state.dashboard.createDashboardArtifact(
         getUniqueArtifactTitle(state, title ?? 'Dashboard'),
         layoutType,
       );
       state.artifacts.setCurrentArtifact(artifactId);
+      if (shouldCreateInitialArtifactChat(context)) {
+        state.artifactAi.createArtifactScopedSession();
+      }
       return {
         success: true,
         commandId: 'dashboard.create-artifact',

--- a/packages/artifacts/README.md
+++ b/packages/artifacts/README.md
@@ -181,7 +181,13 @@ aiSessionArtifacts: Record<string, string>; // sessionId -> artifactId
 ```
 
 Use `artifactAi.createArtifactScopedSession()` when creating chats from an
-artifact-scoped assistant. `artifactAi.selectLatestSessionForArtifact()` and
+artifact-scoped assistant. For default session creation, it reuses the most
+recently opened other empty, non-running session for the current artifact before
+creating a new one. This avoids duplicate blank drafts in history while still
+letting the selected empty draft start a separate chat when the host UI exposes
+a New session action. Calls that provide an explicit `name`, `modelProvider`, or
+`model` always create a fresh session so those options are preserved.
+`artifactAi.selectLatestSessionForArtifact()` and
 `artifactAi.syncCurrentArtifactAiSession()` keep the current AI session aligned
 with `artifacts.config.currentArtifactId`. Sessions without explicit artifact
 ownership are ignored by artifact-scoped history.
@@ -190,10 +196,15 @@ Reusable helpers include:
 
 - `isAiSessionVisibleForArtifact`
 - `getLatestAiSessionIdForArtifact`
+- `getEmptyAiSessionIdForArtifact`
 - `getAiSessionIdsForArtifact`
 - `getAiSessionGroupsByArtifact`
 - `getRunningAiSessionCountsByArtifact`
 - `getOwningArtifactRunContextItems`
+
+`getEmptyAiSessionIdForArtifact()` requires session objects that include
+`prompt` and `uiMessages`; summary-only session rows cannot prove that a chat is
+empty.
 
 `Chat.History` should remain generic: pass a `filterSession` callback built
 with `isAiSessionVisibleForArtifact()` and keep artifact-specific labels in the

--- a/packages/artifacts/__tests__/artifactAiSessions.test.ts
+++ b/packages/artifacts/__tests__/artifactAiSessions.test.ts
@@ -15,6 +15,7 @@ import {
   createArtifactAiSlice,
   getAiSessionGroupsByArtifact,
   getAiSessionIdsForArtifact,
+  getEmptyAiSessionIdForArtifact,
   getLatestAiSessionIdForArtifact,
   getOwningArtifactRunContextItems,
   getRunningAiSessionCountsByArtifact,
@@ -173,6 +174,59 @@ describe('artifact AI session helpers', () => {
     ).toBe('session-a-new');
   });
 
+  it('selects the latest empty owned session for an artifact', () => {
+    expect(
+      getEmptyAiSessionIdForArtifact({
+        sessions: [
+          createSession('empty-older', 1),
+          {...createSession('non-empty-newer', 3), prompt: 'hello'},
+          createSession('empty-newer', 2),
+          createSession('running-empty', 4, true),
+        ],
+        aiSessionArtifacts: {
+          'empty-older': 'artifact-a',
+          'non-empty-newer': 'artifact-a',
+          'empty-newer': 'artifact-a',
+          'running-empty': 'artifact-a',
+        },
+        artifactId: 'artifact-a',
+      }),
+    ).toBe('empty-newer');
+  });
+
+  it('can exclude empty owned sessions when selecting an artifact draft', () => {
+    expect(
+      getEmptyAiSessionIdForArtifact({
+        sessions: [
+          createSession('empty-older', 1),
+          createSession('empty-newer', 2),
+        ],
+        aiSessionArtifacts: {
+          'empty-older': 'artifact-a',
+          'empty-newer': 'artifact-a',
+        },
+        artifactId: 'artifact-a',
+        excludeSessionIds: ['empty-newer'],
+      }),
+    ).toBe('empty-older');
+  });
+
+  it('does not select session summaries that lack message fields as empty', () => {
+    expect(
+      getEmptyAiSessionIdForArtifact({
+        sessions: [
+          {
+            id: 'summary-only',
+            isRunning: false,
+            lastOpenedAt: 1,
+          } as any,
+        ],
+        aiSessionArtifacts: {'summary-only': 'artifact-a'},
+        artifactId: 'artifact-a',
+      }),
+    ).toBeUndefined();
+  });
+
   it('groups and counts running sessions by artifact', () => {
     expect(
       getAiSessionGroupsByArtifact({sessions, aiSessionArtifacts}),
@@ -253,6 +307,93 @@ describe('createArtifactAiSlice', () => {
       'artifact-a',
     );
     expect(store.getState().ai.config.currentSessionId).toBe('session-1');
+  });
+
+  it('reuses an empty artifact-scoped session instead of creating another one', () => {
+    const store = createTestStore();
+    store.getState().artifacts.setCurrentArtifact('artifact-a');
+    store.setState(
+      produce(store.getState(), (draft: TestRoomState) => {
+        draft.ai.config.sessions = [
+          createSession('empty-session', 1),
+          {...createSession('used-session', 2), prompt: 'hello'},
+        ];
+        draft.ai.config.currentSessionId = 'used-session';
+        draft.artifactAi.config.aiSessionArtifacts = {
+          'empty-session': 'artifact-a',
+          'used-session': 'artifact-a',
+        };
+      }),
+    );
+
+    const sessionId = store.getState().artifactAi.createArtifactScopedSession();
+
+    expect(sessionId).toBe('empty-session');
+    expect(store.getState().ai.config.currentSessionId).toBe('empty-session');
+    expect(store.getState().ai.config.sessions).toHaveLength(2);
+    expect(
+      store
+        .getState()
+        .ai.config.sessions.find((session) => session.id === 'empty-session')
+        ?.lastOpenedAt,
+    ).toBe(100);
+  });
+
+  it('creates a new artifact-scoped session instead of reusing the current empty session', () => {
+    const store = createTestStore();
+    store.getState().artifacts.setCurrentArtifact('artifact-a');
+    store.setState(
+      produce(store.getState(), (draft: TestRoomState) => {
+        draft.ai.config.sessions = [createSession('current-empty', 1)];
+        draft.ai.config.currentSessionId = 'current-empty';
+        draft.artifactAi.config.aiSessionArtifacts = {
+          'current-empty': 'artifact-a',
+        };
+      }),
+    );
+
+    const sessionId = store.getState().artifactAi.createArtifactScopedSession();
+
+    expect(sessionId).toBe('session-2');
+    expect(store.getState().ai.config.currentSessionId).toBe('session-2');
+    expect(store.getState().ai.config.sessions).toHaveLength(2);
+    expect(store.getState().artifactAi.getSessionArtifactId('session-2')).toBe(
+      'artifact-a',
+    );
+  });
+
+  it('creates a new artifact-scoped session when explicit session options are provided', () => {
+    const store = createTestStore();
+    store.getState().artifacts.setCurrentArtifact('artifact-a');
+    store.setState(
+      produce(store.getState(), (draft: TestRoomState) => {
+        draft.ai.config.sessions = [createSession('empty-session', 1)];
+        draft.artifactAi.config.aiSessionArtifacts = {
+          'empty-session': 'artifact-a',
+        };
+      }),
+    );
+
+    const sessionId = store
+      .getState()
+      .artifactAi.createArtifactScopedSession(
+        'Named draft',
+        'anthropic',
+        'claude-sonnet-4',
+      );
+
+    expect(sessionId).toBe('session-2');
+    const session = store
+      .getState()
+      .ai.config.sessions.find((candidate) => candidate.id === sessionId);
+    expect(session).toMatchObject({
+      name: 'Named draft',
+      modelProvider: 'anthropic',
+      model: 'claude-sonnet-4',
+    });
+    expect(store.getState().artifactAi.getSessionArtifactId('session-2')).toBe(
+      'artifact-a',
+    );
   });
 
   it('inherits artifact ownership for forked sessions', () => {

--- a/packages/artifacts/src/ai/artifactAiSessionHelpers.ts
+++ b/packages/artifacts/src/ai/artifactAiSessionHelpers.ts
@@ -137,6 +137,16 @@ export function getLatestAiSessionIdForArtifact({
 /**
  * Returns the most recently opened empty AI session explicitly owned by
  * `artifactId`.
+ *
+ * An empty session is not running, has no UI messages, and has no prompt text
+ * after trimming whitespace.
+ *
+ * @param options - Session selection options.
+ * @param options.sessions - Available sessions to search.
+ * @param options.aiSessionArtifacts - Session-to-artifact ownership mapping.
+ * @param options.artifactId - Artifact whose sessions should be searched.
+ * @param options.excludeSessionIds - Session IDs to skip during selection.
+ * @returns The most recently opened empty session ID, or `undefined` if none match.
  */
 export function getEmptyAiSessionIdForArtifact({
   sessions,

--- a/packages/artifacts/src/ai/artifactAiSessionHelpers.ts
+++ b/packages/artifacts/src/ai/artifactAiSessionHelpers.ts
@@ -7,7 +7,15 @@ import type {ArtifactMetadata} from '../ArtifactsSliceConfig';
 export type ArtifactAiSession = Pick<
   ChatSessionSchema,
   'id' | 'isRunning' | 'lastOpenedAt'
->;
+> &
+  Partial<Pick<ChatSessionSchema, 'prompt' | 'uiMessages'>>;
+
+/**
+ * AI session fields required to prove that a session has no draft text or
+ * messages.
+ */
+export type ArtifactAiSessionWithContent = ArtifactAiSession &
+  Pick<ChatSessionSchema, 'prompt' | 'uiMessages'>;
 
 /**
  * Mapping from AI session id to owning artifact id.
@@ -65,6 +73,20 @@ export type ArtifactAiSessionsForArtifactOptions = {
   sessions: ArtifactAiSession[];
   aiSessionArtifacts: ArtifactAiSessionOwnership;
   artifactId: string | undefined;
+  /** Session ids to ignore when selecting a session. */
+  excludeSessionIds?: Iterable<string>;
+};
+
+/**
+ * Input for selecting reusable empty sessions. Callers must provide message
+ * fields; summaries without `prompt` and `uiMessages` are not enough to prove a
+ * session is empty.
+ */
+export type EmptyArtifactAiSessionsForArtifactOptions = Omit<
+  ArtifactAiSessionsForArtifactOptions,
+  'sessions'
+> & {
+  sessions: ArtifactAiSessionWithContent[];
 };
 
 /**
@@ -105,6 +127,45 @@ export function getLatestAiSessionIdForArtifact({
         artifactId,
       }),
     )
+    .sort((a, b) => {
+      const aTime = a.lastOpenedAt ?? 0;
+      const bTime = b.lastOpenedAt ?? 0;
+      return bTime - aTime;
+    })[0]?.id;
+}
+
+/**
+ * Returns the most recently opened empty AI session explicitly owned by
+ * `artifactId`.
+ */
+export function getEmptyAiSessionIdForArtifact({
+  sessions,
+  aiSessionArtifacts,
+  artifactId,
+  excludeSessionIds,
+}: EmptyArtifactAiSessionsForArtifactOptions): string | undefined {
+  if (!artifactId) return undefined;
+  const excludedSessionIds = new Set(excludeSessionIds);
+  return sessions
+    .filter((session) => {
+      if (excludedSessionIds.has(session.id)) return false;
+      if (
+        !isAiSessionVisibleForArtifact({
+          aiSessionArtifacts,
+          sessionId: session.id,
+          artifactId,
+        })
+      ) {
+        return false;
+      }
+      return (
+        !session.isRunning &&
+        Array.isArray(session.uiMessages) &&
+        typeof session.prompt === 'string' &&
+        session.uiMessages.length === 0 &&
+        session.prompt.trim().length === 0
+      );
+    })
     .sort((a, b) => {
       const aTime = a.lastOpenedAt ?? 0;
       const bTime = b.lastOpenedAt ?? 0;

--- a/packages/artifacts/src/ai/artifactAiSlice.ts
+++ b/packages/artifacts/src/ai/artifactAiSlice.ts
@@ -21,6 +21,7 @@ import {z} from 'zod';
 import type {ArtifactsSliceState} from '../ArtifactsSlice';
 import {
   cleanupAiSessionArtifacts,
+  getEmptyAiSessionIdForArtifact,
   getLatestAiSessionIdForArtifact,
 } from './artifactAiSessionHelpers';
 
@@ -272,6 +273,27 @@ export function createArtifactAiSlice<
             !get().artifacts.config.artifactsById[currentArtifactId]
           ) {
             return undefined;
+          }
+
+          const hasExplicitSessionOptions = Boolean(
+            name || modelProvider || model,
+          );
+          if (!hasExplicitSessionOptions) {
+            const currentSessionId = get().ai.config.currentSessionId;
+            const emptySessionId = getEmptyAiSessionIdForArtifact({
+              sessions: get().ai.config.sessions,
+              aiSessionArtifacts: get().artifactAi.config.aiSessionArtifacts,
+              artifactId: currentArtifactId,
+              excludeSessionIds: currentSessionId
+                ? [currentSessionId]
+                : undefined,
+            });
+            if (emptySessionId) {
+              if (currentSessionId !== emptySessionId) {
+                get().ai.switchSession(emptySessionId);
+              }
+              return emptySessionId;
+            }
           }
 
           artifactAiSyncSuspended = true;

--- a/packages/artifacts/src/ai/index.ts
+++ b/packages/artifacts/src/ai/index.ts
@@ -36,6 +36,7 @@ export {
   cleanupAiSessionArtifacts,
   getAiSessionGroupsByArtifact,
   getAiSessionIdsForArtifact,
+  getEmptyAiSessionIdForArtifact,
   getLatestAiSessionIdForArtifact,
   getOwningArtifactRunContextItems,
   getRunningAiSessionCountsByArtifact,
@@ -46,7 +47,9 @@ export type {
   ArtifactAiSessionFilterOptions,
   ArtifactAiSessionGroupsOptions,
   ArtifactAiSessionOwnership,
+  ArtifactAiSessionWithContent,
   ArtifactAiSessionsForArtifactOptions,
   CleanupAiSessionArtifactsOptions,
+  EmptyArtifactAiSessionsForArtifactOptions,
   GetOwningArtifactRunContextItemsOptions,
 } from './artifactAiSessionHelpers';


### PR DESCRIPTION
## Summary

- Create an artifact-scoped empty chat automatically when CLI artifact creation commands create/select a new artifact.
- Reuse the most recently opened empty, non-running chat already owned by the current artifact before creating another blank session.
- Document and test the new reusable artifact AI session helper.

## Why

New artifacts should be immediately ready for artifact-scoped chat, but repeated chat creation should not accumulate duplicate blank sessions. `lastOpenedAt` remains the recency signal; `createdAt` is left intact.

## Validation

- `pnpm --filter @sqlrooms/artifacts test -- artifactAiSessions`
- `pnpm --filter @sqlrooms/artifacts typecheck`
- `pnpm --filter sqlrooms-cli-app typecheck`
- `pnpm build`
- pre-push hook: `knip`, `turbo typecheck`, `turbo test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Artifact creation now reuses the latest eligible “empty” artifact-scoped AI session (when it’s not running and has no draft text/messages), reducing unnecessary new sessions.
  * Initial artifact chat setup is now surface-aware, avoiding it on AI/MCP-related surfaces.
* **Documentation**
  * Updated Artifact-Owned AI Sessions guidance, including how reusable empty sessions are identified and when new sessions are always created.
* **Tests**
  * Added coverage for empty-session reuse, exclusion of specific sessions, and correct behavior when session content is missing or explicit options are provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->