### PR TITLE
feat: hand off artifact chats after AI artifact changes

### DIFF
--- a/apps/sqlrooms-cli-ui/src/artifactChatHandoff.ts
+++ b/apps/sqlrooms-cli-ui/src/artifactChatHandoff.ts
@@ -101,6 +101,9 @@ export function createArtifactChatHandoffController(
     const nextState = store.getState();
     const targetArtifact = nextState.artifacts.getArtifact(target.artifactId);
     if (!targetArtifact) return result;
+    if (nextState.artifacts.config.currentArtifactId !== target.artifactId) {
+      return result;
+    }
 
     pendingHandoff = {
       sourceSessionId,
@@ -132,6 +135,12 @@ export function createArtifactChatHandoffController(
       handoff.target.artifactId,
     );
     if (!targetArtifact) return;
+    if (
+      state.artifactAi.getSessionArtifactId(handoff.sourceSessionId) !==
+      handoff.sourceArtifactId
+    ) {
+      return;
+    }
     if (
       state.artifacts.config.currentArtifactId !== handoff.target.artifactId
     ) {

--- a/apps/sqlrooms-cli-ui/src/artifactChatHandoff.ts
+++ b/apps/sqlrooms-cli-ui/src/artifactChatHandoff.ts
@@ -64,7 +64,7 @@ function getLastAssistantMessage(messages: UIMessage[]) {
 export function createArtifactChatHandoffController(
   store: StoreApi<RoomState>,
 ) {
-  let pendingHandoff: PendingArtifactChatHandoff | undefined;
+  const pendingHandoffs = new Map<string, PendingArtifactChatHandoff>();
 
   const commandMiddleware: RoomCommandMiddleware<RoomState> = async (
     command,
@@ -105,7 +105,7 @@ export function createArtifactChatHandoffController(
       return result;
     }
 
-    pendingHandoff = {
+    pendingHandoffs.set(sourceSessionId, {
       sourceSessionId,
       sourceArtifactId,
       target: {
@@ -114,7 +114,7 @@ export function createArtifactChatHandoffController(
         artifactType: targetArtifact.type,
       },
       commandId: command.id,
-    };
+    });
 
     return result;
   };
@@ -126,9 +126,9 @@ export function createArtifactChatHandoffController(
     sessionId: string;
     messages: UIMessage[];
   }) => {
-    const handoff = pendingHandoff;
-    if (!handoff || handoff.sourceSessionId !== sessionId) return;
-    pendingHandoff = undefined;
+    const handoff = pendingHandoffs.get(sessionId);
+    if (!handoff) return;
+    pendingHandoffs.delete(sessionId);
 
     const state = store.getState();
     const targetArtifact = state.artifacts.getArtifact(

--- a/apps/sqlrooms-cli-ui/src/artifactChatHandoff.ts
+++ b/apps/sqlrooms-cli-ui/src/artifactChatHandoff.ts
@@ -9,7 +9,7 @@ import type {RoomState} from './store-types';
 type PendingArtifactChatHandoff = {
   sourceSessionId: string;
   sourceArtifactId: string;
-  sourceUserMessageId?: string;
+  sourceUserMessageId: string;
   target: ArtifactTargetChange;
   commandId: string;
 };
@@ -62,16 +62,25 @@ function getLastAssistantMessage(messages: UIMessage[]) {
   return undefined;
 }
 
-function getLastUserMessage(messages: UIMessage[]) {
+function getLastUserMessageId(
+  messages: ReadonlyArray<{id?: string; role?: string}>,
+) {
   for (let index = messages.length - 1; index >= 0; index--) {
     const message = messages[index];
-    if (message?.role === 'user') {
-      return message;
+    if (message?.role === 'user' && typeof message.id === 'string') {
+      return message.id;
     }
   }
   return undefined;
 }
 
+/**
+ * Creates the command and chat-finish hooks that continue an artifact-scoped
+ * AI chat when an AI-invoked command switches to another artifact.
+ *
+ * @param store - The CLI room store used to inspect artifact and AI session state.
+ * @returns Hooks for command middleware and completed chat turns.
+ */
 export function createArtifactChatHandoffController(
   store: StoreApi<RoomState>,
 ) {
@@ -115,13 +124,18 @@ export function createArtifactChatHandoffController(
     if (nextState.artifacts.config.currentArtifactId !== target.artifactId) {
       return result;
     }
+    const sourceSession = nextState.ai.config.sessions.find(
+      (session) => session.id === sourceSessionId,
+    );
+    const sourceUserMessageId = getLastUserMessageId(
+      sourceSession?.uiMessages ?? [],
+    );
+    if (!sourceUserMessageId) return result;
 
     pendingHandoffs.set(sourceSessionId, {
       sourceSessionId,
       sourceArtifactId,
-      sourceUserMessageId: getLastUserMessage(
-        nextState.ai.getSession(sourceSessionId)?.uiMessages ?? [],
-      )?.id,
+      sourceUserMessageId,
       target: {
         ...target,
         title: targetArtifact.title,
@@ -163,7 +177,7 @@ export function createArtifactChatHandoffController(
 
     const assistantMessage = getLastAssistantMessage(messages);
     if (!assistantMessage) return;
-    if (getLastUserMessage(messages)?.id !== handoff.sourceUserMessageId) {
+    if (getLastUserMessageId(messages) !== handoff.sourceUserMessageId) {
       return;
     }
 

--- a/apps/sqlrooms-cli-ui/src/artifactChatHandoff.ts
+++ b/apps/sqlrooms-cli-ui/src/artifactChatHandoff.ts
@@ -9,6 +9,7 @@ import type {RoomState} from './store-types';
 type PendingArtifactChatHandoff = {
   sourceSessionId: string;
   sourceArtifactId: string;
+  sourceUserMessageId?: string;
   target: ArtifactTargetChange;
   commandId: string;
 };
@@ -61,6 +62,16 @@ function getLastAssistantMessage(messages: UIMessage[]) {
   return undefined;
 }
 
+function getLastUserMessage(messages: UIMessage[]) {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (message?.role === 'user') {
+      return message;
+    }
+  }
+  return undefined;
+}
+
 export function createArtifactChatHandoffController(
   store: StoreApi<RoomState>,
 ) {
@@ -108,6 +119,9 @@ export function createArtifactChatHandoffController(
     pendingHandoffs.set(sourceSessionId, {
       sourceSessionId,
       sourceArtifactId,
+      sourceUserMessageId: getLastUserMessage(
+        nextState.ai.getSession(sourceSessionId)?.uiMessages ?? [],
+      )?.id,
       target: {
         ...target,
         title: targetArtifact.title,
@@ -149,6 +163,9 @@ export function createArtifactChatHandoffController(
 
     const assistantMessage = getLastAssistantMessage(messages);
     if (!assistantMessage) return;
+    if (getLastUserMessage(messages)?.id !== handoff.sourceUserMessageId) {
+      return;
+    }
 
     const targetSessionId = state.ai.forkSessionFromMessage({
       sourceSessionId: handoff.sourceSessionId,

--- a/apps/sqlrooms-cli-ui/src/artifactChatHandoff.ts
+++ b/apps/sqlrooms-cli-ui/src/artifactChatHandoff.ts
@@ -1,0 +1,169 @@
+import {setAiRunContextPrimaryItem} from '@sqlrooms/ai';
+import type {ArtifactTargetChange} from '@sqlrooms/artifacts/ai';
+import type {RoomCommandMiddleware} from '@sqlrooms/room-shell';
+import type {UIMessage} from 'ai';
+import type {StoreApi} from 'zustand';
+import {CLI_ARTIFACT_TYPES} from './artifactTypeIds';
+import type {RoomState} from './store-types';
+
+type PendingArtifactChatHandoff = {
+  sourceSessionId: string;
+  sourceArtifactId: string;
+  target: ArtifactTargetChange;
+  commandId: string;
+};
+
+const SUPPORTED_HANDOFF_ARTIFACT_TYPES = new Set<string>(CLI_ARTIFACT_TYPES);
+
+function readArtifactTargetChange(
+  result: unknown,
+): ArtifactTargetChange | undefined {
+  if (!result || typeof result !== 'object') return undefined;
+  const data = (result as {data?: unknown}).data;
+  if (!data || typeof data !== 'object') return undefined;
+  const candidate = (data as {artifactTargetChange?: unknown})
+    .artifactTargetChange;
+  if (!candidate || typeof candidate !== 'object') return undefined;
+
+  const record = candidate as Record<string, unknown>;
+  if (
+    typeof record.artifactId !== 'string' ||
+    typeof record.artifactType !== 'string' ||
+    typeof record.title !== 'string' ||
+    (record.change !== 'created' && record.change !== 'selected')
+  ) {
+    return undefined;
+  }
+
+  return {
+    artifactId: record.artifactId,
+    artifactType: record.artifactType,
+    title: record.title,
+    change: record.change,
+    ...(typeof record.shouldContinueChat === 'boolean'
+      ? {shouldContinueChat: record.shouldContinueChat}
+      : {}),
+  };
+}
+
+function getInvocationAiSessionId(metadata?: Record<string, unknown>) {
+  const aiSessionId = metadata?.aiSessionId;
+  return typeof aiSessionId === 'string' ? aiSessionId : undefined;
+}
+
+function getLastAssistantMessage(messages: UIMessage[]) {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (message?.role === 'assistant') {
+      return {message, index};
+    }
+  }
+  return undefined;
+}
+
+export function createArtifactChatHandoffController(
+  store: StoreApi<RoomState>,
+) {
+  let pendingHandoff: PendingArtifactChatHandoff | undefined;
+
+  const commandMiddleware: RoomCommandMiddleware<RoomState> = async (
+    command,
+    _input,
+    context,
+    next,
+  ) => {
+    const sourceSessionId = getInvocationAiSessionId(
+      context.invocation.metadata,
+    );
+    const sourceArtifactId = sourceSessionId
+      ? context.getState().artifactAi.getSessionArtifactId(sourceSessionId)
+      : undefined;
+
+    const result = await next();
+    if (
+      !sourceSessionId ||
+      !sourceArtifactId ||
+      context.invocation.surface !== 'ai'
+    ) {
+      return result;
+    }
+
+    const target = readArtifactTargetChange(result);
+    if (
+      !target ||
+      target.shouldContinueChat === false ||
+      target.artifactId === sourceArtifactId ||
+      !SUPPORTED_HANDOFF_ARTIFACT_TYPES.has(target.artifactType)
+    ) {
+      return result;
+    }
+
+    const nextState = store.getState();
+    const targetArtifact = nextState.artifacts.getArtifact(target.artifactId);
+    if (!targetArtifact) return result;
+
+    pendingHandoff = {
+      sourceSessionId,
+      sourceArtifactId,
+      target: {
+        ...target,
+        title: targetArtifact.title,
+        artifactType: targetArtifact.type,
+      },
+      commandId: command.id,
+    };
+
+    return result;
+  };
+
+  const onChatFinish = ({
+    sessionId,
+    messages,
+  }: {
+    sessionId: string;
+    messages: UIMessage[];
+  }) => {
+    const handoff = pendingHandoff;
+    if (!handoff || handoff.sourceSessionId !== sessionId) return;
+    pendingHandoff = undefined;
+
+    const state = store.getState();
+    const targetArtifact = state.artifacts.getArtifact(
+      handoff.target.artifactId,
+    );
+    if (!targetArtifact) return;
+    if (
+      state.artifacts.config.currentArtifactId !== handoff.target.artifactId
+    ) {
+      return;
+    }
+
+    const assistantMessage = getLastAssistantMessage(messages);
+    if (!assistantMessage) return;
+
+    const targetSessionId = state.ai.forkSessionFromMessage({
+      sourceSessionId: handoff.sourceSessionId,
+      sourceMessageId: assistantMessage.message.id,
+      sourceMessageIndex: assistantMessage.index,
+      name: `Continue: ${targetArtifact.title}`,
+    });
+    if (!targetSessionId) return;
+
+    state.artifactAi.setSessionArtifact(targetSessionId, targetArtifact.id);
+    state.ai.setSessionRunContext(
+      targetSessionId,
+      setAiRunContextPrimaryItem(
+        state.ai.getSessionRunContext(targetSessionId),
+        {
+          kind: 'artifact',
+          id: targetArtifact.id,
+          type: targetArtifact.type,
+          title: targetArtifact.title,
+        },
+      ),
+    );
+    state.artifactAi.selectLatestSessionForArtifact(targetArtifact.id);
+  };
+
+  return {commandMiddleware, onChatFinish};
+}

--- a/apps/sqlrooms-cli-ui/src/createDashboardCommands.ts
+++ b/apps/sqlrooms-cli-ui/src/createDashboardCommands.ts
@@ -97,7 +97,16 @@ function createArtifactCommand(
         success: true,
         commandId: id,
         message: `Created ${group.toLowerCase()} artifact "${artifactId}".`,
-        data: {artifactId},
+        data: {
+          artifactId,
+          artifactTargetChange: {
+            artifactId,
+            artifactType,
+            title: uniqueTitle,
+            change: 'created',
+            shouldContinueChat: true,
+          },
+        },
       };
     },
   };
@@ -134,7 +143,19 @@ function createDashboardCreateArtifactCommand(): RoomCommand<RoomState> {
         success: true,
         commandId: 'dashboard.create-artifact',
         message: `Created dashboard artifact "${artifactId}".`,
-        data: {artifactId},
+        data: {
+          artifactId,
+          artifactTargetChange: {
+            artifactId,
+            artifactType: 'dashboard',
+            title:
+              getState().artifacts.getArtifact(artifactId)?.title ??
+              title ??
+              'Dashboard',
+            change: 'created',
+            shouldContinueChat: true,
+          },
+        },
       };
     },
   };
@@ -206,6 +227,16 @@ export function createDashboardCommands(): RoomCommand<RoomState>[] {
           success: true,
           commandId: 'artifact.select',
           message: `Selected artifact "${artifactId}".`,
+          data: {
+            artifactId,
+            artifactTargetChange: {
+              artifactId,
+              artifactType: artifact.type,
+              title: artifact.title,
+              change: 'selected',
+              shouldContinueChat: true,
+            },
+          },
         };
       },
     },

--- a/apps/sqlrooms-cli-ui/src/createDashboardCommands.ts
+++ b/apps/sqlrooms-cli-ui/src/createDashboardCommands.ts
@@ -149,7 +149,7 @@ function createDashboardCreateArtifactCommand(): RoomCommand<RoomState> {
             artifactId,
             artifactType: 'dashboard',
             title:
-              getState().artifacts.getArtifact(artifactId)?.title ??
+              state.artifacts.getArtifact(artifactId)?.title ??
               title ??
               'Dashboard',
             change: 'created',

--- a/apps/sqlrooms-cli-ui/src/store.ts
+++ b/apps/sqlrooms-cli-ui/src/store.ts
@@ -85,6 +85,7 @@ import {
 } from '@sqlrooms/documents';
 import {createDocumentsCrdtMirror} from '@sqlrooms/documents/crdt';
 import {toast} from '@sqlrooms/ui';
+import {createArtifactChatHandoffController} from './artifactChatHandoff';
 import {ARTIFACT_TYPES} from './artifactTypes';
 import {worksheetAgentTool} from './createWorksheetAgent';
 import {createArtifactContextAiTools} from './context/createArtifactContextAiTools';
@@ -342,6 +343,8 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
       },
     },
     (set, get, store) => {
+      const artifactChatHandoff =
+        createArtifactChatHandoffController(store);
       const getFirstDashboardArtifactId = () =>
         Object.values(get().artifacts.config.artifactsById).find(
           (artifact) => artifact.type === 'dashboard',
@@ -535,6 +538,9 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
           connector,
           config: {title: defaultWorkspaceTitle, dataSources: []},
           layout: createLayout({store}),
+          createCommandProps: {
+            middleware: [artifactChatHandoff.commandMiddleware],
+          },
           createDbProps: {
             duckDb: {
               loadTableSchemasFilter: (() => {
@@ -725,6 +731,7 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
             getRunContext: (sessionId) => getRunContext(store, sessionId),
             formatRunContextInstructions: ({runContext}) =>
               formatRunContextInstructions(runContext, store),
+            onChatFinish: artifactChatHandoff.onChatFinish,
             tools: {
               ...createDefaultAiTools(store, {query: {}}),
               ...createArtifactContextAiTools(store),

--- a/apps/sqlrooms-cli-ui/src/store.ts
+++ b/apps/sqlrooms-cli-ui/src/store.ts
@@ -343,8 +343,7 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
       },
     },
     (set, get, store) => {
-      const artifactChatHandoff =
-        createArtifactChatHandoffController(store);
+      const artifactChatHandoff = createArtifactChatHandoffController(store);
       const getFirstDashboardArtifactId = () =>
         Object.values(get().artifacts.config.artifactsById).find(
           (artifact) => artifact.type === 'dashboard',
@@ -539,7 +538,7 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
           config: {title: defaultWorkspaceTitle, dataSources: []},
           layout: createLayout({store}),
           createCommandProps: {
-            middleware: [artifactChatHandoff.commandMiddleware as any],
+            middleware: [artifactChatHandoff.commandMiddleware],
           },
           createDbProps: {
             duckDb: {

--- a/apps/sqlrooms-cli-ui/src/store.ts
+++ b/apps/sqlrooms-cli-ui/src/store.ts
@@ -539,7 +539,7 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
           config: {title: defaultWorkspaceTitle, dataSources: []},
           layout: createLayout({store}),
           createCommandProps: {
-            middleware: [artifactChatHandoff.commandMiddleware],
+            middleware: [artifactChatHandoff.commandMiddleware as any],
           },
           createDbProps: {
             duckDb: {

--- a/apps/sqlrooms-cli-ui/src/store.ts
+++ b/apps/sqlrooms-cli-ui/src/store.ts
@@ -538,7 +538,9 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
           config: {title: defaultWorkspaceTitle, dataSources: []},
           layout: createLayout({store}),
           createCommandProps: {
-            middleware: [artifactChatHandoff.commandMiddleware],
+            // createRoomShellSlice is typed to the base room state, but this
+            // app middleware needs the composed CLI RoomState at runtime.
+            middleware: [artifactChatHandoff.commandMiddleware as any],
           },
           createDbProps: {
             duckDb: {

--- a/packages/ai-core/README.md
+++ b/packages/ai-core/README.md
@@ -89,6 +89,12 @@ with `onCreateSession`. `Chat.History` also accepts `filterSession` and
 `emptyLabel` so apps can present scoped histories without changing the generic
 AI session schema.
 
+`createAiSlice({onChatFinish})` lets host apps observe a non-aborted turn after
+the completed messages have been persisted and the analysis has ended. Use this
+for app-owned follow-up behavior, such as forking a completed chat into a new
+workspace target, while keeping the generic AI slice unaware of app-specific
+state.
+
 Assistant messages can be forked into a new active chat through
 `ai.forkSessionFromMessage()`. The action snapshots the source session's
 `uiMessages` through the selected message or chat turn, inherits the source

--- a/packages/ai-core/__tests__/AiSlice.onChatFinish.test.ts
+++ b/packages/ai-core/__tests__/AiSlice.onChatFinish.test.ts
@@ -1,0 +1,81 @@
+import {jest} from '@jest/globals';
+import type {UIMessage} from 'ai';
+import {createStore} from 'zustand';
+import {AiSliceState, createAiSlice} from '../src/AiSlice';
+
+function createTestStore(onChatFinish: any) {
+  return createStore<AiSliceState>((set, get, store) =>
+    createAiSlice({
+      tools: {} as any,
+      getInstructions: () => 'test instructions',
+      onChatFinish,
+      config: {
+        currentSessionId: 'session-1',
+        openSessionTabs: ['session-1'],
+        sessions: [
+          {
+            id: 'session-1',
+            name: 'Session 1',
+            modelProvider: 'openai',
+            model: 'gpt-test',
+            createdAt: new Date(),
+            uiMessages: [],
+            messagesRevision: 0,
+            prompt: '',
+            isRunning: true,
+            lastOpenedAt: Date.now(),
+          },
+        ],
+      },
+    })(set, get, store),
+  );
+}
+
+function createCompletedMessages(): UIMessage[] {
+  return [
+    {
+      id: 'user-1',
+      role: 'user',
+      parts: [{type: 'text', text: 'Create a worksheet'}],
+    },
+    {
+      id: 'assistant-1',
+      role: 'assistant',
+      parts: [{type: 'text', text: 'Created it.'}],
+    },
+  ];
+}
+
+describe('AiSlice onChatFinish option', () => {
+  it('runs after completed messages are persisted and the session ends', () => {
+    const onChatFinish = jest.fn();
+    const store = createTestStore(onChatFinish);
+    const messages = createCompletedMessages();
+
+    store.getState().ai.onChatFinish({sessionId: 'session-1', messages});
+
+    expect(onChatFinish).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      messages,
+    });
+    expect(store.getState().ai.getIsRunning('session-1')).toBe(false);
+    expect(store.getState().ai.getCurrentSession()?.uiMessages).toEqual(
+      messages,
+    );
+  });
+
+  it('does not run for aborted turns', () => {
+    const onChatFinish = jest.fn();
+    const store = createTestStore(onChatFinish);
+    const controller = new AbortController();
+    controller.abort('cancelled');
+    store.getState().ai.setAbortController('session-1', controller);
+
+    store.getState().ai.onChatFinish({
+      sessionId: 'session-1',
+      messages: createCompletedMessages(),
+    });
+
+    expect(onChatFinish).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ai-core/src/AiSlice.ts
+++ b/packages/ai-core/src/AiSlice.ts
@@ -269,6 +269,13 @@ export interface AiSliceOptions<TTools extends ToolSet = ToolSet> {
   chatEndPoint?: string;
   /** Optional headers to send with remote endpoint */
   chatHeaders?: Record<string, string>;
+  /**
+   * Called after a non-aborted chat turn has been persisted and fully ended.
+   *
+   * Host apps can use this to compose AI turns with app-level behavior such as
+   * creating a follow-up session from a completed assistant message.
+   */
+  onChatFinish?: (args: {sessionId: string; messages: UIMessage[]}) => void;
   /** Optional devtools-only capture controls. Defaults are all disabled. */
   devtools?: {
     captureAgentSnapshots?: boolean;
@@ -1530,7 +1537,7 @@ export function createAiSlice<TTools extends ToolSet = ToolSet>(
               store.getState().ai.getFullInstructions(sessionId),
           })(endpoint, headers),
 
-        ...createChatHandlers({store}),
+        ...createChatHandlers({store, onChatFinish: params.onChatFinish}),
       },
     };
   });

--- a/packages/ai-core/src/chatTransport.ts
+++ b/packages/ai-core/src/chatTransport.ts
@@ -556,8 +556,10 @@ export function createRemoteChatTransportFactory(params: {
 
 export function createChatHandlers({
   store,
+  onChatFinish,
 }: {
   store: StoreApi<AiSliceStateForTransport>;
+  onChatFinish?: (args: {sessionId: string; messages: UIMessage[]}) => void;
 }) {
   return {
     onChatFinish: ({
@@ -647,6 +649,7 @@ export function createChatHandlers({
         if (shouldEndAnalysis(completedMessages)) {
           state.ai.setIsRunning(sessionId, false);
           state.ai.setAbortController(sessionId, undefined);
+          onChatFinish?.({sessionId, messages: completedMessages});
         }
       } catch (err) {
         console.error('onChatFinish error:', err);

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -66,6 +66,12 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
         ...createDefaultAiTools(store),
       },
       getInstructions: () => createDefaultAiInstructions(store),
+      // Optional: observe completed, non-aborted turns for app-owned follow-up
+      // behavior such as handoff into a newly selected workspace artifact.
+      onChatFinish: ({sessionId, messages}) => {
+        void sessionId;
+        void messages;
+      },
     })(set, get, store),
   }),
 );

--- a/packages/ai/__tests__/commandTools.test.ts
+++ b/packages/ai/__tests__/commandTools.test.ts
@@ -1,0 +1,44 @@
+import {jest} from '@jest/globals';
+import {createCommandTools} from '../src/tools/commandTools';
+
+function createCommandState(
+  invokeCommand: any,
+): ReturnType<typeof createCommandTools> {
+  return createCommandTools({
+    getState: () => ({
+      commands: {
+        registerCommands: jest.fn(),
+        unregisterCommands: jest.fn(),
+        listCommands: jest.fn(() => []),
+        getCommand: jest.fn(() => ({id: 'artifact.create'})),
+        executeCommand: jest.fn(),
+        invokeCommand,
+      },
+    }),
+  } as any) as ReturnType<typeof createCommandTools>;
+}
+
+describe('command tools', () => {
+  it('passes the owning AI session id through command invocation metadata', async () => {
+    const invokeCommand = jest.fn(async () => ({
+      success: true,
+      commandId: 'artifact.create',
+      data: {artifactId: 'artifact-1'},
+    }));
+    const tools = createCommandState(invokeCommand);
+
+    await (tools.execute_command as any).execute(
+      {commandId: 'artifact.create', input: {title: 'Artifact'}},
+      {sessionId: 'session-1'},
+    );
+
+    expect(invokeCommand).toHaveBeenCalledWith(
+      'artifact.create',
+      {title: 'Artifact'},
+      {
+        surface: 'ai',
+        metadata: {aiSessionId: 'session-1'},
+      },
+    );
+  });
+});

--- a/packages/ai/__tests__/commandTools.test.ts
+++ b/packages/ai/__tests__/commandTools.test.ts
@@ -1,9 +1,12 @@
 import {jest} from '@jest/globals';
-import {createCommandTools} from '../src/tools/commandTools';
 
-function createCommandState(
-  invokeCommand: any,
-): ReturnType<typeof createCommandTools> {
+jest.unstable_mockModule('@sqlrooms/room-shell', () => ({
+  hasCommandSliceState: () => true,
+}));
+
+const {createCommandTools} = await import('../src/tools/commandTools');
+
+function createCommandState(invokeCommand: any) {
   return createCommandTools({
     getState: () => ({
       commands: {
@@ -15,7 +18,7 @@ function createCommandState(
         invokeCommand,
       },
     }),
-  } as any) as ReturnType<typeof createCommandTools>;
+  } as any);
 }
 
 describe('command tools', () => {

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -55,6 +55,7 @@
     "zustand": "^5.0.8"
   },
   "devDependencies": {
+    "@jest/globals": "^30.3.0",
     "ts-jest": "^29.4.4"
   },
   "peerDependencies": {

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -31,7 +31,7 @@
     "build": "tsc",
     "dev": "tsc -w",
     "lint": "eslint .",
-    "test": "jest",
+    "test": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest",
     "test:watch": "jest --watch",
     "typecheck": "tsc --noEmit",
     "typedoc": "typedoc"

--- a/packages/ai/src/tools/commandTools.ts
+++ b/packages/ai/src/tools/commandTools.ts
@@ -69,6 +69,10 @@ export type ExecuteCommandToolLlmResult = {
   };
 };
 
+type CommandToolExecutionContext = {
+  sessionId?: string;
+};
+
 export type CommandToolsOptions = {
   listToolName?: string;
   executeToolName?: string;
@@ -137,7 +141,13 @@ Use this before executing commands so you can pick a valid command ID and unders
       description: `Execute a room command by ID.
 Call ${listToolName} first to discover valid command IDs and input requirements.`,
       inputSchema: ExecuteCommandToolParameters,
-      execute: async ({commandId, input}: ExecuteCommandToolParameters) => {
+      execute: async (
+        {commandId, input}: ExecuteCommandToolParameters,
+        executionOptions,
+      ) => {
+        const context = executionOptions as
+          | CommandToolExecutionContext
+          | undefined;
         const state = store.getState();
         if (!hasCommandSliceState(state)) {
           return {
@@ -157,6 +167,10 @@ Call ${listToolName} first to discover valid command IDs and input requirements.
 
         const result = await state.commands.invokeCommand(commandId, input, {
           surface: 'ai',
+          metadata:
+            typeof context?.sessionId === 'string'
+              ? {aiSessionId: context.sessionId}
+              : undefined,
         });
         if (result.success) {
           return {

--- a/packages/artifacts/README.md
+++ b/packages/artifacts/README.md
@@ -141,6 +141,13 @@ Use `createArtifactContextAiTools({store, readArtifact})` in apps that combine
 selection and run-context updates; the app supplies artifact payload readers for
 domain-specific types such as documents or dashboards.
 
+Commands and tools that create or select the user's primary working artifact
+can include `artifactTargetChange` in their result data. The exported
+`ArtifactTargetChange` type is a small metadata shape for host apps that want
+to compose command results with artifact-scoped AI behavior. It does not trigger
+chat changes by itself; apps still own the policy for when an AI chat should
+continue in a new artifact.
+
 ## Artifact-Owned AI Sessions
 
 `@sqlrooms/artifacts/ai` also provides `createArtifactAiSlice()` for apps that

--- a/packages/artifacts/src/ai/artifactTargetChange.ts
+++ b/packages/artifacts/src/ai/artifactTargetChange.ts
@@ -1,0 +1,33 @@
+/**
+ * Describes an artifact selection change that may become the continuation
+ * target for an artifact-scoped AI chat.
+ *
+ * The shape is intentionally metadata-only so generic commands and tools can
+ * report artifact target changes without depending on any host app's handoff
+ * policy. Host apps decide whether and when to fork or switch AI sessions.
+ */
+export type ArtifactTargetChange = {
+  /** Artifact that became the primary working target. */
+  artifactId: string;
+  /** Runtime artifact type, such as `worksheet`, `dashboard`, or `document`. */
+  artifactType: string;
+  /** Human-readable artifact title at the time of the change. */
+  title: string;
+  /** Whether the artifact was newly created or an existing artifact was selected. */
+  change: 'created' | 'selected';
+  /**
+   * Hint that an artifact-scoped AI chat should continue in this target.
+   *
+   * This is not a command to fork by itself. Host apps should still restrict
+   * handoff behavior to their own AI/tool invocation surfaces.
+   */
+  shouldContinueChat?: boolean;
+};
+
+/**
+ * Optional command/tool result payload field for standard artifact target
+ * changes.
+ */
+export type ArtifactTargetChangeData = {
+  artifactTargetChange?: ArtifactTargetChange;
+};

--- a/packages/artifacts/src/ai/index.ts
+++ b/packages/artifacts/src/ai/index.ts
@@ -3,6 +3,10 @@ export {
   createArtifactContextAiTools,
 } from './artifactContextTools';
 export type {
+  ArtifactTargetChange,
+  ArtifactTargetChangeData,
+} from './artifactTargetChange';
+export type {
   ArtifactContextAiTools,
   ArtifactContextArtifactSummary,
   ArtifactContextReadResult,

--- a/packages/documents/src/BlockDocumentCommands.ts
+++ b/packages/documents/src/BlockDocumentCommands.ts
@@ -326,7 +326,19 @@ export function createBlockDocumentCommands<
           success: true,
           commandId: commandId('create'),
           message: `Created ${labelLower} artifact "${artifactId}".`,
-          data: readBlockDocumentData(state, artifactId),
+          data: {
+            ...readBlockDocumentData(state, artifactId),
+            artifactTargetChange: {
+              artifactId,
+              artifactType,
+              title:
+                state.artifacts.getArtifact(artifactId)?.title ??
+                title ??
+                defaultTitle,
+              change: 'created',
+              shouldContinueChat: select,
+            },
+          },
         };
       },
     },

--- a/packages/documents/src/documentCommands.ts
+++ b/packages/documents/src/documentCommands.ts
@@ -174,6 +174,16 @@ export function createDocumentCommands<
             assets: Object.values(
               state.documents.getDocument(artifactId)?.assets ?? {},
             ).map(documentAssetMetadata),
+            artifactTargetChange: {
+              artifactId,
+              artifactType: 'document',
+              title:
+                state.artifacts.getArtifact(artifactId)?.title ??
+                title ??
+                'Document',
+              change: 'created',
+              shouldContinueChat: select,
+            },
           },
         };
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2430,6 +2430,9 @@ importers:
         specifier: ^5.0.8
         version: 5.0.13(@types/react@19.2.7)(immer@11.1.8)(react@19.2.1)(use-sync-external-store@1.6.0(react@19.2.1))
     devDependencies:
+      '@jest/globals':
+        specifier: ^30.3.0
+        version: 30.4.1
       ts-jest:
         specifier: ^29.4.4
         version: 29.4.9(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(jest-util@30.4.1)(jest@30.4.2(@types/node@24.12.4))(typescript@5.9.3)


### PR DESCRIPTION
## Summary

- Add a reusable `ArtifactTargetChange` metadata shape and include it in artifact create/select command results.
- Pass AI session metadata through `execute_command` and add an AI-core `onChatFinish` hook for host-owned completed-turn follow-up behavior.
- Add CLI artifact chat handoff middleware that forks the completed source chat, maps the fork to the new target artifact, updates run context, and keeps manual navigation/forks unchanged.
- Add focused tests for command metadata propagation and completed-turn chat finish hooks.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm build`
- `corepack pnpm --filter @sqlrooms/ai test -- commandTools.test.ts --runInBand`
- `corepack pnpm --filter @sqlrooms/ai-core test -- AiSlice.onChatFinish.test.ts --runInBand`
- `corepack pnpm --filter @sqlrooms/artifacts test -- artifactAiSessions.test.ts --runInBand`
- `corepack pnpm --filter @sqlrooms/ai typecheck`
- `corepack pnpm --filter @sqlrooms/ai-core typecheck`
- `corepack pnpm --filter sqlrooms-cli-app build`
- Dev server smoke: Vite served `http://127.0.0.1:4174/` with HTTP 200.

Note: the in-app browser connector failed with a session metadata error, so full UI automation was not available. Live AI handoff interaction also depends on configured model/API credentials.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI chat now supports seamless transitions between artifacts during conversations. When creating or selecting artifacts, the system intelligently hands off the conversation to the target artifact while preserving chat context.
  * Added `onChatFinish` callback to enable app-level logic for handling completed AI turns, supporting artifact-scoped follow-up behaviors.

* **Documentation**
  * Updated guides to document the new artifact chat handoff capability and `onChatFinish` configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->