### PR TITLE
feat(cli): adapt worksheet internals to block documents

### DIFF
--- a/apps/sqlrooms-cli-ui/README.md
+++ b/apps/sqlrooms-cli-ui/README.md
@@ -232,16 +232,16 @@ instead of mutating app state through hidden paths or rewriting chat messages.
 
 Worksheet AI tools compose generic block-document helpers with CLI-specific
 agent policy. Durable block appends route through the registered
-`worksheet.append-blocks` command, so text and chart block creation use the same
-traceable mutation path as palette, API, and future skill surfaces.
+`block-document.append-blocks` command, so text and chart block creation use the
+same traceable mutation path as palette, API, and future skill surfaces.
 Stateful worksheet blocks use CLI-owned commands that wrap the generic document
 commands and feature-specific state creation:
 
-- `worksheet.add-dashboard-block`
-- `worksheet.add-data-table-block`
-- `worksheet.add-html-app-block`
-- `worksheet.add-map-block`
-- `worksheet.update-block-metadata`
+- `block-document.add-dashboard-block`
+- `block-document.add-data-table-block`
+- `block-document.add-html-app-block`
+- `block-document.add-map-block`
+- `block-document.update-block-metadata`
 
 Topbar artifact title edits route through `artifact.rename`, which preserves
 artifact-type rename hooks and returns previous/new title metadata for traces.

--- a/apps/sqlrooms-cli-ui/src/__tests__/createWorksheetAiAdapter.test.ts
+++ b/apps/sqlrooms-cli-ui/src/__tests__/createWorksheetAiAdapter.test.ts
@@ -7,7 +7,7 @@ import type {RoomState} from '../store-types';
 function createMockStore({
   invokeCommand = jest.fn(async (_commandId, input: any) => ({
     success: true,
-    commandId: 'worksheet.append-blocks',
+    commandId: 'block-document.append-blocks',
     data: {
       blockId: input.blocks[0].id,
     },
@@ -47,7 +47,7 @@ function createMockStore({
 }
 
 describe('createWorksheetAiAdapter', () => {
-  it('adds worksheet blocks through the worksheet append command', async () => {
+  it('adds worksheet blocks through the block document append command', async () => {
     const {store, ensureBlockDocument, invokeCommand} = createMockStore();
     const adapter = createWorksheetAiAdapter(store);
     const block: BlockDocumentBlock = {
@@ -62,14 +62,14 @@ describe('createWorksheetAiAdapter', () => {
 
     expect(ensureBlockDocument).toHaveBeenCalledWith('worksheet-1');
     expect(invokeCommand).toHaveBeenCalledWith(
-      'worksheet.append-blocks',
+      'block-document.append-blocks',
       {
         artifactId: 'worksheet-1',
         blocks: [block],
       },
       {
         surface: 'ai',
-        actor: 'worksheet-agent',
+        actor: 'block-document-agent',
       },
     );
   });
@@ -78,7 +78,7 @@ describe('createWorksheetAiAdapter', () => {
     const {store} = createMockStore({
       invokeCommand: jest.fn(async () => ({
         success: false,
-        commandId: 'worksheet.append-blocks',
+        commandId: 'block-document.append-blocks',
         error: 'Command failed',
       })),
     });

--- a/apps/sqlrooms-cli-ui/src/__tests__/createWorksheetCommands.test.ts
+++ b/apps/sqlrooms-cli-ui/src/__tests__/createWorksheetCommands.test.ts
@@ -42,7 +42,7 @@ function createState() {
     },
   ];
   const invokeCommand = jest.fn(async (commandId: string, input: any) => {
-    if (commandId === 'worksheet.create-stateful-block') {
+    if (commandId === 'block-document.create-stateful-block') {
       return {
         success: true,
         commandId,
@@ -98,27 +98,26 @@ function createState() {
 }
 
 describe('createWorksheetCommands', () => {
-  it('registers the Stage 5 worksheet command IDs', () => {
+  it('registers the block document command IDs for worksheet stateful blocks', () => {
     expect(createWorksheetCommands().map((command) => command.id)).toEqual([
-      'worksheet.add-dashboard-block',
-      'worksheet.add-data-table-block',
-      'worksheet.add-html-app-block',
-      'worksheet.update-block-metadata',
-      'worksheet.add-map-block',
+      'block-document.add-dashboard-block',
+      'block-document.add-data-table-block',
+      'block-document.add-html-app-block',
+      'block-document.update-block-metadata',
+      'block-document.add-map-block',
     ]);
   });
 
   it('adds dashboard blocks through worksheet and dashboard commands', async () => {
     const {state, invokeCommand} = createState();
-    const result = await getCommand('worksheet.add-dashboard-block').execute(
-      createCommandContext(state),
-      {
-        worksheetId: 'worksheet-1',
-        title: 'Dashboard',
-        tableName: 'earthquakes',
-        intent: 'show trends',
-      },
-    );
+    const result = await getCommand(
+      'block-document.add-dashboard-block',
+    ).execute(createCommandContext(state), {
+      worksheetId: 'worksheet-1',
+      title: 'Dashboard',
+      tableName: 'earthquakes',
+      intent: 'show trends',
+    });
 
     expect(result).toMatchObject({
       success: true,
@@ -130,18 +129,18 @@ describe('createWorksheetCommands', () => {
       },
     });
     expect(invokeCommand).toHaveBeenCalledWith(
-      'worksheet.create-stateful-block',
+      'block-document.create-stateful-block',
       expect.objectContaining({
         artifactId: 'worksheet-1',
         blockType: 'dashboard',
         title: 'Dashboard',
       }),
-      {surface: 'ai', actor: 'worksheet-command'},
+      {surface: 'ai', actor: 'block-document-command'},
     );
     expect(invokeCommand).toHaveBeenCalledWith(
       'dashboard.set-selected-table',
       {dashboardId: 'dashboard-id', tableName: earthquakesTableIdentity},
-      {surface: 'ai', actor: 'worksheet-command'},
+      {surface: 'ai', actor: 'block-document-command'},
     );
   });
 
@@ -149,7 +148,7 @@ describe('createWorksheetCommands', () => {
     const {state, invokeCommand} = createState();
 
     await expect(
-      getCommand('worksheet.add-data-table-block').execute(
+      getCommand('block-document.add-data-table-block').execute(
         createCommandContext(state),
         {
           worksheetId: 'worksheet-1',
@@ -166,17 +165,17 @@ describe('createWorksheetCommands', () => {
       },
     });
     expect(invokeCommand).toHaveBeenCalledWith(
-      'worksheet.create-stateful-block',
+      'block-document.create-stateful-block',
       expect.objectContaining({
         artifactId: 'worksheet-1',
         blockType: 'data-table',
         title: earthquakesTableIdentity,
       }),
-      {surface: 'ai', actor: 'worksheet-command'},
+      {surface: 'ai', actor: 'block-document-command'},
     );
 
     await expect(
-      getCommand('worksheet.add-html-app-block').execute(
+      getCommand('block-document.add-html-app-block').execute(
         createCommandContext(state),
         {
           worksheetId: 'worksheet-1',
@@ -193,7 +192,7 @@ describe('createWorksheetCommands', () => {
     const {state, invokeCommand} = createState();
 
     await expect(
-      getCommand('worksheet.add-map-block').execute(
+      getCommand('block-document.add-map-block').execute(
         createCommandContext(state),
         {
           worksheetId: 'worksheet-1',
@@ -220,22 +219,21 @@ describe('createWorksheetCommands', () => {
     expect(invokeCommand).toHaveBeenCalledWith(
       'dashboard.set-selected-table',
       {dashboardId: 'map-1', tableName: earthquakesTableIdentity},
-      {surface: 'ai', actor: 'worksheet-command'},
+      {surface: 'ai', actor: 'block-document-command'},
     );
   });
 
   it('updates worksheet block metadata through the block document slice', async () => {
     const {state, updateBlock} = createState();
 
-    const result = await getCommand('worksheet.update-block-metadata').execute(
-      createCommandContext(state),
-      {
-        worksheetId: 'worksheet-1',
-        blockId: 'block-1',
-        title: 'Updated Map',
-        caption: 'Updated Map',
-      },
-    );
+    const result = await getCommand(
+      'block-document.update-block-metadata',
+    ).execute(createCommandContext(state), {
+      worksheetId: 'worksheet-1',
+      blockId: 'block-1',
+      title: 'Updated Map',
+      caption: 'Updated Map',
+    });
 
     expect(result).toMatchObject({
       success: true,
@@ -261,7 +259,7 @@ describe('createWorksheetCommands', () => {
     const {state, invokeCommand} = createState();
     invokeCommand.mockImplementation(async (commandId: string, input: any) => {
       if (
-        commandId === 'worksheet.create-stateful-block' &&
+        commandId === 'block-document.create-stateful-block' &&
         input.blockType === 'map'
       ) {
         return {
@@ -278,7 +276,7 @@ describe('createWorksheetCommands', () => {
     });
 
     await expect(
-      getCommand('worksheet.add-map-block').execute(
+      getCommand('block-document.add-map-block').execute(
         createCommandContext(state),
         {
           worksheetId: 'worksheet-1',
@@ -321,7 +319,7 @@ describe('createWorksheetCommands', () => {
     }));
     invokeCommand.mockImplementation(async (commandId: string, input: any) => {
       if (
-        commandId === 'worksheet.create-stateful-block' &&
+        commandId === 'block-document.create-stateful-block' &&
         input.blockType === 'map'
       ) {
         mapStateSeeded = true;
@@ -340,7 +338,7 @@ describe('createWorksheetCommands', () => {
       return {success: true, commandId, data: input};
     });
 
-    const result = await getCommand('worksheet.add-map-block').execute(
+    const result = await getCommand('block-document.add-map-block').execute(
       createCommandContext(state),
       {
         worksheetId: 'worksheet-1',
@@ -364,7 +362,7 @@ describe('createWorksheetCommands', () => {
       expect.objectContaining({
         panelId: 'seeded-map-panel',
       }),
-      {surface: 'ai', actor: 'worksheet-command'},
+      {surface: 'ai', actor: 'block-document-command'},
     );
     expect(invokeCommand).not.toHaveBeenCalledWith(
       'dashboard.add-panel',

--- a/apps/sqlrooms-cli-ui/src/ai/constants.ts
+++ b/apps/sqlrooms-cli-ui/src/ai/constants.ts
@@ -1,7 +1,10 @@
-import {KnownDocumentBlockTools} from '@sqlrooms/documents';
+import {
+  BLOCK_DOCUMENT_AGENT_TOOL_NAME,
+  KnownDocumentBlockTools,
+} from '@sqlrooms/documents';
 import {KnownMosaicBlockDocumentTools} from '@sqlrooms/mosaic/ai';
 
-export const WORKSHEET_AGENT_TOOL_NAME = 'worksheet_agent';
+export const WORKSHEET_AGENT_TOOL_NAME = BLOCK_DOCUMENT_AGENT_TOOL_NAME;
 
 export const KnownWorksheetTools = {
   ...KnownDocumentBlockTools,
@@ -9,9 +12,10 @@ export const KnownWorksheetTools = {
   add_html_app_block: 'add_html_app_block',
   embedded_dashboard_agent: 'embedded_dashboard_agent',
   embedded_html_app_agent: 'embedded_html_app_agent',
-  create_worksheet_map_block: 'create_worksheet_map_block',
+  create_block_document_map_block: 'create_block_document_map_block',
 } as const;
 
 export const EXPERIMENTAL_WORKSHEET_AGENT_INSTRUCTIONS = `Direct worksheet map blocks are available in this CLI app.
-For worksheet map requests, call ${KnownWorksheetTools.create_worksheet_map_block}. Do not create a dashboard block just to hold a map.
-If updating an existing worksheet map, call list_block_document_blocks first and pass its statefulBlock.blockInstanceId as mapId to ${KnownWorksheetTools.create_worksheet_map_block}.`;
+In this app, a Worksheet is a block document artifact, and direct map blocks are block-document map blocks.
+For worksheet map requests, call ${KnownWorksheetTools.create_block_document_map_block}. Do not create a dashboard block just to hold a map.
+If updating an existing worksheet map, call list_block_document_blocks first and pass its statefulBlock.blockInstanceId as mapId to ${KnownWorksheetTools.create_block_document_map_block}.`;

--- a/apps/sqlrooms-cli-ui/src/ai/createWorksheetAgentTool.ts
+++ b/apps/sqlrooms-cli-ui/src/ai/createWorksheetAgentTool.ts
@@ -333,8 +333,8 @@ IF user requests DASHBOARD:
 IF user requests a MAP in a worksheet:
 ${
   mapBlocksEnabled
-    ? `1. For a new map, call ${KnownWorksheetTools.create_worksheet_map_block} directly
-2. For an existing map, call ${KnownWorksheetTools.list_blocks} and pass statefulBlock.blockInstanceId as mapId to create_worksheet_map_block`
+    ? `1. For a new map, call ${KnownWorksheetTools.create_block_document_map_block} directly
+2. For an existing map, call ${KnownWorksheetTools.list_blocks} and pass statefulBlock.blockInstanceId as mapId to create_block_document_map_block`
     : `1. Call ${KnownWorksheetTools.list_blocks} to find an existing dashboard block
 2. Reuse an existing dashboardId if available, otherwise call ${KnownWorksheetTools.add_dashboard_block}
 3. Call ${KnownWorksheetTools.embedded_dashboard_agent} with an intent to add a map panel`

--- a/apps/sqlrooms-cli-ui/src/createWorksheetAgent.ts
+++ b/apps/sqlrooms-cli-ui/src/createWorksheetAgent.ts
@@ -38,9 +38,9 @@ Use this for map, geospatial, spatial, longitude/latitude, geometry, H3, route, 
         const result = await store
           .getState()
           .commands.invokeCommand(
-            'worksheet.add-map-block',
+            'block-document.add-map-block',
             {worksheetId, ...params},
-            {surface: 'ai', actor: 'worksheet-agent'},
+            {surface: 'ai', actor: 'block-document-agent'},
           );
         if (!result.success) {
           throw new Error(
@@ -125,9 +125,9 @@ export function worksheetAgentTool(
       const result = await store
         .getState()
         .commands.invokeCommand(
-          'worksheet.add-dashboard-block',
+          'block-document.add-dashboard-block',
           {worksheetId, title, tableName, intent},
-          {surface: 'ai', actor: 'worksheet-agent'},
+          {surface: 'ai', actor: 'block-document-agent'},
         );
       if (!result.success) {
         throw new Error(
@@ -151,9 +151,9 @@ export function worksheetAgentTool(
       const result = await store
         .getState()
         .commands.invokeCommand(
-          'worksheet.add-data-table-block',
+          'block-document.add-data-table-block',
           {worksheetId, title, tableName, intent},
-          {surface: 'ai', actor: 'worksheet-agent'},
+          {surface: 'ai', actor: 'block-document-agent'},
         );
       if (!result.success) {
         throw new Error(
@@ -166,9 +166,9 @@ export function worksheetAgentTool(
       const result = await store
         .getState()
         .commands.invokeCommand(
-          'worksheet.add-html-app-block',
+          'block-document.add-html-app-block',
           {worksheetId, title, intent},
-          {surface: 'ai', actor: 'worksheet-agent'},
+          {surface: 'ai', actor: 'block-document-agent'},
         );
       if (!result.success) {
         throw new Error(
@@ -218,7 +218,7 @@ export function worksheetAgentTool(
         return {
           [KnownWorksheetTools.embedded_html_app_agent]:
             htmlAppAgentTool(store),
-          [KnownWorksheetTools.create_worksheet_map_block]:
+          [KnownWorksheetTools.create_block_document_map_block]:
             createWorksheetMapBlockTool(store, worksheetId),
         };
       }

--- a/apps/sqlrooms-cli-ui/src/createWorksheetAiAdapter.ts
+++ b/apps/sqlrooms-cli-ui/src/createWorksheetAiAdapter.ts
@@ -2,7 +2,7 @@ import type {BlockDocumentAiAdapter} from '@sqlrooms/documents';
 import type {StoreApi} from 'zustand';
 import type {RoomState} from './store-types';
 
-const WORKSHEET_APPEND_BLOCKS_COMMAND_ID = 'worksheet.append-blocks';
+const WORKSHEET_APPEND_BLOCKS_COMMAND_ID = 'block-document.append-blocks';
 
 /**
  * Creates a worksheet-specific adapter for the worksheet agent.
@@ -53,7 +53,7 @@ export function createWorksheetAiAdapter(
         },
         {
           surface: 'ai',
-          actor: 'worksheet-agent',
+          actor: 'block-document-agent',
         },
       );
 

--- a/apps/sqlrooms-cli-ui/src/createWorksheetCommands.ts
+++ b/apps/sqlrooms-cli-ui/src/createWorksheetCommands.ts
@@ -13,10 +13,10 @@ import type {RoomCommand} from '@sqlrooms/room-shell';
 import {z} from 'zod';
 import type {RoomState} from './store-types';
 
-export const CLI_WORKSHEET_COMMAND_OWNER = '@sqlrooms-cli-ui/worksheet';
+export const CLI_WORKSHEET_COMMAND_OWNER = '@sqlrooms-cli-ui/block-document';
 
 const WORKSHEET_CREATE_STATEFUL_BLOCK_COMMAND_ID =
-  'worksheet.create-stateful-block';
+  'block-document.create-stateful-block';
 const DASHBOARD_SET_SELECTED_TABLE_COMMAND_ID = 'dashboard.set-selected-table';
 
 const WorksheetIdInput = z.object({
@@ -124,7 +124,7 @@ async function invokeRequiredCommand(
 ) {
   const result = await state.commands.invokeCommand(commandId, input, {
     surface: 'ai',
-    actor: 'worksheet-command',
+    actor: 'block-document-command',
   });
   if (!result.success) {
     throw new Error(
@@ -188,7 +188,7 @@ function findMapPanel(state: RoomState, mapId: string, panelId?: string) {
 export function createWorksheetCommands(): RoomCommand<RoomState>[] {
   return [
     {
-      id: 'worksheet.add-dashboard-block',
+      id: 'block-document.add-dashboard-block',
       name: 'Add worksheet dashboard block',
       description: 'Add an owned dashboard block to a worksheet.',
       group: 'Worksheet',
@@ -227,7 +227,7 @@ export function createWorksheetCommands(): RoomCommand<RoomState>[] {
         );
         return {
           success: true,
-          commandId: 'worksheet.add-dashboard-block',
+          commandId: 'block-document.add-dashboard-block',
           message: `Added worksheet dashboard block "${title}".`,
           data: {
             worksheetId,
@@ -239,7 +239,7 @@ export function createWorksheetCommands(): RoomCommand<RoomState>[] {
       },
     },
     {
-      id: 'worksheet.add-data-table-block',
+      id: 'block-document.add-data-table-block',
       name: 'Add worksheet data table block',
       description: 'Add a data table explorer block to a worksheet.',
       group: 'Worksheet',
@@ -274,7 +274,7 @@ export function createWorksheetCommands(): RoomCommand<RoomState>[] {
         );
         return {
           success: true,
-          commandId: 'worksheet.add-data-table-block',
+          commandId: 'block-document.add-data-table-block',
           message: `Added worksheet data table block "${title}".`,
           data: {
             worksheetId,
@@ -286,7 +286,7 @@ export function createWorksheetCommands(): RoomCommand<RoomState>[] {
       },
     },
     {
-      id: 'worksheet.add-html-app-block',
+      id: 'block-document.add-html-app-block',
       name: 'Add worksheet HTML app block',
       description: 'Add an owned HTML app block to a worksheet.',
       group: 'Worksheet',
@@ -316,14 +316,14 @@ export function createWorksheetCommands(): RoomCommand<RoomState>[] {
         );
         return {
           success: true,
-          commandId: 'worksheet.add-html-app-block',
+          commandId: 'block-document.add-html-app-block',
           message: `Added worksheet HTML app block "${title}".`,
           data: {worksheetId, blockId, appId},
         };
       },
     },
     {
-      id: 'worksheet.update-block-metadata',
+      id: 'block-document.update-block-metadata',
       name: 'Update worksheet block metadata',
       description: 'Update title, caption, or height for a worksheet block.',
       group: 'Worksheet',
@@ -355,14 +355,14 @@ export function createWorksheetCommands(): RoomCommand<RoomState>[] {
         }
         return {
           success: true,
-          commandId: 'worksheet.update-block-metadata',
+          commandId: 'block-document.update-block-metadata',
           message: `Updated worksheet block "${blockId}".`,
           data: {worksheetId, blockId, title, caption, height},
         };
       },
     },
     {
-      id: 'worksheet.add-map-block',
+      id: 'block-document.add-map-block',
       name: 'Add or update worksheet map block',
       description: 'Create or update a direct worksheet map block.',
       group: 'Worksheet',
@@ -457,7 +457,7 @@ export function createWorksheetCommands(): RoomCommand<RoomState>[] {
         if (existingMapBlock) {
           await invokeRequiredCommand(
             state,
-            'worksheet.update-block-metadata',
+            'block-document.update-block-metadata',
             {
               worksheetId: params.worksheetId,
               blockId: existingMapBlock.id,
@@ -469,7 +469,7 @@ export function createWorksheetCommands(): RoomCommand<RoomState>[] {
 
         return {
           success: true,
-          commandId: 'worksheet.add-map-block',
+          commandId: 'block-document.add-map-block',
           message: params.mapId
             ? `Updated worksheet map block "${title}".`
             : `Added worksheet map block "${title}".`,

--- a/apps/sqlrooms-cli-ui/src/createWorksheetCommands.ts
+++ b/apps/sqlrooms-cli-ui/src/createWorksheetCommands.ts
@@ -17,6 +17,15 @@ export const CLI_WORKSHEET_COMMAND_OWNER = '@sqlrooms-cli-ui/block-document';
 
 const WORKSHEET_CREATE_STATEFUL_BLOCK_COMMAND_ID =
   'block-document.create-stateful-block';
+const WORKSHEET_ADD_DASHBOARD_BLOCK_COMMAND_ID =
+  'block-document.add-dashboard-block';
+const WORKSHEET_ADD_DATA_TABLE_BLOCK_COMMAND_ID =
+  'block-document.add-data-table-block';
+const WORKSHEET_ADD_HTML_APP_BLOCK_COMMAND_ID =
+  'block-document.add-html-app-block';
+const WORKSHEET_UPDATE_BLOCK_METADATA_COMMAND_ID =
+  'block-document.update-block-metadata';
+const WORKSHEET_ADD_MAP_BLOCK_COMMAND_ID = 'block-document.add-map-block';
 const DASHBOARD_SET_SELECTED_TABLE_COMMAND_ID = 'dashboard.set-selected-table';
 
 const WorksheetIdInput = z.object({
@@ -188,7 +197,7 @@ function findMapPanel(state: RoomState, mapId: string, panelId?: string) {
 export function createWorksheetCommands(): RoomCommand<RoomState>[] {
   return [
     {
-      id: 'block-document.add-dashboard-block',
+      id: WORKSHEET_ADD_DASHBOARD_BLOCK_COMMAND_ID,
       name: 'Add worksheet dashboard block',
       description: 'Add an owned dashboard block to a worksheet.',
       group: 'Worksheet',
@@ -227,7 +236,7 @@ export function createWorksheetCommands(): RoomCommand<RoomState>[] {
         );
         return {
           success: true,
-          commandId: 'block-document.add-dashboard-block',
+          commandId: WORKSHEET_ADD_DASHBOARD_BLOCK_COMMAND_ID,
           message: `Added worksheet dashboard block "${title}".`,
           data: {
             worksheetId,
@@ -239,7 +248,7 @@ export function createWorksheetCommands(): RoomCommand<RoomState>[] {
       },
     },
     {
-      id: 'block-document.add-data-table-block',
+      id: WORKSHEET_ADD_DATA_TABLE_BLOCK_COMMAND_ID,
       name: 'Add worksheet data table block',
       description: 'Add a data table explorer block to a worksheet.',
       group: 'Worksheet',
@@ -274,7 +283,7 @@ export function createWorksheetCommands(): RoomCommand<RoomState>[] {
         );
         return {
           success: true,
-          commandId: 'block-document.add-data-table-block',
+          commandId: WORKSHEET_ADD_DATA_TABLE_BLOCK_COMMAND_ID,
           message: `Added worksheet data table block "${title}".`,
           data: {
             worksheetId,
@@ -286,7 +295,7 @@ export function createWorksheetCommands(): RoomCommand<RoomState>[] {
       },
     },
     {
-      id: 'block-document.add-html-app-block',
+      id: WORKSHEET_ADD_HTML_APP_BLOCK_COMMAND_ID,
       name: 'Add worksheet HTML app block',
       description: 'Add an owned HTML app block to a worksheet.',
       group: 'Worksheet',
@@ -316,14 +325,14 @@ export function createWorksheetCommands(): RoomCommand<RoomState>[] {
         );
         return {
           success: true,
-          commandId: 'block-document.add-html-app-block',
+          commandId: WORKSHEET_ADD_HTML_APP_BLOCK_COMMAND_ID,
           message: `Added worksheet HTML app block "${title}".`,
           data: {worksheetId, blockId, appId},
         };
       },
     },
     {
-      id: 'block-document.update-block-metadata',
+      id: WORKSHEET_UPDATE_BLOCK_METADATA_COMMAND_ID,
       name: 'Update worksheet block metadata',
       description: 'Update title, caption, or height for a worksheet block.',
       group: 'Worksheet',
@@ -355,14 +364,14 @@ export function createWorksheetCommands(): RoomCommand<RoomState>[] {
         }
         return {
           success: true,
-          commandId: 'block-document.update-block-metadata',
+          commandId: WORKSHEET_UPDATE_BLOCK_METADATA_COMMAND_ID,
           message: `Updated worksheet block "${blockId}".`,
           data: {worksheetId, blockId, title, caption, height},
         };
       },
     },
     {
-      id: 'block-document.add-map-block',
+      id: WORKSHEET_ADD_MAP_BLOCK_COMMAND_ID,
       name: 'Add or update worksheet map block',
       description: 'Create or update a direct worksheet map block.',
       group: 'Worksheet',
@@ -457,7 +466,7 @@ export function createWorksheetCommands(): RoomCommand<RoomState>[] {
         if (existingMapBlock) {
           await invokeRequiredCommand(
             state,
-            'block-document.update-block-metadata',
+            WORKSHEET_UPDATE_BLOCK_METADATA_COMMAND_ID,
             {
               worksheetId: params.worksheetId,
               blockId: existingMapBlock.id,
@@ -469,7 +478,7 @@ export function createWorksheetCommands(): RoomCommand<RoomState>[] {
 
         return {
           success: true,
-          commandId: 'block-document.add-map-block',
+          commandId: WORKSHEET_ADD_MAP_BLOCK_COMMAND_ID,
           message: params.mapId
             ? `Updated worksheet map block "${title}".`
             : `Added worksheet map block "${title}".`,

--- a/apps/sqlrooms-cli-ui/src/store.ts
+++ b/apps/sqlrooms-cli-ui/src/store.ts
@@ -147,10 +147,12 @@ export type {RoomState} from './store-types';
 
 const DOCUMENT_COMMAND_OWNER = '@sqlrooms/documents';
 const MOSAIC_DASHBOARD_COMMAND_OWNER = '@sqlrooms/mosaic/dashboard';
-const WORKSHEET_COMMAND_OWNER = '@sqlrooms/documents/worksheet';
-const WORKSHEET_PYTHON_COMMAND_OWNER = '@sqlrooms/python/worksheet';
+const WORKSHEET_COMMAND_OWNER = '@sqlrooms/documents/block-document';
+const WORKSHEET_PYTHON_COMMAND_OWNER = '@sqlrooms/python/block-document';
 const AI_SETTINGS_SAVE_FAILED_TOAST_ID = 'ai-settings-save-failed';
 const STABLE_SQLROOMS_CLI_AI_INSTRUCTIONS = `
+In the SQLRooms CLI app, a Worksheet is a block document artifact. When the user asks to create, edit, inspect, or add content to a worksheet, target the current worksheet artifact using block-document commands and block-document agent tools. Use the word Worksheet in user-facing replies, but use block-document tool names and command IDs when invoking tools. The artifact type may still be "worksheet"; its editable content model is a block document.
+
 When the user's primary context artifact is a worksheet or dashboard and they ask to add, update, or create a visualization, chart, or dashboard surface, mutate that artifact through the appropriate agent tool instead of creating a separate artifact, chat-only chart, or markdown image.
 
 - Use ${WORKSHEET_AGENT_TOOL_NAME} when the primary artifact is a worksheet, or when the user explicitly asks to create/edit a top-level worksheet artifact.
@@ -174,10 +176,10 @@ Experimental SQLRooms tools are available in this session. Use them for app, map
 const WORKSHEET_BLOCK_DOCUMENT_OPTIONS = {
   artifactType: 'worksheet',
   artifactLabel: 'Worksheet',
-  commandNamespace: 'worksheet',
+  commandNamespace: 'block-document',
   commandGroup: 'Worksheet',
   defaultTitle: 'Worksheet',
-  blockDocumentAgentToolName: 'worksheet_agent',
+  blockDocumentAgentToolName: WORKSHEET_AGENT_TOOL_NAME,
 } as const;
 
 export const runtimeConfig = await fetchRuntimeConfig();
@@ -1175,7 +1177,7 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
               ...(experimentalEnabled
                 ? {html_app_agent: htmlAppAgentTool(store)}
                 : {}),
-              worksheet_agent: worksheetAgentTool(store, {
+              [WORKSHEET_AGENT_TOOL_NAME]: worksheetAgentTool(store, {
                 experimentalEnabled,
               }),
               ...webContainerToolkit.tools,

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -94,9 +94,9 @@ example, the SQLRooms CLI app uses:
 createPythonBlockCommands({
   artifactType: 'worksheet',
   artifactLabel: 'Worksheet',
-  commandNamespace: 'worksheet',
+  commandNamespace: 'block-document',
 });
 ```
 
-That registers worksheet-scoped command IDs such as
-`worksheet.add-python-block` while keeping the package API generic.
+That keeps Worksheet as the host-facing artifact label while registering
+block-document command IDs such as `block-document.add-python-block`.


### PR DESCRIPTION
## Summary

- Keep the SQLRooms CLI artifact type and visible product label as Worksheet while registering Worksheet block document commands under the canonical `block-document.*` namespace.
- Expose the high-level Worksheet mutation agent as `block_document_agent` and update CLI AI instructions to explain that a Worksheet is a block document artifact.
- Move CLI-owned stateful block command calls, agent actors, direct map tool naming, docs, and focused tests to block-document vocabulary.

## Validation

- `pnpm build`
- `pnpm --filter sqlrooms-cli-app test --runTestsByPath src/__tests__/createWorksheetCommands.test.ts src/__tests__/createWorksheetAiAdapter.test.ts src/ai/__tests__/createWorksheetBlockDocumentAiTools.test.ts`
- `pnpm --filter sqlrooms-cli-app typecheck`
- pre-push hook: `knip`, `turbo typecheck`, circular dependency check, `turbo test`

Originally chained on top of #779; rebased onto `main` after #779 landed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Worksheet actions now use a unified block-document command surface for adding dashboard, data table, HTML app, map, and metadata updates.
  * AI-assisted worksheet interactions now route through the updated block-document agent flow.

* **Bug Fixes**
  * Improved command handling consistency so worksheet operations invoke the correct updated commands and actor context.

* **Documentation**
  * Updated setup and usage docs to match the new command naming and Python block configuration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->