### PR TITLE
feat: add direct worksheet map blocks

### DIFF
--- a/apps/sqlrooms-cli-ui/src/createWorksheetAgent.ts
+++ b/apps/sqlrooms-cli-ui/src/createWorksheetAgent.ts
@@ -55,6 +55,21 @@ function getFirstDatasetSourceTableName(
     .find((source) => source?.tableName)?.tableName;
 }
 
+function hasSqlOnlyDatasetSource(
+  config: DeckMapDashboardConfigToolConfig,
+): boolean {
+  if (!config.datasets || typeof config.datasets !== 'object') {
+    return false;
+  }
+
+  return Object.values(config.datasets).some((dataset) => {
+    const source = (dataset as Record<string, unknown>).source as
+      | {tableName?: string; sqlQuery?: string}
+      | undefined;
+    return Boolean(source?.sqlQuery && !source.tableName);
+  });
+}
+
 function createWorksheetMapBlockTool(
   store: StoreApi<RoomState>,
   worksheetId: string,
@@ -74,6 +89,15 @@ Use this for map, geospatial, spatial, longitude/latitude, geometry, H3, route, 
 
         const tableName =
           params.tableName ?? getFirstDatasetSourceTableName(params.config);
+        if (
+          params.mapId &&
+          !tableName &&
+          hasSqlOnlyDatasetSource(params.config)
+        ) {
+          throw new Error(
+            'tableName is required when updating a worksheet map block with SQL-only dataset sources',
+          );
+        }
         if (tableName && !state.db.findTable(tableName)) {
           throw new Error(`Table ${tableName} was not found`);
         }

--- a/apps/sqlrooms-cli-ui/src/createWorksheetAgent.ts
+++ b/apps/sqlrooms-cli-ui/src/createWorksheetAgent.ts
@@ -55,14 +55,30 @@ Use this for map, geospatial, spatial, longitude/latitude, geometry, H3, route, 
         }
 
         const tableName = params.tableName;
-        if (tableName) {
-          state.db.findTable(tableName);
+        if (tableName && !state.db.findTable(tableName)) {
+          throw new Error(`Table ${tableName} was not found`);
         }
 
         state.blockDocuments.ensureBlockDocument(worksheetId);
 
         const mapId = params.mapId ?? createDefaultBlockDocumentBlockId();
         const title = params.title || 'Map';
+        const existingMapBlock = params.mapId
+          ? state.blockDocuments
+              .getBlocks(worksheetId)
+              .find(
+                (block): block is BlockDocumentStatefulBlockBlock =>
+                  block.type === 'statefulBlock' &&
+                  block.blockType === 'map' &&
+                  block.blockInstanceId === params.mapId,
+              )
+          : undefined;
+        if (params.mapId && !existingMapBlock) {
+          throw new Error(
+            `Worksheet map block ${params.mapId} was not found in worksheet ${worksheetId}`,
+          );
+        }
+
         state.mosaicDashboard.ensureDashboard(mapId, title, 'grid');
         if (tableName) {
           state.mosaicDashboard.setSelectedTable(mapId, tableName);
@@ -98,7 +114,14 @@ Use this for map, geospatial, spatial, longitude/latitude, geometry, H3, route, 
         }
 
         let blockId: string | undefined;
-        if (!params.mapId) {
+        if (existingMapBlock) {
+          state.blockDocuments.updateBlock(worksheetId, existingMapBlock.id, {
+            ...existingMapBlock,
+            title,
+            caption: title,
+          });
+          blockId = existingMapBlock.id;
+        } else {
           const block: BlockDocumentStatefulBlockBlock = {
             type: 'statefulBlock',
             id: createDefaultBlockDocumentBlockId(),

--- a/apps/sqlrooms-cli-ui/src/createWorksheetAgent.ts
+++ b/apps/sqlrooms-cli-ui/src/createWorksheetAgent.ts
@@ -4,7 +4,7 @@ import type {
   BaseAgentToolOptions,
   CreateWorksheetAgentToolOptions,
 } from '@sqlrooms/mosaic/ai';
-import type {Tool} from 'ai';
+import {tool, type Tool} from 'ai';
 import {
   createDashboardAgentTool,
   createWorksheetAgentTool,
@@ -13,8 +13,124 @@ import type {StoreApi} from 'zustand';
 import type {RoomState} from './store-types';
 import {createWorksheetAiAdapter} from './createWorksheetAiAdapter';
 import {createDatabaseAiAdapter} from './createDatabaseAiAdapter';
-import {createDashboardAgentToolWithDeckMaps} from '@sqlrooms/deck';
+import {
+  createDashboardAgentToolWithDeckMaps,
+  createDeckMapPanelFromNativeConfig,
+  DeckMapDashboardToolParameters,
+  DECK_MAP_DASHBOARD_PANEL_TYPE,
+} from '@sqlrooms/deck';
 import {htmlAppAgentTool} from './createHtmlAppAgent';
+import {
+  BlockDocumentStatefulBlockBlock,
+  createDefaultBlockDocumentBlockId,
+} from '@sqlrooms/documents';
+import {z} from 'zod';
+
+const WorksheetMapBlockToolParameters = DeckMapDashboardToolParameters.extend({
+  mapId: z
+    .string()
+    .optional()
+    .describe('Existing worksheet map block resource ID to update.'),
+  intent: z
+    .string()
+    .optional()
+    .describe('Durable purpose for this worksheet map block.'),
+});
+
+function createWorksheetMapBlockTool(
+  store: StoreApi<RoomState>,
+  worksheetId: string,
+): Tool {
+  return tool({
+    description: `Create or update a direct worksheet map block from a native Deck JSON map config.
+
+Use this for map, geospatial, spatial, longitude/latitude, geometry, H3, route, or location visualizations inside a worksheet. This creates a worksheet map block directly; do not create a dashboard block just to show a map.`,
+    inputSchema: WorksheetMapBlockToolParameters,
+    execute: async (params) => {
+      try {
+        const state = store.getState();
+        const artifact = state.artifacts.getArtifact(worksheetId);
+        if (!artifact || artifact.type !== 'worksheet') {
+          throw new Error(`Artifact ${worksheetId} is not a worksheet`);
+        }
+
+        const tableName = params.tableName;
+        if (tableName) {
+          state.db.findTable(tableName);
+        }
+
+        state.blockDocuments.ensureBlockDocument(worksheetId);
+
+        const mapId = params.mapId ?? createDefaultBlockDocumentBlockId();
+        const title = params.title || 'Map';
+        state.mosaicDashboard.ensureDashboard(mapId, title, 'grid');
+        if (tableName) {
+          state.mosaicDashboard.setSelectedTable(mapId, tableName);
+        }
+
+        const panel = createDeckMapPanelFromNativeConfig({
+          title,
+          config: params.config,
+        });
+
+        const dashboard = state.mosaicDashboard.getDashboard(mapId);
+        const existingPanel = params.panelId
+          ? dashboard?.panels.find(
+              (candidate) =>
+                candidate.id === params.panelId &&
+                candidate.type === DECK_MAP_DASHBOARD_PANEL_TYPE,
+            )
+          : dashboard?.panels.find(
+              (candidate) => candidate.type === DECK_MAP_DASHBOARD_PANEL_TYPE,
+            );
+
+        if (params.panelId && !existingPanel) {
+          throw new Error(`Map panel ${params.panelId} was not found`);
+        }
+
+        if (existingPanel) {
+          state.mosaicDashboard.updatePanel(mapId, existingPanel.id, {
+            title: panel.title,
+            config: panel.config,
+          });
+        } else {
+          state.mosaicDashboard.addPanel(mapId, panel);
+        }
+
+        let blockId: string | undefined;
+        if (!params.mapId) {
+          const block: BlockDocumentStatefulBlockBlock = {
+            type: 'statefulBlock',
+            id: createDefaultBlockDocumentBlockId(),
+            blockInstanceId: mapId,
+            blockType: 'map',
+            intent: params.intent,
+            title,
+            caption: title,
+            height: 560,
+          };
+          state.blockDocuments.appendBlocks(worksheetId, [block]);
+          blockId = block.id;
+        }
+
+        return {
+          success: true,
+          mapId,
+          blockId,
+          panelId: existingPanel?.id ?? panel.id,
+          message: params.mapId
+            ? `Updated worksheet map block "${title}".`
+            : `Added worksheet map block "${title}".`,
+        };
+      } catch (error) {
+        return {
+          success: false,
+          errorMessage: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
+  });
+}
 
 export function worksheetAgentTool(
   store: StoreApi<RoomState>,
@@ -62,11 +178,23 @@ export function worksheetAgentTool(
     worksheetAdapter,
     dashboardAgentTool,
     htmlAppBlocksEnabled: experimentalEnabled,
-    extraTools: () => {
+    mapBlocksEnabled: experimentalEnabled,
+    additionalInstructions: experimentalEnabled
+      ? [
+          'Direct worksheet map blocks are available in this CLI app.',
+          'For worksheet map requests, call create_worksheet_map_block. Do not create a dashboard block just to hold a map.',
+          'If updating an existing worksheet map, call list_worksheet_blocks first and pass its mapId to create_worksheet_map_block.',
+        ].join('\n')
+      : undefined,
+    extraTools: ({worksheetId}) => {
       const extraTools: Record<string, Tool> = {};
 
       if (experimentalEnabled) {
         extraTools.embedded_html_app_agent = htmlAppAgentTool(store);
+        extraTools.create_worksheet_map_block = createWorksheetMapBlockTool(
+          store,
+          worksheetId,
+        );
       }
 
       return extraTools;

--- a/apps/sqlrooms-cli-ui/src/createWorksheetAgent.ts
+++ b/apps/sqlrooms-cli-ui/src/createWorksheetAgent.ts
@@ -18,6 +18,7 @@ import {
   createDeckMapPanelFromNativeConfig,
   DeckMapDashboardToolParameters,
   DECK_MAP_DASHBOARD_PANEL_TYPE,
+  type DeckMapDashboardConfigToolConfig,
 } from '@sqlrooms/deck';
 import {htmlAppAgentTool} from './createHtmlAppAgent';
 import {
@@ -37,6 +38,23 @@ const WorksheetMapBlockToolParameters = DeckMapDashboardToolParameters.extend({
     .describe('Durable purpose for this worksheet map block.'),
 });
 
+function getFirstDatasetSourceTableName(
+  config: DeckMapDashboardConfigToolConfig,
+): string | undefined {
+  if (!config.datasets || typeof config.datasets !== 'object') {
+    return undefined;
+  }
+
+  return Object.values(config.datasets)
+    .map(
+      (dataset) =>
+        (dataset as Record<string, unknown>).source as
+          | {tableName?: string}
+          | undefined,
+    )
+    .find((source) => source?.tableName)?.tableName;
+}
+
 function createWorksheetMapBlockTool(
   store: StoreApi<RoomState>,
   worksheetId: string,
@@ -54,7 +72,8 @@ Use this for map, geospatial, spatial, longitude/latitude, geometry, H3, route, 
           throw new Error(`Artifact ${worksheetId} is not a worksheet`);
         }
 
-        const tableName = params.tableName;
+        const tableName =
+          params.tableName ?? getFirstDatasetSourceTableName(params.config);
         if (tableName && !state.db.findTable(tableName)) {
           throw new Error(`Table ${tableName} was not found`);
         }

--- a/apps/sqlrooms-cli-ui/src/statefulBlockArtifactConfigs.ts
+++ b/apps/sqlrooms-cli-ui/src/statefulBlockArtifactConfigs.ts
@@ -3,6 +3,12 @@ import type {
   BlockDocumentStatefulBlockCommandType,
   BlockDocumentStatefulBlockType,
 } from '@sqlrooms/documents';
+import {
+  createDeckMapDashboardPanelConfigForTable,
+  DECK_MAP_DASHBOARD_PANEL_TYPE,
+  findGeometryColumn,
+  findLongitudeLatitudeColumns,
+} from '@sqlrooms/deck';
 import type {RoomState} from './store-types';
 
 export type FeatureStability = 'stable' | 'experimental';
@@ -30,6 +36,44 @@ export type StatefulBlockArtifactConfig<TArtifactType extends string = string> =
     deleteState: (state: RoomState, artifactId: string) => void;
     renameState?: (state: RoomState, artifactId: string, title: string) => void;
   };
+
+function ensureMapBlockState(
+  state: RoomState,
+  artifactId: string,
+  title: string,
+) {
+  state.mosaicDashboard.ensureDashboard(artifactId, title, 'grid');
+
+  const dashboard = state.mosaicDashboard.getDashboard(artifactId);
+  if (
+    !dashboard ||
+    dashboard.panels.some(
+      (panel) => panel.type === DECK_MAP_DASHBOARD_PANEL_TYPE,
+    )
+  ) {
+    return;
+  }
+
+  const table = state.db.tables.find(
+    (candidate) =>
+      Boolean(findLongitudeLatitudeColumns(candidate)) ||
+      Boolean(findGeometryColumn(candidate)),
+  );
+  if (!table) {
+    return;
+  }
+
+  state.mosaicDashboard.setSelectedTable(artifactId, table.tableName);
+  state.mosaicDashboard.addPanel(
+    artifactId,
+    createDeckMapDashboardPanelConfigForTable({
+      title: `${table.tableName} map`,
+      tableName: table.tableName,
+      columns: table.columns,
+      tableReference: table.table,
+    }),
+  );
+}
 
 export const STATEFUL_BLOCK_ARTIFACT_CONFIGS = {
   dashboard: {
@@ -87,6 +131,29 @@ export const STATEFUL_BLOCK_ARTIFACT_CONFIGS = {
     scrollHintLabel: 'this data table',
     ensureState: () => {},
     deleteState: () => {},
+  },
+  map: {
+    artifactType: 'map',
+    stability: 'experimental',
+    label: 'Map',
+    defaultTitle: 'Map',
+    embeddedTitle: 'Embedded Map',
+    embeddedDescription: 'Embedded Deck.gl map',
+    resizableHeight: true,
+    defaultHeight: 560,
+    minHeight: 360,
+    maxHeight: 1600,
+    requireScrollModifier: true,
+    scrollHintLabel: 'this map',
+    ensureState: (state, artifactId, title) => {
+      ensureMapBlockState(state, artifactId, title);
+    },
+    deleteState: (state, artifactId) => {
+      state.mosaicDashboard.removeDashboard(artifactId);
+    },
+    renameState: (state, artifactId, title) => {
+      state.mosaicDashboard.ensureDashboard(artifactId, title, 'grid');
+    },
   },
   document: {
     artifactType: 'document',

--- a/apps/sqlrooms-cli-ui/src/statefulBlockArtifactConfigs.ts
+++ b/apps/sqlrooms-cli-ui/src/statefulBlockArtifactConfigs.ts
@@ -3,12 +3,7 @@ import type {
   BlockDocumentStatefulBlockCommandType,
   BlockDocumentStatefulBlockType,
 } from '@sqlrooms/documents';
-import {
-  createDeckMapDashboardPanelConfigForTable,
-  DECK_MAP_DASHBOARD_PANEL_TYPE,
-  findGeometryColumn,
-  findLongitudeLatitudeColumns,
-} from '@sqlrooms/deck';
+import {ensureDeckMapBlockState} from '@sqlrooms/deck';
 import type {RoomState} from './store-types';
 
 export type FeatureStability = 'stable' | 'experimental';
@@ -36,44 +31,6 @@ export type StatefulBlockArtifactConfig<TArtifactType extends string = string> =
     deleteState: (state: RoomState, artifactId: string) => void;
     renameState?: (state: RoomState, artifactId: string, title: string) => void;
   };
-
-function ensureMapBlockState(
-  state: RoomState,
-  artifactId: string,
-  title: string,
-) {
-  state.mosaicDashboard.ensureDashboard(artifactId, title, 'grid');
-
-  const dashboard = state.mosaicDashboard.getDashboard(artifactId);
-  if (
-    !dashboard ||
-    dashboard.panels.some(
-      (panel) => panel.type === DECK_MAP_DASHBOARD_PANEL_TYPE,
-    )
-  ) {
-    return;
-  }
-
-  const table = state.db.tables.find(
-    (candidate) =>
-      Boolean(findLongitudeLatitudeColumns(candidate)) ||
-      Boolean(findGeometryColumn(candidate)),
-  );
-  if (!table) {
-    return;
-  }
-
-  state.mosaicDashboard.setSelectedTable(artifactId, table.tableName);
-  state.mosaicDashboard.addPanel(
-    artifactId,
-    createDeckMapDashboardPanelConfigForTable({
-      title: `${table.tableName} map`,
-      tableName: table.tableName,
-      columns: table.columns,
-      tableReference: table.table,
-    }),
-  );
-}
 
 export const STATEFUL_BLOCK_ARTIFACT_CONFIGS = {
   dashboard: {
@@ -146,7 +103,7 @@ export const STATEFUL_BLOCK_ARTIFACT_CONFIGS = {
     requireScrollModifier: true,
     scrollHintLabel: 'this map',
     ensureState: (state, artifactId, title) => {
-      ensureMapBlockState(state, artifactId, title);
+      ensureDeckMapBlockState(state, artifactId, title);
     },
     deleteState: (state, artifactId) => {
       state.mosaicDashboard.removeDashboard(artifactId);

--- a/apps/sqlrooms-cli-ui/src/store.ts
+++ b/apps/sqlrooms-cli-ui/src/store.ts
@@ -141,7 +141,7 @@ Experimental SQLRooms tools are available in this session. Use them for app, map
 
 - If the primary artifact is a worksheet and the user asks for an app, HTML app, D3 app, Chart.js app, browser app, or generated interactive visualization inside it, call worksheet_agent. The worksheet agent should create/reuse the worksheet html-app block, then call embedded_html_app_agent with the block's appId.
 - Do not use top-level html_app_agent to populate worksheet stateful blocks inside worksheets.
-- For worksheet map requests, call worksheet_agent. It should add or reuse a dashboard block and delegate to embedded_dashboard_agent.
+- For worksheet map requests, call worksheet_agent. It should add or reuse a direct worksheet map block, not create a dashboard block just to hold the map.
 - For generated HTML, D3, Chart.js, or browser app visualizations only when the primary artifact is an html-app artifact or no worksheet/dashboard artifact is the requested target, write through html_app_agent. html_app_agent requires appId and never creates artifacts or worksheet blocks.
 - If the primary artifact is an html-app artifact, call html_app_agent with appId set to the current artifact id and update it instead of creating a new html-app artifact.
 - For incremental edits to an existing html-app artifact, such as changing title, labels, colors, styles, layout, controls, or interactions, call html_app_agent directly with the current appId and the user's edit request. Do not inspect tables or schemas first unless the user explicitly asks to change the app's data/query behavior.

--- a/apps/sqlrooms-cli-ui/src/workspace/WorksheetArtifact.tsx
+++ b/apps/sqlrooms-cli-ui/src/workspace/WorksheetArtifact.tsx
@@ -15,6 +15,7 @@ import {
   type StatefulBlockArtifactType,
 } from '../statefulBlockArtifactConfigs';
 import {WorksheetDashboardBlockRenderer} from './WorksheetDashboardBlockRenderer';
+import {WorksheetMapBlockRenderer} from './WorksheetMapBlockRenderer';
 import {WorksheetMarkdownDocumentBlockRenderer} from './WorksheetMarkdownDocumentBlockRenderer';
 import {WorksheetPivotBlockRenderer} from './WorksheetPivotBlockRenderer';
 import {WorksheetSqlQueryBlockRenderer} from './WorksheetSqlQueryBlockRenderer';
@@ -99,6 +100,7 @@ const ExperimentalStatefulBlockPlaceholder: FC<
 
 const WORKSHEET_STATEFUL_BLOCK_RENDERERS = {
   dashboard: WorksheetDashboardBlockRenderer,
+  map: WorksheetMapBlockRenderer,
   pivot: WorksheetPivotBlockRenderer,
   'data-table': WorksheetDataTableBlockRenderer,
   document: WorksheetMarkdownDocumentBlockRenderer,
@@ -117,6 +119,7 @@ function createWorksheetStatefulBlockRenderers(
   }
   return {
     ...WORKSHEET_STATEFUL_BLOCK_RENDERERS,
+    map: ExperimentalStatefulBlockPlaceholder,
     pivot: ExperimentalStatefulBlockPlaceholder,
     document: ExperimentalStatefulBlockPlaceholder,
     'sql-query': ExperimentalStatefulBlockPlaceholder,

--- a/apps/sqlrooms-cli-ui/src/workspace/WorksheetMapBlockRenderer.tsx
+++ b/apps/sqlrooms-cli-ui/src/workspace/WorksheetMapBlockRenderer.tsx
@@ -1,15 +1,5 @@
 import type {BlockDocumentStatefulBlockRendererProps} from '@sqlrooms/documents';
-import {
-  createDeckMapDashboardPanelConfigForTable,
-  deckMapDashboardPanelRenderer,
-  DECK_MAP_DASHBOARD_PANEL_TYPE,
-  findGeometryColumn,
-  findLongitudeLatitudeColumns,
-} from '@sqlrooms/deck';
-import {getMosaicDashboardSelectionName} from '@sqlrooms/mosaic';
-import {MapIcon} from 'lucide-react';
-import {useEffect, useMemo} from 'react';
-import {useRoomStore} from '../store';
+import {DeckMapBlockRenderer} from '@sqlrooms/deck';
 
 export const WorksheetMapBlockRenderer = ({
   blockInstanceId,
@@ -17,74 +7,6 @@ export const WorksheetMapBlockRenderer = ({
   title,
   caption,
 }: BlockDocumentStatefulBlockRendererProps) => {
-  const dashboard = useRoomStore(
-    (state) => state.mosaicDashboard.config.dashboardsById[blockInstanceId],
-  );
-  const tables = useRoomStore((state) => state.db.tables);
-  const ensureDashboard = useRoomStore(
-    (state) => state.mosaicDashboard.ensureDashboard,
-  );
-  const setSelectedTable = useRoomStore(
-    (state) => state.mosaicDashboard.setSelectedTable,
-  );
-  const addPanel = useRoomStore((state) => state.mosaicDashboard.addPanel);
-
-  useEffect(() => {
-    if (blockType !== 'map' || !blockInstanceId) {
-      return;
-    }
-
-    ensureDashboard(blockInstanceId, title ?? 'Embedded Map', 'grid');
-  }, [blockInstanceId, blockType, ensureDashboard, title]);
-
-  useEffect(() => {
-    if (blockType !== 'map' || !blockInstanceId || !dashboard) {
-      return;
-    }
-    if (
-      dashboard.panels.some(
-        (panel) => panel.type === DECK_MAP_DASHBOARD_PANEL_TYPE,
-      )
-    ) {
-      return;
-    }
-
-    const table = tables.find(
-      (candidate) =>
-        Boolean(findLongitudeLatitudeColumns(candidate)) ||
-        Boolean(findGeometryColumn(candidate)),
-    );
-    if (!table) {
-      return;
-    }
-
-    setSelectedTable(blockInstanceId, table.tableName);
-    addPanel(
-      blockInstanceId,
-      createDeckMapDashboardPanelConfigForTable({
-        title: `${table.tableName} map`,
-        tableName: table.tableName,
-        columns: table.columns,
-        tableReference: table.table,
-      }),
-    );
-  }, [
-    addPanel,
-    blockInstanceId,
-    blockType,
-    dashboard,
-    setSelectedTable,
-    tables,
-  ]);
-
-  const panel = useMemo(
-    () =>
-      dashboard?.panels.find(
-        (candidate) => candidate.type === DECK_MAP_DASHBOARD_PANEL_TYPE,
-      ),
-    [dashboard?.panels],
-  );
-
   if (!blockInstanceId || blockType !== 'map') {
     return (
       <div className="text-muted-foreground p-4 text-sm">
@@ -93,42 +15,11 @@ export const WorksheetMapBlockRenderer = ({
     );
   }
 
-  if (!dashboard || !panel) {
-    return (
-      <div className="bg-muted/10 flex h-full min-h-[320px] flex-col">
-        <div className="border-border flex shrink-0 items-center gap-2 border-b px-3 py-2 text-sm font-medium">
-          <MapIcon className="h-4 w-4" />
-          <span>{title || 'Embedded Map'}</span>
-        </div>
-        <div className="text-muted-foreground flex min-h-0 flex-1 items-center justify-center p-4 text-center text-sm">
-          No map-ready table found. Add a table with longitude/latitude or
-          geometry columns, or ask the assistant to configure this map.
-        </div>
-      </div>
-    );
-  }
-
-  const HeaderActions = deckMapDashboardPanelRenderer.headerActions;
-  const MapPanel = deckMapDashboardPanelRenderer.component;
-  const rendererProps = {
-    dashboardId: blockInstanceId,
-    dashboard,
-    panel,
-    selectionName: getMosaicDashboardSelectionName(blockInstanceId),
-  };
-
   return (
-    <div className="flex h-full min-h-0 flex-col">
-      <div className="border-border flex shrink-0 items-center justify-between gap-2 border-b px-3 py-2">
-        <div className="flex min-w-0 items-center gap-2 text-sm font-medium">
-          <MapIcon className="h-4 w-4 shrink-0" />
-          <span className="truncate">{caption || title || panel.title}</span>
-        </div>
-        {HeaderActions ? <HeaderActions {...rendererProps} /> : null}
-      </div>
-      <div className="min-h-0 flex-1">
-        <MapPanel {...rendererProps} />
-      </div>
-    </div>
+    <DeckMapBlockRenderer
+      mapId={blockInstanceId}
+      title={title}
+      caption={caption}
+    />
   );
 };

--- a/apps/sqlrooms-cli-ui/src/workspace/WorksheetMapBlockRenderer.tsx
+++ b/apps/sqlrooms-cli-ui/src/workspace/WorksheetMapBlockRenderer.tsx
@@ -1,6 +1,13 @@
 import type {BlockDocumentStatefulBlockRendererProps} from '@sqlrooms/documents';
 import {DeckMapBlockRenderer} from '@sqlrooms/deck';
 
+/**
+ * Renders a worksheet map stateful block through the Deck embeddable map surface.
+ *
+ * @param props - Stateful block renderer props, including the map block instance
+ * ID, block type, title, and caption from the worksheet document.
+ * @returns The configured Deck map block renderer, or an unsupported block message.
+ */
 export const WorksheetMapBlockRenderer = ({
   blockInstanceId,
   blockType,

--- a/apps/sqlrooms-cli-ui/src/workspace/WorksheetMapBlockRenderer.tsx
+++ b/apps/sqlrooms-cli-ui/src/workspace/WorksheetMapBlockRenderer.tsx
@@ -1,0 +1,134 @@
+import type {BlockDocumentStatefulBlockRendererProps} from '@sqlrooms/documents';
+import {
+  createDeckMapDashboardPanelConfigForTable,
+  deckMapDashboardPanelRenderer,
+  DECK_MAP_DASHBOARD_PANEL_TYPE,
+  findGeometryColumn,
+  findLongitudeLatitudeColumns,
+} from '@sqlrooms/deck';
+import {getMosaicDashboardSelectionName} from '@sqlrooms/mosaic';
+import {MapIcon} from 'lucide-react';
+import {useEffect, useMemo} from 'react';
+import {useRoomStore} from '../store';
+
+export const WorksheetMapBlockRenderer = ({
+  blockInstanceId,
+  blockType,
+  title,
+  caption,
+}: BlockDocumentStatefulBlockRendererProps) => {
+  const dashboard = useRoomStore(
+    (state) => state.mosaicDashboard.config.dashboardsById[blockInstanceId],
+  );
+  const tables = useRoomStore((state) => state.db.tables);
+  const ensureDashboard = useRoomStore(
+    (state) => state.mosaicDashboard.ensureDashboard,
+  );
+  const setSelectedTable = useRoomStore(
+    (state) => state.mosaicDashboard.setSelectedTable,
+  );
+  const addPanel = useRoomStore((state) => state.mosaicDashboard.addPanel);
+
+  useEffect(() => {
+    if (blockType !== 'map' || !blockInstanceId) {
+      return;
+    }
+
+    ensureDashboard(blockInstanceId, title ?? 'Embedded Map', 'grid');
+  }, [blockInstanceId, blockType, ensureDashboard, title]);
+
+  useEffect(() => {
+    if (blockType !== 'map' || !blockInstanceId || !dashboard) {
+      return;
+    }
+    if (
+      dashboard.panels.some(
+        (panel) => panel.type === DECK_MAP_DASHBOARD_PANEL_TYPE,
+      )
+    ) {
+      return;
+    }
+
+    const table = tables.find(
+      (candidate) =>
+        Boolean(findLongitudeLatitudeColumns(candidate)) ||
+        Boolean(findGeometryColumn(candidate)),
+    );
+    if (!table) {
+      return;
+    }
+
+    setSelectedTable(blockInstanceId, table.tableName);
+    addPanel(
+      blockInstanceId,
+      createDeckMapDashboardPanelConfigForTable({
+        title: `${table.tableName} map`,
+        tableName: table.tableName,
+        columns: table.columns,
+        tableReference: table.table,
+      }),
+    );
+  }, [
+    addPanel,
+    blockInstanceId,
+    blockType,
+    dashboard,
+    setSelectedTable,
+    tables,
+  ]);
+
+  const panel = useMemo(
+    () =>
+      dashboard?.panels.find(
+        (candidate) => candidate.type === DECK_MAP_DASHBOARD_PANEL_TYPE,
+      ),
+    [dashboard?.panels],
+  );
+
+  if (!blockInstanceId || blockType !== 'map') {
+    return (
+      <div className="text-muted-foreground p-4 text-sm">
+        Unsupported stateful block type: {blockType || 'Unconfigured'}
+      </div>
+    );
+  }
+
+  if (!dashboard || !panel) {
+    return (
+      <div className="bg-muted/10 flex h-full min-h-[320px] flex-col">
+        <div className="border-border flex shrink-0 items-center gap-2 border-b px-3 py-2 text-sm font-medium">
+          <MapIcon className="h-4 w-4" />
+          <span>{title || 'Embedded Map'}</span>
+        </div>
+        <div className="text-muted-foreground flex min-h-0 flex-1 items-center justify-center p-4 text-center text-sm">
+          No map-ready table found. Add a table with longitude/latitude or
+          geometry columns, or ask the assistant to configure this map.
+        </div>
+      </div>
+    );
+  }
+
+  const HeaderActions = deckMapDashboardPanelRenderer.headerActions;
+  const MapPanel = deckMapDashboardPanelRenderer.component;
+  const rendererProps = {
+    dashboardId: blockInstanceId,
+    dashboard,
+    panel,
+    selectionName: getMosaicDashboardSelectionName(blockInstanceId),
+  };
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="border-border flex shrink-0 items-center justify-between gap-2 border-b px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2 text-sm font-medium">
+          <MapIcon className="h-4 w-4 shrink-0" />
+          <span className="truncate">{caption || title || panel.title}</span>
+        </div>
+        {HeaderActions ? <HeaderActions {...rendererProps} /> : null}
+      </div>
+      <div className="min-h-0 flex-1">
+        <MapPanel {...rendererProps} />
+      </div>
+    </div>
+  );
+};

--- a/packages/deck/README.md
+++ b/packages/deck/README.md
@@ -196,6 +196,11 @@ dataset extent using the declared longitude/latitude columns and fits the
 initial map view once, instead of inferring bounds from the loaded Arrow
 payload in React.
 
+Use `createDeckMapPanelFromNativeConfig(...)` when a host surface already has a
+native Deck map config, for example from AI tooling, and needs the same
+dashboard-compatible `deck-json-map` panel shape that the dashboard map tool
+creates.
+
 ## Core Concepts
 
 ### `DeckJsonMap`

--- a/packages/deck/README.md
+++ b/packages/deck/README.md
@@ -201,6 +201,17 @@ native Deck map config, for example from AI tooling, and needs the same
 dashboard-compatible `deck-json-map` panel shape that the dashboard map tool
 creates.
 
+## Embeddable Map Blocks
+
+Host applications that expose document-like block surfaces can render maps
+without first creating a visible dashboard. Use `ensureDeckMapBlockState(...)`
+to initialize persisted map state for a durable block id, then render it with
+`DeckMapBlockRenderer`.
+
+The block primitive reuses the dashboard map panel runtime internally, while
+leaving each host surface free to adapt its own block/document semantics around
+it.
+
 ## Core Concepts
 
 ### `DeckJsonMap`

--- a/packages/deck/__tests__/dashboard-ai-map.test.ts
+++ b/packages/deck/__tests__/dashboard-ai-map.test.ts
@@ -265,15 +265,35 @@ describe('createDeckMapDashboardTool', () => {
 
   it('provides default dashboard slice options with the deck map panel action', () => {
     const options = createDeckMapDashboardSliceOptions();
+    const mapAction = options.addPanelActions?.find(
+      (action) => action.type === DECK_MAP_DASHBOARD_PANEL_TYPE,
+    );
 
     expect(
       options.panelRenderers?.[DECK_MAP_DASHBOARD_PANEL_TYPE],
     ).toBeDefined();
-    expect(options.addPanelActions).toContainEqual(
-      expect.objectContaining({
-        type: DECK_MAP_DASHBOARD_PANEL_TYPE,
+    expect(mapAction).toBeDefined();
+    expect(mapAction?.isEnabled).toBeUndefined();
+    expect(
+      mapAction?.createPanel({
+        dashboardId: 'dashboard-1',
+        dashboard: undefined,
+        selectedTable: {
+          tableName: 'plain_table',
+          columns: [{name: 'name', type: 'VARCHAR'}],
+          table: 'plain_table',
+        } as any,
+        tables: [],
+        chartTypes: undefined,
       }),
-    );
+    ).toMatchObject({
+      type: DECK_MAP_DASHBOARD_PANEL_TYPE,
+      title: 'plain_table map',
+      config: {
+        datasets: {},
+        spec: {layers: []},
+      },
+    });
     expect(options.chartTypes?.length).toBeGreaterThan(0);
   });
 

--- a/packages/deck/src/ai.ts
+++ b/packages/deck/src/ai.ts
@@ -319,7 +319,11 @@ function cloneConfig(
   return JSON.parse(JSON.stringify(normalized)) as DeckMapDashboardPanelConfig;
 }
 
-function createDeckMapPanelFromNativeConfig(
+/**
+ * Creates a dashboard-compatible Deck map panel from the native map config
+ * used by AI tools and embeddable map surfaces.
+ */
+export function createDeckMapPanelFromNativeConfig(
   params: Pick<DeckMapConfigToolParams, 'title' | 'config'>,
 ) {
   return createDeckMapDashboardPanelConfig({

--- a/packages/deck/src/block.tsx
+++ b/packages/deck/src/block.tsx
@@ -1,0 +1,200 @@
+import {
+  getMosaicDashboardSelectionName,
+  type MosaicDashboardStoreState,
+  useStoreWithMosaicDashboard,
+} from '@sqlrooms/mosaic';
+import {MapIcon} from 'lucide-react';
+import {useEffect, useMemo} from 'react';
+import {
+  createDeckMapDashboardPanelConfig,
+  DECK_MAP_DASHBOARD_PANEL_TYPE,
+} from './dashboardConfig';
+import {deckMapDashboardPanelRenderer} from './dashboard';
+import {
+  createDeckMapDashboardPanelConfigForTable,
+  findGeometryColumn,
+  findLongitudeLatitudeColumns,
+} from './mapConfigUtils';
+
+function createEmptyDeckMapDashboardPanelConfig(title = 'Map') {
+  return createDeckMapDashboardPanelConfig({
+    title,
+    spec: {
+      initialViewState: {longitude: 0, latitude: 20, zoom: 1.5},
+      layers: [],
+    },
+    datasets: {},
+  });
+}
+
+/**
+ * Ensures persisted map block state exists for an embeddable map surface.
+ * If a geospatial table is available, the block is seeded with a starter map.
+ */
+export function ensureDeckMapBlockState(
+  state: MosaicDashboardStoreState,
+  mapId: string,
+  title: string,
+) {
+  state.mosaicDashboard.ensureDashboard(mapId, title, 'grid');
+
+  const dashboard = state.mosaicDashboard.getDashboard(mapId);
+  if (
+    !dashboard ||
+    dashboard.panels.some(
+      (panel) => panel.type === DECK_MAP_DASHBOARD_PANEL_TYPE,
+    )
+  ) {
+    return;
+  }
+
+  const table = state.db.tables.find(
+    (candidate) =>
+      Boolean(findLongitudeLatitudeColumns(candidate)) ||
+      Boolean(findGeometryColumn(candidate)),
+  );
+
+  if (table) {
+    state.mosaicDashboard.setSelectedTable(mapId, table.tableName);
+    state.mosaicDashboard.addPanel(
+      mapId,
+      createDeckMapDashboardPanelConfigForTable({
+        title: `${table.tableName} map`,
+        tableName: table.tableName,
+        columns: table.columns,
+        tableReference: table.table,
+      }),
+    );
+    return;
+  }
+
+  state.mosaicDashboard.addPanel(
+    mapId,
+    createEmptyDeckMapDashboardPanelConfig(title),
+  );
+}
+
+/** Props for rendering an embeddable Deck map block. */
+export type DeckMapBlockRendererProps = {
+  /** Durable map block id used to store backing Mosaic dashboard state. */
+  mapId: string;
+  /** Display title used when initializing empty map state. */
+  title?: string;
+  /** Optional header text that overrides the title when rendering. */
+  caption?: string;
+};
+
+/**
+ * Renders an embeddable Deck map block backed by SQLRooms map panel state.
+ */
+export function DeckMapBlockRenderer({
+  mapId,
+  title,
+  caption,
+}: DeckMapBlockRendererProps) {
+  const dashboard = useStoreWithMosaicDashboard(
+    (state) => state.mosaicDashboard.config.dashboardsById[mapId],
+  );
+  const tables = useStoreWithMosaicDashboard((state) => state.db.tables);
+  const ensureDashboard = useStoreWithMosaicDashboard(
+    (state) => state.mosaicDashboard.ensureDashboard,
+  );
+  const setSelectedTable = useStoreWithMosaicDashboard(
+    (state) => state.mosaicDashboard.setSelectedTable,
+  );
+  const addPanel = useStoreWithMosaicDashboard(
+    (state) => state.mosaicDashboard.addPanel,
+  );
+
+  useEffect(() => {
+    if (!mapId) {
+      return;
+    }
+
+    ensureDashboard(mapId, title ?? 'Embedded Map', 'grid');
+  }, [ensureDashboard, mapId, title]);
+
+  useEffect(() => {
+    if (!mapId || !dashboard) {
+      return;
+    }
+    if (
+      dashboard.panels.some(
+        (panel) => panel.type === DECK_MAP_DASHBOARD_PANEL_TYPE,
+      )
+    ) {
+      return;
+    }
+
+    const table = tables.find(
+      (candidate) =>
+        Boolean(findLongitudeLatitudeColumns(candidate)) ||
+        Boolean(findGeometryColumn(candidate)),
+    );
+
+    if (table) {
+      setSelectedTable(mapId, table.tableName);
+      addPanel(
+        mapId,
+        createDeckMapDashboardPanelConfigForTable({
+          title: `${table.tableName} map`,
+          tableName: table.tableName,
+          columns: table.columns,
+          tableReference: table.table,
+        }),
+      );
+      return;
+    }
+
+    addPanel(
+      mapId,
+      createEmptyDeckMapDashboardPanelConfig(title ?? 'Embedded Map'),
+    );
+  }, [addPanel, dashboard, mapId, setSelectedTable, tables, title]);
+
+  const panel = useMemo(
+    () =>
+      dashboard?.panels.find(
+        (candidate) => candidate.type === DECK_MAP_DASHBOARD_PANEL_TYPE,
+      ),
+    [dashboard?.panels],
+  );
+
+  if (!dashboard || !panel) {
+    return (
+      <div className="bg-muted/10 flex h-full min-h-[320px] flex-col">
+        <div className="border-border flex shrink-0 items-center gap-2 border-b px-3 py-2 text-sm font-medium">
+          <MapIcon className="h-4 w-4" />
+          <span>{title || 'Embedded Map'}</span>
+        </div>
+        <div className="text-muted-foreground flex min-h-0 flex-1 items-center justify-center p-4 text-center text-sm">
+          Preparing map...
+        </div>
+      </div>
+    );
+  }
+
+  const HeaderActions = deckMapDashboardPanelRenderer.headerActions;
+  const MapPanel = deckMapDashboardPanelRenderer.component;
+  const rendererProps = {
+    dashboardId: mapId,
+    dashboard,
+    panel,
+    selectionName: getMosaicDashboardSelectionName(mapId),
+  };
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="border-border flex shrink-0 items-center justify-between gap-2 border-b px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2 text-sm font-medium">
+          <MapIcon className="h-4 w-4 shrink-0" />
+          <span className="truncate">{caption || title || panel.title}</span>
+        </div>
+        {HeaderActions ? <HeaderActions {...rendererProps} /> : null}
+      </div>
+      <div className="min-h-0 flex-1">
+        <MapPanel {...rendererProps} />
+      </div>
+    </div>
+  );
+}

--- a/packages/deck/src/block.tsx
+++ b/packages/deck/src/block.tsx
@@ -1,10 +1,13 @@
 import {
+  DataTableSelectorEmptyState,
   getMosaicDashboardSelectionName,
   type MosaicDashboardStoreState,
+  useTablesWithColumns,
   useStoreWithMosaicDashboard,
 } from '@sqlrooms/mosaic';
+import type {DataTable} from '@sqlrooms/duckdb';
 import {MapIcon} from 'lucide-react';
-import {useEffect, useMemo} from 'react';
+import {useCallback, useEffect, useMemo} from 'react';
 import {
   createDeckMapDashboardPanelConfig,
   DECK_MAP_DASHBOARD_PANEL_TYPE,
@@ -96,6 +99,7 @@ export function DeckMapBlockRenderer({
     (state) => state.mosaicDashboard.config.dashboardsById[mapId],
   );
   const tables = useStoreWithMosaicDashboard((state) => state.db.tables);
+  const tablesWithColumns = useTablesWithColumns();
   const ensureDashboard = useStoreWithMosaicDashboard(
     (state) => state.mosaicDashboard.ensureDashboard,
   );
@@ -104,6 +108,9 @@ export function DeckMapBlockRenderer({
   );
   const addPanel = useStoreWithMosaicDashboard(
     (state) => state.mosaicDashboard.addPanel,
+  );
+  const updatePanel = useStoreWithMosaicDashboard(
+    (state) => state.mosaicDashboard.updatePanel,
   );
 
   useEffect(() => {
@@ -159,6 +166,40 @@ export function DeckMapBlockRenderer({
       ),
     [dashboard?.panels],
   );
+  const selectedTable = useMemo(
+    () =>
+      tablesWithColumns.find(
+        (table) => table.table.toString() === dashboard?.selectedTable,
+      ),
+    [dashboard?.selectedTable, tablesWithColumns],
+  );
+
+  const handleTableChange = useCallback(
+    (table: DataTable) => {
+      if (!mapId || !panel) {
+        return;
+      }
+
+      setSelectedTable(mapId, table.table.toString());
+      const hasGeospatialColumns =
+        Boolean(findLongitudeLatitudeColumns(table)) ||
+        Boolean(findGeometryColumn(table));
+      const nextPanel = hasGeospatialColumns
+        ? createDeckMapDashboardPanelConfigForTable({
+            title: `${table.tableName} map`,
+            tableName: table.tableName,
+            columns: table.columns,
+            tableReference: table.table,
+          })
+        : createEmptyDeckMapDashboardPanelConfig(title ?? 'Embedded Map');
+      updatePanel(mapId, panel.id, {
+        title: nextPanel.title,
+        type: nextPanel.type,
+        config: nextPanel.config,
+      });
+    },
+    [mapId, panel, setSelectedTable, title, updatePanel],
+  );
 
   if (!dashboard || !panel) {
     return (
@@ -182,6 +223,8 @@ export function DeckMapBlockRenderer({
     panel,
     selectionName: getMosaicDashboardSelectionName(mapId),
   };
+  const mapConfig = panel.config as {datasets?: Record<string, unknown>};
+  const hasDatasets = Object.keys(mapConfig.datasets ?? {}).length > 0;
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -193,7 +236,15 @@ export function DeckMapBlockRenderer({
         {HeaderActions ? <HeaderActions {...rendererProps} /> : null}
       </div>
       <div className="min-h-0 flex-1">
-        <MapPanel {...rendererProps} />
+        {hasDatasets ? (
+          <MapPanel {...rendererProps} />
+        ) : (
+          <DataTableSelectorEmptyState
+            onChange={handleTableChange}
+            tables={tablesWithColumns}
+            value={selectedTable}
+          />
+        )}
       </div>
     </div>
   );

--- a/packages/deck/src/dashboard.tsx
+++ b/packages/deck/src/dashboard.tsx
@@ -29,6 +29,7 @@ import {MapSettingsPanel} from './MapSettings';
 import {MosaicDashboardPanelLayout} from '@sqlrooms/mosaic';
 import {
   asDeckJsonMapConfig,
+  createDeckMapDashboardPanelConfig,
   createDeckMapDashboardDatasetQuery,
   createDeckMapDashboardDatasets,
   DECK_MAP_DASHBOARD_PANEL_TYPE,
@@ -52,6 +53,17 @@ import {
   findGeometryColumn,
   findLongitudeLatitudeColumns,
 } from './mapConfigUtils';
+
+function createEmptyDeckMapDashboardPanelConfig(title = 'Map') {
+  return createDeckMapDashboardPanelConfig({
+    title,
+    spec: {
+      initialViewState: {longitude: 0, latitude: 20, zoom: 1.5},
+      layers: [],
+    },
+    datasets: {},
+  });
+}
 
 /**
  * Extracts column names from common DuckDB "column not found" error messages
@@ -682,18 +694,22 @@ export const deckMapDashboardAddPanelAction: import('@sqlrooms/mosaic').MosaicDa
     type: DECK_MAP_DASHBOARD_PANEL_TYPE,
     label: 'Map',
     icon: MapIcon,
-    isEnabled: ({selectedTable}) =>
-      Boolean(
-        findLongitudeLatitudeColumns(selectedTable) ??
-        findGeometryColumn(selectedTable),
-      ),
-    createPanel: ({selectedTable}) =>
-      selectedTable
-        ? createDeckMapDashboardPanelConfigForTable({
-            title: `${selectedTable.tableName} map`,
-            tableName: selectedTable.tableName,
-            columns: selectedTable.columns,
-            tableReference: selectedTable.table,
-          })
-        : undefined,
+    createPanel: ({selectedTable}) => {
+      if (
+        selectedTable &&
+        (findLongitudeLatitudeColumns(selectedTable) ??
+          findGeometryColumn(selectedTable))
+      ) {
+        return createDeckMapDashboardPanelConfigForTable({
+          title: `${selectedTable.tableName} map`,
+          tableName: selectedTable.tableName,
+          columns: selectedTable.columns,
+          tableReference: selectedTable.table,
+        });
+      }
+
+      return createEmptyDeckMapDashboardPanelConfig(
+        selectedTable ? `${selectedTable.tableName} map` : 'Map',
+      );
+    },
   };

--- a/packages/deck/src/index.ts
+++ b/packages/deck/src/index.ts
@@ -28,6 +28,11 @@ export {
   deckMapDashboardAddPanelAction,
   deckMapDashboardPanelRenderer,
 } from './dashboard';
+export {
+  DeckMapBlockRenderer,
+  ensureDeckMapBlockState,
+  type DeckMapBlockRendererProps,
+} from './block';
 export {createDeckMapDashboardSliceOptions} from './dashboardIntegration';
 export {
   asDeckJsonMapConfig,

--- a/packages/deck/src/index.ts
+++ b/packages/deck/src/index.ts
@@ -13,6 +13,7 @@ export {
   createDeckMapDashboardAiTools,
   createDeckMapDashboardTool,
   createDeckMapConfigTool,
+  createDeckMapPanelFromNativeConfig,
   DeckMapDashboardConfigParameter,
   DeckMapConfigToolParameters,
   DeckMapDashboardToolParameters,

--- a/packages/deck/src/index.ts
+++ b/packages/deck/src/index.ts
@@ -43,6 +43,7 @@ export {
   createDeckMapDashboardConfigForTable,
   createDeckMapDashboardPanelConfigForTable,
   findDeckMapLongitudeLatitudeColumns,
+  findGeometryColumn,
   findLongitudeLatitudeColumns,
   normalizeDeckMapFillColor,
   quoteDeckMapSqlIdentifier,

--- a/packages/mosaic/README.md
+++ b/packages/mosaic/README.md
@@ -172,6 +172,10 @@ renderer for `@sqlrooms/documents` block documents. Register it with a
 host-provided stateful block type such as `data-table` when a document or
 worksheet surface should embed an interactive Data Table Explorer directly.
 
+Use `DataTableSelector` or `DataTableSelectorEmptyState` when another host
+surface needs the same searchable table picker used by dashboards and data
+table blocks.
+
 ### Worksheet Agent HTML App Tools
 
 `createWorksheetAgentTool` exposes worksheet HTML app block workflows by

--- a/packages/mosaic/__tests__/worksheet-ai.test.ts
+++ b/packages/mosaic/__tests__/worksheet-ai.test.ts
@@ -37,6 +37,13 @@ describe('createWorksheetAiTools', () => {
           blockInstanceId: 'html-app-1',
           title: 'Country Explorer',
         }),
+        blockDocumentBlockToNode({
+          type: 'statefulBlock',
+          id: 'block-3',
+          blockType: 'map',
+          blockInstanceId: 'map-1',
+          title: 'Earthquake Map',
+        }),
       ],
       addBlock: () => 'block-id',
       addDashboardBlock: () => ({
@@ -77,6 +84,13 @@ describe('createWorksheetAiTools', () => {
           blockType: 'html-app',
           htmlAppId: 'html-app-1',
           title: 'Country Explorer',
+        },
+        {
+          blockId: 'block-3',
+          type: 'statefulBlock',
+          blockType: 'map',
+          mapId: 'map-1',
+          title: 'Earthquake Map',
         },
       ],
     });

--- a/packages/mosaic/src/ai/worksheet/createListWorksheetBlocksTool.ts
+++ b/packages/mosaic/src/ai/worksheet/createListWorksheetBlocksTool.ts
@@ -22,6 +22,7 @@ type WorksheetBlockSummary = {
   caption?: string;
   dashboardId?: string;
   htmlAppId?: string;
+  mapId?: string;
   blockType?: string;
   tableName?: string;
 };
@@ -58,6 +59,7 @@ function summarizeBlock(
       ...(block.blockType === 'html-app'
         ? {htmlAppId: block.blockInstanceId}
         : {}),
+      ...(block.blockType === 'map' ? {mapId: block.blockInstanceId} : {}),
       ...(block.title !== undefined ? {title: block.title} : {}),
       ...(block.caption !== undefined ? {caption: block.caption} : {}),
     };
@@ -94,7 +96,7 @@ export function createListWorksheetBlocksTool({
   return tool<ListWorksheetBlocksToolInput, ListWorksheetBlocksToolOutput>({
     description: `List existing blocks in the worksheet.
 
-Use this before updating an existing worksheet dashboard or adding a map to a worksheet. Dashboard blocks include dashboardId; pass that dashboardId to embedded_dashboard_agent to add dashboard panels.${
+Use this before updating an existing worksheet dashboard, map, or app block. Dashboard blocks include dashboardId; pass that dashboardId to embedded_dashboard_agent to add dashboard panels. Map blocks include mapId; pass that mapId to a direct worksheet map tool when available.${
       htmlAppBlocksEnabled
         ? ' HTML app blocks include htmlAppId; pass that htmlAppId to embedded_html_app_agent as appId. For a new worksheet HTML app, use add_html_app_block first.'
         : ''

--- a/packages/mosaic/src/ai/worksheet/createWorksheetAgentTool.ts
+++ b/packages/mosaic/src/ai/worksheet/createWorksheetAgentTool.ts
@@ -219,7 +219,11 @@ ${htmlAppBlocksEnabled ? '❌ Creating a top-level html-app artifact when the us
 ✅ Call create_worksheet_block_* tools to automatically create charts
 ✅ Mix different chart types to show different patterns
 ✅ Use ${KnownWorksheetTools.add_dashboard_block} + ${KnownWorksheetTools.embedded_dashboard_agent} (two-step) when user explicitly asks for dashboard or when coordinated multi-view analysis would enhance exploration
-✅ For map requests, use ${KnownWorksheetTools.list_blocks} then ${KnownWorksheetTools.embedded_dashboard_agent} so the map is added as a dashboard panel
+${
+  mapBlocksEnabled
+    ? '✅ For map requests, use the direct worksheet map block tool; call list_worksheet_blocks first when updating an existing map and pass its mapId'
+    : `✅ For map requests, use ${KnownWorksheetTools.list_blocks} then ${KnownWorksheetTools.embedded_dashboard_agent} so the map is added as a dashboard panel`
+}
 ${htmlAppBlocksEnabled ? `✅ For worksheet app requests, use ${KnownWorksheetTools.add_html_app_block} + ${KnownWorksheetTools.embedded_html_app_agent} so the app is embedded in the worksheet` : ''}
 ✅ Charts are created immediately when you call the create_worksheet_block_* tools`;
 }
@@ -275,6 +279,7 @@ export function createWorksheetAgentTool<
     dashboardAgentTool,
     extraTools,
     htmlAppBlocksEnabled = true,
+    mapBlocksEnabled = false,
   } = options;
 
   return tool({
@@ -289,9 +294,14 @@ IF user requests DASHBOARD:
 2. Call ${KnownWorksheetTools.embedded_dashboard_agent} with dashboardId to populate it with charts
 
 IF user requests a MAP in a worksheet:
-1. Call ${KnownWorksheetTools.list_blocks} to find an existing dashboard block
+${
+  mapBlocksEnabled
+    ? `1. For a new map, call create_worksheet_map_block directly
+2. For an existing map, call ${KnownWorksheetTools.list_blocks} and pass the mapId to create_worksheet_map_block`
+    : `1. Call ${KnownWorksheetTools.list_blocks} to find an existing dashboard block
 2. Reuse an existing dashboardId if available, otherwise call ${KnownWorksheetTools.add_dashboard_block}
-3. Call ${KnownWorksheetTools.embedded_dashboard_agent} with an intent to add a map panel
+3. Call ${KnownWorksheetTools.embedded_dashboard_agent} with an intent to add a map panel`
+}
 
 ${
   htmlAppBlocksEnabled

--- a/packages/mosaic/src/ai/worksheet/createWorksheetAgentTool.ts
+++ b/packages/mosaic/src/ai/worksheet/createWorksheetAgentTool.ts
@@ -18,6 +18,7 @@ function getWorksheetAgentInstructions<TState>(
 ): string {
   const chartTools = resolveChartTypes(options.chartToolsOptions?.chartTypes);
   const htmlAppBlocksEnabled = options.htmlAppBlocksEnabled !== false;
+  const mapBlocksEnabled = options.mapBlocksEnabled === true;
 
   const chartToolsInstructions = createChartToolsInstructions(
     chartTools,
@@ -38,7 +39,11 @@ CRITICAL RULES:
 4. Prefer CHARTS with TEXT BLOCKS for context. Text blocks alone are insufficient.
 5. Use DASHBOARD BLOCKS when interactive exploration of multiple related dimensions would enhance the analysis.
 6. Use DATA TABLE EXPLORER BLOCK when users need to explore raw data in a tabular format. Only add one block per worksheet, and only if the user explicitly requests it or if it is necessary for exploration.
-7. If the user asks to add a map or geospatial visualization to a worksheet dashboard, use a dashboard block and ${KnownWorksheetTools.embedded_dashboard_agent}; worksheet chart tools cannot create map panels.
+7. ${
+    mapBlocksEnabled
+      ? 'If the user asks to add a map or geospatial visualization to a worksheet, use the available direct worksheet map block tool; do not create a dashboard block solely to hold a map.'
+      : `If the user asks to add a map or geospatial visualization to a worksheet dashboard, use a dashboard block and ${KnownWorksheetTools.embedded_dashboard_agent}; worksheet chart tools cannot create map panels.`
+  }
 ${htmlAppBlocksEnabled ? `8. If the user asks for an HTML app, D3 app, Chart.js app, browser app, custom interactive visualization, or generated app inside a worksheet, use ${KnownWorksheetTools.add_html_app_block} + ${KnownWorksheetTools.embedded_html_app_agent}. Do not create a top-level html-app artifact from inside worksheet_agent.` : ''}
 
 ## Creating Blocks
@@ -90,12 +95,14 @@ STEP 2: Populate the dashboard with charts and panels
 
 Use dashboard blocks when:
 - User explicitly requests a dashboard: "add dashboard analyzing sales data"
-- User asks for a map, geospatial visualization, locations, longitude/latitude, geometry, H3, routes, or spatial analysis
+- User asks for a map, geospatial visualization, locations, longitude/latitude, geometry, H3, routes, or spatial analysis and no direct worksheet map block tool is available
 - Interactive exploration would be valuable: multiple related dimensions benefit from coordinated views
 - Dataset has multiple dimensions suitable for multi-faceted analysis
 - The dashboard will contain 3-5 panels showing different aspects of the data
 
-${htmlAppBlocksEnabled ? `
+${
+  htmlAppBlocksEnabled
+    ? `
 ### HTML App Blocks
 To create a custom embedded browser app inside the worksheet, use a TWO-STEP workflow:
 
@@ -121,7 +128,9 @@ Use html-app blocks when:
 
 If updating an existing worksheet app, first call ${KnownWorksheetTools.list_blocks}, find an html-app block, and pass its htmlAppId as appId to ${KnownWorksheetTools.embedded_html_app_agent}.
 For incremental edits to an existing worksheet app, such as changing title, labels, colors, styles, layout, controls, or interactions, do not inspect tables or schemas first unless the user explicitly asks to change the app's data/query behavior.
-` : ''}
+`
+    : ''
+}
 
 ## Workflows
 
@@ -136,7 +145,11 @@ When user asks for specific charts (e.g., "create histogram of depth and magnitu
 1. Call ${KnownWorksheetTools.add_dashboard_block} to create the container
 2. Call ${KnownWorksheetTools.embedded_dashboard_agent} with the returned dashboardId to populate it
 
-**Map requests:** If user asks to add a map to an existing worksheet/dashboard, call ${KnownWorksheetTools.list_blocks}. If a dashboard block exists, call ${KnownWorksheetTools.embedded_dashboard_agent} with that dashboardId and an intent to create or update a map panel. If no dashboard block exists, create one first with ${KnownWorksheetTools.add_dashboard_block}.
+**Map requests:** ${
+    mapBlocksEnabled
+      ? 'If user asks to add a map to a worksheet, use the direct worksheet map block tool. If updating an existing worksheet map, call list_worksheet_blocks first and pass the map resource ID to the map tool.'
+      : `If user asks to add a map to an existing worksheet/dashboard, call ${KnownWorksheetTools.list_blocks}. If a dashboard block exists, call ${KnownWorksheetTools.embedded_dashboard_agent} with that dashboardId and an intent to create or update a map panel. If no dashboard block exists, create one first with ${KnownWorksheetTools.add_dashboard_block}.`
+  }
 
 ${htmlAppBlocksEnabled ? `**HTML app requests:** If user asks to create a new app inside the worksheet, call ${KnownWorksheetTools.add_html_app_block}, then call ${KnownWorksheetTools.embedded_html_app_agent} with the returned appId. If modifying an existing app, call ${KnownWorksheetTools.list_blocks} first and pass the target htmlAppId as appId.` : ''}
 
@@ -155,7 +168,7 @@ When user asks for "comprehensive analysis" or "high-level insights":
 
 **Consider dashboard blocks when:**
 - Dataset has multiple dimensions that benefit from coordinated visualization (e.g., geography + product category + time)
-- A map panel is requested; map panels are dashboard panels, not worksheet chart blocks
+- A map panel is requested and no direct worksheet map block tool is available
 - User wants to "explore" or analyze the data from multiple perspectives
 - Analysis benefits from seeing multiple related views together in one interactive dashboard
 
@@ -280,11 +293,15 @@ IF user requests a MAP in a worksheet:
 2. Reuse an existing dashboardId if available, otherwise call ${KnownWorksheetTools.add_dashboard_block}
 3. Call ${KnownWorksheetTools.embedded_dashboard_agent} with an intent to add a map panel
 
-${htmlAppBlocksEnabled ? `
+${
+  htmlAppBlocksEnabled
+    ? `
 IF user requests an HTML/D3/Chart.js/browser app in a worksheet:
 1. For a new app, call ${KnownWorksheetTools.add_html_app_block} to create the container, then call ${KnownWorksheetTools.embedded_html_app_agent} with the returned appId
 2. For an existing app, call ${KnownWorksheetTools.list_blocks}, then call ${KnownWorksheetTools.embedded_html_app_agent} with the htmlAppId as appId
-` : ''}
+`
+    : ''
+}
 
 Otherwise, create chart and text blocks directly using create_worksheet_block_* tools.
 

--- a/packages/mosaic/src/ai/worksheet/worksheet-types.ts
+++ b/packages/mosaic/src/ai/worksheet/worksheet-types.ts
@@ -94,6 +94,12 @@ export type CreateWorksheetAgentToolOptions<TState> =
      */
     htmlAppBlocksEnabled?: boolean;
     /**
+     * Whether direct worksheet map block tools are available. When enabled,
+     * map requests should use the host-provided map block tool instead of
+     * creating a dashboard block solely to contain a map.
+     */
+    mapBlocksEnabled?: boolean;
+    /**
      * Host-provided worksheet tools keyed by their registered tool name.
      * Register custom tools (e.g., maps, charts, data loaders) to extend
      * the worksheet agent's capabilities.

--- a/packages/mosaic/src/index.ts
+++ b/packages/mosaic/src/index.ts
@@ -56,6 +56,11 @@ export {MosaicDashboardPanelErrorBoundary} from './dashboard/panel/MosaicDashboa
 export {MosaicDashboardPanelLayout} from './dashboard/panel/MosaicDashboardPanelLayout';
 export {createDefaultMosaicDashboardPanelRenderers} from './dashboard/createDefaultMosaicDashboardPanelRenderers';
 export {defaultAddPanelActions} from './dashboard/defaultPanelActions';
+export {
+  DataTableSelector,
+  DataTableSelectorEmptyState,
+  type DataTableSelectorProps,
+} from './components/DataTableSelector';
 
 // Dashboard hooks
 export {useSelectedOrFirstTable} from './dashboard/useSelectedOrFirstTable';


### PR DESCRIPTION
## Summary

- Add an experimental `map` stateful worksheet block in the CLI app.
- Render Deck map panels directly inside worksheets without requiring users or agents to create a dashboard block first.
- Add a worksheet map agent tool, map-aware block listing, and prompt guidance so worksheet map requests target the direct map block.
- Export `createDeckMapPanelFromNativeConfig` for host surfaces that need the same normalized Deck map panel shape as dashboard map tooling.

## Impact

Worksheet users can add or generate maps directly as worksheet blocks. Existing dashboard map panels continue to use the same renderer/config path.

## Validation

- `pnpm build`
- `pnpm --filter sqlrooms-cli-app typecheck`
- `pnpm --filter @sqlrooms/deck test`
- `pnpm --filter @sqlrooms/mosaic test -- worksheet`
- Pre-push hook: `knip`, `turbo typecheck`, `turbo test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental, persistent worksheet **map** stateful blocks with a safe “unsupported/unconfigured” fallback, including title/caption rendering and deck-map panel auto-seeding.
  * Enhanced worksheet AI to optionally prefer direct worksheet map blocks (including reuse/update via map identifiers), with updated workflow guidance.
  * Deck maps now support embeddable block rendering, choosing geospatial tables when available and otherwise showing an empty map.
* **Bug Fixes**
  * Improved deck map panel creation to always return a compatible, dashboard-ready panel shape.
* **Tests**
  * Expanded AI and deck map tests to cover the new **map** block flow.
* **Documentation**
  * Added docs for creating dashboard-compatible Deck map panels and guidance for map/table picker primitives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->