### PR TITLE
fix: enforce table reference boundaries

### DIFF
--- a/dev-docs/table-reference-type-boundary-inventory.md
+++ b/dev-docs/table-reference-type-boundary-inventory.md
@@ -32,3 +32,23 @@ Inventory captured for the staged cleanup in the Obsidian plan `SQLRooms Table R
 - `db.findTable(...)`, `useDataTable(...)`, and related lookup helpers.
 
 Legacy bare table names remain accepted only at explicit resolution boundaries. New write paths should choose a named table-reference helper before persisting or executing.
+
+## Compatibility And Migration Policy
+
+Saved workspace state continues to resolve table references lazily at runtime.
+Dashboard selected tables, dashboard panel dataset sources, worksheet chart
+blocks, data-table blocks, and map blocks may still contain old bare names,
+canonical identities such as `"main"."events"`, fully qualified default-database
+identities such as `"memory"."main"."events"`, or attached-database identities
+such as `"remote"."main"."events"`.
+
+This is intentional for now: runtime resolution can validate old references
+against the currently loaded catalog without silently rewriting portable user
+state. New write paths should store canonical `TableIdentity` values produced by
+`getTableIdentity(...)` after resolving a concrete table. Direct SQL builders
+should use `getRawSqlTableReference(...)` or an explicit legacy/user-input
+quoting boundary.
+
+Do not add eager workspace migration for table-reference strings until there are
+fixture-backed rules for default-database portability and attached-database
+identity preservation.

--- a/packages/cells/src/defaultCellRegistry.tsx
+++ b/packages/cells/src/defaultCellRegistry.tsx
@@ -1,4 +1,5 @@
 import {convertToValidColumnOrTableName} from '@sqlrooms/utils';
+import {getRawSqlTableReference} from '@sqlrooms/duckdb';
 import {produce} from 'immer';
 import {InputCellContent} from './components/InputCellContent';
 import {SqlCellContent} from './components/SqlCellContent';
@@ -136,13 +137,13 @@ export function createDefaultCellRegistry(): CellRegistry {
           cell.data as SqlCellData,
           convertToValidColumnOrTableName,
         );
-        const newTableName = state.db
-          .qualifyTableName({
+        const newTableName = getRawSqlTableReference(
+          state.db.qualifyTableName({
             table: effectiveResultName,
             schema: schemaName,
             database: state.db.currentDatabase,
-          })
-          .toString();
+          }),
+        );
 
         if (newTableName === oldResultView) {
           return;

--- a/packages/cells/src/execution.ts
+++ b/packages/cells/src/execution.ts
@@ -1,4 +1,4 @@
-import {escapeId} from '@sqlrooms/duckdb';
+import {escapeId, getRawSqlTableReference} from '@sqlrooms/duckdb';
 import {convertToValidColumnOrTableName} from '@sqlrooms/utils';
 import {produce} from 'immer';
 import {
@@ -162,13 +162,13 @@ export async function executeSqlCell(
         {signal},
       );
 
-      tableName = db
-        .qualifyTableName({
+      tableName = getRawSqlTableReference(
+        db.qualifyTableName({
           table: effectiveResultName,
           schema: finalSchemaName,
           database: db.currentDatabase,
-        })
-        .toString();
+        }),
+      );
       // Adaptive policy:
       // - first run: choose table when there are downstream dependents,
       //   otherwise keep a lightweight view.

--- a/packages/cells/src/resultRelationPolicy.ts
+++ b/packages/cells/src/resultRelationPolicy.ts
@@ -1,4 +1,5 @@
 import {
+  getRawSqlTableReference,
   quoteParsedRawSqlTableReference,
   type QualifiedTableName,
   type RawSqlTableReference,
@@ -32,7 +33,9 @@ type SqlConnectorLike = {
 
 function toRelationSqlName(relationName: ResultRelationName): string {
   const relationReference =
-    typeof relationName === 'string' ? relationName : relationName.toString();
+    typeof relationName === 'string'
+      ? relationName
+      : getRawSqlTableReference(relationName);
   const rawSqlTableReference =
     quoteParsedRawSqlTableReference(relationReference);
   if (!rawSqlTableReference) {

--- a/packages/db/src/DbSlice.ts
+++ b/packages/db/src/DbSlice.ts
@@ -1,5 +1,5 @@
 import {createDuckDbSlice, CreateDuckDbSliceProps} from '@sqlrooms/duckdb';
-import {escapeId} from '@sqlrooms/duckdb-core';
+import {escapeId, getRawSqlTableReference} from '@sqlrooms/duckdb-core';
 import {createSlice, useBaseRoomStore} from '@sqlrooms/room-store';
 import * as arrow from 'apache-arrow';
 import {produce} from 'immer';
@@ -112,13 +112,13 @@ export function createDbSlice(props?: CreateDbSliceProps) {
         const schemaName =
           schema ?? get().db.config.coreMaterialization.schemaName;
         await ensureSchemaExists({core, schema: schemaName, database});
-        return get()
-          .db.qualifyTableName({
+        return getRawSqlTableReference(
+          get().db.qualifyTableName({
             database,
             schema: schemaName,
             table: relationName,
-          })
-          .toString();
+          }),
+        );
       }
 
       const attachedName =
@@ -132,13 +132,13 @@ export function createDbSlice(props?: CreateDbSliceProps) {
         schema: schemaName,
         database: attachedName,
       });
-      return get()
-        .db.qualifyTableName({
+      return getRawSqlTableReference(
+        get().db.qualifyTableName({
           database: attachedName,
           schema: schemaName,
           table: relationName,
-        })
-        .toString();
+        }),
+      );
     };
     const materializeArrowResult = async (args: {
       table: arrow.Table;

--- a/packages/deck/src/dashboardConfig.ts
+++ b/packages/deck/src/dashboardConfig.ts
@@ -4,6 +4,7 @@ import {
   Query,
 } from '@sqlrooms/mosaic';
 import {
+  getTableIdentity,
   makeQualifiedTableName,
   parseQualifiedSqlIdentifier,
   quoteParsedRawSqlTableReference,
@@ -167,10 +168,12 @@ function stripCatalogPrefix(tableName: string | undefined) {
   if (!parsed?.database || !parsed.schema || !parsed.table) {
     return tableName;
   }
-  return makeQualifiedTableName({
-    schema: parsed.schema,
-    table: parsed.table,
-  }).toString();
+  return getTableIdentity(
+    makeQualifiedTableName({
+      schema: parsed.schema,
+      table: parsed.table,
+    }),
+  );
 }
 
 export function createDeckMapDashboardDatasetQuery(

--- a/packages/documents/__tests__/BlockDocumentsSlice.test.ts
+++ b/packages/documents/__tests__/BlockDocumentsSlice.test.ts
@@ -134,6 +134,66 @@ describe('BlockDocumentsSlice', () => {
     ).toEqual([block]);
   });
 
+  it('preserves legacy worksheet table reference strings in block nodes', () => {
+    const tableReferences = [
+      'events',
+      '"main"."events"',
+      '"memory"."main"."events"',
+      '"remote"."main"."events"',
+    ];
+
+    for (const tableReference of tableReferences) {
+      expect(
+        blockDocumentContentToBlocks({
+          type: 'doc',
+          content: [
+            blockDocumentBlockToNode({
+              id: 'chart',
+              type: 'chart',
+              tableName: tableReference,
+              config: {chartType: 'histogram', settings: {field: 'amount'}},
+            }),
+            blockDocumentBlockToNode({
+              id: 'data-table',
+              type: 'statefulBlock',
+              blockType: 'data-table',
+              blockInstanceId: 'data-table',
+              title: tableReference,
+            }),
+            blockDocumentBlockToNode({
+              id: 'map',
+              type: 'statefulBlock',
+              blockType: 'map',
+              blockInstanceId: 'map',
+              title: tableReference,
+            }),
+          ],
+        }),
+      ).toEqual([
+        {
+          id: 'chart',
+          type: 'chart',
+          tableName: tableReference,
+          config: {chartType: 'histogram', settings: {field: 'amount'}},
+        },
+        {
+          id: 'data-table',
+          type: 'statefulBlock',
+          blockType: 'data-table',
+          blockInstanceId: 'data-table',
+          title: tableReference,
+        },
+        {
+          id: 'map',
+          type: 'statefulBlock',
+          blockType: 'map',
+          blockInstanceId: 'map',
+          title: tableReference,
+        },
+      ]);
+    }
+  });
+
   it('appends, inserts, updates, removes, and moves top-level blocks', () => {
     const store = createTestStore();
 

--- a/packages/duckdb-core/__tests__/qualifiedTableNameToStringAllowlist.test.ts
+++ b/packages/duckdb-core/__tests__/qualifiedTableNameToStringAllowlist.test.ts
@@ -1,0 +1,71 @@
+import {existsSync, readdirSync, readFileSync, statSync} from 'node:fs';
+import {dirname, join, relative} from 'node:path';
+
+function findRepoRoot(start: string): string {
+  let current = start;
+  while (current !== dirname(current)) {
+    const packageJson = join(current, 'package.json');
+    if (
+      existsSync(packageJson) &&
+      JSON.parse(readFileSync(packageJson, 'utf8')).name === 'sqlrooms'
+    ) {
+      return current;
+    }
+    current = dirname(current);
+  }
+  throw new Error('Unable to find sqlrooms repository root.');
+}
+
+const repoRoot = findRepoRoot(process.cwd());
+const sourceRoots = ['packages', 'apps', 'examples'];
+const scannedExtensions = new Set(['.ts', '.tsx']);
+const approvedFiles = new Set(['packages/duckdb-core/src/duckdb-utils.ts']);
+
+const tableToStringPatterns = [
+  /\bqualified(?:TableName|Name)?\.toString\(\)/,
+  /\btableObj\.table\.toString\(\)/,
+  /\btable\.table\.toString\(\)/,
+  /\btableName\.toString\(\)/,
+];
+
+function walk(dir: string): string[] {
+  const entries = readdirSync(dir);
+  return entries.flatMap((entry) => {
+    const path = join(dir, entry);
+    const stat = statSync(path);
+    if (stat.isDirectory()) {
+      if (
+        entry === 'node_modules' ||
+        entry === 'dist' ||
+        entry === 'coverage' ||
+        entry === '.turbo'
+      ) {
+        return [];
+      }
+      return walk(path);
+    }
+    return [path];
+  });
+}
+
+describe('QualifiedTableName.toString allowlist', () => {
+  it('keeps direct table-reference stringification in approved low-level files', () => {
+    const violations = sourceRoots
+      .flatMap((root) => walk(join(repoRoot, root)))
+      .filter((path) =>
+        [...scannedExtensions].some((extension) => path.endsWith(extension)),
+      )
+      .filter((path) => !path.includes('__tests__'))
+      .flatMap((path) => {
+        const relativePath = relative(repoRoot, path);
+        if (approvedFiles.has(relativePath)) return [];
+
+        const text = readFileSync(path, 'utf8');
+        return tableToStringPatterns
+          .filter((pattern) => pattern.test(text))
+          .map((pattern) => `${relativePath} matched ${pattern.source}`);
+      });
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/packages/duckdb-core/__tests__/schemaTreeUtils.test.ts
+++ b/packages/duckdb-core/__tests__/schemaTreeUtils.test.ts
@@ -1,4 +1,5 @@
 import {
+  getTableIdentity,
   makeQualifiedTableName,
   resolveTableReference,
   type QualifiedTableName,
@@ -9,12 +10,18 @@ import type {DataTable} from '../src/types';
 
 function makeTable(
   tableName: string,
-  options: {database?: string; schema?: string; isView?: boolean} = {},
+  options: {
+    database?: string;
+    schema?: string;
+    defaultDatabase?: string;
+    isView?: boolean;
+  } = {},
 ): DataTable {
   const table = makeQualifiedTableName({
     database: options.database,
     schema: options.schema ?? 'main',
     table: tableName,
+    defaultDatabase: options.defaultDatabase,
   });
 
   return {
@@ -31,10 +38,30 @@ describe('resolveTableReference', () => {
   it('resolves canonical quoted table ids', () => {
     const table = makeTable('earthquakes', {database: 'local'});
 
-    const result = resolveTableReference([table], table.table.toString());
+    const result = resolveTableReference(
+      [table],
+      getTableIdentity(table.table),
+    );
 
     expect(result.table).toBe(table);
     expect(result.ambiguousMatches).toBeUndefined();
+  });
+
+  it('resolves legacy saved-state table reference shapes explicitly', () => {
+    const local = makeTable('events', {
+      database: 'memory',
+      defaultDatabase: 'memory',
+    });
+    const remote = makeTable('events', {database: 'remote'});
+    const catalog = [local, remote];
+
+    expect(resolveTableReference(catalog, '"main"."events"').table).toBe(local);
+    expect(
+      resolveTableReference(catalog, '"memory"."main"."events"').table,
+    ).toBe(local);
+    expect(
+      resolveTableReference(catalog, '"remote"."main"."events"').table,
+    ).toBe(remote);
   });
 
   it('resolves qualified SQL identifier strings by parts', () => {

--- a/packages/duckdb-core/src/duckdb-utils.ts
+++ b/packages/duckdb-core/src/duckdb-utils.ts
@@ -21,6 +21,14 @@ export type QualifiedTableName = {
    * this object carries one.
    */
   toFullString: () => string;
+  /**
+   * Returns SQLRooms' canonical persisted table identity.
+   *
+   * Prefer the named boundary helpers instead of calling this directly:
+   * `getTableIdentity(...)` for persisted ids and lookup keys,
+   * `getRawSqlTableReference(...)` for direct SQL builders, and
+   * `getTableDisplayName(...)` for UI labels.
+   */
   toString: () => string;
 };
 
@@ -444,12 +452,13 @@ export function resolveTableReference<T extends TableReferenceCandidate>(
   tableReference: string | QualifiedTableName,
 ): ResolveTableReferenceResult<T> {
   if (typeof tableReference !== 'string') {
+    const tableIdentity = getTableIdentity(tableReference);
+    const fullTableIdentity = qualifiedTableNameToFullString(tableReference);
     return {
       table: tables.find(
         (candidate) =>
-          candidate.table.toString() === tableReference.toString() ||
-          qualifiedTableNameToFullString(candidate.table) ===
-            qualifiedTableNameToFullString(tableReference),
+          getTableIdentity(candidate.table) === tableIdentity ||
+          qualifiedTableNameToFullString(candidate.table) === fullTableIdentity,
       ),
     };
   }
@@ -457,7 +466,7 @@ export function resolveTableReference<T extends TableReferenceCandidate>(
   const trimmedTableReference = tableReference.trim();
   const canonicalMatches = tables.filter(
     (candidate) =>
-      candidate.table.toString() === trimmedTableReference ||
+      getTableIdentity(candidate.table) === trimmedTableReference ||
       qualifiedTableNameToFullString(candidate.table) === trimmedTableReference,
   );
   if (canonicalMatches.length === 1) return {table: canonicalMatches[0]};

--- a/packages/duckdb-core/src/schema-tree/schemaTreeUtils.ts
+++ b/packages/duckdb-core/src/schema-tree/schemaTreeUtils.ts
@@ -1,4 +1,5 @@
 import type {DbSchemaNode, TableNodeObject} from './types';
+import {getTableIdentity} from '../duckdb-utils';
 
 /**
  * Flattens a schema tree and extracts all table nodes.
@@ -49,7 +50,7 @@ export function findTableInSchemaTrees(
           for (const tableNode of schemaNode.children) {
             if (tableNode.object.type === 'table') {
               const tableObj = tableNode.object as TableNodeObject;
-              if (tableObj.table.toString() === qualifiedName) {
+              if (getTableIdentity(tableObj.table) === qualifiedName) {
                 return tableObj;
               }
             }

--- a/packages/duckdb-node/src/helpers.ts
+++ b/packages/duckdb-node/src/helpers.ts
@@ -1,12 +1,18 @@
 import {DuckDBConnection} from '@duckdb/node-api';
-import {literalToSQL, makeQualifiedTableName} from '@sqlrooms/duckdb-core';
+import {
+  getRawSqlTableReference,
+  literalToSQL,
+  makeQualifiedTableName,
+} from '@sqlrooms/duckdb-core';
 import * as arrow from 'apache-arrow';
 
 /**
  * Builds a qualified table name string from table name and optional schema.
  */
 export function buildQualifiedName(tableName: string, schema?: string): string {
-  return makeQualifiedTableName({table: tableName, schema}).toString();
+  return getRawSqlTableReference(
+    makeQualifiedTableName({table: tableName, schema}),
+  );
 }
 
 /**

--- a/packages/duckdb/__tests__/DuckDbSlice.test.ts
+++ b/packages/duckdb/__tests__/DuckDbSlice.test.ts
@@ -7,7 +7,11 @@ import {
 } from '../src/DuckDbSlice';
 import {createBaseRoomSlice, BaseRoomStoreState} from '@sqlrooms/room-store';
 import * as arrow from 'apache-arrow';
-import {DuckDbConnector, makeQualifiedTableName} from '@sqlrooms/duckdb-core';
+import {
+  DuckDbConnector,
+  getTableIdentity,
+  makeQualifiedTableName,
+} from '@sqlrooms/duckdb-core';
 import {loadSchemaCatalog} from '../src/loadTableSchemas';
 
 type TestStoreState = BaseRoomStoreState & DuckDbSliceState;
@@ -191,15 +195,49 @@ describe('DuckDbSlice', () => {
       );
 
       expect(table).toBeDefined();
-      expect(table!.table.toString()).toBe('"analytics.2026"."daily events"');
+      expect(getTableIdentity(table!.table)).toBe(
+        '"analytics.2026"."daily events"',
+      );
       expect(table!.table.toFullString()).toBe(
         `"${store.getState().db.currentDatabase}"."analytics.2026"."daily events"`,
       );
       expect(
         store.getState().db.findTable('"analytics.2026"."daily events"'),
       ).toBe(table);
-      expect(store.getState().db.findTable(table!.table.toString())).toBe(
-        table,
+      expect(
+        store.getState().db.findTable(getTableIdentity(table!.table)),
+      ).toBe(table);
+    });
+
+    it('opens legacy saved table references through lazy runtime resolution', async () => {
+      const connector = await store.getState().db.getConnector();
+      await connector.query('CREATE TABLE events (id INT)');
+      await connector.query("ATTACH ':memory:' AS remote");
+      await connector.query('CREATE TABLE remote.main.events (id INT)');
+      const tables = await store.getState().db.refreshTableSchemas();
+      const defaultDatabase = store.getState().db.currentDatabase;
+      const local = tables.find(
+        (candidate) =>
+          candidate.table.database === defaultDatabase &&
+          candidate.table.schema === 'main' &&
+          candidate.table.table === 'events',
+      );
+      const remote = tables.find(
+        (candidate) =>
+          candidate.table.database === 'remote' &&
+          candidate.table.schema === 'main' &&
+          candidate.table.table === 'events',
+      );
+
+      expect(local).toBeDefined();
+      expect(remote).toBeDefined();
+      expect(store.getState().db.findTable('events')).toBe(local);
+      expect(store.getState().db.findTable('"main"."events"')).toBe(local);
+      expect(
+        store.getState().db.findTable(`"${defaultDatabase}"."main"."events"`),
+      ).toBe(local);
+      expect(store.getState().db.findTable('"remote"."main"."events"')).toBe(
+        remote,
       );
     });
 

--- a/packages/duckdb/src/DuckDbSlice.ts
+++ b/packages/duckdb/src/DuckDbSlice.ts
@@ -5,6 +5,8 @@ import {
   DuckDbConnector,
   escapeVal,
   getColValAsNumber,
+  getRawSqlTableReference,
+  getTableIdentity,
   isQualifiedTableName,
   joinStatements,
   makeQualifiedTableName,
@@ -466,7 +468,9 @@ export function createDuckDbSlice({
         const qualifiedName = isQualifiedTableName(tableName)
           ? get().db.qualifyTableName(tableName)
           : get().db.qualifyTableName(parseTableReferenceParts(tableName));
-        throw new Error(`Relation "${qualifiedName}" not found.`);
+        throw new Error(
+          `Relation "${getRawSqlTableReference(qualifiedName)}" not found.`,
+        );
       };
 
       return {
@@ -612,7 +616,9 @@ export function createDuckDbSlice({
               .filter(Boolean)
               .join(' ');
 
-            const createStatement = `${createKeyword} ${qualifiedName} AS (
+            const createStatement = `${createKeyword} ${getRawSqlTableReference(
+              qualifiedName,
+            )} AS (
               ${lastStatement}
             )`;
 
@@ -662,12 +668,13 @@ export function createDuckDbSlice({
                 ? get().db.qualifyTableName(parseTableReferenceParts(tableName))
                 : get().db.qualifyTableName(tableName);
             const connector = await get().db.getConnector();
+            const qualifiedName = get().db.qualifyTableName({
+              schema,
+              database,
+              table,
+            });
             const result = await connector.query(
-              `SELECT COUNT(*) FROM ${get().db.qualifyTableName({
-                schema,
-                database,
-                table,
-              })}`,
+              `SELECT COUNT(*) FROM ${getRawSqlTableReference(qualifiedName)}`,
             );
             return getColValAsNumber(result);
           },
@@ -711,10 +718,16 @@ export function createDuckDbSlice({
                     parseTableReferenceParts(tableName),
                   ));
             const isView = table?.isView;
+            const qualifiedTableReference =
+              getRawSqlTableReference(qualifiedTable);
             if (isView) {
-              await connector.query(`DROP VIEW IF EXISTS ${qualifiedTable};`);
+              await connector.query(
+                `DROP VIEW IF EXISTS ${qualifiedTableReference};`,
+              );
             } else {
-              await connector.query(`DROP TABLE IF EXISTS ${qualifiedTable};`);
+              await connector.query(
+                `DROP TABLE IF EXISTS ${qualifiedTableReference};`,
+              );
             }
             get().db.refreshTableSchemas();
           },
@@ -735,11 +748,17 @@ export function createDuckDbSlice({
 
             if (table?.isView) {
               throw new Error(
-                `"${qualifiedTable}" is a view. Use dropRelation() to remove views.`,
+                `"${getRawSqlTableReference(
+                  qualifiedTable,
+                )}" is a view. Use dropRelation() to remove views.`,
               );
             }
 
-            await connector.query(`DROP TABLE IF EXISTS ${qualifiedTable};`);
+            await connector.query(
+              `DROP TABLE IF EXISTS ${getRawSqlTableReference(
+                qualifiedTable,
+              )};`,
+            );
             get().db.refreshTableSchemas();
           },
 
@@ -747,11 +766,12 @@ export function createDuckDbSlice({
             const qualifiedName = get().db.qualifyTableName(tableName);
 
             const {db} = get();
+            const tableReference = getRawSqlTableReference(qualifiedName);
             if (data instanceof arrow.Table) {
               // TODO: make sure the table is replaced
-              await db.connector.loadArrow(data, qualifiedName.toString());
+              await db.connector.loadArrow(data, tableReference);
             } else {
-              await db.connector.loadObjects(data, qualifiedName.toString(), {
+              await db.connector.loadObjects(data, tableReference, {
                 replace: true,
               });
             }
@@ -772,7 +792,8 @@ export function createDuckDbSlice({
             const qualifiedName = get().db.qualifyTableName(tableName);
             set((state) =>
               produce(state, (draft) => {
-                draft.db.tableRowCounts[qualifiedName.toString()] = rowCount;
+                draft.db.tableRowCounts[getTableIdentity(qualifiedName)] =
+                  rowCount;
               }),
             );
           },

--- a/packages/mosaic/__tests__/MosaicDashboardSlice.test.ts
+++ b/packages/mosaic/__tests__/MosaicDashboardSlice.test.ts
@@ -72,6 +72,50 @@ function collectPanelIds(
 }
 
 describe('MosaicDashboardSlice generic panels', () => {
+  it('parses legacy dashboard table references without rewriting saved state', () => {
+    const references = [
+      'events',
+      '"main"."events"',
+      '"memory"."main"."events"',
+      '"remote"."main"."events"',
+    ];
+
+    for (const tableReference of references) {
+      const dashboard = MosaicDashboardEntry.parse({
+        id: `dashboard-${tableReference}`,
+        title: 'Legacy dashboard',
+        selectedTable: tableReference,
+        panels: [
+          createMosaicDashboardChartPanelConfig('Chart', {
+            chartType: 'histogram',
+            settings: {field: 'amount'},
+          }),
+          createMosaicDashboardDataTableExplorerPanelConfig(),
+          {
+            id: 'legacy-map-panel',
+            type: 'deck-json-map',
+            title: 'Map',
+            config: {
+              datasets: {
+                events: {source: {tableName: tableReference}},
+              },
+            },
+          },
+        ],
+      });
+
+      expect(dashboard.selectedTable).toBe(tableReference);
+      expect(dashboard.panels[2]).toMatchObject({
+        type: 'deck-json-map',
+        config: {
+          datasets: {
+            events: {source: {tableName: tableReference}},
+          },
+        },
+      });
+    }
+  });
+
   it('defaults parsed legacy dashboards to dock layout type', () => {
     const dashboard = MosaicDashboardEntry.parse({
       id: 'legacy-dashboard',

--- a/packages/schema-tree/src/nodes/TableTreeNode.tsx
+++ b/packages/schema-tree/src/nodes/TableTreeNode.tsx
@@ -1,7 +1,11 @@
 // Copyright 2022 Foursquare Labs, Inc. All Rights Reserved.
 
 import {DataTableModal} from '@sqlrooms/data-table';
-import {TableNodeObject} from '@sqlrooms/duckdb';
+import {
+  getRawSqlTableReference,
+  getTableIdentity,
+  TableNodeObject,
+} from '@sqlrooms/duckdb';
 import {cn, useDisclosure} from '@sqlrooms/ui';
 import {formatCount} from '@sqlrooms/utils';
 import {CopyIcon, EyeIcon, TableIcon, ViewIcon} from 'lucide-react';
@@ -40,7 +44,7 @@ export const defaultRenderTableNodeMenuItems = (
 
       <TreeNodeActionsMenuItem
         onClick={() => {
-          navigator.clipboard.writeText(qualifiedTableName.toString());
+          navigator.clipboard.writeText(getTableIdentity(qualifiedTableName));
         }}
       >
         <CopyIcon width="15px" />
@@ -49,7 +53,9 @@ export const defaultRenderTableNodeMenuItems = (
 
       <TreeNodeActionsMenuItem
         onClick={() => {
-          navigator.clipboard.writeText(`SELECT * FROM ${qualifiedTableName}`);
+          navigator.clipboard.writeText(
+            `SELECT * FROM ${getRawSqlTableReference(qualifiedTableName)}`,
+          );
         }}
       >
         <CopyIcon width="15px" />
@@ -87,7 +93,9 @@ export const TableTreeNode: FC<{
 
   const tableModal = useDisclosure();
   const {name, rowCount, isView, table: qualifiedTableName} = nodeObject;
-  const sqlQuery = `SELECT * FROM ${qualifiedTableName}`;
+  const sqlQuery = `SELECT * FROM ${getRawSqlTableReference(
+    qualifiedTableName,
+  )}`;
 
   return (
     <>


### PR DESCRIPTION
## Summary

- document `QualifiedTableName.toString()` as a low-level canonical identity renderer and route application boundaries through explicit table-reference helpers
- add an allowlist-based guard against new direct table-reference stringification outside approved low-level files
- add legacy compatibility fixtures for dashboard and worksheet table reference shapes, and document the lazy migration policy

## Validation

- `pnpm build`
- `pnpm --filter @sqlrooms/duckdb-core test`
- `pnpm --filter @sqlrooms/duckdb test`
- `pnpm --filter @sqlrooms/documents test`
- `pnpm --filter @sqlrooms/mosaic test`
- `pnpm --filter @sqlrooms/deck test`
- targeted package `typecheck` runs for duckdb-core, duckdb, cells, db, deck, duckdb-node, documents, mosaic
- pre-push hook: `knip`, `turbo typecheck`, circular dependency check, `turbo test`