### PR TITLE
feat: Persist chat request errors in session state

### DIFF
--- a/packages/ai-core/__tests__/AiSlice.modelSelection.test.ts
+++ b/packages/ai-core/__tests__/AiSlice.modelSelection.test.ts
@@ -13,6 +13,7 @@ import {
   CHAT_REQUEST_ERROR_PART_TYPE,
   getChatRequestErrorMessage,
 } from '../src/chatTurns';
+import {sanitizeMessagesForLLM} from '../src/utils';
 
 type TestStoreState = AiSliceState & {
   aiSettings: {
@@ -117,6 +118,77 @@ describe('AiSlice model selection', () => {
     });
     expect(session?.isRunning).toBe(false);
     expect(session?.messagesRevision).toBe(1);
+  });
+
+  it('uses fallback chat messages when the store has an older same-length snapshot', () => {
+    const store = createTestStore();
+    const userMessage: UIMessage = {
+      id: 'user-1',
+      role: 'user',
+      parts: [{type: 'text', text: 'hi'}],
+    };
+    const staleAssistantMessage: UIMessage = {
+      id: 'assistant-1',
+      role: 'assistant',
+      parts: [{type: 'text', text: 'old'}],
+    };
+    const freshAssistantMessage: UIMessage = {
+      id: 'assistant-1',
+      role: 'assistant',
+      parts: [{type: 'text', text: 'new'}],
+    };
+
+    store.getState().ai.setSessionUiMessages('session-1', [
+      userMessage,
+      staleAssistantMessage,
+    ]);
+
+    store
+      .getState()
+      .ai.onChatError('session-1', new TypeError('Failed to fetch'), [
+        userMessage,
+        freshAssistantMessage,
+      ]);
+
+    const session = store.getState().ai.config.sessions[0];
+    const messages = session?.uiMessages as UIMessage[];
+    expect(messages).toHaveLength(3);
+    expect(messages[1]).toMatchObject({
+      id: 'assistant-1',
+      role: 'assistant',
+      parts: [{type: 'text', text: 'new'}],
+    });
+    expect(getChatRequestErrorMessage(messages[0])).toEqual({
+      error: 'Failed to fetch',
+    });
+  });
+
+  it('does not replay chat error marker messages to the model', () => {
+    const messages = sanitizeMessagesForLLM([
+      {
+        id: 'user-1',
+        role: 'user',
+        parts: [{type: 'text', text: 'hi'}],
+      },
+      {
+        id: 'assistant-error',
+        role: 'assistant',
+        parts: [
+          {
+            type: CHAT_REQUEST_ERROR_PART_TYPE,
+            data: {error: 'Failed to fetch'},
+          },
+        ],
+      },
+    ]);
+
+    expect(messages).toEqual([
+      {
+        id: 'user-1',
+        role: 'user',
+        parts: [{type: 'text', text: 'hi'}],
+      },
+    ]);
   });
 
   it('does not keep a phantom current session when initialized with no sessions', () => {

--- a/packages/ai-core/__tests__/AiSlice.modelSelection.test.ts
+++ b/packages/ai-core/__tests__/AiSlice.modelSelection.test.ts
@@ -8,7 +8,10 @@ import {jest} from '@jest/globals';
 import type {UIMessage} from 'ai';
 import {createStore} from 'zustand';
 import {AiSliceState, createAiSlice} from '../src/AiSlice';
-import {withRunContextTools} from '../src/chatTransport';
+import {
+  createRemoteChatTransportFactory,
+  withRunContextTools,
+} from '../src/chatTransport';
 import {
   CHAT_REQUEST_ERROR_PART_TYPE,
   getChatRequestErrorMessage,
@@ -157,10 +160,12 @@ describe('AiSlice model selection', () => {
       parts: [{type: 'text', text: 'new'}],
     };
 
-    store.getState().ai.setSessionUiMessages('session-1', [
-      userMessage,
-      staleAssistantMessage,
-    ]);
+    store
+      .getState()
+      .ai.setSessionUiMessages('session-1', [
+        userMessage,
+        staleAssistantMessage,
+      ]);
 
     store
       .getState()
@@ -208,6 +213,62 @@ describe('AiSlice model selection', () => {
         parts: [{type: 'text', text: 'hi'}],
       },
     ]);
+  });
+
+  it('strips chat error marker messages from remote request bodies', async () => {
+    const store = createTestStore();
+    const userMessage: UIMessage = {
+      id: 'user-1',
+      role: 'user',
+      parts: [{type: 'text', text: 'hi'}],
+    };
+    const errorMessage: UIMessage = {
+      id: 'assistant-error',
+      role: 'assistant',
+      parts: [
+        {
+          type: CHAT_REQUEST_ERROR_PART_TYPE,
+          data: {error: 'Failed to fetch'},
+        },
+      ],
+    };
+    const previousFetch = globalThis.fetch;
+    const fetchMock = jest.fn<typeof fetch>(async () => {
+      return new Response(new ReadableStream(), {status: 200});
+    });
+    globalThis.fetch = fetchMock;
+
+    try {
+      const transport = createRemoteChatTransportFactory({
+        store,
+        defaultProvider: 'openai',
+        defaultModel: 'shared-model',
+        sessionId: 'session-1',
+        getInstructions: () => 'remote instructions',
+      })('https://example.test/api/chat');
+
+      await transport.sendMessages({
+        trigger: 'submit-message',
+        chatId: 'session-1',
+        messageId: undefined,
+        messages: [userMessage, errorMessage],
+        abortSignal: undefined,
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+      const body = JSON.parse(init.body as string) as Record<string, unknown>;
+
+      expect(body.messages).toEqual([userMessage]);
+      expect(body).toMatchObject({
+        modelProvider: 'openai',
+        model: 'shared-model',
+        instructions: 'remote instructions',
+        maxSteps: 50,
+      });
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
   });
 
   it('does not keep a phantom current session when initialized with no sessions', () => {

--- a/packages/ai-core/__tests__/AiSlice.modelSelection.test.ts
+++ b/packages/ai-core/__tests__/AiSlice.modelSelection.test.ts
@@ -118,6 +118,25 @@ describe('AiSlice model selection', () => {
     });
     expect(session?.isRunning).toBe(false);
     expect(session?.messagesRevision).toBe(1);
+
+    store.getState().ai.setSessionUiMessages('session-1', [
+      {
+        id: 'user-1',
+        role: 'user',
+        parts: [{type: 'text', text: 'hi'}],
+      },
+    ]);
+
+    const messagesAfterStaleSync = store.getState().ai.config.sessions[0]
+      ?.uiMessages as UIMessage[];
+    expect(messagesAfterStaleSync).toHaveLength(2);
+    expect(getChatRequestErrorMessage(messagesAfterStaleSync[0])).toEqual({
+      error: 'Failed to fetch',
+    });
+    expect(messagesAfterStaleSync[1]?.parts[0]).toMatchObject({
+      type: CHAT_REQUEST_ERROR_PART_TYPE,
+      data: {error: 'Failed to fetch'},
+    });
   });
 
   it('uses fallback chat messages when the store has an older same-length snapshot', () => {

--- a/packages/ai-core/__tests__/AiSlice.modelSelection.test.ts
+++ b/packages/ai-core/__tests__/AiSlice.modelSelection.test.ts
@@ -9,6 +9,10 @@ import type {UIMessage} from 'ai';
 import {createStore} from 'zustand';
 import {AiSliceState, createAiSlice} from '../src/AiSlice';
 import {withRunContextTools} from '../src/chatTransport';
+import {
+  CHAT_REQUEST_ERROR_PART_TYPE,
+  getChatRequestErrorMessage,
+} from '../src/chatTurns';
 
 type TestStoreState = AiSliceState & {
   aiSettings: {
@@ -77,6 +81,44 @@ function createTestStore(options?: {
 }
 
 describe('AiSlice model selection', () => {
+  it('persists chat request errors when the failed prompt has not synced to the store yet', () => {
+    const store = createTestStore();
+    const userMessage: UIMessage = {
+      id: 'user-1',
+      role: 'user',
+      parts: [{type: 'text', text: 'hi'}],
+    };
+
+    store
+      .getState()
+      .ai.onChatError('session-1', new TypeError('Failed to fetch'), [
+        userMessage,
+      ]);
+
+    const session = store.getState().ai.config.sessions[0];
+    const messages = session?.uiMessages as UIMessage[];
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toMatchObject({
+      id: 'user-1',
+      role: 'user',
+      parts: [{type: 'text', text: 'hi'}],
+    });
+    expect(getChatRequestErrorMessage(messages[0])).toEqual({
+      error: 'Failed to fetch',
+    });
+    expect(messages[1]).toMatchObject({
+      role: 'assistant',
+      parts: [
+        {
+          type: CHAT_REQUEST_ERROR_PART_TYPE,
+          data: {error: 'Failed to fetch'},
+        },
+      ],
+    });
+    expect(session?.isRunning).toBe(false);
+    expect(session?.messagesRevision).toBe(1);
+  });
+
   it('does not keep a phantom current session when initialized with no sessions', () => {
     const store = createStore<AiSliceState>((set, get, store) =>
       createAiSlice({

--- a/packages/ai-core/__tests__/sessionDebugModel.test.ts
+++ b/packages/ai-core/__tests__/sessionDebugModel.test.ts
@@ -8,6 +8,7 @@ import {
   getSessionDebugTimeline,
   getSessionDebugToolCalls,
 } from '../src/devtools/sessionDebugModel';
+import {CHAT_REQUEST_ERROR_PART_TYPE} from '../src/chatTurns';
 
 function createSession(): ChatSessionSchema {
   return {
@@ -140,6 +141,34 @@ describe('sessionDebugModel', () => {
         },
       },
     });
+  });
+
+  it('renders stored chat request errors as visible timeline text', () => {
+    const session = createSession();
+    session.uiMessages.push({
+      id: 'assistant-error',
+      role: 'assistant',
+      parts: [
+        {
+          type: CHAT_REQUEST_ERROR_PART_TYPE,
+          data: {error: 'Failed to fetch'},
+        },
+      ],
+    });
+
+    const timeline = getSessionDebugTimeline({session});
+
+    expect(timeline[2]?.parts).toEqual([
+      {
+        kind: 'text',
+        index: 0,
+        text: 'Failed to fetch',
+        raw: {
+          type: CHAT_REQUEST_ERROR_PART_TYPE,
+          data: {error: 'Failed to fetch'},
+        },
+      },
+    ]);
   });
 
   it('prefers live agent progress over persisted progress', () => {

--- a/packages/ai-core/src/AiSlice.ts
+++ b/packages/ai-core/src/AiSlice.ts
@@ -219,7 +219,11 @@ export type AiSliceState = {
       messages: UIMessage[];
       isError?: boolean;
     }) => void;
-    onChatError: (sessionId: string, error: unknown) => void;
+    onChatError: (
+      sessionId: string,
+      error: unknown,
+      messages?: UIMessage[],
+    ) => void;
   };
 };
 

--- a/packages/ai-core/src/AiSlice.ts
+++ b/packages/ai-core/src/AiSlice.ts
@@ -54,7 +54,10 @@ import type {
   AssistantMessageMetadata,
 } from './types';
 import {normalizeAiConfig, ToolAbortError} from './utils';
-import {getAnalysisResultsFromUiMessages} from './chatTurns';
+import {
+  getAnalysisResultsFromUiMessages,
+  uiMessagesHaveChatRequestError,
+} from './chatTurns';
 import {
   cleanupSessionForks,
   createForkedChatSessionFromMessage,
@@ -1060,6 +1063,21 @@ export function createAiSlice<TTools extends ToolSet = ToolSet>(
                   (s: ChatSessionSchema) => s.id === sessionId,
                 );
                 if (session) {
+                  const existingMessages = (session.uiMessages ??
+                    []) as UIMessage[];
+                  const incomingHasError =
+                    uiMessagesHaveChatRequestError(uiMessages);
+                  const existingHasError =
+                    uiMessagesHaveChatRequestError(existingMessages);
+                  const staleSyncWouldEraseError =
+                    existingHasError &&
+                    !incomingHasError &&
+                    uiMessages.length <= existingMessages.length;
+
+                  if (staleSyncWouldEraseError) {
+                    return;
+                  }
+
                   session.uiMessages = structuredClone(
                     uiMessages,
                   ) as typeof session.uiMessages;

--- a/packages/ai-core/src/chatTransport.ts
+++ b/packages/ai-core/src/chatTransport.ts
@@ -566,10 +566,10 @@ function selectErrorSourceMessages({
   sessionMessages: UIMessage[];
   fallbackMessages?: UIMessage[];
 }): UIMessage[] {
-  if (!fallbackMessages || fallbackMessages.length <= sessionMessages.length) {
-    return sessionMessages;
+  if (fallbackMessages && fallbackMessages.length > 0) {
+    return fallbackMessages;
   }
-  return fallbackMessages;
+  return sessionMessages;
 }
 
 function hasChatRequestErrorPart(message: UIMessage | undefined): boolean {

--- a/packages/ai-core/src/chatTransport.ts
+++ b/packages/ai-core/src/chatTransport.ts
@@ -1,4 +1,5 @@
 import {createOpenAICompatible} from '@ai-sdk/openai-compatible';
+import {createId} from '@paralleldrive/cuid2';
 import {
   setAiRunContextPrimaryItem,
   type AiRunContext,
@@ -21,7 +22,11 @@ import {
 } from 'ai';
 import {produce} from 'immer';
 import {TOOL_CALL_CANCELLED} from './constants';
-import {setChatRequestErrorMessage} from './chatTurns';
+import {
+  CHAT_REQUEST_ERROR_PART_TYPE,
+  createChatRequestErrorPart,
+  setChatRequestErrorMessage,
+} from './chatTurns';
 import type {
   AiSliceStateForTransport,
   AiToolExecutionContext,
@@ -554,6 +559,34 @@ export function createRemoteChatTransportFactory(params: {
   };
 }
 
+function selectErrorSourceMessages({
+  sessionMessages,
+  fallbackMessages,
+}: {
+  sessionMessages: UIMessage[];
+  fallbackMessages?: UIMessage[];
+}): UIMessage[] {
+  if (!fallbackMessages || fallbackMessages.length <= sessionMessages.length) {
+    return sessionMessages;
+  }
+  return fallbackMessages;
+}
+
+function hasChatRequestErrorPart(message: UIMessage | undefined): boolean {
+  return Boolean(
+    message?.role === 'assistant' &&
+    message.parts?.some((part) => part.type === CHAT_REQUEST_ERROR_PART_TYPE),
+  );
+}
+
+function createChatRequestErrorMessage(error: string): UIMessage {
+  return {
+    id: createId(),
+    role: 'assistant',
+    parts: [createChatRequestErrorPart({error})],
+  };
+}
+
 export function createChatHandlers({
   store,
 }: {
@@ -653,7 +686,11 @@ export function createChatHandlers({
         throw err;
       }
     },
-    onChatError: (sessionId: string, error: unknown) => {
+    onChatError: (
+      sessionId: string,
+      error: unknown,
+      fallbackMessages?: UIMessage[],
+    ) => {
       try {
         consumeSessionTokenUsage(sessionId);
         let errMsg = getErrorMessageForDisplay(error);
@@ -681,21 +718,28 @@ export function createChatHandlers({
             if (targetSession) {
               const existingMessages = (targetSession.uiMessages ||
                 []) as UIMessage[];
-              const completedMessages =
-                fixIncompleteToolCalls(existingMessages);
+              const sourceMessages = selectErrorSourceMessages({
+                sessionMessages: existingMessages,
+                fallbackMessages,
+              });
+              const completedMessages = fixIncompleteToolCalls(sourceMessages);
               writeToolTimingsToMetadata(completedMessages, toolTimings);
-              targetSession.uiMessages =
-                completedMessages as ChatSessionSchema['uiMessages'];
-              writeAgentDebugStateToSession(targetSession, currentState);
 
-              const uiMessages = targetSession.uiMessages as UIMessage[];
-              const lastUserMessage = uiMessages
+              const lastUserMessage = completedMessages
                 .filter((msg) => msg.role === 'user')
                 .slice(-1)[0];
 
               if (lastUserMessage) {
                 setChatRequestErrorMessage(lastUserMessage, {error: errMsg});
               }
+
+              if (!hasChatRequestErrorPart(completedMessages.at(-1))) {
+                completedMessages.push(createChatRequestErrorMessage(errMsg));
+              }
+
+              targetSession.uiMessages =
+                completedMessages as ChatSessionSchema['uiMessages'];
+              writeAgentDebugStateToSession(targetSession, currentState);
             }
           }),
         );

--- a/packages/ai-core/src/chatTransport.ts
+++ b/packages/ai-core/src/chatTransport.ts
@@ -526,8 +526,14 @@ export function createRemoteChatTransportFactory(params: {
         typeof parsed === 'object' && parsed !== null
           ? (parsed as Record<string, unknown>)
           : {};
+      const messages = Array.isArray(parsedObj.messages)
+        ? sanitizeMessagesForLLM(
+            fixIncompleteToolCalls(parsedObj.messages as UIMessage[]),
+          )
+        : [];
       const enhancedBody = {
         ...parsedObj,
+        messages,
         modelProvider,
         model,
         instructions: getInstructions(),

--- a/packages/ai-core/src/chatTurns.ts
+++ b/packages/ai-core/src/chatTurns.ts
@@ -5,6 +5,13 @@ export type ChatRequestErrorMessage = {
   error: string;
 };
 
+export const CHAT_REQUEST_ERROR_PART_TYPE = 'data-sqlrooms-chat-error';
+
+export type ChatRequestErrorPart = {
+  type: typeof CHAT_REQUEST_ERROR_PART_TYPE;
+  data: ChatRequestErrorMessage;
+};
+
 export type ChatMessageMetadata = {
   sqlrooms?: {
     errorMessage?: ChatRequestErrorMessage;
@@ -58,6 +65,27 @@ export function setChatRequestErrorMessage(
       errorMessage,
     },
   };
+}
+
+export function createChatRequestErrorPart(
+  errorMessage: ChatRequestErrorMessage,
+): ChatRequestErrorPart {
+  return {
+    type: CHAT_REQUEST_ERROR_PART_TYPE,
+    data: errorMessage,
+  };
+}
+
+export function getChatRequestErrorPartMessage(
+  part: unknown,
+): ChatRequestErrorMessage | undefined {
+  if (!part || typeof part !== 'object') return undefined;
+  const record = part as {type?: unknown; data?: unknown};
+  if (record.type !== CHAT_REQUEST_ERROR_PART_TYPE) return undefined;
+  const data = record.data;
+  if (!data || typeof data !== 'object') return undefined;
+  const error = (data as {error?: unknown}).error;
+  return typeof error === 'string' ? {error} : undefined;
 }
 
 function isPartComplete(part: UIMessagePart): boolean {

--- a/packages/ai-core/src/chatTurns.ts
+++ b/packages/ai-core/src/chatTurns.ts
@@ -88,6 +88,14 @@ export function getChatRequestErrorPartMessage(
   return typeof error === 'string' ? {error} : undefined;
 }
 
+export function uiMessagesHaveChatRequestError(messages: UIMessage[]): boolean {
+  return messages.some(
+    (message) =>
+      !!getChatRequestErrorMessage(message) ||
+      message.parts.some((part) => !!getChatRequestErrorPartMessage(part)),
+  );
+}
+
 function isPartComplete(part: UIMessagePart): boolean {
   if (
     (part.type === 'text' || part.type === 'reasoning') &&

--- a/packages/ai-core/src/devtools/sessionDebugModel.ts
+++ b/packages/ai-core/src/devtools/sessionDebugModel.ts
@@ -6,6 +6,7 @@ import type {
   StoredToolSet,
   ToolRendererRegistry,
 } from '../types';
+import {getChatRequestErrorPartMessage} from '../chatTurns';
 
 /** High-level counts and model/session metadata for a debugged chat session. */
 export type SessionDebugSummary = {
@@ -387,6 +388,16 @@ export function getSessionDebugTimeline({
         }
 
         const type = getPartType(part);
+        const errorPartMessage = getChatRequestErrorPartMessage(part);
+        if (errorPartMessage) {
+          return {
+            kind: 'text' as const,
+            index: partIndex,
+            text: errorPartMessage.error,
+            raw: part,
+          };
+        }
+
         const text = getPartText(part);
         if (type === 'text' && text !== undefined) {
           return {

--- a/packages/ai-core/src/hooks/useSessionChat.ts
+++ b/packages/ai-core/src/hooks/useSessionChat.ts
@@ -110,6 +110,7 @@ export function useSessionChat(sessionId: string): UseSessionChatResult {
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps -- Intentionally exclude uiMessages; only recompute on session change or explicit message deletion
   }, [sessionId, messagesRevision]);
+  const latestMessagesRef = useRef<UIMessage[]>(initialMessages);
 
   const {
     messages,
@@ -138,8 +139,10 @@ export function useSessionChat(sessionId: string): UseSessionChatResult {
       );
     },
     onFinish: ({messages}) => onChatFinish?.({sessionId, messages}),
-    onError: (error) => onChatError?.(sessionId, error),
+    onError: (error) =>
+      onChatError?.(sessionId, error, latestMessagesRef.current),
   });
+  latestMessagesRef.current = messages as UIMessage[];
 
   // If user aborts mid-stream, stop the local chat stream immediately
   useEffect(() => {

--- a/packages/ai-core/src/hooks/useSessionChat.ts
+++ b/packages/ai-core/src/hooks/useSessionChat.ts
@@ -142,7 +142,6 @@ export function useSessionChat(sessionId: string): UseSessionChatResult {
     onError: (error) =>
       onChatError?.(sessionId, error, latestMessagesRef.current),
   });
-  latestMessagesRef.current = messages as UIMessage[];
 
   // If user aborts mid-stream, stop the local chat stream immediately
   useEffect(() => {
@@ -177,6 +176,7 @@ export function useSessionChat(sessionId: string): UseSessionChatResult {
 
   // Sync streaming updates into the store so UiMessages renders incrementally
   useEffect(() => {
+    latestMessagesRef.current = messages as UIMessage[];
     if (!sessionId) return;
     setSessionUiMessages(sessionId, messages as UIMessage[]);
   }, [messages, sessionId, setSessionUiMessages]);

--- a/packages/ai-core/src/hooks/useSessionChat.ts
+++ b/packages/ai-core/src/hooks/useSessionChat.ts
@@ -1,4 +1,4 @@
-import {useEffect, useMemo, useRef} from 'react';
+import {useEffect, useLayoutEffect, useMemo, useRef} from 'react';
 import {useChat} from '@ai-sdk/react';
 import {
   DefaultChatTransport,
@@ -174,9 +174,14 @@ export function useSessionChat(sessionId: string): UseSessionChatResult {
     return () => setAddToolApprovalResponse?.(sessionId, undefined);
   }, [setAddToolApprovalResponse, addToolApprovalResponse, sessionId]);
 
+  // Keep the error fallback current before the passive store sync can race with
+  // an immediately rejected transport request.
+  useLayoutEffect(() => {
+    latestMessagesRef.current = messages as UIMessage[];
+  }, [messages]);
+
   // Sync streaming updates into the store so UiMessages renders incrementally
   useEffect(() => {
-    latestMessagesRef.current = messages as UIMessage[];
     if (!sessionId) return;
     setSessionUiMessages(sessionId, messages as UIMessage[]);
   }, [messages, sessionId, setSessionUiMessages]);

--- a/packages/ai-core/src/utils.ts
+++ b/packages/ai-core/src/utils.ts
@@ -18,6 +18,7 @@ import {
   lastAssistantMessageIsCompleteWithToolCalls,
 } from 'ai';
 import {ABORT_EVENT, TOOL_CALL_CANCELLED} from './constants';
+import {CHAT_REQUEST_ERROR_PART_TYPE} from './chatTurns';
 
 /**
  * Merge multiple AbortSignals into a single signal.
@@ -345,6 +346,13 @@ export function sanitizeMessagesForLLM(
   };
 
   return messages
+    .filter((message) => {
+      if (message.role !== 'assistant') return true;
+      if (!message.parts || message.parts.length === 0) return true;
+      return !message.parts.every(
+        (part) => part.type === CHAT_REQUEST_ERROR_PART_TYPE,
+      );
+    })
     .map((message) => {
       if (!message.parts || message.parts.length === 0) {
         return message;


### PR DESCRIPTION
## Summary
- Capture the latest streamed messages on chat transport errors so failed prompts still persist when the store has not synced yet
- Store chat request errors as explicit assistant parts and surface them in session debug timelines
- Add coverage for the new fallback behavior and debug rendering

## Testing
- Added unit tests for chat error persistence and session debug timeline rendering
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved error handling for failed chat requests with error information now persisted in conversation history.

* **Bug Fixes**
  * Error messages are automatically filtered out before being resent to the model, preventing re-processing of errors.

* **Tests**
  * Added comprehensive test coverage for error handling, persistence, and display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->