### PR TITLE
fix(skill-authoring): prevent skill markdown preview from overflowing

### DIFF
--- a/packages/ai/src/skills/authoring/SkillDraftPreview.tsx
+++ b/packages/ai/src/skills/authoring/SkillDraftPreview.tsx
@@ -44,8 +44,8 @@ export const SkillDraftPreview: React.FC<SkillDraftPreviewProps> = ({
           )}
 
           {hasInstructions ? (
-            <div className="bg-muted/20 rounded-md p-3">
-              <div className="prose prose-sm dark:prose-invert max-w-none">
+            <div className="bg-muted/20 min-w-0 rounded-md p-3">
+              <div className="prose prose-sm dark:prose-invert max-w-none wrap-break-word [&_pre]:overflow-x-auto">
                 <ReactMarkdown remarkPlugins={[remarkGfm]}>
                   {instructions}
                 </ReactMarkdown>
@@ -59,6 +59,7 @@ export const SkillDraftPreview: React.FC<SkillDraftPreviewProps> = ({
           )}
         </div>
         <ScrollBar orientation="vertical" />
+        <ScrollBar orientation="horizontal" />
       </ScrollArea>
     </div>
   );


### PR DESCRIPTION
## Summary
- Add `min-w-0` to the preview container so it can shrink instead of forcing overflow
- Apply `wrap-break-word` and `[&_pre]:overflow-x-auto` to the prose wrapper so long strings wrap and wide code blocks scroll within bounds
- Add a horizontal `ScrollBar` to the preview `ScrollArea`

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the instructions preview layout so long code blocks and markdown content are easier to view without breaking the layout.
  - Added horizontal scrolling support in the preview area to better handle wide content.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->