### PR TITLE
fix: Mosaic table references for memory-backed datasets

### DIFF
--- a/packages/mosaic/__tests__/chart-types/line-chart-spec.test.ts
+++ b/packages/mosaic/__tests__/chart-types/line-chart-spec.test.ts
@@ -83,6 +83,30 @@ describe('createLineChartSpec', () => {
     );
   });
 
+  it('omits memory catalog identities from generated data sources', () => {
+    const settings: LineChartSettings = {
+      x: 'date',
+      yFields: [{field: 'sales'}],
+      showLegend: false,
+    };
+
+    const spec = createLineChartSpec({
+      dataTable: {
+        ...mockDataTable,
+        table: makeQualifiedTableName({
+          database: 'memory',
+          schema: 'main',
+          table: 'events',
+        }),
+      },
+      settings,
+      selectionName: 'test_selection',
+    }) as any;
+
+    expect(spec.plot[0].data.from).toBe('"main"."events"');
+    expect(spec.plot[0].data.from).not.toContain('memory');
+  });
+
   it('generates spec with legend when showLegend is true', () => {
     const settings: LineChartSettings = {
       x: 'date',

--- a/packages/mosaic/__tests__/dashboard-ai-tools.test.ts
+++ b/packages/mosaic/__tests__/dashboard-ai-tools.test.ts
@@ -7,6 +7,7 @@ import type {DatabaseAiAdapter} from '../src/ai/database-types';
 import type {DashboardAiAdapter} from '../src/ai/dashboard/dashboard-types';
 import {MOSAIC_DASHBOARD_CHART_PANEL_TYPE} from '../src/dashboard/dashboard-types';
 import {MOSAIC_DASHBOARD_COMMAND_IDS} from '../src/dashboard/MosaicDashboardCommands';
+import {makeQualifiedTableName} from '@sqlrooms/duckdb';
 
 describe('createDashboardAiTools', () => {
   it('lists dashboard panels with selected table and runtime issues', async () => {
@@ -99,6 +100,11 @@ describe('createDashboardAiTools', () => {
       getTables: () => [],
       findTable: () =>
         ({
+          table: makeQualifiedTableName({
+            database: 'memory',
+            schema: 'main',
+            table: 'earthquakes',
+          }),
           tableName: 'earthquakes',
           columns: [{name: 'depth', type: 'DOUBLE'}],
         }) as any,
@@ -121,7 +127,9 @@ describe('createDashboardAiTools', () => {
 
     expect(result.success).toBe(true);
     expect(addPanel).not.toHaveBeenCalled();
-    expect(setSelectedTable).toHaveBeenCalledWith('earthquakes');
+    expect(setSelectedTable).toHaveBeenCalledWith(
+      '"memory"."main"."earthquakes"',
+    );
     expect(updatePanel).toHaveBeenCalledWith('panel-1', {
       title: 'Depth histogram',
       config: {
@@ -133,9 +141,10 @@ describe('createDashboardAiTools', () => {
 
   it('returns an error when panelId references a missing panel', async () => {
     const updatePanel = jest.fn();
+    const setSelectedTable = jest.fn();
     const dashboardAdapter: DashboardAiAdapter = {
       getPanel: () => undefined,
-      setSelectedTable: () => {},
+      setSelectedTable,
       addPanel: () => 'new-panel',
       updatePanel,
       removePanel: () => {},
@@ -167,11 +176,13 @@ describe('createDashboardAiTools', () => {
 
     expect(result.success).toBe(false);
     expect(result.errorMessage).toContain('Panel "missing-panel" not found');
+    expect(setSelectedTable).not.toHaveBeenCalled();
     expect(updatePanel).not.toHaveBeenCalled();
   });
 
   it('returns an error when panelId references a non-chart panel', async () => {
     const updatePanel = jest.fn();
+    const setSelectedTable = jest.fn();
     const dashboardAdapter: DashboardAiAdapter = {
       getPanel: () => ({
         id: 'panel-1',
@@ -179,7 +190,7 @@ describe('createDashboardAiTools', () => {
         title: 'Data Explorer',
         config: {},
       }),
-      setSelectedTable: () => {},
+      setSelectedTable,
       addPanel: () => 'new-panel',
       updatePanel,
       removePanel: () => {},
@@ -213,6 +224,7 @@ describe('createDashboardAiTools', () => {
     expect(result.errorMessage).toContain(
       'Panel "panel-1" is not a chart panel',
     );
+    expect(setSelectedTable).not.toHaveBeenCalled();
     expect(updatePanel).not.toHaveBeenCalled();
   });
 });

--- a/packages/mosaic/__tests__/data-table-explorer.utils.test.ts
+++ b/packages/mosaic/__tests__/data-table-explorer.utils.test.ts
@@ -46,6 +46,17 @@ describe('dataTableExplorer utils', () => {
     expect(query.toString()).not.toContain('sqlrooms-cli');
   });
 
+  it('builds SQL from DuckDB WASM memory table identities without the catalog', () => {
+    const query = buildDataTableExplorerBaseQuery({
+      columns: ['Magnitude'],
+      tableName: getMosaicSqlTableReference('"memory"."main"."events"'),
+    });
+
+    expect(query.toString()).toContain('FROM "main"."events"');
+    expect(query.toString()).not.toContain('memory');
+    expect(query.toString()).not.toContain('""memory""');
+  });
+
   it('sanitizes invalid pagination values before generating LIMIT/OFFSET', () => {
     const base = buildDataTableExplorerBaseQuery({
       columns: ['Magnitude'],

--- a/packages/mosaic/__tests__/mosaicTableReference.test.ts
+++ b/packages/mosaic/__tests__/mosaicTableReference.test.ts
@@ -1,8 +1,10 @@
 import {makeQualifiedTableName} from '@sqlrooms/db';
 import {
+  getMosaicRawSqlTableReference,
   getMosaicSqlTableReference,
   getMosaicTableIdentity,
-  getMosaicTableReferenceString,
+  getMosaicVgPlotTableReference,
+  resolveMosaicTableReference,
 } from '../src/mosaicTableReference';
 
 describe('mosaic table references', () => {
@@ -22,14 +24,16 @@ describe('mosaic table references', () => {
     expect(getMosaicTableIdentity(second)).toBe('"db2"."main"."orders"');
   });
 
-  it('drops the catalog and quotes schema/table for Mosaic string APIs', () => {
+  it('drops the catalog and quotes schema/table for vgplot string refs', () => {
     const table = makeQualifiedTableName({
       database: 'sqlrooms-cli',
       schema: 'main',
       table: 'earthquakes',
     });
 
-    expect(getMosaicTableReferenceString(table)).toBe('"main"."earthquakes"');
+    expect(getMosaicVgPlotTableReference(table)).toBe(
+      '"main"."earthquakes"',
+    );
   });
 
   it('preserves dotted and quoted identifier boundaries', () => {
@@ -39,7 +43,9 @@ describe('mosaic table references', () => {
       table: 'events"2026',
     });
 
-    expect(getMosaicTableReferenceString(table)).toBe('"ma.in"."events""2026"');
+    expect(getMosaicVgPlotTableReference(table)).toBe(
+      '"ma.in"."events""2026"',
+    );
     expect(getMosaicSqlTableReference(table).toString()).toContain(
       '"ma.in"."events""2026"',
     );
@@ -52,5 +58,66 @@ describe('mosaic table references', () => {
 
     expect(tableRef.toString()).toContain('"main"."earthquakes"');
     expect(tableRef.toString()).not.toContain('sqlrooms-cli');
+  });
+
+  it('keeps memory catalog identities out of Mosaic execution references', () => {
+    const identity = '"memory"."main"."events"';
+
+    expect(getMosaicTableIdentity(identity)).toBe(identity);
+    expect(getMosaicSqlTableReference(identity).toString()).toContain(
+      '"main"."events"',
+    );
+    expect(getMosaicSqlTableReference(identity).toString()).not.toContain(
+      'memory',
+    );
+    expect(getMosaicVgPlotTableReference(identity)).toBe('"main"."events"');
+    expect(getMosaicRawSqlTableReference(identity)).toBe('"main"."events"');
+  });
+
+  it('preserves dotted table identifiers when building raw SQL refs', () => {
+    expect(getMosaicRawSqlTableReference('"main"."events.with.dot"')).toBe(
+      '"main"."events.with.dot"',
+    );
+    expect(
+      getMosaicSqlTableReference('"main"."events.with.dot"').toString(),
+    ).toContain('"main"."events.with.dot"');
+  });
+
+  it('resolves legacy bare table names only when unambiguous', () => {
+    const mainEvents = {
+      table: makeQualifiedTableName({
+        database: 'memory',
+        schema: 'main',
+        table: 'events',
+      }),
+    };
+    const analyticsEvents = {
+      table: makeQualifiedTableName({
+        database: 'memory',
+        schema: 'analytics',
+        table: 'events',
+      }),
+    };
+    const orders = {
+      table: makeQualifiedTableName({
+        database: 'memory',
+        schema: 'main',
+        table: 'orders',
+      }),
+    };
+
+    expect(
+      resolveMosaicTableReference([mainEvents, orders], 'events').table,
+    ).toBe(mainEvents);
+    expect(
+      resolveMosaicTableReference(
+        [mainEvents, analyticsEvents],
+        '"memory"."main"."events"',
+      ).table,
+    ).toBe(mainEvents);
+    expect(
+      resolveMosaicTableReference([mainEvents, analyticsEvents], 'events')
+        .ambiguousMatches,
+    ).toEqual([mainEvents, analyticsEvents]);
   });
 });

--- a/packages/mosaic/src/ai/block-document/createBlockDocumentChartTools.ts
+++ b/packages/mosaic/src/ai/block-document/createBlockDocumentChartTools.ts
@@ -48,7 +48,13 @@ export function createBlockDocumentChartTools({
       const resolvedTable = databaseAdapter.findTable(tableName);
       const tableIdentity = resolvedTable?.table
         ? getMosaicTableIdentity(resolvedTable.table)
-        : tableName;
+        : getMosaicTableIdentity(tableName);
+
+      if (!tableIdentity) {
+        throw new Error(
+          'tableName is required for block document chart blocks but was empty or undefined',
+        );
+      }
 
       return blockDocumentAdapter.addBlock(blockDocumentId, {
         type: 'chart',

--- a/packages/mosaic/src/ai/block-document/createBlockDocumentChartTools.ts
+++ b/packages/mosaic/src/ai/block-document/createBlockDocumentChartTools.ts
@@ -10,6 +10,7 @@ import type {ChartToolsOptions} from '../types';
 import {DEFAULT_CHART_MAX_DATA_POINTS} from '../constants';
 import {resolveChartTypes} from '../../charts/chart-types/resolveChartTypes';
 import {BLOCK_DOCUMENT_CHART_TOOL_PREFIX} from './constants';
+import {getMosaicTableIdentity} from '../../mosaicTableReference';
 
 /**
  * Parameters for creating Mosaic chart tools that append chart blocks to a
@@ -44,11 +45,16 @@ export function createBlockDocumentChartTools({
         );
       }
 
+      const resolvedTable = databaseAdapter.findTable(tableName);
+      const tableIdentity = resolvedTable?.table
+        ? getMosaicTableIdentity(resolvedTable.table)
+        : tableName;
+
       return blockDocumentAdapter.addBlock(blockDocumentId, {
         type: 'chart',
         id: createDefaultBlockDocumentBlockId(),
         config,
-        tableName,
+        tableName: tableIdentity,
         caption: title ?? 'Chart',
       });
     },

--- a/packages/mosaic/src/ai/block-document/createBlockDocumentDataTableExplorerTool.ts
+++ b/packages/mosaic/src/ai/block-document/createBlockDocumentDataTableExplorerTool.ts
@@ -57,7 +57,13 @@ export function createBlockDocumentDataTableExplorerTool({
       const resolvedTable = databaseAdapter.findTable(tableName);
       const tableIdentity = resolvedTable?.table
         ? getMosaicTableIdentity(resolvedTable.table)
-        : tableName;
+        : getMosaicTableIdentity(tableName);
+
+      if (!tableIdentity) {
+        throw new Error(
+          'Table name is required to add a data table explorer block',
+        );
+      }
 
       if (addDataTableExplorerBlock) {
         return await addDataTableExplorerBlock({

--- a/packages/mosaic/src/ai/block-document/createBlockDocumentDataTableExplorerTool.ts
+++ b/packages/mosaic/src/ai/block-document/createBlockDocumentDataTableExplorerTool.ts
@@ -5,6 +5,7 @@ import type {
 } from '@sqlrooms/documents';
 import {createDataTableExplorerTool} from '../createDataTableExplorerTool';
 import type {DatabaseAiAdapter} from '../database-types';
+import {getMosaicTableIdentity} from '../../mosaicTableReference';
 
 /**
  * Parameters for creating a Mosaic data-table explorer block-document tool.
@@ -53,10 +54,15 @@ export function createBlockDocumentDataTableExplorerTool({
       }
 
       blockDocumentAdapter.ensureBlockDocument(blockDocumentId);
+      const resolvedTable = databaseAdapter.findTable(tableName);
+      const tableIdentity = resolvedTable?.table
+        ? getMosaicTableIdentity(resolvedTable.table)
+        : tableName;
+
       if (addDataTableExplorerBlock) {
         return await addDataTableExplorerBlock({
           title: title ?? 'Data Table Explorer',
-          tableName,
+          tableName: tableIdentity,
           intent,
         });
       }
@@ -65,7 +71,7 @@ export function createBlockDocumentDataTableExplorerTool({
         blockDocumentId,
         await createDataTableExplorerBlock({
           title: title ?? 'Data Table Explorer',
-          tableName,
+          tableName: tableIdentity,
           intent,
         }),
       );

--- a/packages/mosaic/src/ai/dashboard/createDashboardAgentTool.ts
+++ b/packages/mosaic/src/ai/dashboard/createDashboardAgentTool.ts
@@ -14,6 +14,7 @@ import {resolveChartTypes} from '../../charts/chart-types/resolveChartTypes';
 import {createChartToolsInstructions} from '../../charts/chart-types/createChartInstructions';
 import {DASHBOARD_CHART_TOOL_PREFIX, KnownDashboardTools} from './constants';
 import {AgentIntentSchemaFields} from '../agentIntent';
+import {getMosaicTableIdentity} from '../../mosaicTableReference';
 
 function getDashboardAgentInstructions<TState>(
   options: CreateDashboardAgentToolOptions<TState>,
@@ -178,9 +179,11 @@ IMPORTANT: IF primary artefact in run context is a dashboard, prioritize using t
           );
         }
 
-        ensureTable(databaseAdapter, tableName);
+        const dataTable = ensureTable(databaseAdapter, tableName);
 
-        await dashboardAdapter.setSelectedTable(tableName);
+        await dashboardAdapter.setSelectedTable(
+          dataTable.table ? getMosaicTableIdentity(dataTable.table) : tableName,
+        );
 
         const dataTools = options.createDataTools?.({store}) ?? {};
 

--- a/packages/mosaic/src/ai/dashboard/createDashboardChartTools.ts
+++ b/packages/mosaic/src/ai/dashboard/createDashboardChartTools.ts
@@ -9,6 +9,7 @@ import {DEFAULT_CHART_MAX_DATA_POINTS} from '../../chart-runtime';
 import {resolveChartTypes} from '../../charts/chart-types/resolveChartTypes';
 import {DASHBOARD_CHART_TOOL_PREFIX} from './constants';
 import {MOSAIC_DASHBOARD_CHART_PANEL_TYPE} from '../../dashboard/dashboard-types';
+import {getMosaicTableIdentity} from '../../mosaicTableReference';
 
 /**
  * Parameters for creating dashboard chart tools.
@@ -44,6 +45,17 @@ export function createDashboardChartTools({
       chartToolsOptions?.chartMaxDataPoints ?? DEFAULT_CHART_MAX_DATA_POINTS,
     databaseAdapter,
     addChart: async ({config, tableName, title, panelId}) => {
+      const resolvedTable = tableName
+        ? databaseAdapter.findTable(tableName)
+        : undefined;
+      const selectedTableIdentity = resolvedTable?.table
+        ? getMosaicTableIdentity(resolvedTable.table)
+        : tableName;
+
+      if (selectedTableIdentity) {
+        await dashboardAdapter.setSelectedTable(selectedTableIdentity);
+      }
+
       if (panelId) {
         const panel = dashboardAdapter.getPanel(panelId);
         if (!panel) {
@@ -55,9 +67,6 @@ export function createDashboardChartTools({
           );
         }
 
-        if (tableName) {
-          await dashboardAdapter.setSelectedTable(tableName);
-        }
         await dashboardAdapter.updatePanel(panelId, {
           title: title ?? panel.title,
           config,

--- a/packages/mosaic/src/ai/dashboard/createDashboardChartTools.ts
+++ b/packages/mosaic/src/ai/dashboard/createDashboardChartTools.ts
@@ -45,17 +45,7 @@ export function createDashboardChartTools({
       chartToolsOptions?.chartMaxDataPoints ?? DEFAULT_CHART_MAX_DATA_POINTS,
     databaseAdapter,
     addChart: async ({config, tableName, title, panelId}) => {
-      const resolvedTable = tableName
-        ? databaseAdapter.findTable(tableName)
-        : undefined;
-      const selectedTableIdentity = resolvedTable?.table
-        ? getMosaicTableIdentity(resolvedTable.table)
-        : tableName;
-
-      if (selectedTableIdentity) {
-        await dashboardAdapter.setSelectedTable(selectedTableIdentity);
-      }
-
+      let panelTitle: string | undefined;
       if (panelId) {
         const panel = dashboardAdapter.getPanel(panelId);
         if (!panel) {
@@ -66,9 +56,23 @@ export function createDashboardChartTools({
             `Panel "${panelId}" is not a chart panel. Cannot update it with a chart tool.`,
           );
         }
+        panelTitle = panel.title;
+      }
 
+      const resolvedTable = tableName
+        ? databaseAdapter.findTable(tableName)
+        : undefined;
+      const selectedTableIdentity = resolvedTable?.table
+        ? getMosaicTableIdentity(resolvedTable.table)
+        : undefined;
+
+      if (selectedTableIdentity) {
+        await dashboardAdapter.setSelectedTable(selectedTableIdentity);
+      }
+
+      if (panelId) {
         await dashboardAdapter.updatePanel(panelId, {
-          title: title ?? panel.title,
+          title: title ?? panelTitle,
           config,
         });
         return panelId;

--- a/packages/mosaic/src/ai/dashboard/createDashboardDataTableExplorerTool.ts
+++ b/packages/mosaic/src/ai/dashboard/createDashboardDataTableExplorerTool.ts
@@ -5,6 +5,7 @@ import {createMosaicDashboardDataTableExplorerPanelConfig} from '../../dashboard
 import {DatabaseAiAdapter} from '../database-types';
 import {DashboardAiAdapter} from './dashboard-types';
 import {getMosaicTableIdentity} from '../../mosaicTableReference';
+import {ensureTable} from '../tool-helpers';
 
 /**
  * Parameters for creating a dashboard data table explorer tool.
@@ -33,14 +34,12 @@ export function createDashboardDataTableExplorerTool({
     databaseAdapter,
     addDataTable: async ({tableName, title}) => {
       const resolvedTable = tableName
-        ? databaseAdapter.findTable(tableName)
+        ? ensureTable(databaseAdapter, tableName)
         : undefined;
       if (resolvedTable?.table) {
         await dashboardAdapter.setSelectedTable(
           getMosaicTableIdentity(resolvedTable.table),
         );
-      } else if (tableName) {
-        await dashboardAdapter.setSelectedTable(tableName);
       }
 
       return dashboardAdapter.addPanel(

--- a/packages/mosaic/src/ai/dashboard/createDashboardDataTableExplorerTool.ts
+++ b/packages/mosaic/src/ai/dashboard/createDashboardDataTableExplorerTool.ts
@@ -4,6 +4,7 @@ import {createDataTableExplorerTool} from '../createDataTableExplorerTool';
 import {createMosaicDashboardDataTableExplorerPanelConfig} from '../../dashboard/MosaicDashboardSlice';
 import {DatabaseAiAdapter} from '../database-types';
 import {DashboardAiAdapter} from './dashboard-types';
+import {getMosaicTableIdentity} from '../../mosaicTableReference';
 
 /**
  * Parameters for creating a dashboard data table explorer tool.
@@ -30,11 +31,23 @@ export function createDashboardDataTableExplorerTool({
 }: CreateDashboardDataTableExplorerToolParams): Tool {
   return createDataTableExplorerTool({
     databaseAdapter,
-    addDataTable: ({title}) =>
-      dashboardAdapter.addPanel(
+    addDataTable: async ({tableName, title}) => {
+      const resolvedTable = tableName
+        ? databaseAdapter.findTable(tableName)
+        : undefined;
+      if (resolvedTable?.table) {
+        await dashboardAdapter.setSelectedTable(
+          getMosaicTableIdentity(resolvedTable.table),
+        );
+      } else if (tableName) {
+        await dashboardAdapter.setSelectedTable(tableName);
+      }
+
+      return dashboardAdapter.addPanel(
         createMosaicDashboardDataTableExplorerPanelConfig({
           title,
         }),
-      ),
+      );
+    },
   });
 }

--- a/packages/mosaic/src/charts/chart-types/base-types.ts
+++ b/packages/mosaic/src/charts/chart-types/base-types.ts
@@ -22,7 +22,7 @@ import type {
 } from '../../chart-runtime';
 import {ChartToolParams} from './tool-types';
 import {DataTable, type QualifiedTableName} from '@sqlrooms/duckdb';
-import {getMosaicTableReferenceString} from '../../mosaicTableReference';
+import {getMosaicVgPlotTableReference} from '../../mosaicTableReference';
 import type {ChartBuilderColumn} from './column-types';
 
 export type {ChartType};
@@ -197,7 +197,7 @@ export type ValidateSpecOptions<TSettings = ChartSettings> = Pick<
 >;
 
 export function getChartTableReference(dataTable: DataTable): string {
-  return getMosaicTableReferenceString(dataTable.table);
+  return getMosaicVgPlotTableReference(dataTable.table);
 }
 
 export const getChartTableReferenceString = getChartTableReference;

--- a/packages/mosaic/src/charts/chart-types/box-plot/renderer/BoxPlotClient.ts
+++ b/packages/mosaic/src/charts/chart-types/box-plot/renderer/BoxPlotClient.ts
@@ -12,7 +12,7 @@ import {
   type ChartRuntimeIssueContext,
   type ChartRuntimeIssueReporter,
 } from '../../../../chart-runtime';
-import {getMosaicSqlTableReference} from '../../../../mosaicTableReference';
+import {getMosaicRawSqlTableReference} from '../../../../mosaicTableReference';
 
 export type BoxPlotSummaryRow = {
   category: unknown;
@@ -48,7 +48,7 @@ export type BoxPlotState = {
  * @property runtimeIssueReporter - Optional reporter used for query and policy failures.
  * @property selection - Mosaic selection used for external filters and y-axis brushing.
  * @property table - Canonical SQLRooms table identity. The client converts it
- *   with `getMosaicSqlTableReference`, so callers should pass the structured
+ *   with `getMosaicRawSqlTableReference`, so callers should pass the structured
  *   `QualifiedTableName` instead of a pre-rendered SQL string.
  * @property x - Category column name.
  * @property y - Numeric value column name.
@@ -151,11 +151,11 @@ type BuildBoxPlotQueryArgs = {
  * @returns SQL that returns summary rows and outlier rows for the box plot.
  *
  * The structured `QualifiedTableName` is converted with
- * `getMosaicSqlTableReference`, which intentionally produces the table
- * reference shape expected by Mosaic queries.
+ * `getMosaicRawSqlTableReference`, which intentionally produces the
+ * catalog-free SQL fragment expected by Mosaic's active connector.
  */
 export function buildBoxPlotQuery(args: BuildBoxPlotQueryArgs): string {
-  const tableReference = getMosaicSqlTableReference(args.table);
+  const tableReference = getMosaicRawSqlTableReference(args.table);
   const x = escapeId(args.x);
   const y = escapeId(args.y);
   const filters = normalizeFilter(args.filter).join(' AND ');

--- a/packages/mosaic/src/charts/dashboard/MosaicDashboardChartRenderer.tsx
+++ b/packages/mosaic/src/charts/dashboard/MosaicDashboardChartRenderer.tsx
@@ -1,5 +1,5 @@
 import {BarChart3Icon} from 'lucide-react';
-import {useCallback, type FC} from 'react';
+import {useCallback, useMemo, type FC} from 'react';
 import {MosaicDashboardChartHeaderActions} from './MosaicDashboardChartHeaderActions';
 import type {ChartPanelConfig} from '../../dashboard/dashboard-types';
 import {
@@ -10,7 +10,8 @@ import {
 } from '../../dashboard/MosaicDashboardSlice';
 import {ChartConfig} from '../chart-types/chart-config';
 import {MosaicChart} from '../MosaicChart';
-import {useDataTable} from '@sqlrooms/db';
+import {useTablesWithColumns} from '../../hooks/useTablesWithColumns';
+import {resolveMosaicTableReference} from '../../mosaicTableReference';
 
 const MosaicDashboardChartRenderer: FC<ChartPanelRendererProps> = ({
   panel,
@@ -19,7 +20,11 @@ const MosaicDashboardChartRenderer: FC<ChartPanelRendererProps> = ({
   selectionName,
 }) => {
   const tableName = dashboard.selectedTable;
-  const dataTable = useDataTable(tableName);
+  const tables = useTablesWithColumns();
+  const dataTable = useMemo(
+    () => resolveMosaicTableReference(tables, tableName).table,
+    [tableName, tables],
+  );
 
   const updatePanel = useStoreWithMosaicDashboard(
     (state) => state.mosaicDashboard.updatePanel,

--- a/packages/mosaic/src/dashboard/panel/MosaicDashboardPanels.tsx
+++ b/packages/mosaic/src/dashboard/panel/MosaicDashboardPanels.tsx
@@ -17,6 +17,10 @@ import {
 import {DataTableSelectorEmptyState} from '../../components/DataTableSelector';
 import {useTablesWithColumns} from '../../hooks/useTablesWithColumns';
 import type {DataTable} from '@sqlrooms/db';
+import {
+  getMosaicTableIdentity,
+  resolveMosaicTableReference,
+} from '../../mosaicTableReference';
 
 const EMPTY_DASHBOARD_PANELS: MosaicDashboardPanelConfig[] = [];
 
@@ -51,10 +55,14 @@ export const MosaicDashboardPanels: React.FC = () => {
   const setSelectedTable = useStoreWithMosaicDashboard(
     (state) => state.mosaicDashboard.setSelectedTable,
   );
+  const selectedDataTable = useMemo(
+    () => resolveMosaicTableReference(tables, selectedTable).table,
+    [selectedTable, tables],
+  );
 
   const handleTableChange = useCallback(
     (table: DataTable) => {
-      setSelectedTable(dashboardId, table.table.toString());
+      setSelectedTable(dashboardId, getMosaicTableIdentity(table.table));
     },
     [dashboardId, setSelectedTable],
   );
@@ -94,7 +102,7 @@ export const MosaicDashboardPanels: React.FC = () => {
     [dashboardId, setLayout],
   );
 
-  if (!selectedTable) {
+  if (!selectedDataTable) {
     return (
       <DataTableSelectorEmptyState
         onChange={handleTableChange}

--- a/packages/mosaic/src/dashboard/toolbar/MosaicDashboardDataTableSelector.tsx
+++ b/packages/mosaic/src/dashboard/toolbar/MosaicDashboardDataTableSelector.tsx
@@ -1,9 +1,12 @@
-import {FC, useCallback} from 'react';
+import {FC, useCallback, useMemo} from 'react';
 import {useStoreWithMosaicDashboard} from '../MosaicDashboardSlice';
 import {DataTableSelector} from '../../components/DataTableSelector';
 import {useTablesWithColumns} from '../../hooks/useTablesWithColumns';
-import {useDataTable} from '@sqlrooms/db';
 import type {DataTable} from '@sqlrooms/db';
+import {
+  getMosaicTableIdentity,
+  resolveMosaicTableReference,
+} from '../../mosaicTableReference';
 
 interface MosaicDashboardDataTableSelectorProps {
   dashboardId: string;
@@ -18,7 +21,10 @@ export const MosaicDashboardDataTableSelector: FC<
   );
   const selectedTableName = dashboard?.selectedTable;
 
-  const selectedTable = useDataTable(selectedTableName);
+  const selectedTable = useMemo(
+    () => resolveMosaicTableReference(tables, selectedTableName).table,
+    [selectedTableName, tables],
+  );
 
   const setSelectedTable = useStoreWithMosaicDashboard(
     (state) => state.mosaicDashboard.setSelectedTable,
@@ -26,7 +32,7 @@ export const MosaicDashboardDataTableSelector: FC<
 
   const handleTableChange = useCallback(
     (table: DataTable) => {
-      setSelectedTable(dashboardId, table.table.toString());
+      setSelectedTable(dashboardId, getMosaicTableIdentity(table.table));
     },
     [dashboardId, setSelectedTable],
   );

--- a/packages/mosaic/src/dashboard/toolbar/MosaicDashboardToolbar.tsx
+++ b/packages/mosaic/src/dashboard/toolbar/MosaicDashboardToolbar.tsx
@@ -1,11 +1,12 @@
-import {FC, useCallback} from 'react';
+import {FC, useCallback, useMemo} from 'react';
 import {useMosaicDashboardContext} from '../MosaicDashboardContext';
 import {useStoreWithMosaicDashboard} from '../MosaicDashboardSlice';
 import {MosaicDashboardAddPanelDropdown} from './MosaicDashboardAddPanelDropdown';
 import {MosaicDashboardResetFiltersButton} from './MosaicDashboardResetFiltersButton';
 import {MosaicDashboardDataTableSelector} from './MosaicDashboardDataTableSelector';
-import {useDataTable} from '@sqlrooms/db';
 import {BlockCaptionEditor} from '../../components/BlockCaptionEditor';
+import {useTablesWithColumns} from '../../hooks/useTablesWithColumns';
+import {resolveMosaicTableReference} from '../../mosaicTableReference';
 
 export const MosaicDashboardToolbar: FC = () => {
   const {dashboardId} = useMosaicDashboardContext();
@@ -16,7 +17,11 @@ export const MosaicDashboardToolbar: FC = () => {
   const selectedTableName = dashboard?.selectedTable;
   const dashboardTitle = dashboard?.title ?? '';
 
-  const selectedTable = useDataTable(selectedTableName);
+  const tables = useTablesWithColumns();
+  const selectedTable = useMemo(
+    () => resolveMosaicTableReference(tables, selectedTableName).table,
+    [selectedTableName, tables],
+  );
   const tableName = selectedTable?.table.table;
 
   const setDashboardTitle = useStoreWithMosaicDashboard(

--- a/packages/mosaic/src/dashboard/useSelectedOrFirstTable.ts
+++ b/packages/mosaic/src/dashboard/useSelectedOrFirstTable.ts
@@ -2,9 +2,10 @@ import {useMemo} from 'react';
 import {type DataTable} from '@sqlrooms/db';
 import {useStoreWithMosaicDashboard} from './MosaicDashboardSlice';
 import {useTablesWithColumns} from '../hooks/useTablesWithColumns';
+import {resolveMosaicTableReference} from '../mosaicTableReference';
 
 /**
- * Returns the last selected table for a dashboard if it exists,
+ * Returns the selected table for a dashboard if it exists,
  * otherwise falls back to the first table with columns.
  *
  * @param dashboardId - The dashboard ID
@@ -19,17 +20,21 @@ export function useSelectedOrFirstTable(
   const tables = useTablesWithColumns();
 
   return useMemo(() => {
-    const lastSelectedTableName = dashboard?.lastSelectedTable;
+    const selectedTableName =
+      dashboard?.selectedTable ?? dashboard?.lastSelectedTable;
 
-    if (!lastSelectedTableName) {
+    if (!selectedTableName) {
       return tables[0];
     }
 
-    // Try to find the last selected table first
-    const lastSelectedTable = tables.find(
-      (table) => table.table.table === lastSelectedTableName,
+    const {table, ambiguousMatches} = resolveMosaicTableReference(
+      tables,
+      selectedTableName,
     );
-    // Fall back to the first table if the selected one doesn't exist
-    return lastSelectedTable ?? tables[0];
-  }, [dashboard?.lastSelectedTable, tables]);
+    if (ambiguousMatches?.length) {
+      return undefined;
+    }
+
+    return table ?? tables[0];
+  }, [dashboard?.lastSelectedTable, dashboard?.selectedTable, tables]);
 }

--- a/packages/mosaic/src/data-table-explorer/dashboard/MosaicDashboardDataTableExplorerPanelRenderer.tsx
+++ b/packages/mosaic/src/data-table-explorer/dashboard/MosaicDashboardDataTableExplorerPanelRenderer.tsx
@@ -9,11 +9,12 @@ import {
 } from '../../dashboard/MosaicDashboardSlice';
 import {usePanelClientRegistration} from '../../dashboard/usePanelClientRegistration';
 import {useDataTableExplorerPanelClients} from './useDataTableExplorerPanelClients';
-import {FC} from 'react';
-import {useDataTable} from '@sqlrooms/db';
+import {FC, useMemo} from 'react';
 import {useDataTableExplorer} from '../useDataTableExplorer';
 import {MosaicDashboardDataTableExplorerHeaderActions} from './MosaicDashboardDataTableExplorerHeaderActions';
 import type {DataTable} from '@sqlrooms/db';
+import {useTablesWithColumns} from '../../hooks/useTablesWithColumns';
+import {resolveMosaicTableReference} from '../../mosaicTableReference';
 
 type MosaicDashboardDataTableExplorerRendererInnerProps = Omit<
   DataTableExplorerPanelRendererProps,
@@ -77,7 +78,11 @@ const MosaicDashboardDataTableExplorerRendererInner: FC<
 const MosaicDashboardDataTableExplorerRenderer: FC<
   DataTableExplorerPanelRendererProps
 > = ({panel, dashboard, selectionName}) => {
-  const selectedTable = useDataTable(dashboard.selectedTable);
+  const tables = useTablesWithColumns();
+  const selectedTable = useMemo(
+    () => resolveMosaicTableReference(tables, dashboard.selectedTable).table,
+    [dashboard.selectedTable, tables],
+  );
 
   if (!selectedTable) {
     return (

--- a/packages/mosaic/src/data-table-explorer/useDataTableExplorer.ts
+++ b/packages/mosaic/src/data-table-explorer/useDataTableExplorer.ts
@@ -13,9 +13,9 @@ import {useDataTableExplorerColumns} from './hooks/useDataTableExplorerColumns';
 import {useDataTableExplorerStatus} from './hooks/useDataTableExplorerStatus';
 import {useDataTableExplorerVisiblePage} from './hooks/useDataTableExplorerVisiblePage';
 import {
+  getMosaicRawSqlTableReference,
   getMosaicSqlTableReference,
   getMosaicTableIdentity,
-  getMosaicTableReferenceString,
 } from '../mosaicTableReference';
 
 /**
@@ -38,12 +38,12 @@ export function useDataTableExplorer(
 
   const tableIdentity = useMemo(() => getMosaicTableIdentity(table), [table]);
   const tableName = useMemo(
-    () => getMosaicTableReferenceString(table),
+    () => getMosaicRawSqlTableReference(table),
     [table],
   );
   const tableReference = useMemo(
-    () => getMosaicSqlTableReference(tableName),
-    [tableName],
+    () => getMosaicSqlTableReference(table),
+    [table],
   );
 
   const connection = useStoreWithMosaic((state) => state.mosaic.connection);

--- a/packages/mosaic/src/mosaicTableReference.ts
+++ b/packages/mosaic/src/mosaicTableReference.ts
@@ -1,10 +1,14 @@
 import {
   parseQualifiedSqlIdentifier,
+  escapeId,
   type QualifiedTableName,
+  resolveTableReference,
+  type ResolveTableReferenceResult,
 } from '@sqlrooms/db';
 import {asTableRef, type TableRefNode} from '@uwdata/mosaic-sql';
 
 export type MosaicTableReferenceInput = string | QualifiedTableName;
+export type MosaicTableReferenceCandidate = {table: QualifiedTableName};
 
 /**
  * Converts SQLRooms table identity into a Mosaic query table reference.
@@ -33,16 +37,54 @@ export function getMosaicTableIdentity(
 }
 
 /**
- * Converts SQLRooms table identity into a schema/table SQL string for APIs that
- * only accept string table references.
+ * Converts SQLRooms table identity into a serializable vgplot `data.from`
+ * reference.
+ *
+ * SQLRooms normalizes this string into a Mosaic TableRefNode before handing the
+ * spec to Mosaic at runtime. Keeping this string SQL-quoted preserves dotted
+ * identifier boundaries through JSON serialization.
  */
-export function getMosaicTableReferenceString(
+export function getMosaicVgPlotTableReference(
+  tableName: MosaicTableReferenceInput,
+): string {
+  return getMosaicRawSqlTableReference(tableName);
+}
+
+/**
+ * Converts SQLRooms table identity into a schema/table SQL fragment for raw SQL
+ * builders. The active Mosaic connector owns the catalog, so the database part
+ * is intentionally omitted.
+ */
+export function getMosaicRawSqlTableReference(
   tableName: MosaicTableReferenceInput,
 ): string {
   return getMosaicTableReferenceParts(tableName)
-    .map(quoteMosaicTableReferencePart)
+    .map(escapeId)
     .join('.');
 }
+
+/**
+ * Resolves a persisted dashboard table identity against the current SQLRooms
+ * table catalog. Canonical identities and qualified SQL identifiers are
+ * preferred; legacy bare names resolve only when unambiguous.
+ */
+export function resolveMosaicTableReference<
+  T extends MosaicTableReferenceCandidate,
+>(
+  tables: T[],
+  tableName: MosaicTableReferenceInput | undefined,
+): ResolveTableReferenceResult<T> {
+  if (!tableName) {
+    return {};
+  }
+  return resolveTableReference(tables, tableName);
+}
+
+/**
+ * @deprecated Use `getMosaicVgPlotTableReference` for chart specs or
+ * `getMosaicRawSqlTableReference` for string-built SQL.
+ */
+export const getMosaicTableReferenceString = getMosaicVgPlotTableReference;
 
 function getMosaicTableReferenceParts(
   tableName: MosaicTableReferenceInput,
@@ -60,8 +102,4 @@ function getMosaicTableReferenceParts(
   }
 
   return [String(tableName).trim()];
-}
-
-function quoteMosaicTableReferencePart(part: string): string {
-  return `"${part.replaceAll('"', '""')}"`;
 }

--- a/packages/mosaic/src/mosaicTableReference.ts
+++ b/packages/mosaic/src/mosaicTableReference.ts
@@ -7,7 +7,20 @@ import {
 } from '@sqlrooms/db';
 import {asTableRef, type TableRefNode} from '@uwdata/mosaic-sql';
 
+/**
+ * SQLRooms table reference input accepted at Mosaic boundaries.
+ *
+ * Strings represent persisted identities or user-provided references;
+ * QualifiedTableName values carry structured SQLRooms table identity.
+ */
 export type MosaicTableReferenceInput = string | QualifiedTableName;
+
+/**
+ * Runtime object carrying a structured SQLRooms table identity.
+ *
+ * Use this shape for catalog candidates so persisted identity strings stay
+ * distinct from resolved runtime table objects.
+ */
 export type MosaicTableReferenceCandidate = {table: QualifiedTableName};
 
 /**
@@ -58,9 +71,7 @@ export function getMosaicVgPlotTableReference(
 export function getMosaicRawSqlTableReference(
   tableName: MosaicTableReferenceInput,
 ): string {
-  return getMosaicTableReferenceParts(tableName)
-    .map(escapeId)
-    .join('.');
+  return getMosaicTableReferenceParts(tableName).map(escapeId).join('.');
 }
 
 /**


### PR DESCRIPTION
## Summary
- Normalize dashboard, chart, and explorer table selection to use stable SQLRooms identities instead of leaking the `memory` catalog.
- Split Mosaic table-reference helpers into execution, raw SQL, and vgplot-friendly forms so queries keep working across DuckDB WASM and serialized specs.
- Update dashboard and block-document flows to resolve selected tables from the live table list before storing or rendering them.
- Add coverage for catalog stripping, dotted identifiers, and ambiguous legacy table-name resolution.

## Testing
- Added and updated unit tests for table-reference resolution, data-table explorer query generation, and line-chart spec generation.
- Not run (not requested).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved table identity resolution for charts, dashboards, and data-table explorers, keeping the selected table consistent across the UI.
  * Cleaner table-reference formatting for chart/SQL outputs, omitting catalog details when appropriate.
* **Bug Fixes**
  * Fixed handling of DuckDB “memory” table identities and ensured generated references don’t include those catalog parts.
  * Improved correctness for quoted and dotted identifiers, plus safer behavior when table names are ambiguous.
* **Tests**
  * Added/updated unit tests covering reference normalization and selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->