### PR TITLE
feat: Show a disconnect dialog for lost DuckDB WebSocket connections

### DIFF
--- a/apps/sqlrooms-cli-ui/src/components/CliDuckDbConnectionLostDialog.tsx
+++ b/apps/sqlrooms-cli-ui/src/components/CliDuckDbConnectionLostDialog.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react';
+import {CircleAlert, RotateCw} from 'lucide-react';
+
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@sqlrooms/ui';
+import {cliDuckDbConnector} from '../store';
+
+function useDuckDbConnectionStatus() {
+  return React.useSyncExternalStore(
+    cliDuckDbConnector.subscribeConnectionStatus,
+    () => cliDuckDbConnector.connectionStatus,
+    () => cliDuckDbConnector.connectionStatus,
+  );
+}
+
+export function CliDuckDbConnectionLostDialog() {
+  const status = useDuckDbConnectionStatus();
+  const hasConnectedRef = React.useRef(status === 'connected');
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  React.useEffect(() => {
+    if (status === 'connected') {
+      hasConnectedRef.current = true;
+      setIsOpen(false);
+      return;
+    }
+
+    if (status === 'disconnected' && hasConnectedRef.current) {
+      setIsOpen(true);
+    }
+  }, [status]);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogContent
+        showCloseButton={false}
+        className="max-w-2xl gap-8 px-10 py-12 sm:rounded-lg"
+      >
+        <div className="mx-auto flex size-14 items-center justify-center rounded-full border-4 border-red-500 text-red-500">
+          <CircleAlert className="size-8" strokeWidth={2.5} />
+        </div>
+
+        <DialogHeader className="items-center space-y-0 text-center">
+          <DialogTitle className="text-3xl leading-tight font-bold">
+            Connection to DuckDB Lost
+          </DialogTitle>
+          <DialogDescription className="sr-only">
+            The connection to the local SQLRooms DuckDB backend was lost.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="text-muted-foreground mx-auto max-w-lg space-y-6 text-lg leading-8">
+          <p>
+            The connection to your local SQLRooms DuckDB backend was lost.
+          </p>
+          <p>
+            This typically happens when the SQLRooms CLI process exits or the
+            local UI server is stopped.
+          </p>
+          <div>
+            <p>To reconnect:</p>
+            <ul className="mt-2 list-disc space-y-1 pl-7">
+              <li>
+                Restart the same <code>sqlrooms</code> command in your terminal.
+              </li>
+              <li>Reload this browser tab after the server is running.</li>
+            </ul>
+          </div>
+        </div>
+
+        <div className="flex justify-center">
+          <Button
+            className="gap-2"
+            type="button"
+            onClick={() => window.location.reload()}
+          >
+            <RotateCw className="size-4" />
+            Reload
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/sqlrooms-cli-ui/src/components/CliDuckDbConnectionLostDialog.tsx
+++ b/apps/sqlrooms-cli-ui/src/components/CliDuckDbConnectionLostDialog.tsx
@@ -38,6 +38,12 @@ function useDuckDbConnectionStatus() {
   );
 }
 
+/**
+ * Renders the SQLRooms server lost-connection dialog and manages automatic
+ * WebSocket reconnect attempts without reloading the page.
+ *
+ * @returns Dialog content for lost SQLRooms server connections.
+ */
 export function CliDuckDbConnectionLostDialog() {
   const status = useDuckDbConnectionStatus();
   const serverEndpoint = React.useMemo(
@@ -95,7 +101,7 @@ export function CliDuckDbConnectionLostDialog() {
   }, []);
 
   React.useEffect(() => {
-    if (!isOpen || status !== 'disconnected') return;
+    if (!hasConnectedRef.current || status !== 'disconnected') return;
     let cancelled = false;
     let timeoutId: number | undefined;
 
@@ -120,7 +126,7 @@ export function CliDuckDbConnectionLostDialog() {
         window.clearTimeout(timeoutId);
       }
     };
-  }, [isOpen, retryConnection, status]);
+  }, [retryConnection, status]);
 
   const handleRetry = React.useCallback(() => {
     autoReconnectAttemptRef.current = 0;

--- a/apps/sqlrooms-cli-ui/src/components/CliDuckDbConnectionLostDialog.tsx
+++ b/apps/sqlrooms-cli-ui/src/components/CliDuckDbConnectionLostDialog.tsx
@@ -9,7 +9,26 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@sqlrooms/ui';
-import {cliDuckDbConnector} from '../store';
+import {cliDuckDbConnector, cliDuckDbWsUrl, roomStore} from '../store';
+
+const AUTO_RECONNECT_INITIAL_DELAY_MS = 1_000;
+const AUTO_RECONNECT_MAX_DELAY_MS = 30_000;
+
+function getAutoReconnectDelayMs(attempt: number) {
+  return Math.min(
+    AUTO_RECONNECT_INITIAL_DELAY_MS * 2 ** attempt,
+    AUTO_RECONNECT_MAX_DELAY_MS,
+  );
+}
+
+function formatServerEndpoint(wsUrl: string) {
+  try {
+    const url = new URL(wsUrl, window.location.href);
+    return url.port ? `${url.hostname}:${url.port}` : url.host;
+  } catch {
+    return wsUrl;
+  }
+}
 
 function useDuckDbConnectionStatus() {
   return React.useSyncExternalStore(
@@ -21,13 +40,24 @@ function useDuckDbConnectionStatus() {
 
 export function CliDuckDbConnectionLostDialog() {
   const status = useDuckDbConnectionStatus();
+  const serverEndpoint = React.useMemo(
+    () => formatServerEndpoint(cliDuckDbWsUrl),
+    [],
+  );
   const hasConnectedRef = React.useRef(status === 'connected');
   const [isOpen, setIsOpen] = React.useState(false);
+  const [isRetrying, setIsRetrying] = React.useState(false);
+  const [retryError, setRetryError] = React.useState<string | null>(null);
+  const retryInFlightRef = React.useRef(false);
+  const autoReconnectAttemptRef = React.useRef(0);
 
   React.useEffect(() => {
     if (status === 'connected') {
       hasConnectedRef.current = true;
       setIsOpen(false);
+      setIsRetrying(false);
+      setRetryError(null);
+      autoReconnectAttemptRef.current = 0;
       return;
     }
 
@@ -36,28 +66,91 @@ export function CliDuckDbConnectionLostDialog() {
     }
   }, [status]);
 
+  const retryConnection = React.useCallback(async (showPending: boolean) => {
+    if (retryInFlightRef.current) return false;
+    retryInFlightRef.current = true;
+    if (showPending) {
+      setIsRetrying(true);
+      setRetryError(null);
+    }
+    try {
+      await cliDuckDbConnector.reconnect();
+      void roomStore.getState().db.refreshTableSchemas();
+      return true;
+    } catch (error) {
+      if (showPending) {
+        setRetryError(
+          error instanceof Error
+            ? error.message
+            : 'Could not reconnect to the SQLRooms server.',
+        );
+      }
+      return false;
+    } finally {
+      retryInFlightRef.current = false;
+      if (showPending) {
+        setIsRetrying(false);
+      }
+    }
+  }, []);
+
+  React.useEffect(() => {
+    if (!isOpen || status !== 'disconnected') return;
+    let cancelled = false;
+    let timeoutId: number | undefined;
+
+    const scheduleNextAttempt = () => {
+      const delayMs = getAutoReconnectDelayMs(
+        autoReconnectAttemptRef.current,
+      );
+      timeoutId = window.setTimeout(async () => {
+        if (cancelled) return;
+        const reconnected = await retryConnection(false);
+        if (cancelled || reconnected) return;
+        autoReconnectAttemptRef.current += 1;
+        scheduleNextAttempt();
+      }, delayMs);
+    };
+
+    scheduleNextAttempt();
+
+    return () => {
+      cancelled = true;
+      if (timeoutId !== undefined) {
+        window.clearTimeout(timeoutId);
+      }
+    };
+  }, [isOpen, retryConnection, status]);
+
+  const handleRetry = React.useCallback(() => {
+    autoReconnectAttemptRef.current = 0;
+    void retryConnection(true);
+  }, [retryConnection]);
+
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <DialogContent
         showCloseButton={false}
-        className="max-w-2xl gap-8 px-10 py-12 sm:rounded-lg"
+        className="max-w-xl gap-6 px-8 py-10 sm:rounded-lg"
       >
-        <div className="mx-auto flex size-14 items-center justify-center rounded-full border-4 border-red-500 text-red-500">
-          <CircleAlert className="size-8" strokeWidth={2.5} />
-        </div>
+        <CircleAlert
+          className="mx-auto size-14 text-red-500"
+          strokeWidth={2.25}
+        />
 
         <DialogHeader className="items-center space-y-0 text-center">
-          <DialogTitle className="text-3xl leading-tight font-bold">
-            Connection to DuckDB Lost
+          <DialogTitle className="text-2xl leading-tight font-bold">
+            Connection to SQLRooms server lost
           </DialogTitle>
           <DialogDescription className="sr-only">
-            The connection to the local SQLRooms DuckDB backend was lost.
+            The connection to the local SQLRooms server was lost.
           </DialogDescription>
         </DialogHeader>
 
-        <div className="text-muted-foreground mx-auto max-w-lg space-y-6 text-lg leading-8">
+        <div className="text-muted-foreground mx-auto max-w-md space-y-5 text-base leading-7">
           <p>
-            The connection to your local SQLRooms DuckDB backend was lost.
+            The connection to your local SQLRooms server on{' '}
+            <code>{serverEndpoint}</code> was lost.
           </p>
           <p>
             This typically happens when the SQLRooms CLI process exits or the
@@ -65,23 +158,29 @@ export function CliDuckDbConnectionLostDialog() {
           </p>
           <div>
             <p>To reconnect:</p>
-            <ul className="mt-2 list-disc space-y-1 pl-7">
+            <ul className="mt-2 list-disc space-y-1 pl-6">
               <li>
                 Restart the same <code>sqlrooms</code> command in your terminal.
               </li>
-              <li>Reload this browser tab after the server is running.</li>
+              <li>Wait for automatic reconnect, or retry manually.</li>
             </ul>
           </div>
+          {retryError && (
+            <p className="text-destructive text-sm leading-6">{retryError}</p>
+          )}
         </div>
 
         <div className="flex justify-center">
           <Button
             className="gap-2"
+            disabled={isRetrying}
             type="button"
-            onClick={() => window.location.reload()}
+            onClick={handleRetry}
           >
-            <RotateCw className="size-4" />
-            Reload
+            <RotateCw
+              className={isRetrying ? 'size-4 animate-spin' : 'size-4'}
+            />
+            {isRetrying ? 'Retrying...' : 'Retry'}
           </Button>
         </div>
       </DialogContent>

--- a/apps/sqlrooms-cli-ui/src/room.tsx
+++ b/apps/sqlrooms-cli-ui/src/room.tsx
@@ -9,6 +9,7 @@ import {
 import {CliWorkspaceTopbar} from './workspace/CliWorkspaceTopbar';
 import {CliWorkspaceSidebar} from './workspace/sidebar';
 import {roomStore} from './store';
+import {CliDuckDbConnectionLostDialog} from './components/CliDuckDbConnectionLostDialog';
 
 export const Room = () => {
   const sqlEditor = useDisclosure();
@@ -22,6 +23,7 @@ export const Room = () => {
             <RoomShell.LayoutComposer className="min-h-0 flex-1 overflow-hidden [&_[data-slot=resizable-handle][aria-controls=assistant-sidebar][aria-valuenow='0']]:hidden" />
             <RoomShell.LoadingProgress />
             <RoomShell.CommandPalette />
+            <CliDuckDbConnectionLostDialog />
             <SqlEditorModal
               isOpen={sqlEditor.isOpen}
               onClose={sqlEditor.onClose}

--- a/apps/sqlrooms-cli-ui/src/store.ts
+++ b/apps/sqlrooms-cli-ui/src/store.ts
@@ -262,6 +262,7 @@ function createDisabledCrdtState(): CrdtSliceState {
 }
 
 const runtimeWsUrl = runtimeConfig.wsUrl || 'ws://localhost:4000';
+export const cliDuckDbWsUrl = runtimeWsUrl;
 const connector = createWebSocketDuckDbConnector({
   wsUrl: runtimeWsUrl,
   initializationQuery: [

--- a/apps/sqlrooms-cli-ui/src/store.ts
+++ b/apps/sqlrooms-cli-ui/src/store.ts
@@ -271,6 +271,7 @@ const connector = createWebSocketDuckDbConnector({
     `CREATE SCHEMA IF NOT EXISTS ${MOSAIC_PREAGG_SCHEMA_REF}`,
   ].join('; '),
 });
+export const cliDuckDbConnector = connector;
 addCliDatabaseInitializationDiagnostics(connector, {
   runtimeConfig,
   wsUrl: runtimeWsUrl,

--- a/packages/duckdb/README.md
+++ b/packages/duckdb/README.md
@@ -57,6 +57,30 @@ function UserList() {
 
 For more information and examples on using the `useSql` hook, see the [useSql API documentation](/api/duckdb/functions/useSql).
 
+### Monitoring WebSocket DuckDB Connections
+
+`createWebSocketDuckDbConnector()` exposes the persistent WebSocket lifecycle
+through `connectionStatus`, `subscribeConnectionStatus()`, and the optional
+`onConnectionStatusChange` callback. Use this for live UI affordances such as
+lost-connection dialogs.
+
+```tsx
+import {createWebSocketDuckDbConnector} from '@sqlrooms/duckdb';
+
+const connector = createWebSocketDuckDbConnector({
+  wsUrl: 'ws://localhost:4000',
+  onConnectionStatusChange: (status) => {
+    console.log('DuckDB WebSocket status:', status);
+  },
+});
+
+const unsubscribe = connector.subscribeConnectionStatus((status) => {
+  if (status === 'disconnected') {
+    console.warn('DuckDB WebSocket disconnected');
+  }
+});
+```
+
 ### Looking up Table Metadata
 
 Use `useDataTable()` in React components or `db.findTable()` from the room

--- a/packages/duckdb/README.md
+++ b/packages/duckdb/README.md
@@ -62,7 +62,8 @@ For more information and examples on using the `useSql` hook, see the [useSql AP
 `createWebSocketDuckDbConnector()` exposes the persistent WebSocket lifecycle
 through `connectionStatus`, `subscribeConnectionStatus()`, and the optional
 `onConnectionStatusChange` callback. Use this for live UI affordances such as
-lost-connection dialogs.
+lost-connection dialogs. Call `reconnect()` to reopen the socket and rerun the
+connector initialization SQL without destroying the connector instance.
 
 ```tsx
 import {createWebSocketDuckDbConnector} from '@sqlrooms/duckdb';
@@ -79,6 +80,8 @@ const unsubscribe = connector.subscribeConnectionStatus((status) => {
     console.warn('DuckDB WebSocket disconnected');
   }
 });
+
+await connector.reconnect();
 ```
 
 ### Looking up Table Metadata

--- a/packages/duckdb/src/connectors/WebSocketDuckDbConnector.ts
+++ b/packages/duckdb/src/connectors/WebSocketDuckDbConnector.ts
@@ -226,6 +226,11 @@ export function createWebSocketDuckDbConnector(
                   opening = null;
                   setConnectionStatus('disconnected');
                   reject(new Error(msg));
+                  try {
+                    ws.close();
+                    // eslint-disable-next-line no-empty
+                  } catch {}
+                  socket = null;
                 }
                 return;
               }

--- a/packages/duckdb/src/connectors/WebSocketDuckDbConnector.ts
+++ b/packages/duckdb/src/connectors/WebSocketDuckDbConnector.ts
@@ -30,6 +30,9 @@ export interface WebSocketDuckDbConnectorOptions {
   /** Optional handler for server notifications `{ type: 'notify', payload }` */
   onNotification?: (payload: any) => void;
 
+  /** Optional handler for persistent WebSocket connection lifecycle changes. */
+  onConnectionStatusChange?: (status: WebSocketDuckDbConnectionStatus) => void;
+
   /** Optional list of channels to subscribe to upon (re)connect */
   subscribeChannels?: string[];
 
@@ -37,8 +40,33 @@ export interface WebSocketDuckDbConnectorOptions {
   authToken?: string;
 }
 
+/**
+ * Persistent WebSocket connection lifecycle status.
+ *
+ * @public
+ */
+export type WebSocketDuckDbConnectionStatus =
+  | 'idle'
+  | 'connecting'
+  | 'connected'
+  | 'disconnected';
+
 export interface WebSocketDuckDbConnector extends DuckDbConnector {
   readonly type: 'ws';
+
+  /**
+   * Current persistent WebSocket connection status.
+   */
+  readonly connectionStatus: WebSocketDuckDbConnectionStatus;
+
+  /**
+   * Subscribe to persistent WebSocket connection lifecycle changes.
+   *
+   * @returns Unsubscribe callback.
+   */
+  subscribeConnectionStatus(
+    listener: (status: WebSocketDuckDbConnectionStatus) => void,
+  ): () => void;
 }
 
 /**
@@ -71,6 +99,11 @@ export function createWebSocketDuckDbConnector(
   // Persistent socket and per-query waiters
   let socket: WebSocket | null = null;
   let opening: Promise<void> | null = null;
+  let intentionalClose = false;
+  let connectionStatus: WebSocketDuckDbConnectionStatus = 'idle';
+  const connectionStatusListeners = new Set<
+    (status: WebSocketDuckDbConnectionStatus) => void
+  >();
   const lastSubscribedChannels: string[] | undefined = subscribeChannels;
   const pending = new Map<
     string,
@@ -104,6 +137,21 @@ export function createWebSocketDuckDbConnector(
     }
   };
 
+  const setConnectionStatus = (status: WebSocketDuckDbConnectionStatus) => {
+    if (connectionStatus === status) return;
+    connectionStatus = status;
+    try {
+      options.onConnectionStatusChange?.(status);
+      // eslint-disable-next-line no-empty
+    } catch {}
+    for (const listener of connectionStatusListeners) {
+      try {
+        listener(status);
+        // eslint-disable-next-line no-empty
+      } catch {}
+    }
+  };
+
   // Guard to avoid duplicate subscribe sends on open + initialize
   const resubscribe = () => {
     if (!socket || socket.readyState !== WebSocket.OPEN) return;
@@ -120,10 +168,12 @@ export function createWebSocketDuckDbConnector(
     if (socket && socket.readyState === WebSocket.OPEN)
       return Promise.resolve();
     if (opening) return opening;
+    setConnectionStatus('connecting');
     opening = new Promise<void>((resolve, reject) => {
       try {
         const ws = new WebSocket(wsUrl);
         socket = ws;
+        intentionalClose = false;
         ws.binaryType = 'arraybuffer';
 
         let authAcked = !authToken;
@@ -140,6 +190,7 @@ export function createWebSocketDuckDbConnector(
               // No auth required; resolve immediately
               opening = null;
               resubscribe();
+              setConnectionStatus('connected');
               resolve();
             }
             // eslint-disable-next-line no-empty
@@ -162,10 +213,12 @@ export function createWebSocketDuckDbConnector(
                   opening = null;
                   // Subscribe once authed
                   resubscribe();
+                  setConnectionStatus('connected');
                   resolve();
                 } else if (t === 'error') {
                   const msg = parsed?.error || 'Unauthorized';
                   opening = null;
+                  setConnectionStatus('disconnected');
                   reject(new Error(msg));
                 }
                 return;
@@ -280,6 +333,7 @@ export function createWebSocketDuckDbConnector(
             ws.close();
             // eslint-disable-next-line no-empty
           } catch {}
+          setConnectionStatus('disconnected');
         };
 
         ws.onclose = () => {
@@ -289,9 +343,12 @@ export function createWebSocketDuckDbConnector(
           }
           closeAndRejectAll('WebSocket closed');
           socket = null;
+          setConnectionStatus(intentionalClose ? 'idle' : 'disconnected');
+          intentionalClose = false;
         };
       } catch (e) {
         opening = null;
+        setConnectionStatus('disconnected');
         reject(e);
       }
     });
@@ -307,10 +364,12 @@ export function createWebSocketDuckDbConnector(
 
     async destroyInternal() {
       try {
+        intentionalClose = true;
         socket?.close();
         // eslint-disable-next-line no-empty
       } catch {}
       socket = null;
+      setConnectionStatus('idle');
     },
 
     async executeQueryInternal<T extends arrow.TypeMap = any>(
@@ -460,6 +519,15 @@ export function createWebSocketDuckDbConnector(
     ...base,
     get type() {
       return 'ws' as const;
+    },
+    get connectionStatus() {
+      return connectionStatus;
+    },
+    subscribeConnectionStatus(listener) {
+      connectionStatusListeners.add(listener);
+      return () => {
+        connectionStatusListeners.delete(listener);
+      };
     },
   };
 }

--- a/packages/duckdb/src/connectors/WebSocketDuckDbConnector.ts
+++ b/packages/duckdb/src/connectors/WebSocketDuckDbConnector.ts
@@ -67,6 +67,12 @@ export interface WebSocketDuckDbConnector extends DuckDbConnector {
   subscribeConnectionStatus(
     listener: (status: WebSocketDuckDbConnectionStatus) => void,
   ): () => void;
+
+  /**
+   * Reopen the persistent WebSocket and rerun connector initialization SQL
+   * without destroying the connector instance.
+   */
+  reconnect(): Promise<void>;
 }
 
 /**
@@ -528,6 +534,15 @@ export function createWebSocketDuckDbConnector(
       return () => {
         connectionStatusListeners.delete(listener);
       };
+    },
+    async reconnect() {
+      await ensureSocket();
+      if (initializationQuery) {
+        await impl.executeQueryInternal(
+          initializationQuery,
+          new AbortController().signal,
+        );
+      }
     },
   };
 }

--- a/packages/duckdb/src/index.ts
+++ b/packages/duckdb/src/index.ts
@@ -25,6 +25,7 @@ export {
 export {
   createWebSocketDuckDbConnector,
   type WebSocketDuckDbConnector,
+  type WebSocketDuckDbConnectionStatus,
   type WebSocketDuckDbConnectorOptions,
 } from './connectors/WebSocketDuckDbConnector';
 


### PR DESCRIPTION
## Summary
- Add persistent WebSocket connection status tracking to the DuckDB connector.
- Surface connection lifecycle changes through a new reconnect API and subscription hook.
- Show a CLI UI dialog when the local SQLRooms server disconnects, with manual retry and auto-reconnect.
- Document the new connection-status APIs in the DuckDB package README.

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added connection loss detection and recovery dialog for DuckDB connections
  * Automatic reconnection with exponential backoff and visible retry feedback
  * Manual retry option available when connection is lost
  * Database table schemas automatically refresh upon successful reconnection

* **Documentation**
  * Added guidance on monitoring WebSocket DuckDB connection status and implementing reconnect handlers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->