### PR TITLE
feat(deck): add table dataset transforms

### DIFF
--- a/apps/sqlrooms-cli-ui/src/workspace/WorksheetMapBlockRenderer.tsx
+++ b/apps/sqlrooms-cli-ui/src/workspace/WorksheetMapBlockRenderer.tsx
@@ -18,6 +18,7 @@ export const WorksheetMapBlockRenderer: FC<
   blockType,
   title,
   caption,
+  selected,
   readOnly,
   onCaptionChange,
 }) => {
@@ -34,6 +35,7 @@ export const WorksheetMapBlockRenderer: FC<
       mapId={blockInstanceId}
       title={title}
       caption={caption}
+      selected={selected}
       onCaptionChange={onCaptionChange}
       readOnly={readOnly}
     />

--- a/packages/deck/README.md
+++ b/packages/deck/README.md
@@ -259,8 +259,8 @@ Each SQLRooms-managed layer binds to exactly one dataset through
 <DeckJsonMap
   spec={spec}
   datasets={{
-    earthquakes: {sqlQuery: 'SELECT * FROM earthquakes'},
-    faults: {sqlQuery: 'SELECT * FROM faults'},
+    earthquakes: {tableName: 'earthquakes'},
+    faults: {tableName: 'faults'},
   }}
 />
 ```
@@ -280,6 +280,21 @@ datasets={{
     geometryColumn: 'geom',
     geometryEncodingHint: 'wkb',
   },
+  earthquakePoints: {
+    tableName: 'earthquakes',
+    transformSql: `
+      SELECT *, ST_AsWKB(ST_Point(longitude, latitude)) AS geom
+      FROM __sqlrooms_source
+      WHERE longitude IS NOT NULL AND latitude IS NOT NULL
+    `,
+    geometryColumn: 'geom',
+    geometryEncodingHint: 'wkb',
+  },
+  faults: {
+    tableName: 'faults',
+    geometryColumn: 'geom',
+    geometryEncodingHint: 'wkb',
+  },
   preview: {
     arrowTable,
     geometryColumn: 'geom',
@@ -289,7 +304,16 @@ datasets={{
 ```
 
 - `sqlQuery`
-  Runs through the DuckDB slice execution path.
+  Runs a standalone literal query through the DuckDB slice execution path. This
+  query is not rewritten by dashboard table selection.
+- `tableName`
+  Reads directly from a table or schema-qualified table reference.
+- `tableName` + `transformSql`
+  Reads a structured table source through a SQL transform. `transformSql` must
+  be a complete `SELECT` statement that reads from SQLRooms' reserved
+  `__sqlrooms_source` relation. SQLRooms binds that relation to the quoted
+  `tableName` at execution time, so dashboards can swap the table source
+  without editing authored SQL.
 - `arrowTable`
   Uses an already available Apache Arrow table. This is the right input for
   Arrow-native SQLRooms hooks such as `useSql` and `useMosaicClient`.

--- a/packages/deck/__tests__/dashboard-ai-map.test.ts
+++ b/packages/deck/__tests__/dashboard-ai-map.test.ts
@@ -209,6 +209,41 @@ describe('createDeckMapBoundsQuery', () => {
     expect(query).not.toContain('"events"."2026"');
   });
 
+  it('builds fit-to-data bounds queries from literal SQL sources', () => {
+    const query = createDeckMapBoundsQuery({
+      source: {
+        sqlQuery: 'SELECT * FROM events WHERE value > 0',
+      },
+      fitToData: {
+        dataset: 'events',
+        longitudeColumn: 'lon',
+        latitudeColumn: 'lat',
+      },
+    });
+
+    expect(query).toContain(
+      'SELECT * FROM (SELECT * FROM events WHERE value > 0) AS "__sqlrooms_dashboard_map_source"',
+    );
+  });
+
+  it('builds fit-to-data bounds queries from table transforms', () => {
+    const query = createDeckMapBoundsQuery({
+      source: {
+        tableName: 'events',
+        transformSql:
+          'SELECT *, ST_AsWKB(ST_Point(lon, lat)) AS geom FROM __sqlrooms_source',
+      },
+      fitToData: {
+        dataset: 'events',
+        geometryColumn: 'geom',
+      },
+    });
+
+    expect(query).toContain('WITH __sqlrooms_source AS');
+    expect(query).toContain('SELECT * FROM "events"');
+    expect(query).toContain('ST_GeomFromWKB("geom")');
+  });
+
   it('rejects invalid table sources in bounds queries', () => {
     expect(() =>
       createDeckMapBoundsQuery({
@@ -507,6 +542,24 @@ describe('createDeckMapDashboardTool', () => {
     });
     expect(panel.config.datasets.earthquakes.source).toEqual({
       tableName: 'earthquakes',
+      transformSql:
+        'SELECT *, ST_AsWKB(ST_Point("longitude", "latitude")) AS "__sqlrooms_geom" FROM __sqlrooms_source WHERE "longitude" IS NOT NULL AND "latitude" IS NOT NULL',
+    });
+  });
+
+  it('preserves explicit table references in generated lon/lat transforms', () => {
+    const panel = createDeckMapDashboardPanelConfigForTable({
+      title: 'Attached earthquake map',
+      tableName: 'earthquakes',
+      tableReference: {database: 'remote', schema: 'main', table: 'events'},
+      columns: [
+        {name: 'longitude', type: 'DOUBLE'},
+        {name: 'latitude', type: 'DOUBLE'},
+      ],
+    });
+
+    expect(panel.config.datasets.earthquakes.source).toMatchObject({
+      tableName: '"remote"."main"."events"',
       transformSql:
         'SELECT *, ST_AsWKB(ST_Point("longitude", "latitude")) AS "__sqlrooms_geom" FROM __sqlrooms_source WHERE "longitude" IS NOT NULL AND "latitude" IS NOT NULL',
     });

--- a/packages/deck/__tests__/dashboard-ai-map.test.ts
+++ b/packages/deck/__tests__/dashboard-ai-map.test.ts
@@ -54,8 +54,9 @@ const normalizedScatterConfig = {
   datasets: {
     earthquakes: {
       source: {
-        sqlQuery:
-          'SELECT *, ST_AsWKB(ST_Point("longitude", "latitude")) AS "geom" FROM "earthquakes" WHERE "longitude" IS NOT NULL AND "latitude" IS NOT NULL',
+        tableName: 'earthquakes',
+        transformSql:
+          'SELECT *, ST_AsWKB(ST_Point("longitude", "latitude")) AS "geom" FROM __sqlrooms_source WHERE "longitude" IS NOT NULL AND "latitude" IS NOT NULL',
       },
       geometryColumn: 'geom',
       geometryEncodingHint: 'wkb',
@@ -504,9 +505,11 @@ describe('createDeckMapDashboardTool', () => {
         latitudeColumn: 'latitude',
       },
     });
-    expect(panel.config.datasets.earthquakes.source.sqlQuery).toContain(
-      'ST_Point("longitude", "latitude")',
-    );
+    expect(panel.config.datasets.earthquakes.source).toEqual({
+      tableName: 'earthquakes',
+      transformSql:
+        'SELECT *, ST_AsWKB(ST_Point("longitude", "latitude")) AS "__sqlrooms_geom" FROM __sqlrooms_source WHERE "longitude" IS NOT NULL AND "latitude" IS NOT NULL',
+    });
   });
 
   it('strips trailing semicolons from wrapped manual source SQL queries', () => {

--- a/packages/deck/__tests__/dashboard.test.ts
+++ b/packages/deck/__tests__/dashboard.test.ts
@@ -60,7 +60,7 @@ describe('deck dashboard integration', () => {
     });
   });
 
-  it('rewrites dataset sqlQuery FROM clause with dashboard.selectedTable', () => {
+  it('keeps literal dataset sqlQuery pinned when dashboard.selectedTable changes', () => {
     const dashboard = createDashboard('dashboard_table');
     const panel = createDeckMapDashboardPanelConfig({
       spec: {layers: []},
@@ -71,7 +71,6 @@ describe('deck dashboard integration', () => {
       },
     });
 
-    // Dashboard table rewrites the FROM clause in dataset sqlQuery
     expect(
       resolveDeckMapDashboardDatasetSource({
         dashboard,
@@ -80,7 +79,7 @@ describe('deck dashboard integration', () => {
           source: {sqlQuery: 'SELECT * FROM dataset_table'},
         },
       }),
-    ).toEqual({sqlQuery: 'SELECT * FROM "dashboard_table"'});
+    ).toEqual({sqlQuery: 'SELECT * FROM dataset_table'});
 
     // Falls back to dashboard source when no dataset source
     expect(
@@ -92,7 +91,41 @@ describe('deck dashboard integration', () => {
     ).toEqual({tableName: 'dashboard_table'});
   });
 
-  it('omits catalog-qualified selected table identities in map runtime SQL', () => {
+  it('resolves table dataset inputs with dashboard.selectedTable', () => {
+    const dashboard = createDashboard('dashboard_table');
+    const panel = createDeckMapDashboardPanelConfig({
+      spec: {layers: []},
+      datasets: {
+        dataset: {
+          source: {
+            tableName: 'dataset_table',
+            transformSql:
+              'SELECT *, ST_AsWKB(ST_Point(lon, lat)) AS geom FROM __sqlrooms_source',
+          },
+        },
+      },
+    });
+
+    expect(
+      resolveDeckMapDashboardDatasetSource({
+        dashboard,
+        panel,
+        dataset: {
+          source: {
+            tableName: 'dataset_table',
+            transformSql:
+              'SELECT *, ST_AsWKB(ST_Point(lon, lat)) AS geom FROM __sqlrooms_source',
+          },
+        },
+      }),
+    ).toEqual({
+      tableName: 'dashboard_table',
+      transformSql:
+        'SELECT *, ST_AsWKB(ST_Point(lon, lat)) AS geom FROM __sqlrooms_source',
+    });
+  });
+
+  it('omits catalog-qualified selected table identities in structured map runtime SQL', () => {
     const dashboard = createDashboard('"memory"."main"."events.2026"');
     const panel = createDeckMapDashboardPanelConfig({
       spec: {layers: []},
@@ -104,10 +137,10 @@ describe('deck dashboard integration', () => {
         dashboard,
         panel,
         dataset: {
-          source: {sqlQuery: 'SELECT * FROM "main"."old.events"'},
+          source: {tableName: '"main"."old.events"'},
         },
       }),
-    ).toEqual({sqlQuery: 'SELECT * FROM "main"."events.2026"'});
+    ).toEqual({tableName: '"main"."events.2026"'});
 
     expect(
       resolveDeckMapDashboardDatasetSource({
@@ -125,7 +158,7 @@ describe('deck dashboard integration', () => {
     expect(tableSql).not.toContain('"events"."2026"');
   });
 
-  it('normalizes catalog-qualified source tables before rewriting dataset SQL', () => {
+  it('does not rewrite literal SQL containing nested FROM clauses', () => {
     const dashboard = createDashboard('"memory"."main"."events.2026"');
     const panel = createDeckMapDashboardPanelConfig({
       spec: {layers: []},
@@ -138,18 +171,18 @@ describe('deck dashboard integration', () => {
         panel,
         dataset: {
           source: {
-            tableName: '"memory"."main"."old.events"',
             sqlQuery:
-              'SELECT * FROM "memory"."main"."old.events" WHERE value > 0',
+              'WITH nested AS (SELECT * FROM other_table) SELECT * FROM "memory"."main"."old.events" WHERE value > 0',
           },
         },
       }),
     ).toEqual({
-      sqlQuery: 'SELECT * FROM "main"."events.2026" WHERE value > 0',
+      sqlQuery:
+        'WITH nested AS (SELECT * FROM other_table) SELECT * FROM "memory"."main"."old.events" WHERE value > 0',
     });
   });
 
-  it('strips catalog-qualified source SQL when the source matches the selected table', () => {
+  it('strips catalog-qualified structured source tables', () => {
     const dashboard = createDashboard('"memory"."main"."events"');
     const panel = createDeckMapDashboardPanelConfig({
       spec: {layers: []},
@@ -163,18 +196,23 @@ describe('deck dashboard integration', () => {
         dataset: {
           source: {
             tableName: '"memory"."main"."events"',
-            sqlQuery: 'SELECT * FROM "memory"."main"."events" WHERE value > 0',
           },
         },
       }),
-    ).toEqual({
-      sqlQuery: 'SELECT * FROM "main"."events" WHERE value > 0',
-    });
+    ).toEqual({tableName: '"main"."events"'});
   });
 
-  it('builds Mosaic dataset queries for table and trusted SQL sources', () => {
+  it('builds Mosaic dataset queries for table, transform, and trusted SQL sources', () => {
     const tableSql = createDeckMapDashboardDatasetQuery(
       {tableName: 'earthquakes'},
+      [],
+    ).toString();
+    const transformSql = createDeckMapDashboardDatasetQuery(
+      {
+        tableName: 'earthquakes',
+        transformSql:
+          'SELECT *, ST_AsWKB(ST_Point(lon, lat)) AS geom FROM __sqlrooms_source',
+      },
       [],
     ).toString();
     const subquerySql = createDeckMapDashboardDatasetQuery(
@@ -188,6 +226,9 @@ describe('deck dashboard integration', () => {
     expect(subquerySql).toContain(
       'FROM (SELECT * FROM earthquakes WHERE Magnitude > 4)',
     );
+    expect(transformSql).toContain('WITH __sqlrooms_source AS');
+    expect(transformSql).toContain('SELECT * FROM "earthquakes"');
+    expect(transformSql).toContain('FROM __sqlrooms_source');
   });
 
   it('wires Arrow client results into DeckJsonMap dataset inputs', () => {

--- a/packages/deck/__tests__/dashboard.test.ts
+++ b/packages/deck/__tests__/dashboard.test.ts
@@ -158,6 +158,24 @@ describe('deck dashboard integration', () => {
     expect(tableSql).not.toContain('"events"."2026"');
   });
 
+  it('preserves authored catalog-qualified table sources when no dashboard table is selected', () => {
+    const dashboard = createDashboard();
+    const panel = createDeckMapDashboardPanelConfig({
+      spec: {layers: []},
+      datasets: {},
+    });
+
+    expect(
+      resolveDeckMapDashboardDatasetSource({
+        dashboard,
+        panel,
+        dataset: {
+          source: {tableName: '"remote"."main"."events"'},
+        },
+      }),
+    ).toEqual({tableName: '"remote"."main"."events"'});
+  });
+
   it('does not rewrite literal SQL containing nested FROM clauses', () => {
     const dashboard = createDashboard('"memory"."main"."events.2026"');
     const panel = createDeckMapDashboardPanelConfig({

--- a/packages/deck/__tests__/normalizeDatasets.test.ts
+++ b/packages/deck/__tests__/normalizeDatasets.test.ts
@@ -3,7 +3,11 @@ import {
   normalizeDatasets,
   resolveArrowTable,
 } from '../src/datasets/normalizeDatasets';
-import {isArrowTableDatasetInput, isSqlDatasetInput} from '../src/types';
+import {
+  isArrowTableDatasetInput,
+  isSqlDatasetInput,
+  isTableDatasetInput,
+} from '../src/types';
 
 describe('normalizeDatasets', () => {
   it('normalizes arrowTable dataset entries', () => {
@@ -56,6 +60,27 @@ describe('normalizeDatasets', () => {
     });
 
     expect(isSqlDatasetInput(datasets.earthquakes!)).toBe(true);
+  });
+
+  it('normalizes table dataset entries', () => {
+    const datasets = normalizeDatasets({
+      earthquakes: {
+        tableName: 'earthquakes',
+        transformSql:
+          'SELECT *, ST_AsWKB(ST_Point(lon, lat)) AS geom FROM __sqlrooms_source',
+        geometryColumn: 'geom',
+        geometryEncodingHint: 'wkb',
+      },
+    });
+
+    expect(datasets.earthquakes).toEqual({
+      tableName: 'earthquakes',
+      transformSql:
+        'SELECT *, ST_AsWKB(ST_Point(lon, lat)) AS geom FROM __sqlrooms_source',
+      geometryColumn: 'geom',
+      geometryEncodingHint: 'wkb',
+    });
+    expect(isTableDatasetInput(datasets.earthquakes!)).toBe(true);
   });
 
   it('rejects empty dataset registries', () => {

--- a/packages/deck/__tests__/preparedDatasetStore.test.ts
+++ b/packages/deck/__tests__/preparedDatasetStore.test.ts
@@ -121,6 +121,49 @@ describe('PreparedDatasetStore', () => {
     });
   });
 
+  it('executes table dataset inputs through compiled SQL', async () => {
+    const table = new Table({value: vectorFromArray([1, 2, 3])});
+    const connector = {};
+    const prepareDataset = jest.fn(
+      ({datasetId, table: nextTable}: {datasetId: string; table: Table}) =>
+        createPreparedDataset(datasetId, nextTable),
+    );
+    const executeSql = jest.fn(
+      async () => Promise.resolve(table) as unknown as QueryHandle,
+    );
+    const store = createPreparedDatasetStore({prepareDataset});
+    const input: DeckDatasetInput = {
+      tableName: 'earthquakes',
+      transformSql:
+        'SELECT *, ST_AsWKB(ST_Point(lon, lat)) AS geom FROM __sqlrooms_source',
+      geometryColumn: 'geom',
+    };
+    const cacheKey = resolvePreparedDatasetCacheKey({
+      input,
+      sqlSourceIdentity: connector,
+    })!;
+
+    store.getState().syncConsumer('consumer-a', [cacheKey]);
+    store.getState().ensureEntry({
+      cacheKey,
+      datasetId: 'earthquakes',
+      executeSql,
+      input,
+    });
+
+    await waitForEntry(store, cacheKey);
+
+    expect(executeSql).toHaveBeenCalledWith(
+      [
+        'WITH __sqlrooms_source AS (',
+        '  SELECT * FROM "earthquakes"',
+        ')',
+        'SELECT *, ST_AsWKB(ST_Point(lon, lat)) AS geom FROM __sqlrooms_source',
+      ].join('\n'),
+    );
+    expect(prepareDataset).toHaveBeenCalledTimes(1);
+  });
+
   it('changes cache keys when geometry options or sql source change', () => {
     const table = new Table({value: vectorFromArray([1, 2, 3])});
     const connectorA = {};

--- a/packages/deck/__tests__/preparedDatasetStore.test.ts
+++ b/packages/deck/__tests__/preparedDatasetStore.test.ts
@@ -164,6 +164,51 @@ describe('PreparedDatasetStore', () => {
     expect(prepareDataset).toHaveBeenCalledTimes(1);
   });
 
+  it('isolates invalid table dataset inputs during consumer sync', async () => {
+    const table = new Table({value: vectorFromArray([1, 2, 3])});
+    const connector = {};
+    const prepareDataset = jest.fn(
+      ({datasetId, table: nextTable}: {datasetId: string; table: Table}) =>
+        createPreparedDataset(datasetId, nextTable),
+    );
+    const executeSql = jest.fn(
+      async () => Promise.resolve(table) as unknown as QueryHandle,
+    );
+    const store = createPreparedDatasetStore({prepareDataset});
+    const validInput: DeckDatasetInput = {sqlQuery: 'select 1'};
+    const invalidInput: DeckDatasetInput = {tableName: 'main.'};
+    const validKey = resolvePreparedDatasetCacheKey({
+      input: validInput,
+      sqlSourceIdentity: connector,
+    })!;
+    const invalidKey = resolvePreparedDatasetCacheKey({
+      input: invalidInput,
+      sqlSourceIdentity: connector,
+    })!;
+
+    expect(() =>
+      store.getState().syncDatasetsForConsumer({
+        consumerId: 'consumer-a',
+        datasets: {
+          valid: validInput,
+          invalid: invalidInput,
+        },
+        executeSql,
+        sqlSourceIdentity: connector,
+      }),
+    ).not.toThrow();
+
+    await waitForEntry(store, validKey);
+    await waitForEntry(store, invalidKey);
+
+    expect(store.getState().entries[validKey]).toMatchObject({
+      status: 'ready',
+    });
+    expect(store.getState().entries[invalidKey]).toMatchObject({
+      status: 'error',
+    });
+  });
+
   it('changes cache keys when geometry options or sql source change', () => {
     const table = new Table({value: vectorFromArray([1, 2, 3])});
     const connectorA = {};

--- a/packages/deck/__tests__/preparedDatasetStore.test.ts
+++ b/packages/deck/__tests__/preparedDatasetStore.test.ts
@@ -158,7 +158,10 @@ describe('PreparedDatasetStore', () => {
         'WITH __sqlrooms_source AS (',
         '  SELECT * FROM "earthquakes"',
         ')',
+        'SELECT *',
+        'FROM (',
         'SELECT *, ST_AsWKB(ST_Point(lon, lat)) AS geom FROM __sqlrooms_source',
+        ') AS "__sqlrooms_transform"',
       ].join('\n'),
     );
     expect(prepareDataset).toHaveBeenCalledTimes(1);

--- a/packages/deck/__tests__/tableDatasetSql.test.ts
+++ b/packages/deck/__tests__/tableDatasetSql.test.ts
@@ -25,6 +25,7 @@ describe('createDeckTableDatasetSql', () => {
 
     expect(sql).toContain(`WITH ${DECK_TABLE_DATASET_SOURCE_RELATION} AS (`);
     expect(sql).toContain('SELECT * FROM "events"');
+    expect(sql).toContain(',\nnested AS (SELECT * FROM other_table)');
     expect(sql).toContain('FROM other_table');
     expect(sql).toContain(
       `SELECT * FROM ${DECK_TABLE_DATASET_SOURCE_RELATION}`,
@@ -35,6 +36,24 @@ describe('createDeckTableDatasetSql', () => {
       ),
     ).toHaveLength(1);
     expect(sql.trim().endsWith(';')).toBe(false);
+  });
+
+  it('preserves recursive transform CTEs by making the full CTE list recursive', () => {
+    const sql = createDeckTableDatasetSql({
+      tableName: 'events',
+      transformSql: [
+        'WITH RECURSIVE nested AS (',
+        `  SELECT * FROM ${DECK_TABLE_DATASET_SOURCE_RELATION}`,
+        ')',
+        'SELECT * FROM nested',
+      ].join(' '),
+    });
+
+    expect(sql).toContain(
+      `WITH RECURSIVE ${DECK_TABLE_DATASET_SOURCE_RELATION} AS (`,
+    );
+    expect(sql).toContain(',\nnested AS (');
+    expect(sql).not.toMatch(/\)\s*WITH\s+RECURSIVE/i);
   });
 
   it('rejects transform SQL that does not read from the source relation', () => {

--- a/packages/deck/__tests__/tableDatasetSql.test.ts
+++ b/packages/deck/__tests__/tableDatasetSql.test.ts
@@ -17,7 +17,32 @@ describe('createDeckTableDatasetSql', () => {
     const sql = createDeckTableDatasetSql({
       tableName: 'events',
       transformSql: [
-        'WITH nested AS (SELECT * FROM other_table)',
+        'SELECT id',
+        `FROM ${DECK_TABLE_DATASET_SOURCE_RELATION}`,
+        'WHERE id > 10;',
+      ].join(' '),
+    });
+
+    expect(sql).toBe(
+      [
+        `WITH ${DECK_TABLE_DATASET_SOURCE_RELATION} AS (`,
+        '  SELECT * FROM "events"',
+        ')',
+        'SELECT *',
+        'FROM (',
+        `SELECT id FROM ${DECK_TABLE_DATASET_SOURCE_RELATION} WHERE id > 10`,
+        ') AS "__sqlrooms_transform"',
+      ].join('\n'),
+    );
+  });
+
+  it('nests transform CTEs without merging authored SQL', () => {
+    const sql = createDeckTableDatasetSql({
+      tableName: 'events',
+      transformSql: [
+        'WITH nested AS (',
+        `  SELECT id FROM ${DECK_TABLE_DATASET_SOURCE_RELATION}`,
+        ')',
         `SELECT * FROM ${DECK_TABLE_DATASET_SOURCE_RELATION}`,
         'WHERE id IN (SELECT id FROM nested);',
       ].join(' '),
@@ -25,20 +50,15 @@ describe('createDeckTableDatasetSql', () => {
 
     expect(sql).toContain(`WITH ${DECK_TABLE_DATASET_SOURCE_RELATION} AS (`);
     expect(sql).toContain('SELECT * FROM "events"');
-    expect(sql).toContain(',\nnested AS (SELECT * FROM other_table)');
-    expect(sql).toContain('FROM other_table');
+    expect(sql).toContain('FROM (\nWITH nested AS (');
+    expect(sql).not.toContain(',\nnested AS (');
     expect(sql).toContain(
       `SELECT * FROM ${DECK_TABLE_DATASET_SOURCE_RELATION}`,
     );
-    expect(
-      sql.match(
-        new RegExp(`WITH\\s+${DECK_TABLE_DATASET_SOURCE_RELATION}\\s+AS`, 'gi'),
-      ),
-    ).toHaveLength(1);
     expect(sql.trim().endsWith(';')).toBe(false);
   });
 
-  it('preserves recursive transform CTEs by making the full CTE list recursive', () => {
+  it('preserves recursive transform CTEs inside the nested transform query', () => {
     const sql = createDeckTableDatasetSql({
       tableName: 'events',
       transformSql: [
@@ -49,11 +69,9 @@ describe('createDeckTableDatasetSql', () => {
       ].join(' '),
     });
 
-    expect(sql).toContain(
-      `WITH RECURSIVE ${DECK_TABLE_DATASET_SOURCE_RELATION} AS (`,
-    );
-    expect(sql).toContain(',\nnested AS (');
-    expect(sql).not.toMatch(/\)\s*WITH\s+RECURSIVE/i);
+    expect(sql).toContain(`WITH ${DECK_TABLE_DATASET_SOURCE_RELATION} AS (`);
+    expect(sql).toContain('FROM (\nWITH RECURSIVE nested AS (');
+    expect(sql).toContain(') AS "__sqlrooms_transform"');
   });
 
   it('rejects transform SQL that does not read from the source relation', () => {

--- a/packages/deck/__tests__/tableDatasetSql.test.ts
+++ b/packages/deck/__tests__/tableDatasetSql.test.ts
@@ -1,0 +1,50 @@
+import {
+  DECK_TABLE_DATASET_SOURCE_RELATION,
+  createDeckTableDatasetSql,
+} from '../src/datasets/tableDatasetSql';
+
+describe('createDeckTableDatasetSql', () => {
+  it('compiles direct table inputs with quoted table references', () => {
+    expect(createDeckTableDatasetSql({tableName: 'main.events'})).toBe(
+      'SELECT * FROM "main"."events"',
+    );
+    expect(createDeckTableDatasetSql({tableName: 'main."events.2026"'})).toBe(
+      'SELECT * FROM "main"."events.2026"',
+    );
+  });
+
+  it('wraps transform inputs with one SQLRooms-owned source CTE', () => {
+    const sql = createDeckTableDatasetSql({
+      tableName: 'events',
+      transformSql: [
+        'WITH nested AS (SELECT * FROM other_table)',
+        `SELECT * FROM ${DECK_TABLE_DATASET_SOURCE_RELATION}`,
+        'WHERE id IN (SELECT id FROM nested);',
+      ].join(' '),
+    });
+
+    expect(sql).toContain(`WITH ${DECK_TABLE_DATASET_SOURCE_RELATION} AS (`);
+    expect(sql).toContain('SELECT * FROM "events"');
+    expect(sql).toContain('FROM other_table');
+    expect(sql).toContain(
+      `SELECT * FROM ${DECK_TABLE_DATASET_SOURCE_RELATION}`,
+    );
+    expect(
+      sql.match(
+        new RegExp(`WITH\\s+${DECK_TABLE_DATASET_SOURCE_RELATION}\\s+AS`, 'gi'),
+      ),
+    ).toHaveLength(1);
+    expect(sql.trim().endsWith(';')).toBe(false);
+  });
+
+  it('rejects transform SQL that does not read from the source relation', () => {
+    expect(() =>
+      createDeckTableDatasetSql({
+        tableName: 'events',
+        transformSql: 'SELECT * FROM events',
+      }),
+    ).toThrow(
+      `Deck table dataset transformSql must reference ${DECK_TABLE_DATASET_SOURCE_RELATION}.`,
+    );
+  });
+});

--- a/packages/deck/src/MapSettings.tsx
+++ b/packages/deck/src/MapSettings.tsx
@@ -198,9 +198,13 @@ export const MapSettingsPanel: FC<MapSettingsPanelProps> = ({
   // Resolve the table for column listing: prefer the dashboard's selected
   // table (which represents the user's active choice), falling back to the
   // dataset's explicit source table when no dashboard table is selected.
+  const activeLayerDatasetSource = activeLayerDataset?.source;
   const fallbackTableName =
-    activeLayerDataset?.source?.tableName ||
-    extractTableFromSqlQuery(activeLayerDataset?.source?.sqlQuery);
+    activeLayerDatasetSource && 'tableName' in activeLayerDatasetSource
+      ? activeLayerDatasetSource.tableName
+      : activeLayerDatasetSource && 'sqlQuery' in activeLayerDatasetSource
+        ? extractTableFromSqlQuery(activeLayerDatasetSource.sqlQuery)
+        : undefined;
   const fallbackTable = useDataTable(fallbackTableName);
   const dataTable = selectedDataTable ?? fallbackTable;
 

--- a/packages/deck/src/MapSettings.tsx
+++ b/packages/deck/src/MapSettings.tsx
@@ -33,7 +33,11 @@ import {
 } from '@sqlrooms/ui';
 import {LatitudeSelector} from './LatitudeSelector';
 import {LongitudeSelector} from './LongitudeSelector';
-import type {DeckMapDashboardPanelConfig} from './dashboardConfig';
+import {
+  isDeckMapDashboardSqlDatasetSource,
+  isDeckMapDashboardTableDatasetSource,
+  type DeckMapDashboardPanelConfig,
+} from './dashboardConfig';
 import {
   clearDeckMapLayerColorScale,
   createDeckMapLayerColorScale,
@@ -199,12 +203,13 @@ export const MapSettingsPanel: FC<MapSettingsPanelProps> = ({
   // table (which represents the user's active choice), falling back to the
   // dataset's explicit source table when no dashboard table is selected.
   const activeLayerDatasetSource = activeLayerDataset?.source;
-  const fallbackTableName =
-    activeLayerDatasetSource && 'tableName' in activeLayerDatasetSource
-      ? activeLayerDatasetSource.tableName
-      : activeLayerDatasetSource && 'sqlQuery' in activeLayerDatasetSource
-        ? extractTableFromSqlQuery(activeLayerDatasetSource.sqlQuery)
-        : undefined;
+  const fallbackTableName = isDeckMapDashboardTableDatasetSource(
+    activeLayerDatasetSource,
+  )
+    ? activeLayerDatasetSource.tableName
+    : isDeckMapDashboardSqlDatasetSource(activeLayerDatasetSource)
+      ? extractTableFromSqlQuery(activeLayerDatasetSource.sqlQuery)
+      : undefined;
   const fallbackTable = useDataTable(fallbackTableName);
   const dataTable = selectedDataTable ?? fallbackTable;
 

--- a/packages/deck/src/ai.ts
+++ b/packages/deck/src/ai.ts
@@ -19,24 +19,8 @@ import {
   DECK_MAP_DASHBOARD_PANEL_TYPE,
   type DeckMapDashboardPanelConfig,
 } from './dashboardConfig';
+import {DECK_TABLE_DATASET_SOURCE_RELATION} from './datasets/tableDatasetSql';
 import {quoteDeckMapSqlIdentifier} from './mapConfigUtils';
-
-function splitIdentifierPathOutsideQuotes(input: string): string[] {
-  const parts: string[] = [];
-  let current = '';
-  let inQuotes = false;
-  for (const ch of input) {
-    if (ch === '"') inQuotes = !inQuotes;
-    if (ch === '.' && !inQuotes) {
-      parts.push(current);
-      current = '';
-    } else {
-      current += ch;
-    }
-  }
-  parts.push(current);
-  return parts.filter(Boolean);
-}
 
 export const DECK_MAP_AI_INSTRUCTIONS = `
 Deck map tools:
@@ -45,26 +29,27 @@ Deck map tools:
 - Use map tools when the user asks for a map, geospatial/spatial visualization, locations, longitude/latitude data, or geometry columns.
 - Author maps with config.spec.layers using Deck JSON layer classes in @@type, such as GeoArrowScatterplotLayer, GeoArrowHeatmapLayer, GeoArrowPolygonLayer, GeoArrowPathLayer, GeoArrowTripsLayer, GeoArrowArcLayer, or GeoArrowH3HexagonLayer.
 - LAYER SELECTION: Choose the layer type based on the geometry type in the data.
-  IMPORTANT: Only create a layer if the table contains data suitable for that layer type, or if you can transform the data into the required format with a sqlQuery. Do NOT create a layer if the data is clearly incompatible (e.g. do not create a path layer from point-only data without aggregation, do not create a polygon layer from point coordinates, do not create an arc layer without origin-destination pairs).
+  IMPORTANT: Only create a layer if the table contains data suitable for that layer type, or if you can transform the data into the required format with transformSql or a standalone sqlQuery. Do NOT create a layer if the data is clearly incompatible (e.g. do not create a path layer from point-only data without aggregation, do not create a polygon layer from point coordinates, do not create an arc layer without origin-destination pairs).
   - Point data (lon/lat coordinates, point geometry): GeoArrowScatterplotLayer (Point layer), GeoArrowHeatmapLayer, GeoArrowColumnLayer. Requires rows with individual point positions — either separate longitude/latitude numeric columns, or a point geometry column. Each row represents one point on the map.
   - Polygon data (building footprints, boundaries, areas, parcels, zones): GeoArrowPolygonLayer or GeoArrowSolidPolygonLayer. Requires a geometry column containing polygon or multipolygon WKB/GeoArrow data. Typically loaded from GeoJSON/Shapefile/GeoParquet or produced by spatial queries. Do NOT use for point data.
-  - Line data (roads, routes, paths, rivers): GeoArrowPathLayer. CRITICAL: GeoArrowPathLayer requires LineString geometry, NOT individual point rows. If the table has one row per waypoint (indicated by columns like path_id/route_id + order/sequence + lat/lon), you MUST aggregate them with a sqlQuery: "SELECT path_id, label, ST_AsWKB(ST_MakeLine(LIST(ST_Point(lon, lat) ORDER BY waypoint_order))) AS geom FROM tableName GROUP BY path_id, label". Set geometryColumn to "geom" and geometryEncodingHint to "wkb". If the table already has a geometry/geom column with linestring data, use it directly with tableName. NEVER pass raw waypoint rows to GeoArrowPathLayer — it will fail.
-  - Animated trip data (routes with timestamps): GeoArrowTripsLayer. Same geometry requirements as GeoArrowPathLayer (LineString), plus a timestamps column. The sqlQuery MUST aggregate both the geometry and timestamps: "SELECT path_id, label, ST_AsWKB(ST_MakeLine(LIST(ST_Point(lon, lat) ORDER BY waypoint_order))) AS geom, LIST(timestamp ORDER BY waypoint_order) AS timestamps FROM tableName GROUP BY path_id, label". Set geometryColumn to "geom", geometryEncodingHint to "wkb", and _sqlroomsBinding.timestampColumn to "timestamps". The timestamps column must be a list of numbers (seconds) matching the order of waypoints in the linestring. Also set currentTime on the layer to control animation position. Do NOT use unless the data has or can produce both paths and ordered timestamps.
-- CRITICAL geometryColumn rule: The geometryColumn field (in datasets[id].geometryColumn, _sqlroomsBinding.geometryColumn, and fitToData.geometryColumn) MUST match the exact column alias that produces the WKB geometry in the sqlQuery output — typically the "AS geom" alias in ST_AsWKB(...) AS geom. It must NEVER be set to a GROUP BY key, an ID column, or any other non-geometry column. For example, if the sqlQuery is "SELECT path_id, ST_AsWKB(ST_MakeLine(...)) AS geom ... GROUP BY path_id", geometryColumn must be "geom" (the geometry output), NOT "path_id" (the grouping key). Setting geometryColumn to a non-geometry column will cause the layer to fail silently.
-  - Arc data (origin-destination pairs): GeoArrowArcLayer. Requires two sets of coordinates per row (source and target). The table must have source_lon/source_lat AND target_lon/target_lat columns (or equivalent). The dataset source MUST use a sqlQuery that creates WKB geometry columns from lat/lon, for example: "SELECT *, ST_AsWKB(ST_Point(source_lon, source_lat)) AS source_geom, ST_AsWKB(ST_Point(target_lon, target_lat)) AS target_geom FROM tableName". Set sourceGeometryColumn to "source_geom" and targetGeometryColumn to "target_geom". Set geometryEncodingHint to "wkb". To render straight lines instead of arcs, set "getHeight": 0 on the layer. Do NOT use for data with only one set of coordinates per row. When the source data has H3 indices instead of lat/lon, convert H3 to coordinates using h3_cell_to_lng(h3_index) and h3_cell_to_lat(h3_index) (the H3 extension is pre-loaded at startup), for example: "SELECT *, ST_AsWKB(ST_Point(h3_cell_to_lng(source_h3), h3_cell_to_lat(source_h3))) AS source_geom, ST_AsWKB(ST_Point(h3_cell_to_lng(target_h3), h3_cell_to_lat(target_h3))) AS target_geom FROM tableName". Do NOT use h3_latlng() — it does not exist.
+  - Line data (roads, routes, paths, rivers): GeoArrowPathLayer. CRITICAL: GeoArrowPathLayer requires LineString geometry, NOT individual point rows. If the table has one row per waypoint (indicated by columns like path_id/route_id + order/sequence + lat/lon), you MUST aggregate them with transformSql: "SELECT path_id, label, ST_AsWKB(ST_MakeLine(LIST(ST_Point(lon, lat) ORDER BY waypoint_order))) AS geom FROM ${DECK_TABLE_DATASET_SOURCE_RELATION} GROUP BY path_id, label". Set geometryColumn to "geom" and geometryEncodingHint to "wkb". If the table already has a geometry/geom column with linestring data, use it directly with tableName. NEVER pass raw waypoint rows to GeoArrowPathLayer — it will fail.
+  - Animated trip data (routes with timestamps): GeoArrowTripsLayer. Same geometry requirements as GeoArrowPathLayer (LineString), plus a timestamps column. The transformSql MUST aggregate both the geometry and timestamps: "SELECT path_id, label, ST_AsWKB(ST_MakeLine(LIST(ST_Point(lon, lat) ORDER BY waypoint_order))) AS geom, LIST(timestamp ORDER BY waypoint_order) AS timestamps FROM ${DECK_TABLE_DATASET_SOURCE_RELATION} GROUP BY path_id, label". Set geometryColumn to "geom", geometryEncodingHint to "wkb", and _sqlroomsBinding.timestampColumn to "timestamps". The timestamps column must be a list of numbers (seconds) matching the order of waypoints in the linestring. Also set currentTime on the layer to control animation position. Do NOT use unless the data has or can produce both paths and ordered timestamps.
+- CRITICAL geometryColumn rule: The geometryColumn field (in datasets[id].geometryColumn, _sqlroomsBinding.geometryColumn, and fitToData.geometryColumn) MUST match the exact column alias that produces the WKB geometry in the final query output — typically the "AS geom" alias in ST_AsWKB(...) AS geom. It must NEVER be set to a GROUP BY key, an ID column, or any other non-geometry column. For example, if the transformSql is "SELECT path_id, ST_AsWKB(ST_MakeLine(...)) AS geom ... GROUP BY path_id", geometryColumn must be "geom" (the geometry output), NOT "path_id" (the grouping key). Setting geometryColumn to a non-geometry column will cause the layer to fail silently.
+  - Arc data (origin-destination pairs): GeoArrowArcLayer. Requires two sets of coordinates per row (source and target). The table must have source_lon/source_lat AND target_lon/target_lat columns (or equivalent). The dataset source MUST use transformSql that creates WKB geometry columns from lat/lon, for example: "SELECT *, ST_AsWKB(ST_Point(source_lon, source_lat)) AS source_geom, ST_AsWKB(ST_Point(target_lon, target_lat)) AS target_geom FROM ${DECK_TABLE_DATASET_SOURCE_RELATION}". Set sourceGeometryColumn to "source_geom" and targetGeometryColumn to "target_geom". Set geometryEncodingHint to "wkb". To render straight lines instead of arcs, set "getHeight": 0 on the layer. Do NOT use for data with only one set of coordinates per row. When the source data has H3 indices instead of lat/lon, convert H3 to coordinates using h3_cell_to_lng(h3_index) and h3_cell_to_lat(h3_index) (the H3 extension is pre-loaded at startup), for example: "SELECT *, ST_AsWKB(ST_Point(h3_cell_to_lng(source_h3), h3_cell_to_lat(source_h3))) AS source_geom, ST_AsWKB(ST_Point(h3_cell_to_lng(target_h3), h3_cell_to_lat(target_h3))) AS target_geom FROM ${DECK_TABLE_DATASET_SOURCE_RELATION}". Do NOT use h3_latlng() — it does not exist.
   - H3 hexagon data (h3 index column): GeoArrowH3HexagonLayer. Requires a column containing H3 string indices. Bind to dataset with _sqlroomsBinding.dataset. Set "getHexagon": "@@=h3_column_name" where h3_column_name is the column containing H3 string indices. Always include "fitToData": {"dataset": "datasetId"} so the map can zoom to the data extent. Do NOT use unless the table has an H3 index column. DuckDB H3 extension functions: h3_cell_to_lat(index), h3_cell_to_lng(index), h3_cell_to_latlng(index). Do NOT use h3_latlng(), h3_to_lat(), or other non-existent function names.
-- CRITICAL: The sqlQuery field must contain ONLY a single SELECT statement. NEVER put INSTALL, LOAD, CREATE, or other DDL/meta-commands in sqlQuery — they will fail because sqlQuery is wrapped in a subquery at runtime. Extensions like h3 and spatial are pre-loaded at startup.
+- CRITICAL: The transformSql and sqlQuery fields must contain ONLY a single SELECT statement. NEVER put INSTALL, LOAD, CREATE, or other DDL/meta-commands in dataset SQL — they will fail because dataset SQL is wrapped in a subquery at runtime. Extensions like h3 and spatial are pre-loaded at startup.
   - GeoJSON files typically contain polygon or multipolygon features (boundaries, buildings, parcels); use GeoArrowPolygonLayer for these. If a GeoJSON file contains point features, use GeoArrowScatterplotLayer (Point layer) instead.
 - RADIUS AND WIDTH: For GeoArrowScatterplotLayer (Point layer) use getRadius with radiusUnits: "pixels" (typically 2–6 pixels); large radii cause overdraw and rendering lag, especially with many points. For GeoArrowColumnLayer use the "radius" property (NOT getRadius) — it sets column radius in meters; typical values are 20–200 for city-scale data or smaller for dense datasets. Do NOT use getRadius or radiusUnits on column layers. For GeoArrowArcLayer, GeoArrowPathLayer, and GeoArrowTripsLayer use getWidth with widthUnits: "pixels" (typically 1–3 pixels).
 - HEATMAP: For GeoArrowHeatmapLayer, do NOT set colorRange manually. The UI provides a scheme selector that generates the correct color array. If you set colorRange to hand-picked RGB arrays, it will be out of sync with the scheme selector shown in the UI. Just omit colorRange entirely and let the default apply — users can change the scheme through the map settings panel.
 - ARC vs LINE: GeoArrowArcLayer renders curved 3D arcs by default. If the user asks for "lines" or "straight connections" between origin-destination pairs (not arcs), set "getHeight": 0 on the layer to render flat straight lines. Use arcs for flight routes or connections where the curve adds clarity; use flat lines for direct relationships, edges, or when the user explicitly requests lines.
 - ELEVATION: For extruded layers, getElevation with @@function "scale" passes the raw field value as meters. Use elevationScale on the layer to multiply values to a useful visual height. For example, if the field is "floors" (1-10), set elevationScale to 3 (meters per floor). Do NOT use negative values for elevation. Avoid using diverging scales for elevation. IMPORTANT: Keep elevation moderate — if extruded polygons or H3 hexagons are too tall, users can't see the tops when zoomed in. Prefer elevationScale values that produce heights of a few hundred meters at most for city-scale data. A good rule of thumb: the maximum elevation (field max × elevationScale) should not exceed ~500m for typical zoom levels.
-- Bind layers to datasets with _sqlroomsBinding.dataset and put tableName or sqlQuery sources in config.datasets.
-- Each dataset in config.datasets should have a source.tableName or source.sqlQuery that describes the original table the map was authored against. At runtime, the dashboard's selected table (from the table selector) overrides the source table — when the user switches the active table, all map panels automatically update. If the new table lacks required columns, an incompatibility error is shown.
-- IMPORTANT: Always pass tableName in the create_dashboard_map tool params (the top-level tableName field). Use the table currently selected in the dashboard (dashboard.selectedTable from list_dashboard_panels). At runtime, the dashboard's selected table always overrides the authored table — this param only seeds the initial selection when no table is selected yet.
-- IMPORTANT: If you are creating a map layer for a table that is NOT the currently selected dashboard table, you MUST switch the dashboard's selected table to that dataset BEFORE or WHEN calling create_dashboard_map (pass the correct tableName). The map panel resolves data from the dashboard's active table — if you don't switch it, the layer will query the wrong table and fail.
+- Bind layers to datasets with _sqlroomsBinding.dataset and put tableName, tableName+transformSql, or sqlQuery sources in config.datasets.
+- Use source.tableName for direct table-backed datasets. Use source.tableName plus source.transformSql when the map needs generated geometry or aggregation but should still follow the dashboard selected table. transformSql must read from ${DECK_TABLE_DATASET_SOURCE_RELATION}, not from the authored table name.
+- Use source.sqlQuery only for a standalone literal query that should remain pinned to the authored SQL. Dashboard selected table replacement applies only to structured tableName sources, not literal sqlQuery sources.
+- IMPORTANT: Always pass tableName in the create_dashboard_map tool params (the top-level tableName field). Use the table currently selected in the dashboard (dashboard.selectedTable from list_dashboard_panels). At runtime, the dashboard's selected table overrides structured source.tableName values — this param seeds or changes that selection.
+- IMPORTANT: If you are creating a structured table-backed map layer for a table that is NOT the currently selected dashboard table, you MUST switch the dashboard's selected table to that dataset BEFORE or WHEN calling create_dashboard_map (pass the correct tableName). Structured table-backed map panels resolve data from the dashboard's active table — if you don't switch it, the layer will query the wrong table and fail.
 - IMPORTANT: When referencing tables in tableName or sqlQuery, use ONLY the bare table name (e.g. "my_table") or schema-qualified name (e.g. "main.my_table"). NEVER include the database/catalog prefix (e.g. do NOT use "sqlrooms-cli.main.my_table") — the catalog does not exist in the query execution context.
-- IMPORTANT: For point data with longitude/latitude columns, the dataset source MUST use a sqlQuery that creates a geometry column, for example: "SELECT *, ST_AsWKB(ST_Point(\\"Longitude\\", \\"Latitude\\")) AS \\"__sqlrooms_geom\\" FROM tableName WHERE \\"Longitude\\" IS NOT NULL AND \\"Latitude\\" IS NOT NULL". Set geometryColumn to the same name used in the AS clause (e.g. "__sqlrooms_geom") and geometryEncodingHint to "wkb".
+- IMPORTANT: For point data with longitude/latitude columns that should follow dashboard table switching, use source.tableName plus source.transformSql to create a geometry column, for example: "SELECT *, ST_AsWKB(ST_Point(\\"Longitude\\", \\"Latitude\\")) AS \\"__sqlrooms_geom\\" FROM ${DECK_TABLE_DATASET_SOURCE_RELATION} WHERE \\"Longitude\\" IS NOT NULL AND \\"Latitude\\" IS NOT NULL". Set geometryColumn to the same name used in the AS clause (e.g. "__sqlrooms_geom") and geometryEncodingHint to "wkb".
 - IMPORTANT: When providing fitToData, it MUST be a flat object (NOT nested by dataset ID). Include either longitudeColumn+latitudeColumn (for point data with separate coordinate columns) OR geometryColumn (for data with a WKB geometry column like GeoJSON). For H3 hexagon layers, just specify the dataset: "fitToData": {"dataset": "datasetId"} — the H3 column is auto-detected from the layer binding. For GeoJSON/spatial files with a "geom" column, use: "fitToData": {"dataset": "datasetId", "geometryColumn": "geom"}. For point data use: "fitToData": {"dataset": "datasetId", "longitudeColumn": "lon", "latitudeColumn": "lat"}. NEVER nest fitToData as {"datasetId": {...}} — always use a flat object with "dataset" as a string field.
 - IMPORTANT: For GeoJSON or spatial files that already have a native geometry column (e.g. "geometry", "geom"), use the table directly with source.tableName (no sqlQuery needed), set the dataset's geometryColumn to "geom", set geometryEncodingHint to "wkb", and use fitToData with geometryColumn: {"dataset": "datasetId", "geometryColumn": "geom"}.
 - IMPORTANT: When a GeoJSON file (.geojson) is loaded as a table, DuckDB uses ST_Read to produce a table with a WKB "geom" column and all feature properties as columns. Use source.tableName, set geometryColumn to "geom" and geometryEncodingHint to "wkb". Use "fitToData": {"dataset": "datasetId", "geometryColumn": "geom"} to zoom to the data extent.
@@ -159,6 +144,7 @@ const DeckMapSpec = z.looseObject({
 
 const DeckMapDatasetSource = z.looseObject({
   tableName: z.string().optional(),
+  transformSql: z.string().optional(),
   sqlQuery: z.string().optional(),
 });
 
@@ -181,7 +167,7 @@ export const DeckMapDashboardConfigParameter = z.looseObject({
   datasets: z
     .record(z.string(), DeckMapDatasetConfig)
     .describe(
-      'Datasets keyed by dataset id. Layers bind to these ids through _sqlroomsBinding.dataset. Each dataset source may use tableName or sqlQuery.',
+      'Datasets keyed by dataset id. Layers bind to these ids through _sqlroomsBinding.dataset. Each dataset source may use tableName, tableName+transformSql, or sqlQuery.',
     ),
   mapStyle: z.string().optional(),
   mapProps: z.record(z.string(), z.unknown()).optional(),
@@ -265,7 +251,7 @@ const DEFAULT_AI_GEOMETRY_COLUMN = '__sqlrooms_geom';
 /**
  * Normalizes an AI-generated map config to ensure dataset sources produce
  * the expected geometry column when fitToData specifies coordinate columns
- * but the dataset only uses a tableName without a sqlQuery.
+ * but the dataset only uses a tableName without a transformSql.
  */
 function normalizeAiMapConfig(
   config: DeckMapDashboardConfigToolConfig,
@@ -312,12 +298,12 @@ function normalizeAiMapConfig(
   }
 
   const source = targetDataset.source as
-    | {tableName?: string; sqlQuery?: string}
+    | {tableName?: string; transformSql?: string; sqlQuery?: string}
     | undefined;
 
-  // Always normalize when using tableName without sqlQuery and fitToData
+  // Always normalize when using tableName without transformSql and fitToData
   // provides coordinate columns — the geometry must be computed from them.
-  if (!source?.tableName || source.sqlQuery) {
+  if (!source?.tableName || source.sqlQuery || source.transformSql) {
     return config;
   }
 
@@ -328,14 +314,9 @@ function normalizeAiMapConfig(
   const quotedLon = quoteDeckMapSqlIdentifier(lonCol);
   const quotedLat = quoteDeckMapSqlIdentifier(latCol);
   const quotedGeom = quoteDeckMapSqlIdentifier(geometryColumn);
-  const tableParts = splitIdentifierPathOutsideQuotes(source.tableName)
-    .map((p) =>
-      p.startsWith('"') && p.endsWith('"') ? p : quoteDeckMapSqlIdentifier(p),
-    )
-    .join('.');
-  const sqlQuery = [
+  const transformSql = [
     `SELECT *, ST_AsWKB(ST_Point(${quotedLon}, ${quotedLat})) AS ${quotedGeom}`,
-    `FROM ${tableParts}`,
+    `FROM ${DECK_TABLE_DATASET_SOURCE_RELATION}`,
     `WHERE ${quotedLon} IS NOT NULL AND ${quotedLat} IS NOT NULL`,
   ].join(' ');
 
@@ -345,7 +326,7 @@ function normalizeAiMapConfig(
       ...datasets,
       [targetDatasetId]: {
         ...targetDataset,
-        source: {sqlQuery},
+        source: {tableName: source.tableName, transformSql},
         geometryColumn,
         geometryEncodingHint: 'wkb',
       },
@@ -394,7 +375,7 @@ export function createDeckMapConfigTool(): Tool {
   return tool({
     description: `Deck map config: validates and returns a reusable native Deck JSON map configuration without requiring a dashboard artifact.
 
-Use when: a chat, agent, or artifact outside a dashboard needs a geospatial map config. Author the map using native Deck JSON: put layer classes in spec.layers[].@@type, bind layers to datasets through _sqlroomsBinding.dataset, and put tableName or sqlQuery sources in config.datasets. For data-driven colors, use color accessors such as getFillColor, getLineColor, getColor, getSourceColor, or getTargetColor with {"@@function":"colorScale", "field":"...", "type":"...", "scheme":"...", "domain":"auto"}. For categorical fields use scheme from: Tableau10, Set2, Category10, etc. For numeric fields use sequential schemes like Viridis.`,
+Use when: a chat, agent, or artifact outside a dashboard needs a geospatial map config. Author the map using native Deck JSON: put layer classes in spec.layers[].@@type, bind layers to datasets through _sqlroomsBinding.dataset, and put tableName, tableName+transformSql, or sqlQuery sources in config.datasets. For data-driven colors, use color accessors such as getFillColor, getLineColor, getColor, getSourceColor, or getTargetColor with {"@@function":"colorScale", "field":"...", "type":"...", "scheme":"...", "domain":"auto"}. For categorical fields use scheme from: Tableau10, Set2, Category10, etc. For numeric fields use sequential schemes like Viridis.`,
     inputSchema: DeckMapConfigToolParameters,
     execute: async (params) => {
       try {
@@ -461,7 +442,7 @@ export function createDeckMapDashboardTool({
   return tool({
     description: `Deck map panel: creates or updates an interactive geospatial map panel in a Mosaic dashboard from a native Deck JSON config.
 
-Use when: the user asks for a map in a dashboard. Author the map using native Deck JSON: choose layer classes with spec.layers[].@@type, bind layers to datasets through _sqlroomsBinding.dataset, and put tableName or sqlQuery sources in config.datasets. For data-driven colors, use color accessors such as getFillColor, getLineColor, getColor, getSourceColor, or getTargetColor with {"@@function":"colorScale", "field":"...", "type":"...", "scheme":"...", "domain":"auto"}. For categorical fields use scheme from: Tableau10, Set2, Category10, etc. For numeric fields use sequential schemes like Viridis.`,
+Use when: the user asks for a map in a dashboard. Author the map using native Deck JSON: choose layer classes with spec.layers[].@@type, bind layers to datasets through _sqlroomsBinding.dataset, and put tableName, tableName+transformSql, or sqlQuery sources in config.datasets. For data-driven colors, use color accessors such as getFillColor, getLineColor, getColor, getSourceColor, or getTargetColor with {"@@function":"colorScale", "field":"...", "type":"...", "scheme":"...", "domain":"auto"}. For categorical fields use scheme from: Tableau10, Set2, Category10, etc. For numeric fields use sequential schemes like Viridis.`,
     inputSchema: DeckMapDashboardToolParameters,
     execute: async (params) => {
       try {

--- a/packages/deck/src/block.tsx
+++ b/packages/deck/src/block.tsx
@@ -6,8 +6,10 @@ import {
   useTablesWithColumns,
   useStoreWithMosaicDashboard,
 } from '@sqlrooms/mosaic';
+import {useBlockSettingsStore} from '@sqlrooms/documents';
 import {getTableIdentity, type DataTable} from '@sqlrooms/duckdb';
-import {MapIcon} from 'lucide-react';
+import {MapIcon, SlidersVerticalIcon} from 'lucide-react';
+import {Button} from '@sqlrooms/ui';
 import {useCallback, useEffect, useMemo} from 'react';
 import {
   createDeckMapDashboardPanelConfig,
@@ -91,6 +93,8 @@ export type DeckMapBlockRendererProps = {
   caption?: string;
   /** Callback when caption changes. */
   onCaptionChange?: (caption: string | undefined) => void;
+  /** Whether the containing document block is selected. */
+  selected?: boolean;
   /** Whether the block is read-only. */
   readOnly?: boolean;
 };
@@ -103,6 +107,7 @@ export function DeckMapBlockRenderer({
   title,
   caption,
   onCaptionChange,
+  selected,
   readOnly,
 }: DeckMapBlockRendererProps) {
   const dashboard = useStoreWithMosaicDashboard(
@@ -122,6 +127,16 @@ export function DeckMapBlockRenderer({
   const updatePanel = useStoreWithMosaicDashboard(
     (state) => state.mosaicDashboard.updatePanel,
   );
+  const requestOpenSettingsPanel = useBlockSettingsStore(
+    (state) => state.blockSettings.requestOpenSettingsPanel,
+  );
+  const requestCloseSettingsPanel = useBlockSettingsStore(
+    (state) => state.blockSettings.requestCloseSettingsPanel,
+  );
+  const isSettingsPanelOpen = useBlockSettingsStore(
+    (state) => state.blockSettings.runtime.isSettingsPanelOpen,
+  );
+  const isSettingsShown = Boolean(selected && isSettingsPanelOpen);
 
   useEffect(() => {
     if (!mapId) {
@@ -210,6 +225,14 @@ export function DeckMapBlockRenderer({
     },
     [mapId, panel, setSelectedTable, title, updatePanel],
   );
+  const handleSettingsClick = useCallback(() => {
+    if (isSettingsShown) {
+      requestCloseSettingsPanel();
+      return;
+    }
+
+    requestOpenSettingsPanel();
+  }, [isSettingsShown, requestCloseSettingsPanel, requestOpenSettingsPanel]);
 
   if (!dashboard || !panel) {
     return (
@@ -248,7 +271,22 @@ export function DeckMapBlockRenderer({
             onChange={(value: string) => onCaptionChange?.(value || undefined)}
           />
         </div>
-        {HeaderActions ? <HeaderActions {...rendererProps} /> : null}
+        <div className="flex items-center gap-0.5">
+          {HeaderActions ? <HeaderActions {...rendererProps} /> : null}
+          <Button
+            type="button"
+            variant={isSettingsShown ? 'secondary' : 'ghost'}
+            size="icon"
+            className="h-6 w-6 shrink-0"
+            aria-label={
+              isSettingsShown ? 'Close map settings' : 'Open map settings'
+            }
+            aria-pressed={isSettingsShown}
+            onClick={handleSettingsClick}
+          >
+            <SlidersVerticalIcon className="h-3.5 w-3.5" aria-hidden />
+          </Button>
+        </div>
       </div>
       <div className="min-h-0 flex-1">
         {hasDatasets ? (

--- a/packages/deck/src/dashboard.tsx
+++ b/packages/deck/src/dashboard.tsx
@@ -26,6 +26,8 @@ import {
   createDeckMapDashboardDatasets,
   DECK_MAP_DASHBOARD_PANEL_TYPE,
   DEFAULT_DECK_MAP_MAX_DATA_POINTS,
+  isDeckMapDashboardSqlDatasetSource,
+  isDeckMapDashboardTableDatasetSource,
   resolveDeckMapDashboardDatasetSource,
   type DeckMapDashboardFitToDataConfig,
   type DeckMapDashboardDatasetClientState,
@@ -277,16 +279,14 @@ function DeckMapDashboardDatasetClient({
     },
     [datasetId, onDatasetState],
   );
-  const sourceKey =
-    source && 'tableName' in source
-      ? source.tableName
-      : (dashboard.selectedTable ?? '');
-  const sourceQueryKey =
-    source && 'sqlQuery' in source
-      ? source.sqlQuery
-      : source && 'tableName' in source
-        ? (source.transformSql ?? '')
-        : '';
+  const sourceKey = isDeckMapDashboardTableDatasetSource(source)
+    ? source.tableName
+    : (dashboard.selectedTable ?? '');
+  const sourceQueryKey = isDeckMapDashboardSqlDatasetSource(source)
+    ? source.sqlQuery
+    : isDeckMapDashboardTableDatasetSource(source)
+      ? (source.transformSql ?? '')
+      : '';
   const {data, error, isLoading, client} = useMosaicClient({
     id: `${panel.id}:${datasetId}:${sourceKey}:${sourceQueryKey}`,
     selectionName,

--- a/packages/deck/src/dashboard.tsx
+++ b/packages/deck/src/dashboard.tsx
@@ -281,7 +281,9 @@ function DeckMapDashboardDatasetClient({
   );
   const sourceKey = isDeckMapDashboardTableDatasetSource(source)
     ? source.tableName
-    : (dashboard.selectedTable ?? '');
+    : isDeckMapDashboardSqlDatasetSource(source)
+      ? ''
+      : (dashboard.selectedTable ?? '');
   const sourceQueryKey = isDeckMapDashboardSqlDatasetSource(source)
     ? source.sqlQuery
     : isDeckMapDashboardTableDatasetSource(source)

--- a/packages/deck/src/dashboard.tsx
+++ b/packages/deck/src/dashboard.tsx
@@ -277,8 +277,16 @@ function DeckMapDashboardDatasetClient({
     },
     [datasetId, onDatasetState],
   );
-  const sourceKey = source?.tableName ?? dashboard.selectedTable ?? '';
-  const sourceQueryKey = source?.sqlQuery ?? '';
+  const sourceKey =
+    source && 'tableName' in source
+      ? source.tableName
+      : (dashboard.selectedTable ?? '');
+  const sourceQueryKey =
+    source && 'sqlQuery' in source
+      ? source.sqlQuery
+      : source && 'tableName' in source
+        ? (source.transformSql ?? '')
+        : '';
   const {data, error, isLoading, client} = useMosaicClient({
     id: `${panel.id}:${datasetId}:${sourceKey}:${sourceQueryKey}`,
     selectionName,

--- a/packages/deck/src/dashboardConfig.ts
+++ b/packages/deck/src/dashboardConfig.ts
@@ -11,7 +11,12 @@ import {
 import {createId} from '@paralleldrive/cuid2';
 import {verbatim} from '@uwdata/mosaic-sql';
 import type {Table as ArrowTable} from 'apache-arrow';
-import type {DeckJsonMapProps, DeckSqlDatasetInput} from './types';
+import {createDeckTableDatasetSql} from './datasets/tableDatasetSql';
+import type {
+  DeckJsonMapProps,
+  DeckSqlDatasetInput,
+  DeckTableDatasetInput,
+} from './types';
 
 export const DECK_MAP_DASHBOARD_PANEL_TYPE = 'deck-json-map';
 export const DEFAULT_DECK_MAP_MAX_DATA_POINTS = 100_000;
@@ -26,8 +31,12 @@ export type DeckMapDashboardDatasetConfig = Omit<
   DeckSqlDatasetInput,
   'sqlQuery'
 > & {
-  source?: {tableName?: string; sqlQuery?: string};
+  source?: DeckMapDashboardDatasetSource;
 };
+
+export type DeckMapDashboardDatasetSource =
+  | Pick<DeckSqlDatasetInput, 'sqlQuery'>
+  | Pick<DeckTableDatasetInput, 'tableName' | 'transformSql'>;
 
 export type DeckMapDashboardInteractionConfig = {
   type: 'point-radius-brush';
@@ -107,80 +116,38 @@ export function resolveDeckMapDashboardDatasetSource(options: {
   panel: MosaicDashboardPanelConfigType;
   dataset?: DeckMapDashboardDatasetConfig;
   fitToData?: DeckMapDashboardFitToDataConfig;
-}): {tableName?: string; sqlQuery?: string} | undefined {
+}): DeckMapDashboardDatasetSource | undefined {
   const datasetSource = options.dataset?.source;
   const dashboardTable = stripCatalogPrefix(options.dashboard.selectedTable);
 
   // The dashboard's selected table always takes precedence as the data source.
-  // When the user switches the table in the selector, all panels update.
-  const baseTableName = dashboardTable || datasetSource?.tableName;
-  if (!baseTableName && !datasetSource?.sqlQuery) {
-    return undefined;
-  }
-
-  // If the dataset has a sqlQuery, rewrite the FROM clause to use the
-  // dashboard's runtime table form.
-  if (datasetSource?.sqlQuery && dashboardTable) {
-    const sourceTable = datasetSource.tableName;
-    const originalTable = stripCatalogPrefix(sourceTable);
-    const quotedDashboard = quoteRuntimeTableReference(dashboardTable);
-    if (!quotedDashboard) {
-      return datasetSource;
-    }
-
-    if (originalTable) {
-      const quotedOriginal = quoteRuntimeTableReference(originalTable);
-      if (quotedOriginal) {
-        const originalReferences = Array.from(
-          new Set(
-            [
-              sourceTable,
-              quoteParsedRawSqlTableReference(sourceTable),
-              originalTable,
-              quotedOriginal,
-            ].filter((reference): reference is string => Boolean(reference)),
-          ),
-        );
-        const rewritten = originalReferences.reduce(
-          (sqlQuery, originalReference) =>
-            sqlQuery.replace(
-              new RegExp(
-                `\\bFROM\\s+${escapeRegExp(originalReference)}(?=\\s|$|[,;)\\[\\]])`,
-                'gi',
-              ),
-              `FROM ${quotedDashboard}`,
-            ),
-          datasetSource.sqlQuery,
-        );
-        return {sqlQuery: rewritten};
-      }
-    }
-
-    if (!originalTable) {
-      // No explicit tableName — replace the first FROM <identifier> with the dashboard table.
-      const rewritten = datasetSource.sqlQuery.replace(
-        /\bFROM\s+((?:"[^"]*"(?:\."[^"]*")*)|(?:[a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)*))(?=\s|$|[,;)[\]])/i,
-        `FROM ${quotedDashboard}`,
-      );
-      if (rewritten !== datasetSource.sqlQuery) {
-        return {sqlQuery: rewritten};
-      }
-    }
-
+  // When the user switches the table in the selector, structured table-backed
+  // datasets update while literal SQL remains pinned to its authored query.
+  if (datasetSource && 'sqlQuery' in datasetSource) {
     return datasetSource;
   }
 
-  const resolvedSource = {tableName: baseTableName!};
+  const baseTableName =
+    dashboardTable ||
+    stripCatalogPrefix(
+      datasetSource && 'tableName' in datasetSource
+        ? datasetSource.tableName
+        : undefined,
+    );
+  if (!baseTableName) {
+    return undefined;
+  }
+
+  const resolvedSource: DeckMapDashboardDatasetSource = {
+    tableName: baseTableName,
+    ...(datasetSource &&
+    'tableName' in datasetSource &&
+    datasetSource.transformSql
+      ? {transformSql: datasetSource.transformSql}
+      : {}),
+  };
 
   return resolvedSource;
-}
-
-function quoteRuntimeTableReference(tableName: string | undefined) {
-  return quoteParsedRawSqlTableReference(stripCatalogPrefix(tableName));
-}
-
-function escapeRegExp(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function stripCatalogPrefix(tableName: string | undefined) {
@@ -195,24 +162,28 @@ function stripCatalogPrefix(tableName: string | undefined) {
 }
 
 export function createDeckMapDashboardDatasetQuery(
-  source: {tableName?: string; sqlQuery?: string},
+  source: DeckMapDashboardDatasetSource,
   filter: unknown,
   options?: {sampleRows?: number},
 ) {
-  const tableReference = source.sqlQuery
-    ? ''
-    : getDeckMapDatasetSourceTableReference(source.tableName);
+  const isSqlSource = 'sqlQuery' in source;
+  const isDirectTableSource = 'tableName' in source && !source.transformSql;
+  const tableReference = isDirectTableSource
+    ? getDeckMapDatasetSourceTableReference(source.tableName)
+    : '';
   // Apply USING SAMPLE at the source level so Mosaic filters work on top.
-  const sourceExpr: string = source.sqlQuery
+  const sourceExpr: string = isSqlSource
     ? `(${source.sqlQuery})`
-    : tableReference;
+    : isDirectTableSource
+      ? tableReference
+      : `(${createDeckTableDatasetSql(source)})`;
 
   const sampledSource = options?.sampleRows
     ? `(SELECT * FROM ${sourceExpr} USING SAMPLE ${options.sampleRows} ROWS)`
     : sourceExpr;
 
   const query =
-    source.sqlQuery || options?.sampleRows
+    isSqlSource || !isDirectTableSource || options?.sampleRows
       ? Query.from({
           __dashboard_map_dataset: verbatim(sampledSource),
         })

--- a/packages/deck/src/dashboardConfig.ts
+++ b/packages/deck/src/dashboardConfig.ts
@@ -38,6 +38,18 @@ export type DeckMapDashboardDatasetSource =
   | Pick<DeckSqlDatasetInput, 'sqlQuery'>
   | Pick<DeckTableDatasetInput, 'tableName' | 'transformSql'>;
 
+export function isDeckMapDashboardSqlDatasetSource(
+  source: DeckMapDashboardDatasetSource | undefined,
+): source is Pick<DeckSqlDatasetInput, 'sqlQuery'> {
+  return Boolean(source && 'sqlQuery' in source);
+}
+
+export function isDeckMapDashboardTableDatasetSource(
+  source: DeckMapDashboardDatasetSource | undefined,
+): source is Pick<DeckTableDatasetInput, 'tableName' | 'transformSql'> {
+  return Boolean(source && 'tableName' in source);
+}
+
 export type DeckMapDashboardInteractionConfig = {
   type: 'point-radius-brush';
   dataset: string;
@@ -123,14 +135,14 @@ export function resolveDeckMapDashboardDatasetSource(options: {
   // The dashboard's selected table always takes precedence as the data source.
   // When the user switches the table in the selector, structured table-backed
   // datasets update while literal SQL remains pinned to its authored query.
-  if (datasetSource && 'sqlQuery' in datasetSource) {
+  if (isDeckMapDashboardSqlDatasetSource(datasetSource)) {
     return datasetSource;
   }
 
   const baseTableName =
     dashboardTable ||
     stripCatalogPrefix(
-      datasetSource && 'tableName' in datasetSource
+      isDeckMapDashboardTableDatasetSource(datasetSource)
         ? datasetSource.tableName
         : undefined,
     );
@@ -140,8 +152,7 @@ export function resolveDeckMapDashboardDatasetSource(options: {
 
   const resolvedSource: DeckMapDashboardDatasetSource = {
     tableName: baseTableName,
-    ...(datasetSource &&
-    'tableName' in datasetSource &&
+    ...(isDeckMapDashboardTableDatasetSource(datasetSource) &&
     datasetSource.transformSql
       ? {transformSql: datasetSource.transformSql}
       : {}),
@@ -166,8 +177,9 @@ export function createDeckMapDashboardDatasetQuery(
   filter: unknown,
   options?: {sampleRows?: number},
 ) {
-  const isSqlSource = 'sqlQuery' in source;
-  const isDirectTableSource = 'tableName' in source && !source.transformSql;
+  const isSqlSource = isDeckMapDashboardSqlDatasetSource(source);
+  const isTableSource = isDeckMapDashboardTableDatasetSource(source);
+  const isDirectTableSource = isTableSource && !source.transformSql;
   const tableReference = isDirectTableSource
     ? getDeckMapDatasetSourceTableReference(source.tableName)
     : '';

--- a/packages/deck/src/dashboardConfig.ts
+++ b/packages/deck/src/dashboardConfig.ts
@@ -34,16 +34,19 @@ export type DeckMapDashboardDatasetConfig = Omit<
   source?: DeckMapDashboardDatasetSource;
 };
 
+/** Dashboard map source that is either a pinned SQL query or table-backed data. */
 export type DeckMapDashboardDatasetSource =
   | Pick<DeckSqlDatasetInput, 'sqlQuery'>
   | Pick<DeckTableDatasetInput, 'tableName' | 'transformSql'>;
 
+/** Returns true when a dashboard map source is a literal pinned SQL query. */
 export function isDeckMapDashboardSqlDatasetSource(
   source: DeckMapDashboardDatasetSource | undefined,
 ): source is Pick<DeckSqlDatasetInput, 'sqlQuery'> {
   return Boolean(source && 'sqlQuery' in source);
 }
 
+/** Returns true when a dashboard map source is backed by a structured table. */
 export function isDeckMapDashboardTableDatasetSource(
   source: DeckMapDashboardDatasetSource | undefined,
 ): source is Pick<DeckTableDatasetInput, 'tableName' | 'transformSql'> {
@@ -141,11 +144,9 @@ export function resolveDeckMapDashboardDatasetSource(options: {
 
   const baseTableName =
     dashboardTable ||
-    stripCatalogPrefix(
-      isDeckMapDashboardTableDatasetSource(datasetSource)
-        ? datasetSource.tableName
-        : undefined,
-    );
+    (isDeckMapDashboardTableDatasetSource(datasetSource)
+      ? datasetSource.tableName
+      : undefined);
   if (!baseTableName) {
     return undefined;
   }

--- a/packages/deck/src/datasets/PreparedDatasetStore.ts
+++ b/packages/deck/src/datasets/PreparedDatasetStore.ts
@@ -3,6 +3,7 @@ import {createStore} from 'zustand/vanilla';
 import {prepareDeckDataset} from '../prepare/prepareDeckDataset';
 import {
   isSqlDatasetInput,
+  isTableDatasetInput,
   type DeckDatasetInput,
   type PreparedDeckDatasetState,
 } from '../types';
@@ -15,6 +16,7 @@ import {
   touchEntry,
 } from './helpers';
 import {resolveArrowTable} from './normalizeDatasets';
+import {createDeckTableDatasetSql} from './tableDatasetSql';
 import type {
   PreparedDatasetCacheEntry,
   PreparedDatasetStoreOptions,
@@ -159,8 +161,14 @@ export function createPreparedDatasetStore(
       const promise = Promise.resolve().then(async () => {
         try {
           let table = resolveArrowTable(input);
-          if (!table && isSqlDatasetInput(input)) {
-            const queryHandle = await executeSql(input.sqlQuery);
+          if (
+            !table &&
+            (isSqlDatasetInput(input) || isTableDatasetInput(input))
+          ) {
+            const sql = isSqlDatasetInput(input)
+              ? input.sqlQuery
+              : createDeckTableDatasetSql(input);
+            const queryHandle = await executeSql(sql);
             if (!queryHandle) {
               throw new Error(
                 `Query for dataset "${datasetId}" was cancelled.`,

--- a/packages/deck/src/datasets/helpers.ts
+++ b/packages/deck/src/datasets/helpers.ts
@@ -1,6 +1,11 @@
 import type * as arrow from 'apache-arrow';
-import {isSqlDatasetInput, type DeckDatasetInput} from '../types';
+import {
+  isSqlDatasetInput,
+  isTableDatasetInput,
+  type DeckDatasetInput,
+} from '../types';
 import {resolveArrowTable} from './normalizeDatasets';
+import {createDeckTableDatasetSql} from './tableDatasetSql';
 import type {PreparedDatasetCacheEntry} from './types';
 
 export const DEFAULT_MAX_PREPARED_DATASET_ENTRIES = 20;
@@ -65,7 +70,7 @@ export function buildGeometryKey(input: DeckDatasetInput): string {
  * The key intentionally ignores the user-facing dataset id and instead uses
  * the underlying data identity:
  *
- * - SQL datasets: DuckDB connector identity + SQL text + geometry options
+ * - SQL/table datasets: DuckDB connector identity + compiled SQL + geometry options
  * - Arrow datasets: table object identity + geometry options
  *
  * Unresolved Arrow inputs (`arrowTable: undefined`) return `undefined`, which
@@ -77,17 +82,21 @@ export function resolvePreparedDatasetCacheKey(options: {
 }): string | undefined {
   const {input, sqlSourceIdentity} = options;
 
-  if (isSqlDatasetInput(input)) {
+  if (isSqlDatasetInput(input) || isTableDatasetInput(input)) {
     if (!sqlSourceIdentity) {
       throw new Error(
-        'SQL dataset cache keys require a sqlSourceIdentity object.',
+        'SQL-backed dataset cache keys require a sqlSourceIdentity object.',
       );
     }
+
+    const sql = isSqlDatasetInput(input)
+      ? input.sqlQuery
+      : createDeckTableDatasetSql(input);
 
     return [
       'sql',
       getSqlSourceIdentity(sqlSourceIdentity),
-      input.sqlQuery,
+      sql,
       buildGeometryKey(input),
     ].join('\u0001');
   }

--- a/packages/deck/src/datasets/helpers.ts
+++ b/packages/deck/src/datasets/helpers.ts
@@ -5,7 +5,6 @@ import {
   type DeckDatasetInput,
 } from '../types';
 import {resolveArrowTable} from './normalizeDatasets';
-import {createDeckTableDatasetSql} from './tableDatasetSql';
 import type {PreparedDatasetCacheEntry} from './types';
 
 export const DEFAULT_MAX_PREPARED_DATASET_ENTRIES = 20;
@@ -89,14 +88,20 @@ export function resolvePreparedDatasetCacheKey(options: {
       );
     }
 
-    const sql = isSqlDatasetInput(input)
-      ? input.sqlQuery
-      : createDeckTableDatasetSql(input);
+    if (isTableDatasetInput(input)) {
+      return [
+        'table',
+        getSqlSourceIdentity(sqlSourceIdentity),
+        input.tableName,
+        input.transformSql ?? '',
+        buildGeometryKey(input),
+      ].join('\u0001');
+    }
 
     return [
       'sql',
       getSqlSourceIdentity(sqlSourceIdentity),
-      sql,
+      input.sqlQuery,
       buildGeometryKey(input),
     ].join('\u0001');
   }

--- a/packages/deck/src/datasets/normalizeDatasets.ts
+++ b/packages/deck/src/datasets/normalizeDatasets.ts
@@ -2,6 +2,7 @@ import type * as arrow from 'apache-arrow';
 import {
   isArrowTableDatasetInput,
   isSqlDatasetInput,
+  isTableDatasetInput,
   type DeckDatasetInput,
   type DeckJsonMapProps,
 } from '../types';
@@ -27,8 +28,17 @@ function normalizeDatasetEntry(
     };
   }
 
+  if (isTableDatasetInput(input)) {
+    return {
+      tableName: input.tableName,
+      transformSql: input.transformSql,
+      geometryColumn: input.geometryColumn,
+      geometryEncodingHint: input.geometryEncodingHint,
+    };
+  }
+
   throw new Error(
-    `Dataset "${datasetId}" has an unrecognized input shape. Expected either { sqlQuery } or { arrowTable }.`,
+    `Dataset "${datasetId}" has an unrecognized input shape. Expected { sqlQuery }, { tableName }, { tableName, transformSql }, or { arrowTable }.`,
   );
 }
 

--- a/packages/deck/src/datasets/tableDatasetSql.ts
+++ b/packages/deck/src/datasets/tableDatasetSql.ts
@@ -1,25 +1,53 @@
 import {quoteParsedRawSqlTableReference} from '@sqlrooms/duckdb';
 import type {DeckTableDatasetInput} from '../types';
 
+/** Reserved relation name that table dataset transforms must read from. */
 export const DECK_TABLE_DATASET_SOURCE_RELATION = '__sqlrooms_source';
+
+/** Error thrown when a table dataset input cannot be compiled to a table ref. */
+export class DeckTableDatasetInvalidTableNameError extends Error {
+  constructor() {
+    super('Deck table dataset input requires a valid tableName.');
+    this.name = 'DeckTableDatasetInvalidTableNameError';
+  }
+}
 
 function cleanTransformSql(transformSql: string): string {
   return transformSql.trim().replace(/(?:\s*;+\s*)+$/, '');
+}
+
+function createTransformedTableDatasetSql(options: {
+  tableReference: string;
+  transformSql: string;
+}) {
+  const leadingWith = /^\s*WITH\s+(RECURSIVE\s+)?/i.exec(options.transformSql);
+  const withKeyword = leadingWith?.[1] ? 'WITH RECURSIVE' : 'WITH';
+  const transformBody = leadingWith
+    ? options.transformSql.slice(leadingWith[0].length)
+    : options.transformSql;
+  const cteSeparator = leadingWith ? ',' : '';
+
+  return [
+    `${withKeyword} ${DECK_TABLE_DATASET_SOURCE_RELATION} AS (`,
+    `  SELECT * FROM ${options.tableReference}`,
+    `)${cteSeparator}`,
+    transformBody,
+  ].join('\n');
 }
 
 /**
  * Compiles a structured table dataset input into executable SQL.
  *
  * Direct table inputs compile to `SELECT * FROM <quoted table>`. Transformed
- * inputs bind the table to the reserved `__sqlrooms_source` CTE and leave the
- * authored transform SQL untouched.
+ * inputs bind the table to the reserved `__sqlrooms_source` CTE and preserve
+ * any authored CTEs from `transformSql`.
  */
 export function createDeckTableDatasetSql(
   input: DeckTableDatasetInput,
 ): string {
   const tableReference = quoteParsedRawSqlTableReference(input.tableName);
   if (!tableReference) {
-    throw new Error('Deck table dataset input requires a valid tableName.');
+    throw new DeckTableDatasetInvalidTableNameError();
   }
 
   if (!input.transformSql?.trim()) {
@@ -37,10 +65,8 @@ export function createDeckTableDatasetSql(
     );
   }
 
-  return [
-    `WITH ${DECK_TABLE_DATASET_SOURCE_RELATION} AS (`,
-    `  SELECT * FROM ${tableReference}`,
-    ')',
+  return createTransformedTableDatasetSql({
+    tableReference,
     transformSql,
-  ].join('\n');
+  });
 }

--- a/packages/deck/src/datasets/tableDatasetSql.ts
+++ b/packages/deck/src/datasets/tableDatasetSql.ts
@@ -1,0 +1,46 @@
+import {quoteParsedRawSqlTableReference} from '@sqlrooms/duckdb';
+import type {DeckTableDatasetInput} from '../types';
+
+export const DECK_TABLE_DATASET_SOURCE_RELATION = '__sqlrooms_source';
+
+function cleanTransformSql(transformSql: string): string {
+  return transformSql.trim().replace(/(?:\s*;+\s*)+$/, '');
+}
+
+/**
+ * Compiles a structured table dataset input into executable SQL.
+ *
+ * Direct table inputs compile to `SELECT * FROM <quoted table>`. Transformed
+ * inputs bind the table to the reserved `__sqlrooms_source` CTE and leave the
+ * authored transform SQL untouched.
+ */
+export function createDeckTableDatasetSql(
+  input: DeckTableDatasetInput,
+): string {
+  const tableReference = quoteParsedRawSqlTableReference(input.tableName);
+  if (!tableReference) {
+    throw new Error('Deck table dataset input requires a valid tableName.');
+  }
+
+  if (!input.transformSql?.trim()) {
+    return `SELECT * FROM ${tableReference}`;
+  }
+
+  const transformSql = cleanTransformSql(input.transformSql);
+  if (
+    !new RegExp(`\\b${DECK_TABLE_DATASET_SOURCE_RELATION}\\b`, 'i').test(
+      transformSql,
+    )
+  ) {
+    throw new Error(
+      `Deck table dataset transformSql must reference ${DECK_TABLE_DATASET_SOURCE_RELATION}.`,
+    );
+  }
+
+  return [
+    `WITH ${DECK_TABLE_DATASET_SOURCE_RELATION} AS (`,
+    `  SELECT * FROM ${tableReference}`,
+    ')',
+    transformSql,
+  ].join('\n');
+}

--- a/packages/deck/src/datasets/tableDatasetSql.ts
+++ b/packages/deck/src/datasets/tableDatasetSql.ts
@@ -20,18 +20,14 @@ function createTransformedTableDatasetSql(options: {
   tableReference: string;
   transformSql: string;
 }) {
-  const leadingWith = /^\s*WITH\s+(RECURSIVE\s+)?/i.exec(options.transformSql);
-  const withKeyword = leadingWith?.[1] ? 'WITH RECURSIVE' : 'WITH';
-  const transformBody = leadingWith
-    ? options.transformSql.slice(leadingWith[0].length)
-    : options.transformSql;
-  const cteSeparator = leadingWith ? ',' : '';
-
   return [
-    `${withKeyword} ${DECK_TABLE_DATASET_SOURCE_RELATION} AS (`,
+    `WITH ${DECK_TABLE_DATASET_SOURCE_RELATION} AS (`,
     `  SELECT * FROM ${options.tableReference}`,
-    `)${cteSeparator}`,
-    transformBody,
+    `)`,
+    `SELECT *`,
+    `FROM (`,
+    options.transformSql,
+    `) AS "__sqlrooms_transform"`,
   ].join('\n');
 }
 
@@ -39,8 +35,8 @@ function createTransformedTableDatasetSql(options: {
  * Compiles a structured table dataset input into executable SQL.
  *
  * Direct table inputs compile to `SELECT * FROM <quoted table>`. Transformed
- * inputs bind the table to the reserved `__sqlrooms_source` CTE and preserve
- * any authored CTEs from `transformSql`.
+ * inputs bind the table to the reserved `__sqlrooms_source` CTE and nest the
+ * authored `transformSql` so its CTEs remain self-contained.
  */
 export function createDeckTableDatasetSql(
   input: DeckTableDatasetInput,

--- a/packages/deck/src/index.ts
+++ b/packages/deck/src/index.ts
@@ -44,6 +44,8 @@ export {
   createDeckMapDashboardPanelConfig,
   DEFAULT_DECK_MAP_MAX_DATA_POINTS,
   DECK_MAP_DASHBOARD_PANEL_TYPE,
+  isDeckMapDashboardSqlDatasetSource,
+  isDeckMapDashboardTableDatasetSource,
   resolveDeckMapDashboardDatasetSource,
 } from './dashboardConfig';
 export {getDeckMapDataPolicy} from './mapDataPolicy';

--- a/packages/deck/src/index.ts
+++ b/packages/deck/src/index.ts
@@ -92,7 +92,15 @@ export type {
   ResolvedGeometryColumn,
   ResolvedGeometryEncoding,
 } from './prepare/types';
-export {isArrowTableDatasetInput, isSqlDatasetInput} from './types';
+export {
+  isArrowTableDatasetInput,
+  isSqlDatasetInput,
+  isTableDatasetInput,
+} from './types';
+export {
+  DECK_TABLE_DATASET_SOURCE_RELATION,
+  createDeckTableDatasetSql,
+} from './datasets/tableDatasetSql';
 export type {
   CreateDeckJsonSpecFromDatasetsOptions,
   DeckArrowTableDatasetInput,
@@ -102,6 +110,7 @@ export type {
   DeckJsonMapProps,
   DeckJsonSpecDatasetHint,
   DeckSqlDatasetInput,
+  DeckTableDatasetInput,
   DeckTable,
   PreparedDeckDatasetState,
 } from './types';

--- a/packages/deck/src/mapConfigUtils.ts
+++ b/packages/deck/src/mapConfigUtils.ts
@@ -10,6 +10,7 @@ import {
   createDeckMapDashboardPanelConfig,
   type DeckMapDashboardPanelConfig,
 } from './dashboardConfig';
+import {DECK_TABLE_DATASET_SOURCE_RELATION} from './datasets/tableDatasetSql';
 import type {GeometryEncodingHint} from './prepare/types';
 
 const LONGITUDE_COLUMN_NAMES = ['longitude', 'lon', 'lng', 'long', 'x'];
@@ -198,6 +199,21 @@ function createDeckMapPointSourceSql(options: {
   ].join(' ');
 }
 
+function createDeckMapPointTransformSql(options: {
+  longitudeColumn: string;
+  latitudeColumn: string;
+  geometryColumn: string;
+}) {
+  const quotedLongitude = quoteDeckMapSqlIdentifier(options.longitudeColumn);
+  const quotedLatitude = quoteDeckMapSqlIdentifier(options.latitudeColumn);
+
+  return [
+    `SELECT *, ST_AsWKB(ST_Point(${quotedLongitude}, ${quotedLatitude})) AS ${quoteDeckMapSqlIdentifier(options.geometryColumn)}`,
+    `FROM ${DECK_TABLE_DATASET_SOURCE_RELATION}`,
+    `WHERE ${quotedLongitude} IS NOT NULL AND ${quotedLatitude} IS NOT NULL`,
+  ].join(' ');
+}
+
 export function normalizeDeckMapFillColor(
   fillColor?: number[],
 ): DeckMapFillColor {
@@ -253,15 +269,24 @@ export function createDeckMapDashboardConfigForTable(options: {
     options.geometryEncodingHint ??
     detectedGeometryColumn?.geometryEncodingHint;
   const source = coordinates
-    ? {
-        sqlQuery: createDeckMapPointSourceSql({
-          sourceSqlQuery: options.sourceSqlQuery,
-          tableReference: options.tableReference ?? options.tableName,
-          longitudeColumn: coordinates.longitudeColumn,
-          latitudeColumn: coordinates.latitudeColumn,
-          geometryColumn,
-        }),
-      }
+    ? options.sourceSqlQuery
+      ? {
+          sqlQuery: createDeckMapPointSourceSql({
+            sourceSqlQuery: options.sourceSqlQuery,
+            tableReference: options.tableReference ?? options.tableName,
+            longitudeColumn: coordinates.longitudeColumn,
+            latitudeColumn: coordinates.latitudeColumn,
+            geometryColumn,
+          }),
+        }
+      : {
+          tableName: options.tableName,
+          transformSql: createDeckMapPointTransformSql({
+            longitudeColumn: coordinates.longitudeColumn,
+            latitudeColumn: coordinates.latitudeColumn,
+            geometryColumn,
+          }),
+        }
     : options.sourceSqlQuery
       ? {sqlQuery: options.sourceSqlQuery}
       : {tableName: options.tableName};

--- a/packages/deck/src/mapConfigUtils.ts
+++ b/packages/deck/src/mapConfigUtils.ts
@@ -280,7 +280,9 @@ export function createDeckMapDashboardConfigForTable(options: {
           }),
         }
       : {
-          tableName: options.tableName,
+          tableName: options.tableReference
+            ? quoteDeckMapSqlTableReference(options.tableReference)
+            : options.tableName,
           transformSql: createDeckMapPointTransformSql({
             longitudeColumn: coordinates.longitudeColumn,
             latitudeColumn: coordinates.latitudeColumn,

--- a/packages/deck/src/types.ts
+++ b/packages/deck/src/types.ts
@@ -31,7 +31,26 @@ export type DeckAutoLayerType =
   | 'GeoArrowH3HexagonLayer';
 
 export type DeckSqlDatasetInput = DeckDatasetBase & {
+  /**
+   * Literal SQL query used as the full dataset source.
+   *
+   * SQLRooms does not rewrite this query when dashboard selected tables change.
+   * Use `DeckTableDatasetInput` when a dataset should follow a structured
+   * table source.
+   */
   sqlQuery: string;
+};
+
+/**
+ * Structured table-backed dataset source.
+ *
+ * `tableName` identifies the source relation. When `transformSql` is present,
+ * it must be a complete SELECT query that reads from the reserved
+ * `__sqlrooms_source` relation supplied by SQLRooms at execution time.
+ */
+export type DeckTableDatasetInput = DeckDatasetBase & {
+  tableName: string;
+  transformSql?: string;
 };
 
 export type DeckTable = arrow.Table;
@@ -39,7 +58,10 @@ export type DeckTable = arrow.Table;
 export type DeckArrowTableDatasetInput = DeckDatasetBase & {
   arrowTable: DeckTable | undefined;
 };
-export type DeckDatasetInput = DeckSqlDatasetInput | DeckArrowTableDatasetInput;
+export type DeckDatasetInput =
+  | DeckSqlDatasetInput
+  | DeckTableDatasetInput
+  | DeckArrowTableDatasetInput;
 
 export type DeckJsonSpecDatasetHint = {
   prefer?: 'heatmap';
@@ -96,6 +118,13 @@ export function isSqlDatasetInput(
   input: DeckDatasetInput,
 ): input is DeckSqlDatasetInput {
   return 'sqlQuery' in input;
+}
+
+/** Returns true when the dataset input describes a structured table source. */
+export function isTableDatasetInput(
+  input: DeckDatasetInput,
+): input is DeckTableDatasetInput {
+  return 'tableName' in input;
 }
 
 export function isArrowTableDatasetInput(

--- a/packages/deck/src/useDeckMapFitToBounds.ts
+++ b/packages/deck/src/useDeckMapFitToBounds.ts
@@ -12,6 +12,7 @@ import type {Table as ArrowTable} from 'apache-arrow';
 import {useEffect, useMemo, useState, type RefObject} from 'react';
 import {
   asDeckJsonMapConfig,
+  isDeckMapDashboardSqlDatasetSource,
   resolveDeckMapDashboardDatasetSource,
   type DeckMapDashboardDatasetSource,
   type DeckMapDashboardFitToDataConfig,
@@ -111,10 +112,9 @@ export function createDeckMapBoundsQuery(options: {
   if (!isDeckMapFitToDataValid(fitToData)) {
     return null;
   }
-  const baseSourceSql =
-    'sqlQuery' in source
-      ? `SELECT * FROM (${source.sqlQuery}) AS "__sqlrooms_dashboard_map_source"`
-      : createDeckMapBoundsTableSourceSql(source);
+  const baseSourceSql = isDeckMapDashboardSqlDatasetSource(source)
+    ? `SELECT * FROM (${source.sqlQuery}) AS "__sqlrooms_dashboard_map_source"`
+    : createDeckMapBoundsTableSourceSql(source);
 
   if (fitToData.h3Column) {
     const h3Col = escapeId(fitToData.h3Column);
@@ -131,8 +131,9 @@ export function createDeckMapBoundsQuery(options: {
 
   if (fitToData.geometryColumn) {
     const geometryCol = escapeId(fitToData.geometryColumn);
-    const sourceSql =
-      'sqlQuery' in source ? source.sqlQuery : (source.transformSql ?? '');
+    const sourceSql = isDeckMapDashboardSqlDatasetSource(source)
+      ? source.sqlQuery
+      : (source.transformSql ?? '');
     const isWkb = sourceSql.toLowerCase().includes('st_aswkb');
     const geomExpr = isWkb
       ? `ST_GeomFromWKB(${geometryCol})`

--- a/packages/deck/src/useDeckMapFitToBounds.ts
+++ b/packages/deck/src/useDeckMapFitToBounds.ts
@@ -17,7 +17,10 @@ import {
   type DeckMapDashboardDatasetSource,
   type DeckMapDashboardFitToDataConfig,
 } from './dashboardConfig';
-import {createDeckTableDatasetSql} from './datasets/tableDatasetSql';
+import {
+  DeckTableDatasetInvalidTableNameError,
+  createDeckTableDatasetSql,
+} from './datasets/tableDatasetSql';
 import type {DeckJsonMapHandle} from './types';
 
 type DeckMapDashboardFitState = {
@@ -220,10 +223,7 @@ function createDeckMapBoundsTableSourceSql(
   try {
     return createDeckTableDatasetSql(source);
   } catch (error) {
-    if (
-      error instanceof Error &&
-      error.message === 'Deck table dataset input requires a valid tableName.'
-    ) {
+    if (error instanceof DeckTableDatasetInvalidTableNameError) {
       throw new Error('Deck map fit-to-data requires a valid table source.');
     }
     throw error;

--- a/packages/deck/src/useDeckMapFitToBounds.ts
+++ b/packages/deck/src/useDeckMapFitToBounds.ts
@@ -2,7 +2,6 @@ import {WebMercatorViewport} from '@deck.gl/core';
 import {
   escapeId,
   getColValAsNumber,
-  quoteParsedRawSqlTableReference,
   useStoreWithDuckDb,
 } from '@sqlrooms/duckdb';
 import type {
@@ -14,8 +13,10 @@ import {useEffect, useMemo, useState, type RefObject} from 'react';
 import {
   asDeckJsonMapConfig,
   resolveDeckMapDashboardDatasetSource,
+  type DeckMapDashboardDatasetSource,
   type DeckMapDashboardFitToDataConfig,
 } from './dashboardConfig';
+import {createDeckTableDatasetSql} from './datasets/tableDatasetSql';
 import type {DeckJsonMapHandle} from './types';
 
 type DeckMapDashboardFitState = {
@@ -103,16 +104,17 @@ function resolveFitToData(
 }
 
 export function createDeckMapBoundsQuery(options: {
-  source: {tableName?: string; sqlQuery?: string};
+  source: DeckMapDashboardDatasetSource;
   fitToData: DeckMapDashboardFitToDataConfig;
 }) {
   const {source, fitToData} = options;
   if (!isDeckMapFitToDataValid(fitToData)) {
     return null;
   }
-  const baseSourceSql = source.sqlQuery
-    ? `SELECT * FROM (${source.sqlQuery}) AS "__sqlrooms_dashboard_map_source"`
-    : `SELECT * FROM ${getDeckMapBoundsSourceTableReference(source.tableName)}`;
+  const baseSourceSql =
+    'sqlQuery' in source
+      ? `SELECT * FROM (${source.sqlQuery}) AS "__sqlrooms_dashboard_map_source"`
+      : createDeckMapBoundsTableSourceSql(source);
 
   if (fitToData.h3Column) {
     const h3Col = escapeId(fitToData.h3Column);
@@ -129,8 +131,9 @@ export function createDeckMapBoundsQuery(options: {
 
   if (fitToData.geometryColumn) {
     const geometryCol = escapeId(fitToData.geometryColumn);
-    const isWkb =
-      source.sqlQuery && source.sqlQuery.toLowerCase().includes('st_aswkb');
+    const sourceSql =
+      'sqlQuery' in source ? source.sqlQuery : (source.transformSql ?? '');
+    const isWkb = sourceSql.toLowerCase().includes('st_aswkb');
     const geomExpr = isWkb
       ? `ST_GeomFromWKB(${geometryCol})`
       : `${geometryCol}::GEOMETRY`;
@@ -184,14 +187,6 @@ export function createDeckMapBoundsQuery(options: {
   `;
 }
 
-function getDeckMapBoundsSourceTableReference(tableName: string | undefined) {
-  const tableReference = quoteParsedRawSqlTableReference(tableName);
-  if (!tableReference) {
-    throw new Error('Deck map fit-to-data requires a valid table source.');
-  }
-  return tableReference;
-}
-
 function readBoundsFromExtentResult(result: ArrowTable) {
   const minLongitude = getColValAsNumber(result, 'min_longitude');
   const minLatitude = getColValAsNumber(result, 'min_latitude');
@@ -216,6 +211,22 @@ function readBoundsFromExtentResult(result: ArrowTable) {
       minLatitude === maxLatitude ? maxLatitude + 0.01 : maxLatitude,
     ],
   ] as const;
+}
+
+function createDeckMapBoundsTableSourceSql(
+  source: Exclude<DeckMapDashboardDatasetSource, {sqlQuery: string}>,
+) {
+  try {
+    return createDeckTableDatasetSql(source);
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message === 'Deck table dataset input requires a valid tableName.'
+    ) {
+      throw new Error('Deck map fit-to-data requires a valid table source.');
+    }
+    throw error;
+  }
 }
 
 function fitViewStateToBounds(options: {

--- a/packages/documents/src/BlockDocumentEditor/node-views/BlockDocumentStatefulBlockNodeView.tsx
+++ b/packages/documents/src/BlockDocumentEditor/node-views/BlockDocumentStatefulBlockNodeView.tsx
@@ -379,6 +379,7 @@ export const BlockDocumentStatefulBlockNodeView: FC<
             title={title}
             caption={caption}
             height={resolvedHeight}
+            selected={selected}
             readOnly={readOnly}
             onTitleChange={handleTitleChange}
             onCaptionChange={handleCaptionChange}

--- a/packages/documents/src/BlockDocumentStatefulBlockRendererContext.tsx
+++ b/packages/documents/src/BlockDocumentStatefulBlockRendererContext.tsx
@@ -16,6 +16,7 @@ export type BlockDocumentStatefulBlockRendererProps = {
   title?: string;
   caption?: string;
   height?: number;
+  selected?: boolean;
   readOnly?: boolean;
   onTitleChange?: (title: string | undefined) => void;
   onCaptionChange?: (caption: string | undefined) => void;


### PR DESCRIPTION
## Summary

Adds a structured Deck table dataset input for `@sqlrooms/deck` so maps can express direct table sources and table-relative transforms without rewriting authored SQL strings.

## What changed

- Added `DeckTableDatasetInput`, `isTableDatasetInput`, and `createDeckTableDatasetSql` with the reserved `__sqlrooms_source` relation.
- Compiled table inputs in DeckJsonMap prepared dataset execution and dashboard Mosaic dataset queries.
- Removed dashboard `sqlQuery` `FROM` rewrites; literal `sqlQuery` sources now stay pinned while structured `tableName` sources follow dashboard table selection.
- Updated generated dashboard point maps and AI normalization to emit `tableName + transformSql`.
- Updated docs, AI instructions, and focused regression tests for nested `FROM` clauses and structured source swapping.

## Validation

- `pnpm build`
- `pnpm --filter @sqlrooms/deck build`
- `pnpm --filter @sqlrooms/deck test -- --runTestsByPath packages/deck/__tests__/normalizeDatasets.test.ts packages/deck/__tests__/tableDatasetSql.test.ts packages/deck/__tests__/dashboard.test.ts packages/deck/__tests__/preparedDatasetStore.test.ts packages/deck/__tests__/dashboard-ai-map.test.ts`
- Pre-push hook: `knip`, `turbo typecheck`, `npx madge --exclude "dist" --circular packages/*/src/index.ts`, `turbo test`

## Notes

Created the follow-up Obsidian plan `SQLRooms Generated Column Aware Map Selector Cleanup Plan` for the generated-column-aware settings cleanup that the implementation plan intentionally scoped out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for table-backed datasets with optional `transformSql`, including map point geometry generation from table coordinates.
  * Deck map/dashboard blocks now carry and react to a “selected” state to drive settings panel behavior.
* **Bug Fixes**
  * Preserved literal authored SQL (no rewriting when the selected table changes).
  * Improved dataset source resolution and bounds/geometry SQL generation for both SQL and transformed table inputs.
* **Documentation**
  * Updated deck README examples and clarified `tableName` / `transformSql` requirements.
* **Tests**
  * Expanded Jest coverage for dataset normalization, SQL compilation, and bounds/source handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->