### PR TITLE
feat: Add python block artifacts to the CLI UI

### DIFF
--- a/apps/sqlrooms-cli-ui/src/artifactTypeIds.ts
+++ b/apps/sqlrooms-cli-ui/src/artifactTypeIds.ts
@@ -6,6 +6,7 @@ export const CLI_ARTIFACT_TYPES = [
   'document',
   'sql-query',
   'html-app',
+  'python',
   'canvas',
   'app',
 ] as const;

--- a/apps/sqlrooms-cli-ui/src/artifactTypes.tsx
+++ b/apps/sqlrooms-cli-ui/src/artifactTypes.tsx
@@ -10,6 +10,7 @@ import {
 import {createMarkdownDocumentBlockDefinition} from '@sqlrooms/documents';
 import {createMosaicDashboardBlockDefinition} from '@sqlrooms/mosaic';
 import {createPivotBlockDefinition} from '@sqlrooms/pivot';
+import {createPythonBlockDefinition} from '@sqlrooms/python/block';
 import type {RoomPanelComponent} from '@sqlrooms/layout';
 import {
   AppWindow,
@@ -41,6 +42,7 @@ const ARTIFACT_STABILITY = {
   document: 'experimental',
   'sql-query': 'experimental',
   'html-app': 'experimental',
+  python: 'experimental',
   canvas: 'experimental',
   app: 'experimental',
 } as const satisfies Record<CliArtifactType, FeatureStability>;
@@ -111,6 +113,11 @@ const htmlAppBlockDefinition = createHtmlAppBlockDefinition<RoomState>({
     requestedCapabilities: ['query'],
     grantedCapabilities: ['query'],
   },
+});
+
+const pythonBlockDefinition = createPythonBlockDefinition<RoomState>({
+  label: STATEFUL_BLOCK_ARTIFACT_CONFIGS.python.label,
+  defaultTitle: STATEFUL_BLOCK_ARTIFACT_CONFIGS.python.defaultTitle,
 });
 
 export function createCliArtifactTypes({
@@ -210,6 +217,11 @@ export function createCliArtifactTypes({
     'html-app': withStability(
       'html-app',
       createArtifactTypeFromStatefulBlock(htmlAppBlockDefinition),
+      experimentalEnabled,
+    ),
+    python: withStability(
+      'python',
+      createArtifactTypeFromStatefulBlock(pythonBlockDefinition),
       experimentalEnabled,
     ),
     canvas: withStability('canvas', canvasDefinition, experimentalEnabled),

--- a/apps/sqlrooms-cli-ui/src/createDashboardCommands.ts
+++ b/apps/sqlrooms-cli-ui/src/createDashboardCommands.ts
@@ -111,6 +111,8 @@ function createArtifactCommand(
         state.canvas.ensureArtifact(artifactId);
       } else if (artifactType === 'pivot') {
         state.pivot.ensurePivot(artifactId, {title: uniqueTitle});
+      } else if (artifactType === 'python') {
+        state.python.ensureBlock(artifactId, {title: uniqueTitle});
       }
       state.artifacts.setCurrentArtifact(artifactId);
       if (shouldCreateInitialArtifactChat(context)) {
@@ -222,6 +224,10 @@ const ARTIFACT_CREATE_COMMANDS: {
     command: () => createArtifactCommand('html-app', 'HTML App'),
   },
   {
+    artifactType: 'python',
+    command: () => createArtifactCommand('python', 'Python'),
+  },
+  {
     artifactType: 'canvas',
     command: () => createArtifactCommand('canvas', 'Canvas'),
   },
@@ -305,6 +311,9 @@ export function createDashboardCommands({
         }
         if (artifact.type === 'pivot') {
           state.pivot.ensurePivot(artifactId, {title: artifact.title});
+        }
+        if (artifact.type === 'python') {
+          state.python.ensureBlock(artifactId, {title: artifact.title});
         }
         return {
           success: true,


### PR DESCRIPTION
## Summary
- Add `python` to the CLI artifact type registry and stability map
- Wire artifact creation and selection to initialize Python blocks
- Expose a Python artifact creation command alongside the existing types

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Python support to the CLI, allowing users to create, manage, and interact with Python artifacts within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->