### PR TITLE
fix: align CLI workspace item actions

### DIFF
--- a/apps/sqlrooms-cli-ui/src/workspace/sidebar/CliArtifactsSidebarSection.tsx
+++ b/apps/sqlrooms-cli-ui/src/workspace/sidebar/CliArtifactsSidebarSection.tsx
@@ -113,6 +113,7 @@ export function CliArtifactsSidebarSection() {
                       className="data-[active=true]:bg-primary/15 data-[active=true]:text-primary hover:bg-sidebar-accent h-7 max-w-full min-w-0 gap-2 px-2 text-sm font-normal [&>svg]:size-3.5"
                       isActive={artifact.id === artifactTabs.selectedTabId}
                       onClick={() => artifactTabs.selectArtifact(artifact.id)}
+                      size="sm"
                       type="button"
                       title={artifact.name}
                     >
@@ -247,7 +248,7 @@ function ArtifactSidebarItemMenu({
         <SidebarMenuAction
           type="button"
           showOnHover
-          className="top-1/2 right-1 size-6 w-6 -translate-y-1/2"
+          className="right-1.5"
           aria-label={`More actions for ${artifactName}`}
           onClick={(event) => event.stopPropagation()}
         >


### PR DESCRIPTION
## Summary
- Align CLI Workspace sidebar artifact action buttons with the sidebar menu row sizing.
- Remove the conflicting custom vertical centering classes that pulled the three-dot menu upward.

## Root Cause
The artifact row forced a 28px height while leaving the shared `SidebarMenuButton` at its default size metadata. The action trigger then combined custom `top-1/2 -translate-y-1/2` classes with the shared sidebar action top-offset rules, which could leave the ellipsis visually high in the row.

## Validation
- `pnpm --filter sqlrooms-cli-app typecheck`
- `pnpm build`
- Browser geometry check on `http://localhost:4175/new`: artifact menu actions report `centerDelta: 0` against their 28px rows.
- Pre-push hook passed: `knip`, `turbo typecheck`, and `turbo test`.