### PR TITLE
fix(deck): compile all color scale properties on a layer

### DIFF
--- a/packages/deck/__tests__/createDeckJsonConfiguration.test.ts
+++ b/packages/deck/__tests__/createDeckJsonConfiguration.test.ts
@@ -356,4 +356,87 @@ describe('createDeckJsonConfiguration', () => {
 
     expect(typeof converted.layers[0]?.props.getFillColor).toBe('function');
   });
+
+  it('compiles multiple colorScale properties on the same layer', () => {
+    const table = createPointTable();
+    const converter = createConverter({
+      earthquakes: {
+        status: 'ready',
+        prepared: createPreparedDataset(table),
+      },
+    });
+
+    const converted = converter.convert({
+      layers: [
+        {
+          '@@type': 'GeoArrowScatterplotLayer',
+          id: 'earthquakes',
+          getFillColor: {
+            '@@function': 'colorScale',
+            field: 'magnitude',
+            type: 'sequential',
+            scheme: 'Viridis',
+            domain: 'auto',
+          },
+          getLineColor: {
+            '@@function': 'colorScale',
+            field: 'magnitude',
+            type: 'sequential',
+            scheme: 'YlOrRd',
+            domain: [0, 10],
+          },
+        },
+      ],
+    }) as {layers: Array<{props: Record<string, unknown>}>};
+
+    expect(typeof converted.layers[0]?.props.getFillColor).toBe('function');
+    expect(typeof converted.layers[0]?.props.getLineColor).toBe('function');
+
+    const updateTriggers = converted.layers[0]?.props.updateTriggers as
+      | Record<string, unknown>
+      | undefined;
+    expect(updateTriggers?.getFillColor).toBeTruthy();
+    expect(updateTriggers?.getLineColor).toBeTruthy();
+  });
+
+  it('compiles both getSourceColor and getTargetColor on arc layers', () => {
+    const table = createPointTable();
+    const converter = createConverter({
+      earthquakes: {
+        status: 'ready',
+        prepared: createPreparedDataset(table),
+      },
+    });
+
+    const converted = converter.convert({
+      layers: [
+        {
+          '@@type': 'GeoArrowArcLayer',
+          id: 'arcs',
+          _sqlroomsBinding: {
+            dataset: 'earthquakes',
+            sourceGeometryColumn: 'source_geom',
+            targetGeometryColumn: 'target_geom',
+          },
+          getSourceColor: {
+            '@@function': 'colorScale',
+            field: 'magnitude',
+            type: 'sequential',
+            scheme: 'Blues',
+            domain: 'auto',
+          },
+          getTargetColor: {
+            '@@function': 'colorScale',
+            field: 'magnitude',
+            type: 'sequential',
+            scheme: 'Reds',
+            domain: 'auto',
+          },
+        },
+      ],
+    }) as {layers: Array<{props: Record<string, unknown>}>};
+
+    expect(typeof converted.layers[0]?.props.getSourceColor).toBe('function');
+    expect(typeof converted.layers[0]?.props.getTargetColor).toBe('function');
+  });
 });

--- a/packages/deck/__tests__/createDeckJsonConfiguration.test.ts
+++ b/packages/deck/__tests__/createDeckJsonConfiguration.test.ts
@@ -10,6 +10,7 @@ import {
   vectorFromArray,
 } from 'apache-arrow';
 import {createDeckJsonConfiguration} from '../src/json/createDeckJsonConfiguration';
+import {extractColorScaleLegends} from '../src/json/extractColorScaleLegends';
 import type {PreparedDeckDataset} from '../src/prepare/types';
 import type {PreparedDeckDatasetState} from '../src/types';
 
@@ -438,5 +439,117 @@ describe('createDeckJsonConfiguration', () => {
 
     expect(typeof converted.layers[0]?.props.getSourceColor).toBe('function');
     expect(typeof converted.layers[0]?.props.getTargetColor).toBe('function');
+  });
+});
+
+describe('extractColorScaleLegends', () => {
+  function createReadyState(table: Table): PreparedDeckDatasetState {
+    return {
+      status: 'ready',
+      prepared: createPreparedDataset(table),
+    };
+  }
+
+  it('returns a legend for each color scale property on a layer', () => {
+    const table = createPointTable();
+    const legends = extractColorScaleLegends({
+      spec: {
+        layers: [
+          {
+            '@@type': 'GeoArrowScatterplotLayer',
+            id: 'points',
+            _sqlroomsBinding: {dataset: 'earthquakes'},
+            getFillColor: {
+              '@@function': 'colorScale',
+              field: 'magnitude',
+              type: 'sequential',
+              scheme: 'Viridis',
+              domain: 'auto',
+            },
+            getLineColor: {
+              '@@function': 'colorScale',
+              field: 'magnitude',
+              type: 'sequential',
+              scheme: 'YlOrRd',
+              domain: 'auto',
+            },
+          },
+        ],
+      },
+      datasetIds: ['earthquakes'],
+      datasetStates: {earthquakes: createReadyState(table)},
+    });
+
+    expect(legends).toHaveLength(2);
+  });
+
+  it('uses the correct legend title for each accessor', () => {
+    const table = createPointTable();
+    const legends = extractColorScaleLegends({
+      spec: {
+        layers: [
+          {
+            '@@type': 'GeoArrowScatterplotLayer',
+            id: 'points',
+            _sqlroomsBinding: {dataset: 'earthquakes'},
+            getFillColor: {
+              '@@function': 'colorScale',
+              field: 'magnitude',
+              type: 'sequential',
+              scheme: 'Viridis',
+              domain: 'auto',
+              legend: {title: 'Fill Legend'},
+            },
+            getLineColor: {
+              '@@function': 'colorScale',
+              field: 'magnitude',
+              type: 'sequential',
+              scheme: 'YlOrRd',
+              domain: 'auto',
+              legend: {title: 'Line Legend'},
+            },
+          },
+        ],
+      },
+      datasetIds: ['earthquakes'],
+      datasetStates: {earthquakes: createReadyState(table)},
+    });
+
+    expect(legends).toHaveLength(2);
+    expect(legends[0]!.title).toBe('Fill Legend');
+    expect(legends[1]!.title).toBe('Line Legend');
+  });
+
+  it('skips a failing color scale without blocking others', () => {
+    const table = createPointTable();
+    const legends = extractColorScaleLegends({
+      spec: {
+        layers: [
+          {
+            '@@type': 'GeoArrowScatterplotLayer',
+            id: 'points',
+            _sqlroomsBinding: {dataset: 'earthquakes'},
+            getFillColor: {
+              '@@function': 'colorScale',
+              field: 'nonexistent_column',
+              type: 'sequential',
+              scheme: 'Viridis',
+              domain: 'auto',
+            },
+            getLineColor: {
+              '@@function': 'colorScale',
+              field: 'magnitude',
+              type: 'sequential',
+              scheme: 'YlOrRd',
+              domain: 'auto',
+            },
+          },
+        ],
+      },
+      datasetIds: ['earthquakes'],
+      datasetStates: {earthquakes: createReadyState(table)},
+    });
+
+    expect(legends).toHaveLength(1);
   });
 });

--- a/packages/deck/src/DeckJsonMap.tsx
+++ b/packages/deck/src/DeckJsonMap.tsx
@@ -259,11 +259,9 @@ function DeckOverlayControl({
     }
   }, [clearing, overlay]);
 
-  useEffect(() => {
-    if (!clearing && overlay) {
-      overlay.setProps(deckProps);
-    }
-  });
+  if (!clearing && overlay) {
+    overlay.setProps(deckProps);
+  }
 
   return null;
 }

--- a/packages/deck/src/DeckJsonMap.tsx
+++ b/packages/deck/src/DeckJsonMap.tsx
@@ -259,9 +259,11 @@ function DeckOverlayControl({
     }
   }, [clearing, overlay]);
 
-  if (!clearing && overlay) {
-    overlay.setProps(deckProps);
-  }
+  useEffect(() => {
+    if (!clearing && overlay) {
+      overlay.setProps(deckProps);
+    }
+  });
 
   return null;
 }

--- a/packages/deck/src/json/colorScaleFunction.ts
+++ b/packages/deck/src/json/colorScaleFunction.ts
@@ -31,17 +31,32 @@ export function isColorScaleMarker(value: unknown): value is ColorScaleMarker {
   );
 }
 
+export type ColorScalePropName =
+  | 'getFillColor'
+  | 'getLineColor'
+  | 'getColor'
+  | 'getSourceColor'
+  | 'getTargetColor';
+
 export function getColorScale(props: Record<string, unknown>):
   | {
-      propName:
-        | 'getFillColor'
-        | 'getLineColor'
-        | 'getColor'
-        | 'getSourceColor'
-        | 'getTargetColor';
+      propName: ColorScalePropName;
       colorScale: ColorScaleConfig;
     }
   | undefined {
+  const all = getAllColorScales(props);
+  return all.length > 0 ? all[0] : undefined;
+}
+
+export function getAllColorScales(props: Record<string, unknown>): Array<{
+  propName: ColorScalePropName;
+  colorScale: ColorScaleConfig;
+}> {
+  const results: Array<{
+    propName: ColorScalePropName;
+    colorScale: ColorScaleConfig;
+  }> = [];
+
   for (const propName of [
     'getFillColor',
     'getLineColor',
@@ -51,18 +66,11 @@ export function getColorScale(props: Record<string, unknown>):
   ] as const) {
     const value = props[propName];
     if (isColorScaleMarker(value)) {
-      return {
-        propName,
-        colorScale: value.colorScale,
-      };
-    }
-    if (isColorScaleFunction(value)) {
-      return {
-        propName,
-        colorScale: value,
-      };
+      results.push({propName, colorScale: value.colorScale});
+    } else if (isColorScaleFunction(value)) {
+      results.push({propName, colorScale: value});
     }
   }
 
-  return undefined;
+  return results;
 }

--- a/packages/deck/src/json/colorScaleFunction.ts
+++ b/packages/deck/src/json/colorScaleFunction.ts
@@ -31,6 +31,7 @@ export function isColorScaleMarker(value: unknown): value is ColorScaleMarker {
   );
 }
 
+/** Names of layer accessor props that can carry a color scale. */
 export type ColorScalePropName =
   | 'getFillColor'
   | 'getLineColor'
@@ -38,6 +39,10 @@ export type ColorScalePropName =
   | 'getSourceColor'
   | 'getTargetColor';
 
+/**
+ * Returns the first color scale entry found on the layer props, if any.
+ * Prefer {@link getAllColorScales} when a layer may define multiple color scale accessors.
+ */
 export function getColorScale(props: Record<string, unknown>):
   | {
       propName: ColorScalePropName;
@@ -48,6 +53,7 @@ export function getColorScale(props: Record<string, unknown>):
   return all.length > 0 ? all[0] : undefined;
 }
 
+/** Returns every color scale entry found across all known accessor props on the layer. */
 export function getAllColorScales(props: Record<string, unknown>): Array<{
   propName: ColorScalePropName;
   colorScale: ColorScaleConfig;

--- a/packages/deck/src/json/createDeckJsonConfiguration.ts
+++ b/packages/deck/src/json/createDeckJsonConfiguration.ts
@@ -4,7 +4,7 @@ import type {ColorScaleConfig} from '@sqlrooms/color-scales';
 import {wkbGeometryDecoder} from '../prepare/wkbDecoder';
 import {tryAggregateWaypointsToLineStrings} from './aggregateWaypoints';
 import type {LayerBindingProps, PreparedDeckDatasetState} from '../types';
-import {createColorScaleMarker, getColorScale} from './colorScaleFunction';
+import {createColorScaleMarker, getAllColorScales} from './colorScaleFunction';
 import {compileColorScale} from './compileColorScale';
 import {
   DEFAULT_DECK_JSON_CLASSES,
@@ -37,31 +37,34 @@ function applyColorScale(options: {
   table: import('apache-arrow').Table;
 }) {
   const {props, table} = options;
-  const resolved = getColorScale(props);
-  if (!resolved) {
+  const allScales = getAllColorScales(props);
+  if (allScales.length === 0) {
     return props;
   }
 
-  const {propName, colorScale} = resolved;
+  let result = props;
+  for (const {propName, colorScale} of allScales) {
+    const updateTriggers =
+      result.updateTriggers &&
+      typeof result.updateTriggers === 'object' &&
+      !Array.isArray(result.updateTriggers)
+        ? (result.updateTriggers as Record<string, unknown>)
+        : {};
 
-  const updateTriggers =
-    props.updateTriggers &&
-    typeof props.updateTriggers === 'object' &&
-    !Array.isArray(props.updateTriggers)
-      ? (props.updateTriggers as Record<string, unknown>)
-      : {};
+    result = {
+      ...result,
+      [propName]: compileColorScale({
+        table,
+        colorScale,
+      }),
+      updateTriggers: {
+        ...updateTriggers,
+        [propName]: JSON.stringify(colorScale),
+      },
+    };
+  }
 
-  return {
-    ...props,
-    [propName]: compileColorScale({
-      table,
-      colorScale,
-    }),
-    updateTriggers: {
-      ...updateTriggers,
-      [propName]: JSON.stringify(colorScale),
-    },
-  };
+  return result;
 }
 
 function resolveGeoArrowBindings(options: {

--- a/packages/deck/src/json/extractColorScaleLegends.ts
+++ b/packages/deck/src/json/extractColorScaleLegends.ts
@@ -5,13 +5,14 @@ import {buildColorScaleLegend} from './compileColorScale';
 import {DEFAULT_HEATMAP_COLOR_RANGE} from './heatmapDefaults';
 import {resolveColorLegend, resolveDatasetId} from './layerConfig';
 
+import type {ColorScalePropName} from './colorScaleFunction';
+
 function resolveLegendTitle(
   layerProps: Record<string, unknown>,
+  propName: ColorScalePropName,
   fallbackField: string,
 ) {
-  const legend =
-    resolveColorLegend(layerProps, 'getFillColor') ??
-    resolveColorLegend(layerProps, 'getLineColor');
+  const legend = resolveColorLegend(layerProps, propName);
   if (
     legend &&
     typeof legend === 'object' &&
@@ -97,13 +98,13 @@ export function extractColorScaleLegends(options: {
       continue;
     }
 
-    for (const {colorScale} of resolvedColorScales) {
+    for (const {propName, colorScale} of resolvedColorScales) {
       let resolvedLegend: ResolvedColorLegend | null = null;
       try {
         resolvedLegend = buildColorScaleLegend({
           table: datasetState.prepared.table,
           colorScale,
-          title: resolveLegendTitle(layerProps, colorScale.field),
+          title: resolveLegendTitle(layerProps, propName, colorScale.field),
         });
       } catch {
         continue;

--- a/packages/deck/src/json/extractColorScaleLegends.ts
+++ b/packages/deck/src/json/extractColorScaleLegends.ts
@@ -1,6 +1,6 @@
 import type {ResolvedColorLegend} from '@sqlrooms/color-scales';
 import type {PreparedDeckDatasetState} from '../types';
-import {getColorScale} from './colorScaleFunction';
+import {getAllColorScales} from './colorScaleFunction';
 import {buildColorScaleLegend} from './compileColorScale';
 import {DEFAULT_HEATMAP_COLOR_RANGE} from './heatmapDefaults';
 import {resolveColorLegend, resolveDatasetId} from './layerConfig';
@@ -82,11 +82,10 @@ export function extractColorScaleLegends(options: {
       continue;
     }
 
-    const resolvedColorScale = getColorScale(layerProps);
-    if (!resolvedColorScale) {
+    const resolvedColorScales = getAllColorScales(layerProps);
+    if (resolvedColorScales.length === 0) {
       continue;
     }
-    const {colorScale} = resolvedColorScale;
 
     const datasetId = resolveDatasetId(layerProps, datasetIds);
     if (!datasetId) {
@@ -98,20 +97,21 @@ export function extractColorScaleLegends(options: {
       continue;
     }
 
-    let resolvedLegend: ResolvedColorLegend | null = null;
-    try {
-      resolvedLegend = buildColorScaleLegend({
-        table: datasetState.prepared.table,
-        colorScale,
-        title: resolveLegendTitle(layerProps, colorScale.field),
-      });
-    } catch {
-      // Skip legends for fields that don't exist in the dataset
-      continue;
-    }
+    for (const {colorScale} of resolvedColorScales) {
+      let resolvedLegend: ResolvedColorLegend | null = null;
+      try {
+        resolvedLegend = buildColorScaleLegend({
+          table: datasetState.prepared.table,
+          colorScale,
+          title: resolveLegendTitle(layerProps, colorScale.field),
+        });
+      } catch {
+        continue;
+      }
 
-    if (resolvedLegend) {
-      legends.push(resolvedLegend);
+      if (resolvedLegend) {
+        legends.push(resolvedLegend);
+      }
     }
   }
 


### PR DESCRIPTION
Previously `applyColorScale` only resolved the first color scale property found on a layer. If a layer defined both `getFillColor` and `getLineColor` (or `getSourceColor`/`getTargetColor` on arc layers) as color scales, only the first was compiled — the second remained unresolved.

- Add `getAllColorScales()` and loop in `applyColorScale` to compile every color scale property
- Fix `extractColorScaleLegends` to render legends for all color scale properties
- Add tests for multi-color-scale layers and dual-color arc layers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Layers can now provide multiple color scale configurations at once; each supported color property is compiled separately with its own update triggers.
  * Arc layers can scale both source and target colors together.
* **Bug Fixes**
  * Legend generation now produces legends for each configured color scale accessor, skipping failures for individual accessors instead of blocking all legends.
  * Legend titles now respect per-accessor title overrides and use the appropriate fallback when no override is provided.
* **Tests**
  * Expanded coverage for multi–color-scale compilation and legend extraction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->