### PR TITLE
fix: Remove hardcoded agent temperatures

### DIFF
--- a/apps/sqlrooms-cli-ui/src/ai/createWorksheetAgentTool.ts
+++ b/apps/sqlrooms-cli-ui/src/ai/createWorksheetAgentTool.ts
@@ -280,13 +280,6 @@ const WorksheetAgentInputSchema = z.object({
     .optional()
     .default(20)
     .describe('Maximum exploration steps (default: 20, range: 5-50)'),
-  temperature: z
-    .number()
-    .optional()
-    .default(0.7)
-    .describe(
-      'Model temperature for creativity vs consistency (default: 0.7, range: 0.0-1.0)',
-    ),
 });
 
 type WorksheetAgentInputSchema = z.infer<typeof WorksheetAgentInputSchema>;
@@ -352,7 +345,7 @@ ${htmlAppBlocksEnabled ? '- App requests in worksheets: "create an app", "make a
 IMPORTANT: IF primary artefact in run context is a worksheet, prioritize using this tool for any queries or data analysis tasks.`,
     inputSchema: WorksheetAgentInputSchema,
     execute: async (params, toolOptions): Promise<WorksheetAgentResult> => {
-      const {worksheetId, maxSteps, temperature} = params;
+      const {worksheetId, maxSteps} = params;
       const {intent} = params;
 
       try {
@@ -377,7 +370,6 @@ IMPORTANT: IF primary artefact in run context is a worksheet, prioritize using t
             }),
             ...dataTools,
           },
-          temperature: Math.max(0, Math.min(1, temperature ?? 0.7)),
           stopWhen: [stepCountIs(Math.max(5, Math.min(50, maxSteps ?? 20)))],
           instructions: [
             options.instructions ?? getWorksheetAgentInstructions(options),

--- a/apps/sqlrooms-cli-ui/src/createHtmlAppAgent.ts
+++ b/apps/sqlrooms-cli-ui/src/createHtmlAppAgent.ts
@@ -270,7 +270,6 @@ Use this after making the requested scoped edit to the existing files. Preserve 
     tools: {
       write_html_app_source: writeHtmlAppSourceTool,
     },
-    temperature: 0.1,
     stopWhen: [
       stepCountIs(
         Math.max(3, Math.min(10, (input.maxRepairAttempts ?? 1) + 4)),
@@ -350,7 +349,6 @@ For a self-contained iframe app, prefer the html field. Use files only when mult
       ...dataTools,
       write_html_app_source: writeHtmlAppSourceTool,
     },
-    temperature: 0.2,
     stopWhen: [
       stepCountIs(
         Math.max(4, Math.min(16, (input.maxRepairAttempts ?? 1) + 6)),

--- a/packages/ai/src/skills/authoring/SkillAuthoringAgent.ts
+++ b/packages/ai/src/skills/authoring/SkillAuthoringAgent.ts
@@ -37,7 +37,7 @@ export interface CreateSkillAuthoringAgentOptions {
   onSave: SaveSkillCallback;
   /** Maximum tool-loop steps. Defaults to `DEFAULT_SKILL_AUTHORING_STOP_STEPS`. */
   stopSteps?: number;
-  /** Sampling temperature. Defaults to `0.2` for focused scaffolding output. */
+  /** Optional sampling temperature. Omit it to use the model/provider default. */
   temperature?: number;
 }
 
@@ -52,7 +52,7 @@ export function createSkillAuthoringAgent({
   draftStore,
   onSave,
   stopSteps = DEFAULT_SKILL_AUTHORING_STOP_STEPS,
-  temperature = 0.2,
+  temperature,
 }: CreateSkillAuthoringAgentOptions) {
   const tools = {
     writeManifest: createWriteManifestTool(draftStore, context),
@@ -65,6 +65,6 @@ export function createSkillAuthoringAgent({
     tools,
     instructions: buildSkillAuthoringSystemPrompt(context),
     stopWhen: stepCountIs(stopSteps),
-    temperature,
+    ...(temperature === undefined ? {} : {temperature}),
   });
 }

--- a/packages/mosaic/src/ai/dashboard/createDashboardAgentTool.ts
+++ b/packages/mosaic/src/ai/dashboard/createDashboardAgentTool.ts
@@ -120,13 +120,6 @@ const DashboardAgentInputSchema = z.object({
     .optional()
     .default(20)
     .describe('Maximum exploration steps (default: 20, range: 5-50)'),
-  temperature: z
-    .number()
-    .optional()
-    .default(0.7)
-    .describe(
-      'Model temperature for creativity vs consistency (default: 0.7, range: 0.0-1.0)',
-    ),
 });
 
 type DashboardAgentInputSchema = z.infer<typeof DashboardAgentInputSchema>;
@@ -169,7 +162,7 @@ The agent will explore the data and create 3-5 panels showing different aspects 
 IMPORTANT: IF primary artefact in run context is a dashboard, prioritize using this tool for any queries or data analysis tasks.`,
     inputSchema: DashboardAgentInputSchema,
     execute: async (params, toolOptions): Promise<DashboardAgentResult> => {
-      const {dashboardId, maxSteps, temperature} = params;
+      const {dashboardId, maxSteps} = params;
       const {intent} = params;
 
       const dashboardAdapter = createDashboardAiAdapter(store, dashboardId);
@@ -202,7 +195,6 @@ IMPORTANT: IF primary artefact in run context is a dashboard, prioritize using t
               extraTools,
             }),
           },
-          temperature: Math.max(0, Math.min(1, temperature ?? 0.7)),
           stopWhen: [stepCountIs(Math.max(5, Math.min(50, maxSteps ?? 20)))],
           instructions: [
             options.instructions ?? getDashboardAgentInstructions(options),


### PR DESCRIPTION
## Summary
- stop passing fixed temperature values into worksheet, dashboard, and HTML app agents
- let skill authoring use the model or provider default unless a temperature is explicitly supplied
- update the skill authoring option docs to reflect the optional behavior

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed custom temperature configuration from worksheet agent, HTML app agents, skill authoring agent, and dashboard agent tools. These agents will now use default temperature settings from the underlying model providers instead of accepting user-specified values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->