### PR TITLE
fix: Stabilize block document renderer props to reduce rerenders

### DIFF
--- a/packages/documents/src/BlockDocumentChartRendererContext.tsx
+++ b/packages/documents/src/BlockDocumentChartRendererContext.tsx
@@ -1,6 +1,7 @@
 import {
   createContext,
   useContext,
+  useMemo,
   type FC,
   type PropsWithChildren,
 } from 'react';
@@ -34,8 +35,10 @@ export type BlockDocumentChartRendererProviderProps = PropsWithChildren<{
 export const BlockDocumentChartRendererProvider: FC<
   BlockDocumentChartRendererProviderProps
 > = ({renderer, children}) => {
+  const contextValue = useMemo(() => ({renderer}), [renderer]);
+
   return (
-    <BlockDocumentChartRendererContext.Provider value={{renderer}}>
+    <BlockDocumentChartRendererContext.Provider value={contextValue}>
       {children}
     </BlockDocumentChartRendererContext.Provider>
   );

--- a/packages/documents/src/BlockDocumentChartRendererContext.tsx
+++ b/packages/documents/src/BlockDocumentChartRendererContext.tsx
@@ -28,10 +28,12 @@ type BlockDocumentChartRendererContextValue = {
 const BlockDocumentChartRendererContext =
   createContext<BlockDocumentChartRendererContextValue>({});
 
+/** Props for providing a chart renderer to block document chart node views. */
 export type BlockDocumentChartRendererProviderProps = PropsWithChildren<{
   renderer?: BlockDocumentChartRenderer;
 }>;
 
+/** Provides the chart renderer used by block document chart node views. */
 export const BlockDocumentChartRendererProvider: FC<
   BlockDocumentChartRendererProviderProps
 > = ({renderer, children}) => {

--- a/packages/documents/src/BlockDocumentEditor/node-views/BlockDocumentChartNodeView.tsx
+++ b/packages/documents/src/BlockDocumentEditor/node-views/BlockDocumentChartNodeView.tsx
@@ -1,7 +1,18 @@
 import {cn} from '@sqlrooms/ui';
 import {NodeViewWrapper} from '@tiptap/react';
-import {createElement, useCallback, type FC} from 'react';
-import {useBlockDocumentChartRenderer} from '../../BlockDocumentChartRendererContext';
+import {
+  createElement,
+  memo,
+  useCallback,
+  useEffect,
+  useRef,
+  type FC,
+} from 'react';
+import {
+  type BlockDocumentChartRenderer,
+  type BlockDocumentChartRendererProps,
+  useBlockDocumentChartRenderer,
+} from '../../BlockDocumentChartRendererContext';
 import {useBlockDocumentEditorContext} from '../BlockDocumentEditorContext';
 import {optionalString, unknownRecord} from './nodeViewUtils';
 
@@ -11,38 +22,51 @@ type BlockDocumentChartNodeViewProps = {
   updateAttributes: (attrs: Record<string, unknown>) => void;
 };
 
+type ChartRendererBoundaryProps = BlockDocumentChartRendererProps & {
+  Renderer: BlockDocumentChartRenderer;
+};
+
+const ChartRendererBoundary = memo(
+  ({Renderer, ...props}: ChartRendererBoundaryProps) =>
+    createElement(Renderer, props),
+);
+
+ChartRendererBoundary.displayName = 'ChartRendererBoundary';
+
 export const BlockDocumentChartNodeView: FC<
   BlockDocumentChartNodeViewProps
 > = ({node, selected, updateAttributes}) => {
   const {documentId, readOnly} = useBlockDocumentEditorContext();
   const Renderer = useBlockDocumentChartRenderer();
+  const updateAttributesRef = useRef(updateAttributes);
+  const readOnlyRef = useRef(readOnly);
   const attrs = unknownRecord(node.attrs);
   const blockId = optionalString(attrs.id) ?? '';
   const tableName = optionalString(attrs.tableName) ?? '';
   const selectionGroupId = optionalString(attrs.selectionGroupId);
   const caption = optionalString(attrs.caption);
   const config = attrs.config ?? {};
-  const handleTableNameChange = useCallback(
-    (nextTableName: string) => {
-      if (readOnly) return;
-      updateAttributes({tableName: nextTableName});
-    },
-    [readOnly, updateAttributes],
-  );
-  const handleConfigChange = useCallback(
-    (nextConfig: unknown) => {
-      if (readOnly) return;
-      updateAttributes({config: nextConfig});
-    },
-    [readOnly, updateAttributes],
-  );
-  const handleCaptionChange = useCallback(
-    (nextCaption: string | undefined) => {
-      if (readOnly) return;
-      updateAttributes({caption: nextCaption});
-    },
-    [readOnly, updateAttributes],
-  );
+
+  useEffect(() => {
+    updateAttributesRef.current = updateAttributes;
+  }, [updateAttributes]);
+
+  useEffect(() => {
+    readOnlyRef.current = readOnly;
+  }, [readOnly]);
+
+  const handleTableNameChange = useCallback((nextTableName: string) => {
+    if (readOnlyRef.current) return;
+    updateAttributesRef.current({tableName: nextTableName});
+  }, []);
+  const handleConfigChange = useCallback((nextConfig: unknown) => {
+    if (readOnlyRef.current) return;
+    updateAttributesRef.current({config: nextConfig});
+  }, []);
+  const handleCaptionChange = useCallback((nextCaption: string | undefined) => {
+    if (readOnlyRef.current) return;
+    updateAttributesRef.current({caption: nextCaption});
+  }, []);
 
   return (
     <NodeViewWrapper
@@ -54,18 +78,19 @@ export const BlockDocumentChartNodeView: FC<
       data-block-document-widget-node-view=""
     >
       {Renderer ? (
-        createElement(Renderer, {
-          documentId,
-          blockId,
-          tableName,
-          config,
-          selectionGroupId,
-          caption,
-          readOnly,
-          onTableNameChange: handleTableNameChange,
-          onConfigChange: handleConfigChange,
-          onCaptionChange: handleCaptionChange,
-        })
+        <ChartRendererBoundary
+          Renderer={Renderer}
+          documentId={documentId}
+          blockId={blockId}
+          tableName={tableName}
+          config={config}
+          selectionGroupId={selectionGroupId}
+          caption={caption}
+          readOnly={readOnly}
+          onTableNameChange={handleTableNameChange}
+          onConfigChange={handleConfigChange}
+          onCaptionChange={handleCaptionChange}
+        />
       ) : (
         <div className="p-4">
           <div className="text-sm font-medium">Chart block</div>

--- a/packages/documents/src/BlockDocumentEditor/node-views/BlockDocumentChartNodeView.tsx
+++ b/packages/documents/src/BlockDocumentEditor/node-views/BlockDocumentChartNodeView.tsx
@@ -26,6 +26,8 @@ type ChartRendererBoundaryProps = BlockDocumentChartRendererProps & {
   Renderer: BlockDocumentChartRenderer;
 };
 
+const EMPTY_CHART_CONFIG: Record<string, never> = {};
+
 const ChartRendererBoundary = memo(
   ({Renderer, ...props}: ChartRendererBoundaryProps) =>
     createElement(Renderer, props),
@@ -33,6 +35,7 @@ const ChartRendererBoundary = memo(
 
 ChartRendererBoundary.displayName = 'ChartRendererBoundary';
 
+/** Renders a chart block as a Tiptap node view inside the block document editor. */
 export const BlockDocumentChartNodeView: FC<
   BlockDocumentChartNodeViewProps
 > = ({node, selected, updateAttributes}) => {
@@ -45,7 +48,7 @@ export const BlockDocumentChartNodeView: FC<
   const tableName = optionalString(attrs.tableName) ?? '';
   const selectionGroupId = optionalString(attrs.selectionGroupId);
   const caption = optionalString(attrs.caption);
-  const config = attrs.config ?? {};
+  const config = attrs.config ?? EMPTY_CHART_CONFIG;
 
   useEffect(() => {
     updateAttributesRef.current = updateAttributes;

--- a/packages/documents/src/BlockDocumentEditor/node-views/BlockDocumentStatefulBlockNodeView.tsx
+++ b/packages/documents/src/BlockDocumentEditor/node-views/BlockDocumentStatefulBlockNodeView.tsx
@@ -3,6 +3,7 @@ import {isMacOS} from '@sqlrooms/utils';
 import {NodeViewWrapper} from '@tiptap/react';
 import {
   createElement,
+  memo,
   useCallback,
   useEffect,
   useMemo,
@@ -12,6 +13,8 @@ import {
   useState,
 } from 'react';
 import {
+  type BlockDocumentStatefulBlockRenderer,
+  type BlockDocumentStatefulBlockRendererProps,
   useBlockDocumentStatefulBlockRenderer,
   useBlockDocumentStatefulBlockTypes,
 } from '../../BlockDocumentStatefulBlockRendererContext';
@@ -23,6 +26,18 @@ type BlockDocumentStatefulBlockNodeViewProps = {
   selected: boolean;
   updateAttributes: (attrs: Record<string, unknown>) => void;
 };
+
+type StatefulBlockRendererBoundaryProps =
+  BlockDocumentStatefulBlockRendererProps & {
+    Renderer: BlockDocumentStatefulBlockRenderer;
+  };
+
+const StatefulBlockRendererBoundary = memo(
+  ({Renderer, ...props}: StatefulBlockRendererBoundaryProps) =>
+    createElement(Renderer, props),
+);
+
+StatefulBlockRendererBoundary.displayName = 'StatefulBlockRendererBoundary';
 
 const SCROLL_HINT_HIDE_DELAY_MS = 900;
 const SCROLL_EPSILON = 1;
@@ -112,6 +127,7 @@ export const BlockDocumentStatefulBlockNodeView: FC<
   BlockDocumentStatefulBlockNodeViewProps
 > = ({node, selected, updateAttributes}) => {
   const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const updateAttributesRef = useRef(updateAttributes);
   const hideScrollHintTimeoutRef = useRef<number | undefined>(undefined);
   const scrollHintTargetRef = useRef<HTMLElement | null>(null);
   const resizeCleanupRef = useRef<(() => void) | null>(null);
@@ -144,7 +160,14 @@ export const BlockDocumentStatefulBlockNodeView: FC<
   const [showScrollHint, setShowScrollHint] = useState(false);
   const resolvedHeight = resizingHeight ?? persistedHeight;
 
-  const wrapperStyle = resolvedHeight ? {height: resolvedHeight} : undefined;
+  const wrapperStyle = useMemo(
+    () => (resolvedHeight ? {height: resolvedHeight} : undefined),
+    [resolvedHeight],
+  );
+
+  useEffect(() => {
+    updateAttributesRef.current = updateAttributes;
+  }, [updateAttributes]);
 
   useEffect(() => {
     return () => {
@@ -303,6 +326,14 @@ export const BlockDocumentStatefulBlockNodeView: FC<
     window.addEventListener('mouseup', handleMouseUp);
   };
 
+  const handleTitleChange = useCallback((nextTitle: string | undefined) => {
+    updateAttributesRef.current({title: nextTitle || undefined});
+  }, []);
+
+  const handleCaptionChange = useCallback((nextCaption: string | undefined) => {
+    updateAttributesRef.current({caption: nextCaption});
+  }, []);
+
   return (
     <NodeViewWrapper
       className={cn(
@@ -319,21 +350,20 @@ export const BlockDocumentStatefulBlockNodeView: FC<
         data-scroll-modifier-required={requireScrollModifier || undefined}
       >
         {Renderer ? (
-          createElement(Renderer, {
-            documentId,
-            blockId,
-            blockType,
-            blockInstanceId,
-            ownership,
-            title,
-            caption,
-            height: resolvedHeight,
-            readOnly,
-            onTitleChange: (nextTitle: string | undefined) =>
-              updateAttributes({title: nextTitle || undefined}),
-            onCaptionChange: (nextCaption: string | undefined) =>
-              updateAttributes({caption: nextCaption}),
-          })
+          <StatefulBlockRendererBoundary
+            Renderer={Renderer}
+            documentId={documentId}
+            blockId={blockId}
+            blockType={blockType}
+            blockInstanceId={blockInstanceId}
+            ownership={ownership}
+            title={title}
+            caption={caption}
+            height={resolvedHeight}
+            readOnly={readOnly}
+            onTitleChange={handleTitleChange}
+            onCaptionChange={handleCaptionChange}
+          />
         ) : (
           <div className="p-4">
             <div className="text-sm font-medium">Stateful block</div>

--- a/packages/documents/src/BlockDocumentEditor/node-views/BlockDocumentStatefulBlockNodeView.tsx
+++ b/packages/documents/src/BlockDocumentEditor/node-views/BlockDocumentStatefulBlockNodeView.tsx
@@ -123,15 +123,17 @@ function scrollElementByWheel(element: HTMLElement, event: WheelEvent) {
   });
 }
 
+/** Renders a stateful block as a Tiptap node view inside the block document editor. */
 export const BlockDocumentStatefulBlockNodeView: FC<
   BlockDocumentStatefulBlockNodeViewProps
 > = ({node, selected, updateAttributes}) => {
+  const {documentId, readOnly} = useBlockDocumentEditorContext();
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const updateAttributesRef = useRef(updateAttributes);
+  const readOnlyRef = useRef(readOnly);
   const hideScrollHintTimeoutRef = useRef<number | undefined>(undefined);
   const scrollHintTargetRef = useRef<HTMLElement | null>(null);
   const resizeCleanupRef = useRef<(() => void) | null>(null);
-  const {documentId, readOnly} = useBlockDocumentEditorContext();
   const attrs = unknownRecord(node.attrs);
   const blockId = optionalString(attrs.id) ?? '';
   const blockType = optionalString(attrs.blockType) ?? '';
@@ -167,7 +169,8 @@ export const BlockDocumentStatefulBlockNodeView: FC<
 
   useEffect(() => {
     updateAttributesRef.current = updateAttributes;
-  }, [updateAttributes]);
+    readOnlyRef.current = readOnly;
+  }, [readOnly, updateAttributes]);
 
   useEffect(() => {
     return () => {
@@ -327,10 +330,12 @@ export const BlockDocumentStatefulBlockNodeView: FC<
   };
 
   const handleTitleChange = useCallback((nextTitle: string | undefined) => {
+    if (readOnlyRef.current) return;
     updateAttributesRef.current({title: nextTitle || undefined});
   }, []);
 
   const handleCaptionChange = useCallback((nextCaption: string | undefined) => {
+    if (readOnlyRef.current) return;
     updateAttributesRef.current({caption: nextCaption});
   }, []);
 


### PR DESCRIPTION
## Summary
- memoize chart renderer context values to keep provider identity stable
- wrap chart and stateful block renderers in memoized boundaries
- route NodeView change handlers through refs to avoid stale closures while preserving read-only checks
- memoize stateful block wrapper styles when height is resolved

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized rendering for chart and stateful block components using memoized boundaries and stable render props.
  * Improved context stability by keeping the provided value reference consistent when the renderer doesn’t change.
  * Fixed potential stale-closure behavior in title/caption/table-name/config update handlers by synchronizing read-only and update logic with refs.
  * Standardized default chart config handling and reduced unnecessary recomputation (e.g., wrapper styles).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->