### PR TITLE
feat: add intent metadata for AI-created blocks

### DIFF
--- a/apps/sqlrooms-cli-ui/README.md
+++ b/apps/sqlrooms-cli-ui/README.md
@@ -80,7 +80,7 @@ dashboard charts. Charts with the same `selectionGroupId` in one Worksheet share
 a crossfilter selection; charts without a group are independent.
 Agent-created blocks can persist an `intent` string describing the purpose they
 were created to serve, which helps later edits distinguish durable intent from
-raw model prompts.
+raw model input.
 
 Hosted dashboards are stored as direct stateful blocks keyed by their block
 instance id. Each hosted dashboard keeps its own Mosaic dashboard state and

--- a/apps/sqlrooms-cli-ui/README.md
+++ b/apps/sqlrooms-cli-ui/README.md
@@ -78,6 +78,9 @@ SQL queries, and Markdown documents.
 Standalone chart blocks reuse the same Mosaic chart view and settings panel as
 dashboard charts. Charts with the same `selectionGroupId` in one Worksheet share
 a crossfilter selection; charts without a group are independent.
+Agent-created blocks can persist an `intent` string describing the purpose they
+were created to serve, which helps later edits distinguish durable intent from
+raw model prompts.
 
 Hosted dashboards are stored as direct stateful blocks keyed by their block
 instance id. Each hosted dashboard keeps its own Mosaic dashboard state and

--- a/apps/sqlrooms-cli-ui/src/createHtmlAppAgent.ts
+++ b/apps/sqlrooms-cli-ui/src/createHtmlAppAgent.ts
@@ -15,11 +15,18 @@ const HtmlAppDependencySchema = z.object({
   global: z.string().optional(),
 });
 
-export const HtmlAppRuntimeInputSchema = z.object({
+const HtmlAppRuntimeInputFields = z.object({
   reasoning: z
     .string()
     .describe('Reasoning for why the HTML app agent is being called.'),
-  prompt: z.string().describe('The app or visualization the user wants.'),
+  intent: z
+    .string()
+    .optional()
+    .describe('The app or visualization objective to satisfy.'),
+  prompt: z
+    .string()
+    .optional()
+    .describe('Deprecated alias for intent. Use intent for new callers.'),
   title: z.string().optional().describe('Optional app title.'),
   querySql: z
     .string()
@@ -51,13 +58,37 @@ export const HtmlAppRuntimeInputSchema = z.object({
     .describe('Maximum expected observe/repair attempts for the caller.'),
 });
 
-const HtmlAppAgentInputSchema = HtmlAppRuntimeInputSchema.extend({
+function requireHtmlAppIntent(
+  value: {intent?: string; prompt?: string},
+  ctx: z.RefinementCtx,
+) {
+  if (resolveHtmlAppIntent(value)) return;
+  ctx.addIssue({
+    code: 'custom',
+    path: ['intent'],
+    message: 'intent is required. prompt is accepted as a deprecated alias.',
+  });
+}
+
+function resolveHtmlAppIntent(value: {intent?: string; prompt?: string}) {
+  return value.intent?.trim() || value.prompt?.trim();
+}
+
+function resolvedHtmlAppIntentPatch(value: {intent?: string; prompt?: string}) {
+  const intent = resolveHtmlAppIntent(value);
+  return intent ? {intent} : {};
+}
+
+export const HtmlAppRuntimeInputSchema =
+  HtmlAppRuntimeInputFields.superRefine(requireHtmlAppIntent);
+
+const HtmlAppAgentInputSchema = HtmlAppRuntimeInputFields.extend({
   appId: z
     .string()
     .describe(
       'HTML app runtime id to write. The caller must create or identify the top-level html-app artifact or embedded html-app block before calling this tool.',
     ),
-});
+}).superRefine(requireHtmlAppIntent);
 
 type HtmlAppAgentInput = z.infer<typeof HtmlAppAgentInputSchema>;
 export type HtmlAppRuntimeWriteInput = Omit<
@@ -67,9 +98,10 @@ export type HtmlAppRuntimeWriteInput = Omit<
   maxRepairAttempts?: number;
 };
 
-const WriteHtmlAppFilesInputSchema = HtmlAppRuntimeInputSchema.omit({
+const WriteHtmlAppFilesInputSchema = HtmlAppRuntimeInputFields.omit({
   maxRepairAttempts: true,
   prompt: true,
+  intent: true,
 });
 
 const DEFAULT_DIAGNOSTIC_OBSERVATION_MS = 2_000;
@@ -83,7 +115,7 @@ Use this after the caller has created or identified the right container:
 - top-level html-app artifact id
 - embedded worksheet html-app blockInstanceId
 
-This tool does not create artifacts, select artifacts, or create worksheet blocks. It creates complete app source for the requested prompt, writes it to durable html-app runtime state, observes runtime diagnostics, and repairs files when diagnostics report errors. If explicit html or files are provided, it writes that source directly. For incremental edits to an existing app, provide appId plus the edit prompt; the tool edits the current source without re-discovering data unless the request explicitly changes data/query behavior. For title-only rename requests, provide title without source; the tool updates metadata and obvious HTML title locations without regenerating the app.`,
+This tool does not create artifacts, select artifacts, or create worksheet blocks. It creates complete app source for the requested intent, writes it to durable html-app runtime state, observes runtime diagnostics, and repairs files when diagnostics report errors. If explicit html or files are provided, it writes that source directly. For incremental edits to an existing app, provide appId plus the edit intent; the tool edits the current source without re-discovering data unless the request explicitly changes data/query behavior. For title-only rename requests, provide title without source; the tool updates metadata and obvious HTML title locations without regenerating the app. prompt is accepted only as a deprecated alias for intent.`,
     inputSchema: HtmlAppAgentInputSchema,
     execute: async (input, toolOptions): Promise<Record<string, unknown>> => {
       if (input.html || input.files) {
@@ -117,10 +149,10 @@ function isTitleOnlyRequest(input: HtmlAppAgentInput) {
     return false;
   }
 
-  const prompt = input.prompt.toLowerCase();
+  const intent = resolveHtmlAppIntent(input)?.toLowerCase() ?? '';
   return (
-    /\b(rename|change|set|update)\b[\s\S]{0,80}\b(title|name)\b/.test(prompt) ||
-    /\b(title|name)\b[\s\S]{0,80}\b(to|as)\b/.test(prompt)
+    /\b(rename|change|set|update)\b[\s\S]{0,80}\b(title|name)\b/.test(intent) ||
+    /\b(title|name)\b[\s\S]{0,80}\b(to|as)\b/.test(intent)
   );
 }
 
@@ -172,17 +204,17 @@ function isIncrementalAppEditRequest(input: HtmlAppAgentInput) {
     return false;
   }
 
-  const prompt = input.prompt.toLowerCase();
+  const intent = resolveHtmlAppIntent(input)?.toLowerCase() ?? '';
   if (
     /\b(new|another|fresh|separate)\b[\s\S]{0,40}\b(app|artifact)\b/.test(
-      prompt,
+      intent,
     )
   ) {
     return false;
   }
 
   return /\b(change|update|edit|modify|rename|set|tweak|adjust|fix|improve|make|remove|replace|add)\b/.test(
-    prompt,
+    intent,
   );
 }
 
@@ -221,7 +253,7 @@ Use this after making the requested scoped edit to the existing files. Preserve 
       latestWriteResult = await writeHtmlAppRuntimeState(store, {
         ...writeInput,
         appId: input.appId,
-        prompt: input.prompt,
+        ...resolvedHtmlAppIntentPatch(input),
         title: writeInput.title ?? input.title ?? app.title,
         dependencies: writeInput.dependencies ?? app.dependencies,
         maxRepairAttempts: input.maxRepairAttempts,
@@ -296,7 +328,7 @@ For a self-contained iframe app, prefer the html field. Use files only when mult
       latestWriteResult = await writeHtmlAppRuntimeState(store, {
         ...writeInput,
         appId: input.appId,
-        prompt: input.prompt,
+        ...resolvedHtmlAppIntentPatch(input),
         maxRepairAttempts: input.maxRepairAttempts,
       });
       return latestWriteResult;
@@ -358,6 +390,7 @@ export async function writeHtmlAppRuntimeState(
 ): Promise<Record<string, unknown>> {
   const appId = input.appId;
   const title = input.title?.trim() || 'HTML App';
+  const intent = resolveHtmlAppIntent(input);
   const dependencies = resolveDependencies(input);
   const files = normalizeHtmlAppFiles(input);
 
@@ -400,6 +433,7 @@ export async function writeHtmlAppRuntimeState(
 
   store.getState().htmlApps.ensureApp(appId, {
     title,
+    ...(intent ? {intent} : {}),
     files,
     entryHtmlPath: '/index.html',
     dependencies,
@@ -542,10 +576,11 @@ Important constraints:
 }
 
 function formatHtmlAppGenerationPrompt(input: HtmlAppAgentInput) {
+  const intent = resolveHtmlAppIntent(input) ?? '';
   const parts = [
     `App runtime id: ${input.appId}`,
     `Title: ${input.title?.trim() || 'HTML App'}`,
-    `User request: ${input.prompt}`,
+    `Intent: ${intent}`,
   ];
 
   if (input.querySql) {
@@ -569,11 +604,13 @@ function formatHtmlAppEditPrompt(
   input: HtmlAppAgentInput,
   app: NonNullable<ReturnType<RoomState['htmlApps']['getApp']>>,
 ) {
+  const intent = resolveHtmlAppIntent(input) ?? '';
   const parts = [
     `App runtime id: ${input.appId}`,
     `Current title: ${app.title}`,
     `Requested title: ${input.title?.trim() || app.title}`,
-    `User request: ${input.prompt}`,
+    ...(app.intent ? [`Current intent: ${app.intent}`] : []),
+    `Edit intent: ${intent}`,
     `Entry HTML path: ${app.entryHtmlPath || '/index.html'}`,
   ];
 

--- a/apps/sqlrooms-cli-ui/src/createHtmlAppAgent.ts
+++ b/apps/sqlrooms-cli-ui/src/createHtmlAppAgent.ts
@@ -21,12 +21,8 @@ const HtmlAppRuntimeInputFields = z.object({
     .describe('Reasoning for why the HTML app agent is being called.'),
   intent: z
     .string()
-    .optional()
+    .min(1, 'intent cannot be empty')
     .describe('The app or visualization objective to satisfy.'),
-  prompt: z
-    .string()
-    .optional()
-    .describe('Deprecated alias for intent. Use intent for new callers.'),
   title: z.string().optional().describe('Optional app title.'),
   querySql: z
     .string()
@@ -58,29 +54,7 @@ const HtmlAppRuntimeInputFields = z.object({
     .describe('Maximum expected observe/repair attempts for the caller.'),
 });
 
-function requireHtmlAppIntent(
-  value: {intent?: string; prompt?: string},
-  ctx: z.RefinementCtx,
-) {
-  if (resolveHtmlAppIntent(value)) return;
-  ctx.addIssue({
-    code: 'custom',
-    path: ['intent'],
-    message: 'intent is required. prompt is accepted as a deprecated alias.',
-  });
-}
-
-function resolveHtmlAppIntent(value: {intent?: string; prompt?: string}) {
-  return value.intent?.trim() || value.prompt?.trim();
-}
-
-function resolvedHtmlAppIntentPatch(value: {intent?: string; prompt?: string}) {
-  const intent = resolveHtmlAppIntent(value);
-  return intent ? {intent} : {};
-}
-
-export const HtmlAppRuntimeInputSchema =
-  HtmlAppRuntimeInputFields.superRefine(requireHtmlAppIntent);
+export const HtmlAppRuntimeInputSchema = HtmlAppRuntimeInputFields;
 
 const HtmlAppAgentInputSchema = HtmlAppRuntimeInputFields.extend({
   appId: z
@@ -88,7 +62,7 @@ const HtmlAppAgentInputSchema = HtmlAppRuntimeInputFields.extend({
     .describe(
       'HTML app runtime id to write. The caller must create or identify the top-level html-app artifact or embedded html-app block before calling this tool.',
     ),
-}).superRefine(requireHtmlAppIntent);
+});
 
 type HtmlAppAgentInput = z.infer<typeof HtmlAppAgentInputSchema>;
 export type HtmlAppRuntimeWriteInput = Omit<
@@ -100,7 +74,6 @@ export type HtmlAppRuntimeWriteInput = Omit<
 
 const WriteHtmlAppFilesInputSchema = HtmlAppRuntimeInputFields.omit({
   maxRepairAttempts: true,
-  prompt: true,
   intent: true,
 });
 
@@ -115,7 +88,7 @@ Use this after the caller has created or identified the right container:
 - top-level html-app artifact id
 - embedded worksheet html-app blockInstanceId
 
-This tool does not create artifacts, select artifacts, or create worksheet blocks. It creates complete app source for the requested intent, writes it to durable html-app runtime state, observes runtime diagnostics, and repairs files when diagnostics report errors. If explicit html or files are provided, it writes that source directly. For incremental edits to an existing app, provide appId plus the edit intent; the tool edits the current source without re-discovering data unless the request explicitly changes data/query behavior. For title-only rename requests, provide title without source; the tool updates metadata and obvious HTML title locations without regenerating the app. prompt is accepted only as a deprecated alias for intent.`,
+This tool does not create artifacts, select artifacts, or create worksheet blocks. It creates complete app source for the requested intent, writes it to durable html-app runtime state, observes runtime diagnostics, and repairs files when diagnostics report errors. If explicit html or files are provided, it writes that source directly. For incremental edits to an existing app, provide appId plus the edit intent; the tool edits the current source without re-discovering data unless the request explicitly changes data/query behavior. For title-only rename requests, provide title without source; the tool updates metadata and obvious HTML title locations without regenerating the app.`,
     inputSchema: HtmlAppAgentInputSchema,
     execute: async (input, toolOptions): Promise<Record<string, unknown>> => {
       if (input.html || input.files) {
@@ -149,7 +122,7 @@ function isTitleOnlyRequest(input: HtmlAppAgentInput) {
     return false;
   }
 
-  const intent = resolveHtmlAppIntent(input)?.toLowerCase() ?? '';
+  const intent = input.intent.toLowerCase();
   return (
     /\b(rename|change|set|update)\b[\s\S]{0,80}\b(title|name)\b/.test(intent) ||
     /\b(title|name)\b[\s\S]{0,80}\b(to|as)\b/.test(intent)
@@ -204,7 +177,7 @@ function isIncrementalAppEditRequest(input: HtmlAppAgentInput) {
     return false;
   }
 
-  const intent = resolveHtmlAppIntent(input)?.toLowerCase() ?? '';
+  const intent = input.intent.toLowerCase();
   if (
     /\b(new|another|fresh|separate)\b[\s\S]{0,40}\b(app|artifact)\b/.test(
       intent,
@@ -253,6 +226,7 @@ Use this after making the requested scoped edit to the existing files. Preserve 
       latestWriteResult = await writeHtmlAppRuntimeState(store, {
         ...writeInput,
         appId: input.appId,
+        intent: input.intent,
         title: writeInput.title ?? input.title ?? app.title,
         dependencies: writeInput.dependencies ?? app.dependencies,
         maxRepairAttempts: input.maxRepairAttempts,
@@ -277,7 +251,7 @@ Use this after making the requested scoped edit to the existing files. Preserve 
 
   const result = await streamSubAgent(
     agent,
-    formatHtmlAppEditPrompt(input, app),
+    formatHtmlAppEditMessage(input, app),
     store,
     parentToolCallId,
     abortSignal,
@@ -327,7 +301,7 @@ For a self-contained iframe app, prefer the html field. Use files only when mult
       latestWriteResult = await writeHtmlAppRuntimeState(store, {
         ...writeInput,
         appId: input.appId,
-        ...resolvedHtmlAppIntentPatch(input),
+        intent: input.intent,
         maxRepairAttempts: input.maxRepairAttempts,
       });
       return latestWriteResult;
@@ -357,7 +331,7 @@ For a self-contained iframe app, prefer the html field. Use files only when mult
 
   const result = await streamSubAgent(
     agent,
-    formatHtmlAppGenerationPrompt(input),
+    formatHtmlAppGenerationMessage(input),
     store,
     parentToolCallId,
     abortSignal,
@@ -389,7 +363,7 @@ export async function writeHtmlAppRuntimeState(
 ): Promise<Record<string, unknown>> {
   const appId = input.appId;
   const title = input.title?.trim() || 'HTML App';
-  const intent = resolveHtmlAppIntent(input);
+  const {intent} = input;
   const dependencies = resolveDependencies(input);
   const files = normalizeHtmlAppFiles(input);
 
@@ -544,7 +518,7 @@ Required workflow:
 6. Do not finish without calling write_html_app_source at least once.
 
 Important constraints:
-- Do not write a placeholder, scaffold, generic bar chart, or prompt summary. The rendered app must implement the requested app.
+- Do not write a placeholder, scaffold, generic bar chart, or request summary. The rendered app must implement the requested app.
 - Use window.sqlrooms.queryRows(sql) or window.sqlrooms.query(sql) for data access.
 - Query results may contain BigInt values. Convert all plotted numeric values with Number(value) before passing them to D3, Chart.js, scales, Math functions, or SVG attributes.
 - Prefer the html field with a complete self-contained document unless multiple files materially improve clarity.
@@ -569,17 +543,16 @@ Required workflow:
 Important constraints:
 - This is an incremental edit path, not a rebuild path.
 - Do not re-discover data or change SQL unless the user explicitly asks for a data/schema/query change.
-- Do not replace the app with a placeholder, scaffold, generic chart, or prompt summary.
+- Do not replace the app with a placeholder, scaffold, generic chart, or request summary.
 - Query results may contain BigInt values. Preserve or add Number(value) conversions before passing values to D3, Chart.js, scales, Math functions, or SVG attributes.
 - Prefer preserving the existing file structure. Use the html field only when the app is currently a single /index.html file.`;
 }
 
-function formatHtmlAppGenerationPrompt(input: HtmlAppAgentInput) {
-  const intent = resolveHtmlAppIntent(input) ?? '';
+function formatHtmlAppGenerationMessage(input: HtmlAppAgentInput) {
   const parts = [
     `App runtime id: ${input.appId}`,
     `Title: ${input.title?.trim() || 'HTML App'}`,
-    `Intent: ${intent}`,
+    `Intent: ${input.intent}`,
   ];
 
   if (input.querySql) {
@@ -599,17 +572,16 @@ function formatHtmlAppGenerationPrompt(input: HtmlAppAgentInput) {
   return parts.join('\n\n');
 }
 
-function formatHtmlAppEditPrompt(
+function formatHtmlAppEditMessage(
   input: HtmlAppAgentInput,
   app: NonNullable<ReturnType<RoomState['htmlApps']['getApp']>>,
 ) {
-  const intent = resolveHtmlAppIntent(input) ?? '';
   const parts = [
     `App runtime id: ${input.appId}`,
     `Current title: ${app.title}`,
     `Requested title: ${input.title?.trim() || app.title}`,
     ...(app.intent ? [`Current intent: ${app.intent}`] : []),
-    `Edit intent: ${intent}`,
+    `Edit intent: ${input.intent}`,
     `Entry HTML path: ${app.entryHtmlPath || '/index.html'}`,
   ];
 

--- a/apps/sqlrooms-cli-ui/src/createHtmlAppAgent.ts
+++ b/apps/sqlrooms-cli-ui/src/createHtmlAppAgent.ts
@@ -253,7 +253,6 @@ Use this after making the requested scoped edit to the existing files. Preserve 
       latestWriteResult = await writeHtmlAppRuntimeState(store, {
         ...writeInput,
         appId: input.appId,
-        ...resolvedHtmlAppIntentPatch(input),
         title: writeInput.title ?? input.title ?? app.title,
         dependencies: writeInput.dependencies ?? app.dependencies,
         maxRepairAttempts: input.maxRepairAttempts,

--- a/apps/sqlrooms-cli-ui/src/createWorksheetAiAdapter.ts
+++ b/apps/sqlrooms-cli-ui/src/createWorksheetAiAdapter.ts
@@ -56,7 +56,7 @@ export function createWorksheetAiAdapter(
       return block.id;
     },
 
-    addDashboardBlock: (worksheetId, title, tableName) => {
+    addDashboardBlock: (worksheetId, title, tableName, intent) => {
       ensureWorksheet(worksheetId);
 
       const state = store.getState();
@@ -69,6 +69,7 @@ export function createWorksheetAiAdapter(
         id: createDefaultBlockDocumentBlockId(),
         blockInstanceId: dashboardId,
         blockType: 'dashboard',
+        intent,
         caption: title,
       };
 
@@ -82,7 +83,7 @@ export function createWorksheetAiAdapter(
       };
     },
 
-    addDataTableExplorerBlock: (worksheetId, title, tableName) => {
+    addDataTableExplorerBlock: (worksheetId, title, tableName, intent) => {
       ensureWorksheet(worksheetId);
 
       const state = store.getState();
@@ -91,6 +92,7 @@ export function createWorksheetAiAdapter(
         id: createDefaultBlockDocumentBlockId(),
         blockInstanceId: createDefaultBlockDocumentBlockId(),
         blockType: 'data-table',
+        intent,
         title: tableName,
         caption: title,
       };

--- a/apps/sqlrooms-cli-ui/src/store-types.ts
+++ b/apps/sqlrooms-cli-ui/src/store-types.ts
@@ -25,19 +25,13 @@ import {DbSettingsSliceState} from '@sqlrooms/db-settings';
 
 const AppBuilderProjectEntries = z.record(
   z.string(),
-  z
-    .object({
-      name: z.string().default('Untitled App'),
-      intent: z.string().default(''),
-      prompt: z.string().optional(),
-      template: z.string().default('mosaic-dashboard'),
-      files: z.record(z.string(), z.string()).default({}),
-      updatedAt: z.number().default(0),
-    })
-    .transform(({prompt, intent, ...entry}) => ({
-      ...entry,
-      intent: intent || prompt || '',
-    })),
+  z.object({
+    name: z.string().default('Untitled App'),
+    intent: z.string().default(''),
+    template: z.string().default('mosaic-dashboard'),
+    files: z.record(z.string(), z.string()).default({}),
+    updatedAt: z.number().default(0),
+  }),
 );
 
 export const AppBuilderProjectConfig = z.object({

--- a/apps/sqlrooms-cli-ui/src/store-types.ts
+++ b/apps/sqlrooms-cli-ui/src/store-types.ts
@@ -25,13 +25,19 @@ import {DbSettingsSliceState} from '@sqlrooms/db-settings';
 
 const AppBuilderProjectEntries = z.record(
   z.string(),
-  z.object({
-    name: z.string().default('Untitled App'),
-    prompt: z.string().default(''),
-    template: z.string().default('mosaic-dashboard'),
-    files: z.record(z.string(), z.string()).default({}),
-    updatedAt: z.number().default(0),
-  }),
+  z
+    .object({
+      name: z.string().default('Untitled App'),
+      intent: z.string().default(''),
+      prompt: z.string().optional(),
+      template: z.string().default('mosaic-dashboard'),
+      files: z.record(z.string(), z.string()).default({}),
+      updatedAt: z.number().default(0),
+    })
+    .transform(({prompt, intent, ...entry}) => ({
+      ...entry,
+      intent: intent || prompt || '',
+    })),
 );
 
 export const AppBuilderProjectConfig = z.object({

--- a/apps/sqlrooms-cli-ui/src/store.ts
+++ b/apps/sqlrooms-cli-ui/src/store.ts
@@ -471,7 +471,7 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
                   artifactId
                 ] ?? {
                   name: app.name,
-                  prompt: '',
+                  intent: '',
                   template: 'mosaic-dashboard',
                   files: {},
                   updatedAt: 0,

--- a/apps/sqlrooms-cli-ui/src/workspace/AppBuilderArtifact.tsx
+++ b/apps/sqlrooms-cli-ui/src/workspace/AppBuilderArtifact.tsx
@@ -16,8 +16,8 @@ const TEMPLATE_OPTIONS = [
   {id: 'basic-dashboard', label: 'Basic dashboard (table + chart)'},
 ];
 
-function deriveAppName(prompt: string): string {
-  const trimmed = prompt.trim();
+function deriveAppName(intent: string): string {
+  const trimmed = intent.trim();
   if (!trimmed) return `App ${new Date().toLocaleTimeString()}`;
   return trimmed.split(/\s+/).slice(0, 6).join(' ');
 }
@@ -36,7 +36,7 @@ export const AppBuilderArtifact: RoomPanelComponent = ({panelId, meta}) => {
   const initializeWebContainer = useRoomStore((s) => s.webContainer.initialize);
   const webContainerStatus = useRoomStore((s) => s.webContainer.serverStatus);
 
-  const [prompt, setPrompt] = React.useState('');
+  const [intent, setIntent] = React.useState('');
   const [template, setTemplate] = React.useState('mosaic-dashboard');
   const [name, setName] = React.useState('');
   const [status, setStatus] = React.useState<string>('');
@@ -102,17 +102,17 @@ export const AppBuilderArtifact: RoomPanelComponent = ({panelId, meta}) => {
   if (!artifactId) return null;
 
   const onCreate = async () => {
-    const finalName = (name || deriveAppName(prompt)).trim();
+    const finalName = (name || deriveAppName(intent)).trim();
     setBusy(true);
     setStatus('Generating app...');
     try {
-      const result = generateAppFromPromptLocal({prompt, template});
+      const result = generateAppFromIntentLocal({intent, template});
       const filesRecord = Object.fromEntries(
         result.files.map((f) => [f.path, f.content]),
       );
       upsertArtifactApp(artifactId, {
         name: finalName,
-        prompt,
+        intent,
         template,
         files: filesRecord,
       });
@@ -182,11 +182,11 @@ export const AppBuilderArtifact: RoomPanelComponent = ({panelId, meta}) => {
   return (
     <div className="mx-auto flex h-full w-full max-w-2xl flex-col gap-3 p-4">
       <h3 className="text-base font-medium">Create New App</h3>
-      <label className="text-muted-foreground text-xs">Prompt</label>
+      <label className="text-muted-foreground text-xs">Intent</label>
       <textarea
         className="bg-background min-h-28 rounded-md border p-2 text-sm"
-        value={prompt}
-        onChange={(e) => setPrompt(e.target.value)}
+        value={intent}
+        onChange={(e) => setIntent(e.target.value)}
         placeholder="Build an interactive dashboard for sales by region..."
       />
       <label className="text-muted-foreground text-xs">Template</label>
@@ -208,10 +208,10 @@ export const AppBuilderArtifact: RoomPanelComponent = ({panelId, meta}) => {
         className="bg-background rounded-md border p-2 text-sm"
         value={name}
         onChange={(e) => setName(e.target.value)}
-        placeholder={deriveAppName(prompt)}
+        placeholder={deriveAppName(intent)}
       />
       <div>
-        <Button disabled={busy || !prompt.trim()} onClick={onCreate}>
+        <Button disabled={busy || !intent.trim()} onClick={onCreate}>
           {busy ? 'Creating...' : 'Create App'}
         </Button>
       </div>
@@ -346,8 +346,8 @@ function ensureRuntimePreludeInHtml(html: string): string {
   return `${prelude}\n${html}`;
 }
 
-function generateAppFromPromptLocal(input: {
-  prompt: string;
+function generateAppFromIntentLocal(input: {
+  intent: string;
   template: string;
 }): {
   status: 'ok' | 'error';
@@ -379,7 +379,7 @@ export default function App() {
   return (
     <main style={{padding: 16}}>
       <h1>${appTitle}</h1>
-      <p>Prompt: {${JSON.stringify(input.prompt)}}</p>
+      <p>Intent: {${JSON.stringify(input.intent)}}</p>
       <p>Template: {${JSON.stringify(input.template)}}</p>
       <pre>{JSON.stringify(rows, null, 2)}</pre>
     </main>

--- a/packages/app-runtime/README.md
+++ b/packages/app-runtime/README.md
@@ -83,6 +83,10 @@ string:
 default is `/index.html`. The host injects the app-runtime prelude before user
 scripts run, so generated apps can call:
 
+`HtmlAppState.intent` can store the durable natural-language objective for a
+generated or edited app. Prefer this over storing raw model prompts in app
+state.
+
 ```js
 const {rows, columns, truncated} = await window.sqlrooms.query(
   'select category, count(*) as n from events group by category',

--- a/packages/app-runtime/README.md
+++ b/packages/app-runtime/README.md
@@ -84,8 +84,7 @@ default is `/index.html`. The host injects the app-runtime prelude before user
 scripts run, so generated apps can call:
 
 `HtmlAppState.intent` can store the durable natural-language objective for a
-generated or edited app. Prefer this over storing raw model prompts in app
-state.
+generated or edited app. Prefer this over storing raw model input in app state.
 
 ```js
 const {rows, columns, truncated} = await window.sqlrooms.query(

--- a/packages/app-runtime/src/html-app.tsx
+++ b/packages/app-runtime/src/html-app.tsx
@@ -36,6 +36,7 @@ export type HtmlAppSourceFileMap = z.infer<typeof HtmlAppSourceFileMap>;
 export const HtmlAppState = z.object({
   id: z.string(),
   title: z.string(),
+  intent: z.string().optional(),
   files: HtmlAppSourceFileMap,
   entryHtmlPath: z.string().default('/index.html'),
   requestedCapabilities: z.array(AppCapability).default([]),

--- a/packages/documents/README.md
+++ b/packages/documents/README.md
@@ -347,6 +347,12 @@ the package API generic.
 Hosts can pass `statefulBlockTypes` to expose supported feature-backed block
 types to `block-document.create-stateful-block`.
 
+Structured block payloads may include an optional `intent` string. Use it for
+the durable natural-language purpose of an agent- or command-created block,
+such as the question a chart should answer or the job an embedded dashboard
+should serve. It is persisted with the block, unlike transient mutation
+metadata.
+
 ## CRDT
 
 `@sqlrooms/documents/crdt` exposes Loro Mirror bindings for document state:

--- a/packages/documents/__tests__/BlockDocumentCommands.test.ts
+++ b/packages/documents/__tests__/BlockDocumentCommands.test.ts
@@ -162,6 +162,7 @@ describe('block document commands', () => {
       .commands.invokeCommand('block-document.create-chart-block', {
         artifactId,
         blockId: 'chart-1',
+        intent: 'Show the revenue distribution for the sales review.',
         tableName: 'sales',
         config: {chartType: 'histogram', settings: {field: 'revenue'}},
         selectionGroupId: 'overview',
@@ -171,6 +172,7 @@ describe('block document commands', () => {
       {
         id: 'chart-1',
         type: 'chart',
+        intent: 'Show the revenue distribution for the sales review.',
         tableName: 'sales',
         config: {chartType: 'histogram', settings: {field: 'revenue'}},
         selectionGroupId: 'overview',
@@ -192,6 +194,7 @@ describe('block document commands', () => {
         artifactId,
         blockId: 'dashboard-block',
         blockType: 'dashboard',
+        intent: 'Explore regional sales interactively.',
         title: 'Regional Dashboard',
         caption: 'Regions',
       });
@@ -201,6 +204,7 @@ describe('block document commands', () => {
       {
         id: 'dashboard-block',
         type: 'statefulBlock',
+        intent: 'Explore regional sales interactively.',
         blockType: 'dashboard',
         blockInstanceId: 'dashboard-block',
         ownership: 'owned',

--- a/packages/documents/__tests__/BlockDocumentsSlice.test.ts
+++ b/packages/documents/__tests__/BlockDocumentsSlice.test.ts
@@ -108,6 +108,32 @@ describe('BlockDocumentsSlice', () => {
     ).toEqual([{id: 'block-1', type: 'heading', level: 2, text: 'Original'}]);
   });
 
+  it('round-trips block intent through document nodes', () => {
+    const block: BlockDocumentBlockType = {
+      id: 'chart',
+      type: 'chart',
+      intent: 'Compare regional revenue in the executive summary.',
+      tableName: 'sales',
+      config: {chartType: 'histogram', settings: {field: 'revenue'}},
+      caption: 'Revenue',
+    };
+
+    expect(blockDocumentBlockToNode(block)).toMatchObject({
+      type: 'blockDocumentChart',
+      attrs: {
+        id: 'chart',
+        intent: 'Compare regional revenue in the executive summary.',
+      },
+    });
+
+    expect(
+      blockDocumentContentToBlocks({
+        type: 'doc',
+        content: [blockDocumentBlockToNode(block)],
+      }),
+    ).toEqual([block]);
+  });
+
   it('appends, inserts, updates, removes, and moves top-level blocks', () => {
     const store = createTestStore();
 

--- a/packages/documents/src/BlockDocumentCommands.ts
+++ b/packages/documents/src/BlockDocumentCommands.ts
@@ -127,6 +127,12 @@ const BlockDocumentMoveBlockInput = BlockDocumentBlockIdInput.extend({
 const BlockDocumentCreateChartBlockInput = z.object({
   artifactId: z.string().describe('Target block document artifact ID.'),
   blockId: z.string().optional().describe('Optional explicit chart block ID.'),
+  intent: z
+    .string()
+    .optional()
+    .describe(
+      'Optional natural-language objective this chart block should satisfy.',
+    ),
   tableName: z.string().describe('Mosaic table name to render.'),
   config: z
     .unknown()
@@ -162,6 +168,12 @@ const BlockDocumentCreateStatefulBlockInput = z.object({
   blockType: z
     .string()
     .describe('Stateful block type to create, for example dashboard or pivot.'),
+  intent: z
+    .string()
+    .optional()
+    .describe(
+      'Optional natural-language objective this stateful block should satisfy.',
+    ),
   blockId: z
     .string()
     .optional()
@@ -515,6 +527,7 @@ export function createBlockDocumentCommands<
         const {
           artifactId,
           blockId = createBlockDocumentBlockId(),
+          intent,
           tableName,
           config,
           selectionGroupId,
@@ -533,6 +546,7 @@ export function createBlockDocumentCommands<
         const block = BlockDocumentChartBlock.parse({
           id: blockId,
           type: 'chart',
+          intent,
           tableName,
           config,
           selectionGroupId,
@@ -563,6 +577,7 @@ export function createBlockDocumentCommands<
         const {
           artifactId,
           blockType,
+          intent,
           blockId = createBlockDocumentBlockId(),
           ownership = 'owned',
           title,
@@ -614,6 +629,7 @@ export function createBlockDocumentCommands<
         const block = BlockDocumentStatefulBlockBlock.parse({
           id: blockId,
           type: 'statefulBlock',
+          intent,
           blockType,
           blockInstanceId,
           ownership,

--- a/packages/documents/src/BlockDocumentSliceConfig.ts
+++ b/packages/documents/src/BlockDocumentSliceConfig.ts
@@ -72,6 +72,7 @@ type TextContent = Array<{
 
 const BlockDocumentTextBlockBase = {
   id: z.string(),
+  intent: z.string().optional(),
 };
 
 export const BlockDocumentHeadingBlock = z.object({
@@ -230,23 +231,28 @@ export function createEmptyBlockDocumentContent(): BlockDocumentContent {
 export function blockDocumentBlockToNode(
   block: BlockDocumentBlock,
 ): BlockDocumentNode {
+  const baseAttrs = {
+    id: block.id,
+    ...(block.intent !== undefined ? {intent: block.intent} : {}),
+  };
+
   switch (block.type) {
     case 'heading':
       return {
         type: 'heading',
-        attrs: {id: block.id, level: block.level},
+        attrs: {...baseAttrs, level: block.level},
         content: textContent(block.text),
       };
     case 'paragraph':
       return {
         type: 'paragraph',
-        attrs: {id: block.id},
+        attrs: baseAttrs,
         content: textContent(block.text),
       };
     case 'list':
       return {
         type: block.ordered ? 'orderedList' : 'bulletList',
-        attrs: {id: block.id},
+        attrs: baseAttrs,
         content: block.items.map((item) => ({
           type: 'listItem',
           content: [
@@ -260,7 +266,7 @@ export function blockDocumentBlockToNode(
     case 'todo':
       return {
         type: 'taskList',
-        attrs: {id: block.id},
+        attrs: baseAttrs,
         content: [
           {
             type: 'taskItem',
@@ -278,7 +284,7 @@ export function blockDocumentBlockToNode(
       return {
         type: 'blockDocumentImage',
         attrs: {
-          id: block.id,
+          ...baseAttrs,
           assetId: block.assetId,
           ...(block.caption !== undefined ? {caption: block.caption} : {}),
         },
@@ -287,7 +293,7 @@ export function blockDocumentBlockToNode(
       return {
         type: 'blockDocumentChartImage',
         attrs: {
-          id: block.id,
+          ...baseAttrs,
           assetId: block.assetId,
           ...(block.caption !== undefined ? {caption: block.caption} : {}),
         },
@@ -296,7 +302,7 @@ export function blockDocumentBlockToNode(
       return {
         type: 'blockDocumentChart',
         attrs: {
-          id: block.id,
+          ...baseAttrs,
           tableName: block.tableName,
           config: block.config,
           ...(block.selectionGroupId !== undefined
@@ -309,7 +315,7 @@ export function blockDocumentBlockToNode(
       return {
         type: 'blockDocumentStatefulBlock',
         attrs: {
-          id: block.id,
+          ...baseAttrs,
           blockType: block.blockType,
           blockInstanceId: block.blockInstanceId,
           ...(block.ownership !== undefined
@@ -328,23 +334,26 @@ export function blockDocumentNodeToBlock(
 ): BlockDocumentBlock | undefined {
   const id = nodeId(node);
   if (!id) return undefined;
+  const intent = optionalString(node.attrs?.intent);
 
   switch (node.type) {
     case 'heading': {
       const level = node.attrs?.level;
       return BlockDocumentHeadingBlock.parse({
         id,
+        intent,
         type: 'heading',
         level: level === 1 || level === 2 || level === 3 ? level : 1,
         text: textFromNode(node),
       });
     }
     case 'paragraph':
-      return {id, type: 'paragraph', text: textFromNode(node)};
+      return {id, intent, type: 'paragraph', text: textFromNode(node)};
     case 'bulletList':
     case 'orderedList':
       return {
         id,
+        intent,
         type: 'list',
         ordered: node.type === 'orderedList' ? true : undefined,
         items:
@@ -354,6 +363,7 @@ export function blockDocumentNodeToBlock(
       const item = node.content?.[0];
       return {
         id,
+        intent,
         type: 'todo',
         checked: Boolean(item?.attrs?.checked),
         text: textFromNode(item?.content?.[0]),
@@ -362,6 +372,7 @@ export function blockDocumentNodeToBlock(
     case 'blockDocumentImage': {
       const result = BlockDocumentImageBlock.safeParse({
         id,
+        intent,
         type: 'image',
         assetId: node.attrs?.assetId,
         caption: optionalString(node.attrs?.caption),
@@ -371,6 +382,7 @@ export function blockDocumentNodeToBlock(
     case 'blockDocumentChartImage': {
       const result = BlockDocumentChartImageBlock.safeParse({
         id,
+        intent,
         type: 'chartImage',
         assetId: node.attrs?.assetId,
         caption: optionalString(node.attrs?.caption),
@@ -380,6 +392,7 @@ export function blockDocumentNodeToBlock(
     case 'blockDocumentChart': {
       const result = BlockDocumentChartBlock.safeParse({
         id,
+        intent,
         type: 'chart',
         tableName: node.attrs?.tableName,
         config: node.attrs?.config,
@@ -391,6 +404,7 @@ export function blockDocumentNodeToBlock(
     case 'blockDocumentStatefulBlock': {
       const result = BlockDocumentStatefulBlockBlock.safeParse({
         id,
+        intent,
         type: 'statefulBlock',
         blockType: node.attrs?.blockType,
         blockInstanceId: node.attrs?.blockInstanceId,

--- a/packages/mosaic/README.md
+++ b/packages/mosaic/README.md
@@ -356,8 +356,7 @@ dashboard slice.
 including chart tools, a Data Table Explorer panel tool, and an optional
 exploratory `dashboard_agent`. Client apps supply small adapters that map
 Mosaic's generic dashboard operations to their store and table metadata.
-Agent tools use `intent` for the natural-language objective they should satisfy;
-`prompt` is accepted only as a deprecated alias for older callers.
+Agent tools use `intent` for the natural-language objective they should satisfy.
 
 ```ts
 import {

--- a/packages/mosaic/README.md
+++ b/packages/mosaic/README.md
@@ -356,6 +356,8 @@ dashboard slice.
 including chart tools, a Data Table Explorer panel tool, and an optional
 exploratory `dashboard_agent`. Client apps supply small adapters that map
 Mosaic's generic dashboard operations to their store and table metadata.
+Agent tools use `intent` for the natural-language objective they should satisfy;
+`prompt` is accepted only as a deprecated alias for older callers.
 
 ```ts
 import {
@@ -411,6 +413,8 @@ Worksheet agents also accept host tools through `extraTools`. Worksheet extra
 tool factories receive the active `worksheetId` alongside the worksheet and
 database adapters, so host apps can add worksheet-scoped tools such as embedded
 stateful blocks without guessing which worksheet the sub-agent is editing.
+Worksheet block-container tools propagate optional `intent` onto the created
+block when the host adapter persists block document state.
 
 ### Box Plot Chart Type
 

--- a/packages/mosaic/__tests__/dashboard-ai-tools.test.ts
+++ b/packages/mosaic/__tests__/dashboard-ai-tools.test.ts
@@ -121,7 +121,7 @@ describe('createDashboardAgentTool', () => {
 
     const result = await (tool as any).execute({
       dashboardId: 'dashboard-1',
-      prompt: 'add a histogram of magnitude',
+      intent: 'add a histogram of magnitude',
       reasoning: 'user asked to update the dashboard',
     });
 

--- a/packages/mosaic/__tests__/worksheet-ai.test.ts
+++ b/packages/mosaic/__tests__/worksheet-ai.test.ts
@@ -149,7 +149,7 @@ describe('createWorksheetAiTools', () => {
     );
     const embeddedHtmlAppAgent = tool({
       description: 'mock embedded html app agent',
-      inputSchema: z.object({appId: z.string(), prompt: z.string()}),
+      inputSchema: z.object({appId: z.string(), intent: z.string()}),
       execute: async ({appId}) => ({success: true, appId}),
     });
     const worksheetAdapter: WorksheetAiAdapter = {
@@ -196,7 +196,7 @@ describe('createWorksheetAiTools', () => {
       tools[KnownWorksheetTools.embedded_html_app_agent] as any
     ).execute({
       appId: htmlAppBlock.htmlAppId,
-      prompt: 'Update the existing app.',
+      intent: 'Update the existing app.',
     });
 
     expect(updateResult).toEqual({success: true, appId: 'html-app-1'});

--- a/packages/mosaic/__tests__/worksheet-ai.test.ts
+++ b/packages/mosaic/__tests__/worksheet-ai.test.ts
@@ -113,6 +113,7 @@ describe('createWorksheetAiTools', () => {
       tools[KnownWorksheetTools.add_html_app_block] as any
     ).execute({
       reasoning: 'The user asked for a custom D3 app.',
+      intent: 'Build a country explorer app.',
       appTitle: 'Country Explorer',
     });
 
@@ -134,6 +135,7 @@ describe('createWorksheetAiTools', () => {
         blockType: 'html-app',
         blockInstanceId: result.appId,
         ownership: 'owned',
+        intent: 'Build a country explorer app.',
         title: 'Country Explorer',
         caption: 'Country Explorer',
         height: 560,

--- a/packages/mosaic/src/ai/agentIntent.ts
+++ b/packages/mosaic/src/ai/agentIntent.ts
@@ -1,0 +1,33 @@
+import {z} from 'zod';
+
+type AgentIntentInput = {
+  intent?: string;
+  prompt?: string;
+};
+
+export const AgentIntentSchemaFields = {
+  intent: z
+    .string()
+    .optional()
+    .describe('The natural-language objective for the agent to satisfy.'),
+  prompt: z
+    .string()
+    .optional()
+    .describe('Deprecated alias for intent. Use intent for new callers.'),
+};
+
+export function requireAgentIntent(
+  value: AgentIntentInput,
+  ctx: z.RefinementCtx,
+) {
+  if (resolveAgentIntent(value)) return;
+  ctx.addIssue({
+    code: 'custom',
+    path: ['intent'],
+    message: 'intent is required. prompt is accepted as a deprecated alias.',
+  });
+}
+
+export function resolveAgentIntent(value: AgentIntentInput) {
+  return value.intent?.trim() || value.prompt?.trim();
+}

--- a/packages/mosaic/src/ai/agentIntent.ts
+++ b/packages/mosaic/src/ai/agentIntent.ts
@@ -1,33 +1,8 @@
 import {z} from 'zod';
 
-type AgentIntentInput = {
-  intent?: string;
-  prompt?: string;
-};
-
 export const AgentIntentSchemaFields = {
   intent: z
     .string()
-    .optional()
+    .min(1, 'intent cannot be empty')
     .describe('The natural-language objective for the agent to satisfy.'),
-  prompt: z
-    .string()
-    .optional()
-    .describe('Deprecated alias for intent. Use intent for new callers.'),
 };
-
-export function requireAgentIntent(
-  value: AgentIntentInput,
-  ctx: z.RefinementCtx,
-) {
-  if (resolveAgentIntent(value)) return;
-  ctx.addIssue({
-    code: 'custom',
-    path: ['intent'],
-    message: 'intent is required. prompt is accepted as a deprecated alias.',
-  });
-}
-
-export function resolveAgentIntent(value: AgentIntentInput) {
-  return value.intent?.trim() || value.prompt?.trim();
-}

--- a/packages/mosaic/src/ai/createDataTableExplorerTool.ts
+++ b/packages/mosaic/src/ai/createDataTableExplorerTool.ts
@@ -17,6 +17,12 @@ export const DataTableExplorerParameters = z.object({
     .optional()
     .default('Data Table Explorer')
     .describe('Title for the Data Table Explorer panel.'),
+  intent: z
+    .string()
+    .optional()
+    .describe(
+      'Optional natural-language objective this Data Table Explorer should satisfy.',
+    ),
 });
 
 /**

--- a/packages/mosaic/src/ai/dashboard/createDashboardAgentTool.ts
+++ b/packages/mosaic/src/ai/dashboard/createDashboardAgentTool.ts
@@ -13,6 +13,11 @@ import {createDashboardAiAdapter} from './createDashboardAiAdapter';
 import {resolveChartTypes} from '../../charts/chart-types/resolveChartTypes';
 import {createChartToolsInstructions} from '../../charts/chart-types/createChartInstructions';
 import {DASHBOARD_CHART_TOOL_PREFIX, KnownDashboardTools} from './constants';
+import {
+  AgentIntentSchemaFields,
+  requireAgentIntent,
+  resolveAgentIntent,
+} from '../agentIntent';
 
 function getDashboardAgentInstructions<TState>(
   options: CreateDashboardAgentToolOptions<TState>,
@@ -98,35 +103,35 @@ When user asks to discover insights:
 - **Handle errors gracefully:** If a query or chart creation fails, try alternative approach`;
 }
 
-const DashboardAgentInputSchema = z.object({
-  reasoning: z
-    .string()
-    .describe('Reasoning for why the dashboard agent is being called'),
-  prompt: z
-    .string()
-    .describe('The exploratory data analysis prompt for the agent'),
-  tableName: z
-    .string()
-    .optional()
-    .describe(
-      'The name of the table/dataset to analyze. Optional when the target dashboard already has a selected table.',
-    ),
-  dashboardId: z
-    .string()
-    .describe('The ID of an existing dashboard to update.'),
-  maxSteps: z
-    .number()
-    .optional()
-    .default(20)
-    .describe('Maximum exploration steps (default: 20, range: 5-50)'),
-  temperature: z
-    .number()
-    .optional()
-    .default(0.7)
-    .describe(
-      'Model temperature for creativity vs consistency (default: 0.7, range: 0.0-1.0)',
-    ),
-});
+const DashboardAgentInputSchema = z
+  .object({
+    reasoning: z
+      .string()
+      .describe('Reasoning for why the dashboard agent is being called'),
+    ...AgentIntentSchemaFields,
+    tableName: z
+      .string()
+      .optional()
+      .describe(
+        'The name of the table/dataset to analyze. Optional when the target dashboard already has a selected table.',
+      ),
+    dashboardId: z
+      .string()
+      .describe('The ID of an existing dashboard to update.'),
+    maxSteps: z
+      .number()
+      .optional()
+      .default(20)
+      .describe('Maximum exploration steps (default: 20, range: 5-50)'),
+    temperature: z
+      .number()
+      .optional()
+      .default(0.7)
+      .describe(
+        'Model temperature for creativity vs consistency (default: 0.7, range: 0.0-1.0)',
+      ),
+  })
+  .superRefine(requireAgentIntent);
 
 type DashboardAgentInputSchema = z.infer<typeof DashboardAgentInputSchema>;
 
@@ -158,17 +163,19 @@ This agent:
 
 REQUIRED PARAMETERS:
 - dashboardId: The ID of the dashboard to populate
-- prompt: What insights, patterns, or specific charts to create
+- intent: What insights, patterns, or specific charts to create
 
 OPTIONAL PARAMETERS:
 - tableName: The dataset to analyze. If omitted, the dashboard's selected table is used.
+- prompt: Deprecated alias for intent.
 
-The agent will explore the data and create 3-5 panels showing different aspects based on the prompt.
+The agent will explore the data and create 3-5 panels showing different aspects based on the intent.
 
 IMPORTANT: IF primary artefact in run context is a dashboard, prioritize using this tool for any queries or data analysis tasks.`,
     inputSchema: DashboardAgentInputSchema,
     execute: async (params, toolOptions): Promise<DashboardAgentResult> => {
-      const {prompt, dashboardId, maxSteps, temperature} = params;
+      const {dashboardId, maxSteps, temperature} = params;
+      const intent = resolveAgentIntent(params) ?? '';
 
       const dashboardAdapter = createDashboardAiAdapter(store, dashboardId);
 
@@ -212,7 +219,7 @@ IMPORTANT: IF primary artefact in run context is a dashboard, prioritize using t
 
         const result = await options.runSubAgent({
           agent,
-          prompt,
+          prompt: intent,
           store,
           parentToolCallId: toolOptions?.toolCallId || '',
           abortSignal: toolOptions?.abortSignal,

--- a/packages/mosaic/src/ai/dashboard/createDashboardAgentTool.ts
+++ b/packages/mosaic/src/ai/dashboard/createDashboardAgentTool.ts
@@ -13,11 +13,7 @@ import {createDashboardAiAdapter} from './createDashboardAiAdapter';
 import {resolveChartTypes} from '../../charts/chart-types/resolveChartTypes';
 import {createChartToolsInstructions} from '../../charts/chart-types/createChartInstructions';
 import {DASHBOARD_CHART_TOOL_PREFIX, KnownDashboardTools} from './constants';
-import {
-  AgentIntentSchemaFields,
-  requireAgentIntent,
-  resolveAgentIntent,
-} from '../agentIntent';
+import {AgentIntentSchemaFields} from '../agentIntent';
 
 function getDashboardAgentInstructions<TState>(
   options: CreateDashboardAgentToolOptions<TState>,
@@ -103,35 +99,33 @@ When user asks to discover insights:
 - **Handle errors gracefully:** If a query or chart creation fails, try alternative approach`;
 }
 
-const DashboardAgentInputSchema = z
-  .object({
-    reasoning: z
-      .string()
-      .describe('Reasoning for why the dashboard agent is being called'),
-    ...AgentIntentSchemaFields,
-    tableName: z
-      .string()
-      .optional()
-      .describe(
-        'The name of the table/dataset to analyze. Optional when the target dashboard already has a selected table.',
-      ),
-    dashboardId: z
-      .string()
-      .describe('The ID of an existing dashboard to update.'),
-    maxSteps: z
-      .number()
-      .optional()
-      .default(20)
-      .describe('Maximum exploration steps (default: 20, range: 5-50)'),
-    temperature: z
-      .number()
-      .optional()
-      .default(0.7)
-      .describe(
-        'Model temperature for creativity vs consistency (default: 0.7, range: 0.0-1.0)',
-      ),
-  })
-  .superRefine(requireAgentIntent);
+const DashboardAgentInputSchema = z.object({
+  reasoning: z
+    .string()
+    .describe('Reasoning for why the dashboard agent is being called'),
+  ...AgentIntentSchemaFields,
+  tableName: z
+    .string()
+    .optional()
+    .describe(
+      'The name of the table/dataset to analyze. Optional when the target dashboard already has a selected table.',
+    ),
+  dashboardId: z
+    .string()
+    .describe('The ID of an existing dashboard to update.'),
+  maxSteps: z
+    .number()
+    .optional()
+    .default(20)
+    .describe('Maximum exploration steps (default: 20, range: 5-50)'),
+  temperature: z
+    .number()
+    .optional()
+    .default(0.7)
+    .describe(
+      'Model temperature for creativity vs consistency (default: 0.7, range: 0.0-1.0)',
+    ),
+});
 
 type DashboardAgentInputSchema = z.infer<typeof DashboardAgentInputSchema>;
 
@@ -167,7 +161,6 @@ REQUIRED PARAMETERS:
 
 OPTIONAL PARAMETERS:
 - tableName: The dataset to analyze. If omitted, the dashboard's selected table is used.
-- prompt: Deprecated alias for intent.
 
 The agent will explore the data and create 3-5 panels showing different aspects based on the intent.
 
@@ -175,7 +168,7 @@ IMPORTANT: IF primary artefact in run context is a dashboard, prioritize using t
     inputSchema: DashboardAgentInputSchema,
     execute: async (params, toolOptions): Promise<DashboardAgentResult> => {
       const {dashboardId, maxSteps, temperature} = params;
-      const intent = resolveAgentIntent(params) ?? '';
+      const {intent} = params;
 
       const dashboardAdapter = createDashboardAiAdapter(store, dashboardId);
 

--- a/packages/mosaic/src/ai/worksheet/createAddDashboardBlockTool.ts
+++ b/packages/mosaic/src/ai/worksheet/createAddDashboardBlockTool.ts
@@ -7,6 +7,10 @@ import {ToolOutput} from '../tool-types';
 const AddDashboardBlockParameters = z.object({
   dashboardTitle: z.string().describe('The title of the dashboard'),
   tableName: z.string().describe('The name of the table/dataset to analyze.'),
+  intent: z
+    .string()
+    .optional()
+    .describe('Optional natural-language objective for this dashboard block.'),
 });
 
 type AddDashboardBlockParameters = z.infer<typeof AddDashboardBlockParameters>;
@@ -48,12 +52,13 @@ This tool ONLY creates the container structure. To populate it with charts and p
 
 Use this when you need to create a dashboard block in a worksheet.`,
     inputSchema: AddDashboardBlockToolInput,
-    execute: async ({dashboardTitle, tableName}) => {
+    execute: async ({dashboardTitle, tableName, intent}) => {
       try {
         const {dashboardId} = worksheetAdapter.addDashboardBlock(
           worksheetId,
           dashboardTitle,
           tableName,
+          intent,
         );
 
         return {

--- a/packages/mosaic/src/ai/worksheet/createAddHtmlAppBlockTool.ts
+++ b/packages/mosaic/src/ai/worksheet/createAddHtmlAppBlockTool.ts
@@ -10,6 +10,10 @@ import type {WorksheetAiAdapter} from './worksheet-types';
 
 const AddHtmlAppBlockToolInput = z.object({
   reasoning: z.string().describe('Brief rationale for HTML app block choice.'),
+  intent: z
+    .string()
+    .optional()
+    .describe('Optional natural-language objective for this HTML app block.'),
   appTitle: z.string().describe('The title of the HTML app block.'),
 });
 
@@ -46,7 +50,7 @@ This tool ONLY creates the container structure. To write app files and observe r
 
 Use this when you need to create a custom HTML, D3, Chart.js, or browser app block inside a worksheet.`,
     inputSchema: AddHtmlAppBlockToolInput,
-    execute: async ({appTitle}) => {
+    execute: async ({appTitle, intent}) => {
       try {
         worksheetAdapter.ensureWorksheet(worksheetId);
         worksheetAdapter.setCurrentWorksheet(worksheetId);
@@ -58,6 +62,7 @@ Use this when you need to create a custom HTML, D3, Chart.js, or browser app blo
           blockType: 'html-app',
           blockInstanceId: appId,
           ownership: 'owned',
+          intent,
           title: appTitle,
           caption: appTitle,
           height: 560,

--- a/packages/mosaic/src/ai/worksheet/createWorksheetAgentTool.ts
+++ b/packages/mosaic/src/ai/worksheet/createWorksheetAgentTool.ts
@@ -11,11 +11,7 @@ import {createWorksheetAiTools} from './createWorksheetAiTools';
 import {createChartToolsInstructions} from '../../charts/chart-types/createChartInstructions';
 import {WORKSHEET_CHART_TOOL_PREFIX, KnownWorksheetTools} from './constants';
 import {resolveChartTypes} from '../../charts/chart-types/resolveChartTypes';
-import {
-  AgentIntentSchemaFields,
-  requireAgentIntent,
-  resolveAgentIntent,
-} from '../agentIntent';
+import {AgentIntentSchemaFields} from '../agentIntent';
 
 function getWorksheetAgentInstructions<TState>(
   options: CreateWorksheetAgentToolOptions<TState>,
@@ -208,31 +204,29 @@ When user asks for "comprehensive analysis" or "high-level insights":
 ✅ Charts are created immediately when you call the create_worksheet_block_* tools`;
 }
 
-const WorksheetAgentInputSchema = z
-  .object({
-    reasoning: z
-      .string()
-      .describe('Reasoning for why the worksheet agent is being called'),
-    ...AgentIntentSchemaFields,
-    worksheetId: z
-      .string()
-      .describe(
-        'Target worksheet ID. If provided, charts will be added to this worksheet.',
-      ),
-    maxSteps: z
-      .number()
-      .optional()
-      .default(20)
-      .describe('Maximum exploration steps (default: 20, range: 5-50)'),
-    temperature: z
-      .number()
-      .optional()
-      .default(0.7)
-      .describe(
-        'Model temperature for creativity vs consistency (default: 0.7, range: 0.0-1.0)',
-      ),
-  })
-  .superRefine(requireAgentIntent);
+const WorksheetAgentInputSchema = z.object({
+  reasoning: z
+    .string()
+    .describe('Reasoning for why the worksheet agent is being called'),
+  ...AgentIntentSchemaFields,
+  worksheetId: z
+    .string()
+    .describe(
+      'Target worksheet ID. If provided, charts will be added to this worksheet.',
+    ),
+  maxSteps: z
+    .number()
+    .optional()
+    .default(20)
+    .describe('Maximum exploration steps (default: 20, range: 5-50)'),
+  temperature: z
+    .number()
+    .optional()
+    .default(0.7)
+    .describe(
+      'Model temperature for creativity vs consistency (default: 0.7, range: 0.0-1.0)',
+    ),
+});
 
 type WorksheetAgentInputSchema = z.infer<typeof WorksheetAgentInputSchema>;
 
@@ -293,7 +287,7 @@ IMPORTANT: IF primary artefact in run context is a worksheet, prioritize using t
     inputSchema: WorksheetAgentInputSchema,
     execute: async (params, toolOptions): Promise<WorksheetAgentResult> => {
       const {worksheetId, maxSteps, temperature} = params;
-      const intent = resolveAgentIntent(params) ?? '';
+      const {intent} = params;
 
       try {
         worksheetAdapter.ensureWorksheet(worksheetId);

--- a/packages/mosaic/src/ai/worksheet/createWorksheetAgentTool.ts
+++ b/packages/mosaic/src/ai/worksheet/createWorksheetAgentTool.ts
@@ -11,6 +11,11 @@ import {createWorksheetAiTools} from './createWorksheetAiTools';
 import {createChartToolsInstructions} from '../../charts/chart-types/createChartInstructions';
 import {WORKSHEET_CHART_TOOL_PREFIX, KnownWorksheetTools} from './constants';
 import {resolveChartTypes} from '../../charts/chart-types/resolveChartTypes';
+import {
+  AgentIntentSchemaFields,
+  requireAgentIntent,
+  resolveAgentIntent,
+} from '../agentIntent';
 
 function getWorksheetAgentInstructions<TState>(
   options: CreateWorksheetAgentToolOptions<TState>,
@@ -58,6 +63,7 @@ To add text context or summaries, use the ${KnownWorksheetTools.add_text_block} 
 To add a data table explorer block, use the ${KnownWorksheetTools.add_data_table_explorer} tool:
 - Provide a title for the block
 - Provide the dataset (table name) to explore
+- Provide intent when the request includes a durable purpose for the block
 - Only add one data table explorer block per worksheet
 - Only add if user explicitly requests it or if it is necessary for exploration
 
@@ -72,13 +78,14 @@ STEP 1: Create the empty dashboard block container
 - Call ${KnownWorksheetTools.add_dashboard_block} with:
   - dashboardTitle: title for the dashboard
   - tableName: the dataset to analyze
+  - intent: durable purpose for this dashboard block
 - This returns a dashboardId
 
 STEP 2: Populate the dashboard with charts and panels
 - Call ${KnownWorksheetTools.embedded_dashboard_agent} with:
   - dashboardId: the ID from step 1
   - tableName: the dataset to analyze
-  - prompt: what insights or charts to create
+  - intent: what insights or charts to create
 
 Use dashboard blocks when:
 - User explicitly requests a dashboard: "add dashboard analyzing sales data"
@@ -97,12 +104,13 @@ If the worksheet already has an html-app block that matches the request, reuse i
 STEP 1: Create the empty html-app block container
 - Call ${KnownWorksheetTools.add_html_app_block} with:
   - appTitle: title for the app
+  - intent: durable purpose for this app block
 - This returns an appId
 
 STEP 2: Write the app files and observe runtime diagnostics
 - Call ${KnownWorksheetTools.embedded_html_app_agent} with:
   - appId: the ID from step 1
-  - prompt: what app or visualization to create
+  - intent: what app or visualization to create
 
 Use html-app blocks when:
 - User explicitly asks for an app, HTML app, D3 app, Chart.js app, browser app, or custom interactive visualization
@@ -125,7 +133,7 @@ When user asks for specific charts (e.g., "create histogram of depth and magnitu
 1. Call ${KnownWorksheetTools.add_dashboard_block} to create the container
 2. Call ${KnownWorksheetTools.embedded_dashboard_agent} with the returned dashboardId to populate it
 
-**Map requests:** If user asks to add a map to an existing worksheet/dashboard, call ${KnownWorksheetTools.list_blocks}. If a dashboard block exists, call ${KnownWorksheetTools.embedded_dashboard_agent} with that dashboardId and a prompt to create or update a map panel. If no dashboard block exists, create one first with ${KnownWorksheetTools.add_dashboard_block}.
+**Map requests:** If user asks to add a map to an existing worksheet/dashboard, call ${KnownWorksheetTools.list_blocks}. If a dashboard block exists, call ${KnownWorksheetTools.embedded_dashboard_agent} with that dashboardId and an intent to create or update a map panel. If no dashboard block exists, create one first with ${KnownWorksheetTools.add_dashboard_block}.
 
 **HTML app requests:** If user asks to create a new app inside the worksheet, call ${KnownWorksheetTools.add_html_app_block}, then call ${KnownWorksheetTools.embedded_html_app_agent} with the returned appId. If modifying an existing app, call ${KnownWorksheetTools.list_blocks} first and pass the target htmlAppId as appId.
 
@@ -200,31 +208,31 @@ When user asks for "comprehensive analysis" or "high-level insights":
 ✅ Charts are created immediately when you call the create_worksheet_block_* tools`;
 }
 
-const WorksheetAgentInputSchema = z.object({
-  reasoning: z
-    .string()
-    .describe('Reasoning for why the worksheet agent is being called'),
-  prompt: z
-    .string()
-    .describe('The exploratory data analysis prompt for the agent'),
-  worksheetId: z
-    .string()
-    .describe(
-      'Target worksheet ID. If provided, charts will be added to this worksheet.',
-    ),
-  maxSteps: z
-    .number()
-    .optional()
-    .default(20)
-    .describe('Maximum exploration steps (default: 20, range: 5-50)'),
-  temperature: z
-    .number()
-    .optional()
-    .default(0.7)
-    .describe(
-      'Model temperature for creativity vs consistency (default: 0.7, range: 0.0-1.0)',
-    ),
-});
+const WorksheetAgentInputSchema = z
+  .object({
+    reasoning: z
+      .string()
+      .describe('Reasoning for why the worksheet agent is being called'),
+    ...AgentIntentSchemaFields,
+    worksheetId: z
+      .string()
+      .describe(
+        'Target worksheet ID. If provided, charts will be added to this worksheet.',
+      ),
+    maxSteps: z
+      .number()
+      .optional()
+      .default(20)
+      .describe('Maximum exploration steps (default: 20, range: 5-50)'),
+    temperature: z
+      .number()
+      .optional()
+      .default(0.7)
+      .describe(
+        'Model temperature for creativity vs consistency (default: 0.7, range: 0.0-1.0)',
+      ),
+  })
+  .superRefine(requireAgentIntent);
 
 type WorksheetAgentInputSchema = z.infer<typeof WorksheetAgentInputSchema>;
 
@@ -267,7 +275,7 @@ IF user requests DASHBOARD:
 IF user requests a MAP in a worksheet:
 1. Call ${KnownWorksheetTools.list_blocks} to find an existing dashboard block
 2. Reuse an existing dashboardId if available, otherwise call ${KnownWorksheetTools.add_dashboard_block}
-3. Call ${KnownWorksheetTools.embedded_dashboard_agent} with a prompt to add a map panel
+3. Call ${KnownWorksheetTools.embedded_dashboard_agent} with an intent to add a map panel
 
 IF user requests an HTML/D3/Chart.js/browser app in a worksheet:
 1. For a new app, call ${KnownWorksheetTools.add_html_app_block} to create the container, then call ${KnownWorksheetTools.embedded_html_app_agent} with the returned appId
@@ -284,7 +292,8 @@ Use this for:
 IMPORTANT: IF primary artefact in run context is a worksheet, prioritize using this tool for any queries or data analysis tasks.`,
     inputSchema: WorksheetAgentInputSchema,
     execute: async (params, toolOptions): Promise<WorksheetAgentResult> => {
-      const {prompt, worksheetId, maxSteps, temperature} = params;
+      const {worksheetId, maxSteps, temperature} = params;
+      const intent = resolveAgentIntent(params) ?? '';
 
       try {
         worksheetAdapter.ensureWorksheet(worksheetId);
@@ -317,7 +326,7 @@ IMPORTANT: IF primary artefact in run context is a worksheet, prioritize using t
 
         const result = await options.runSubAgent({
           agent,
-          prompt,
+          prompt: intent,
           store,
           parentToolCallId: toolOptions?.toolCallId || '',
           abortSignal: toolOptions?.abortSignal,

--- a/packages/mosaic/src/ai/worksheet/createWorksheetDataTableExplorerTool.ts
+++ b/packages/mosaic/src/ai/worksheet/createWorksheetDataTableExplorerTool.ts
@@ -31,14 +31,19 @@ export function createWorksheetDataTableExplorerTool({
 }: CreateWorksheetDataTableExplorerToolParams): Tool {
   return createDataTableExplorerTool({
     databaseAdapter,
-    addDataTable: ({title, tableName}) => {
+    addDataTable: ({title, tableName, intent}) => {
       if (!tableName) {
         throw new Error(
           'Table name is required to add a data table explorer block',
         );
       }
 
-      worksheetAdapter.addDataTableExplorerBlock(worksheetId, title, tableName);
+      worksheetAdapter.addDataTableExplorerBlock(
+        worksheetId,
+        title,
+        tableName,
+        intent,
+      );
     },
   });
 }

--- a/packages/mosaic/src/ai/worksheet/worksheet-types.ts
+++ b/packages/mosaic/src/ai/worksheet/worksheet-types.ts
@@ -36,12 +36,14 @@ export type WorksheetAiAdapter = {
     worksheetId: string,
     title: string,
     tableName: string,
+    intent?: string,
   ): AddDashboardBlockResult;
 
   addDataTableExplorerBlock: (
     worksheetId: string,
     title: string,
     tableName: string,
+    intent?: string,
   ) => string;
 };
 


### PR DESCRIPTION
## What changed

- Added optional `intent` metadata to block document blocks and HTML app runtime state.
- Updated dashboard, worksheet, and HTML app agent tool schemas to require `intent` at creation boundaries.
- Propagated worksheet block-container intent through dashboard, Data Table Explorer, and HTML app block creation paths.
- Migrated the CLI app-builder project state from `prompt` to `intent`.
- Documented the new terminology and added tests for command/block intent persistence.

## Why

`prompt` was being used at several creation-tool boundaries to mean a durable artifact or block objective, not a raw model prompt. `intent` makes that purpose explicit and gives future modification flows a stable piece of context to preserve or revise.

## Validation

- `pnpm --filter @sqlrooms/documents test`
- `pnpm --filter @sqlrooms/mosaic test`
- `pnpm --filter @sqlrooms/app-runtime test`
- `pnpm --filter @sqlrooms/documents typecheck`
- `pnpm --filter @sqlrooms/mosaic typecheck`
- `pnpm --filter @sqlrooms/app-runtime typecheck`
- `pnpm --filter sqlrooms-cli-app typecheck`
- `pnpm build`
- `pnpm --filter sqlrooms-cli-app build`
- pre-commit hook: lint-staged formatting/lint
- pre-push hook: `knip`, full `turbo typecheck`, full `turbo test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation explaining how blocks can store an `intent` field to describe their creation purpose.

* **New Features**
  * Blocks now persistently store intent metadata alongside their configuration.

* **Style**
  * Replaced "Prompt" with "Intent" terminology throughout the app builder interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->