### PR TITLE
feat: extract reusable CLI package primitives

### DIFF
--- a/apps/sqlrooms-cli-ui/src/__tests__/createHtmlAppRevisionCommands.test.ts
+++ b/apps/sqlrooms-cli-ui/src/__tests__/createHtmlAppRevisionCommands.test.ts
@@ -1,4 +1,8 @@
 import {jest} from '@jest/globals';
+import {
+  HTML_APP_RENAME_COMMAND_ID,
+  HTML_APP_WRITE_REVISION_COMMAND_ID,
+} from '@sqlrooms/app-runtime';
 import {createHtmlAppRevisionCommands} from '../createHtmlAppRevisionCommands';
 
 function createCommandContext(state: unknown) {
@@ -74,7 +78,7 @@ describe('createHtmlAppRevisionCommands', () => {
   it('writes committed HTML app revisions with metadata', async () => {
     const {state, commitAppRevision} = createState();
 
-    const result = await getCommand('html-app.write-revision').execute(
+    const result = await getCommand(HTML_APP_WRITE_REVISION_COMMAND_ID).execute(
       createCommandContext(state),
       {
         appId: 'app-1',
@@ -101,7 +105,7 @@ describe('createHtmlAppRevisionCommands', () => {
     );
     expect(result).toMatchObject({
       success: true,
-      commandId: 'html-app.write-revision',
+      commandId: HTML_APP_WRITE_REVISION_COMMAND_ID,
       data: {
         appId: 'app-1',
         title: 'Updated App',
@@ -114,7 +118,7 @@ describe('createHtmlAppRevisionCommands', () => {
   it('renames HTML apps directly when no source files are committed', async () => {
     const {state, renameApp, commitAppRevision} = createState();
 
-    const result = await getCommand('html-app.rename').execute(
+    const result = await getCommand(HTML_APP_RENAME_COMMAND_ID).execute(
       createCommandContext(state),
       {appId: 'app-1', title: 'Renamed App'},
     );
@@ -123,7 +127,7 @@ describe('createHtmlAppRevisionCommands', () => {
     expect(commitAppRevision).not.toHaveBeenCalled();
     expect(result).toMatchObject({
       success: true,
-      commandId: 'html-app.rename',
+      commandId: HTML_APP_RENAME_COMMAND_ID,
       data: {
         appId: 'app-1',
         previousTitle: 'App',
@@ -135,7 +139,7 @@ describe('createHtmlAppRevisionCommands', () => {
   it('commits metadata-backed title-only renames as revisions', async () => {
     const {state, renameApp, commitAppRevision} = createState();
 
-    const result = await getCommand('html-app.rename').execute(
+    const result = await getCommand(HTML_APP_RENAME_COMMAND_ID).execute(
       createCommandContext(state),
       {
         appId: 'app-1',
@@ -157,7 +161,7 @@ describe('createHtmlAppRevisionCommands', () => {
     );
     expect(result).toMatchObject({
       success: true,
-      commandId: 'html-app.rename',
+      commandId: HTML_APP_RENAME_COMMAND_ID,
       data: {
         appId: 'app-1',
         previousTitle: 'App',
@@ -170,7 +174,7 @@ describe('createHtmlAppRevisionCommands', () => {
   it('renames HTML apps through a revision when updated files are provided', async () => {
     const {state, renameApp, commitAppRevision} = createState();
 
-    const result = await getCommand('html-app.rename').execute(
+    const result = await getCommand(HTML_APP_RENAME_COMMAND_ID).execute(
       createCommandContext(state),
       {
         appId: 'app-1',
@@ -193,7 +197,7 @@ describe('createHtmlAppRevisionCommands', () => {
     );
     expect(result).toMatchObject({
       success: true,
-      commandId: 'html-app.rename',
+      commandId: HTML_APP_RENAME_COMMAND_ID,
       data: {
         appId: 'app-1',
         previousTitle: 'App',

--- a/apps/sqlrooms-cli-ui/src/__tests__/createWorksheetAiAdapter.test.ts
+++ b/apps/sqlrooms-cli-ui/src/__tests__/createWorksheetAiAdapter.test.ts
@@ -1,5 +1,9 @@
 import {jest} from '@jest/globals';
-import type {BlockDocumentBlock} from '@sqlrooms/documents';
+import {
+  BLOCK_DOCUMENT_AGENT_ACTOR,
+  BLOCK_DOCUMENT_APPEND_BLOCKS_COMMAND_ID,
+  type BlockDocumentBlock,
+} from '@sqlrooms/documents';
 import type {StoreApi} from 'zustand';
 import {createWorksheetAiAdapter} from '../createWorksheetAiAdapter';
 import type {RoomState} from '../store-types';
@@ -7,7 +11,7 @@ import type {RoomState} from '../store-types';
 function createMockStore({
   invokeCommand = jest.fn(async (_commandId, input: any) => ({
     success: true,
-    commandId: 'block-document.append-blocks',
+    commandId: BLOCK_DOCUMENT_APPEND_BLOCKS_COMMAND_ID,
     data: {
       blockId: input.blocks[0].id,
     },
@@ -62,14 +66,14 @@ describe('createWorksheetAiAdapter', () => {
 
     expect(ensureBlockDocument).toHaveBeenCalledWith('worksheet-1');
     expect(invokeCommand).toHaveBeenCalledWith(
-      'block-document.append-blocks',
+      BLOCK_DOCUMENT_APPEND_BLOCKS_COMMAND_ID,
       {
         artifactId: 'worksheet-1',
         blocks: [block],
       },
       {
         surface: 'ai',
-        actor: 'block-document-agent',
+        actor: BLOCK_DOCUMENT_AGENT_ACTOR,
       },
     );
   });
@@ -78,7 +82,7 @@ describe('createWorksheetAiAdapter', () => {
     const {store} = createMockStore({
       invokeCommand: jest.fn(async () => ({
         success: false,
-        commandId: 'block-document.append-blocks',
+        commandId: BLOCK_DOCUMENT_APPEND_BLOCKS_COMMAND_ID,
         error: 'Command failed',
       })),
     });

--- a/apps/sqlrooms-cli-ui/src/ai/createAddHtmlAppBlockDocumentBlockTool.ts
+++ b/apps/sqlrooms-cli-ui/src/ai/createAddHtmlAppBlockDocumentBlockTool.ts
@@ -1,4 +1,4 @@
-import {HTML_APP_BLOCK_TYPE} from '@sqlrooms/app-runtime';
+import {createHtmlAppBlockDocumentBlock as createHtmlAppRuntimeBlockDocumentBlock} from '@sqlrooms/app-runtime';
 import {
   createDefaultBlockDocumentBlockId,
   type BlockDocumentAiAdapter,
@@ -43,19 +43,18 @@ export function createHtmlAppBlockDocumentBlock({
   appId?: string;
   blockId?: string;
 }): {appId: string; block: BlockDocumentStatefulBlockBlock} {
-  return {
-    appId,
-    block: {
-      type: 'statefulBlock',
-      id: blockId,
-      blockType: HTML_APP_BLOCK_TYPE,
-      blockInstanceId: appId,
-      ownership: 'owned',
-      intent,
+  const {appId: runtimeAppId, block: runtimeBlock} =
+    createHtmlAppRuntimeBlockDocumentBlock({
+      appId,
+      blockId,
       title,
-      caption: title,
+      intent,
       height,
-    },
+    });
+  const block: BlockDocumentStatefulBlockBlock = runtimeBlock;
+  return {
+    appId: runtimeAppId,
+    block,
   };
 }
 

--- a/apps/sqlrooms-cli-ui/src/createDatabaseAiAdapter.ts
+++ b/apps/sqlrooms-cli-ui/src/createDatabaseAiAdapter.ts
@@ -1,21 +1,12 @@
-import {getTablesForAiScope} from '@sqlrooms/ai';
-import type {DatabaseAiAdapter} from '@sqlrooms/mosaic/ai';
+import {
+  createDuckDbDatabaseAiAdapter,
+  type DatabaseAiAdapter,
+} from '@sqlrooms/mosaic/ai';
 import type {StoreApi} from 'zustand';
 import type {RoomState} from './store-types';
 
 export function createDatabaseAiAdapter(
   store: StoreApi<RoomState>,
 ): DatabaseAiAdapter {
-  return {
-    getTables: () => {
-      const state = store.getState();
-
-      return getTablesForAiScope(state.db.tables, state.db.currentDatabase, {
-        scope: 'all',
-      });
-    },
-    findTable: (tableName) => {
-      return store.getState().db.findTable(tableName);
-    },
-  };
+  return createDuckDbDatabaseAiAdapter(store);
 }

--- a/apps/sqlrooms-cli-ui/src/createHtmlAppAgent.ts
+++ b/apps/sqlrooms-cli-ui/src/createHtmlAppAgent.ts
@@ -5,6 +5,8 @@ import {ToolLoopAgent, stepCountIs} from 'ai';
 import type {StoreApi} from 'zustand';
 import {z} from 'zod';
 import {
+  HTML_APP_RENAME_COMMAND_ID,
+  HTML_APP_WRITE_REVISION_COMMAND_ID,
   createDefaultHtmlAppFiles,
   type HtmlAppDependency,
   type HtmlAppRevision,
@@ -167,7 +169,7 @@ async function renameHtmlAppTitle(
   let revision: HtmlAppRevision | undefined;
   if (app.revisions.length === 0 && isDefaultHtmlAppScaffold(app)) {
     const result = await store.getState().commands.invokeCommand(
-      'html-app.rename',
+      HTML_APP_RENAME_COMMAND_ID,
       {
         appId: input.appId,
         title,
@@ -190,7 +192,7 @@ async function renameHtmlAppTitle(
   } else {
     const seededBaselineRevision = seedHtmlAppBaselineRevision(store, app);
     const result = await store.getState().commands.invokeCommand(
-      'html-app.rename',
+      HTML_APP_RENAME_COMMAND_ID,
       {
         appId: input.appId,
         title,
@@ -573,7 +575,7 @@ async function commitHtmlAppRevisionWithCommand(
   const result = await store
     .getState()
     .commands.invokeCommand(
-      'html-app.write-revision',
+      HTML_APP_WRITE_REVISION_COMMAND_ID,
       {appId, patch, metadata},
       {surface: 'ai', actor: 'html-app-agent'},
     );

--- a/apps/sqlrooms-cli-ui/src/createHtmlAppRevisionCommands.ts
+++ b/apps/sqlrooms-cli-ui/src/createHtmlAppRevisionCommands.ts
@@ -1,332 +1,50 @@
-import type {
-  CommitHtmlAppRevisionMetadata,
-  HtmlAppRevisionPatch,
+import {
+  createHtmlAppRevisionCommands as createRuntimeHtmlAppRevisionCommands,
+  type CommitHtmlAppRevisionMetadata,
+  type HtmlAppRevisionPatch,
+  type RestoreHtmlAppRevisionMetadata,
 } from '@sqlrooms/app-runtime';
 import type {RoomCommand} from '@sqlrooms/room-shell';
-import {z} from 'zod';
-
 import type {RoomState} from './store-types';
 
 export const HTML_APP_REVISION_COMMAND_OWNER =
   '@sqlrooms-cli-ui/html-app-revisions';
 
-const HtmlAppRevisionCommandInput = z
-  .object({
-    appId: z.string().optional().describe('Target HTML app runtime id.'),
-    revisionId: z
-      .string()
-      .optional()
-      .describe('Target revision id for restore.'),
-  })
-  .default({});
-type HtmlAppRevisionCommandInput = z.infer<typeof HtmlAppRevisionCommandInput>;
-
-const HtmlAppRestoreRevisionCommandInput =
-  HtmlAppRevisionCommandInput.removeDefault().extend({
-    revisionId: z.string().describe('Target revision id for restore.'),
-  });
-type HtmlAppRestoreRevisionCommandInput = z.infer<
-  typeof HtmlAppRestoreRevisionCommandInput
->;
-
-const HtmlAppRevisionPatchInput = z.object({
-  title: z.string().optional(),
-  intent: z.string().optional(),
-  files: z.record(z.string(), z.string()).optional(),
-  entryHtmlPath: z.string().optional(),
-  dependencies: z.array(z.unknown()).optional(),
-  requestedCapabilities: z.array(z.string()).optional(),
-  grantedCapabilities: z.array(z.string()).optional(),
-  diagnostics: z.array(z.unknown()).optional(),
-});
-
-const HtmlAppRevisionMetadataInput = z
-  .object({
-    name: z.string().optional(),
-    description: z.string().optional(),
-    source: z.enum(['assistant', 'user', 'system', 'restore']).optional(),
-    sourcePrompt: z.string().optional(),
-    sessionId: z.string().optional(),
-    toolCallId: z.string().optional(),
-    commitGroupId: z.string().optional(),
-    parentRevisionId: z.string().optional(),
-    createdAt: z.number().optional(),
-    revisionId: z.string().optional(),
-    clearRedo: z.boolean().optional(),
-  })
-  .default({});
-
-const HtmlAppWriteRevisionCommandInput = z.object({
-  appId: z.string().describe('Target HTML app runtime id.'),
-  patch: HtmlAppRevisionPatchInput.describe('Durable HTML app state patch.'),
-  metadata: HtmlAppRevisionMetadataInput.optional(),
-});
-type HtmlAppWriteRevisionCommandInput = z.infer<
-  typeof HtmlAppWriteRevisionCommandInput
->;
-
-const HtmlAppRenameCommandInput = z.object({
-  appId: z.string().describe('Target HTML app runtime id.'),
-  title: z.string().min(1).describe('New HTML app title.'),
-  files: z
-    .record(z.string(), z.string())
-    .optional()
-    .describe('Optional source files with title updates already applied.'),
-  metadata: HtmlAppRevisionMetadataInput.optional(),
-});
-type HtmlAppRenameCommandInput = z.infer<typeof HtmlAppRenameCommandInput>;
-
 /**
  * Create room commands for restoring, undoing, and redoing HTML app revisions.
  */
 export function createHtmlAppRevisionCommands(): RoomCommand<RoomState>[] {
-  return [
-    {
-      id: 'html-app.write-revision',
-      name: 'Write HTML app revision',
-      description: 'Commit a durable source revision for an HTML app.',
-      group: 'HTML App',
-      keywords: ['html-app', 'revision', 'write', 'commit'],
-      inputSchema: HtmlAppWriteRevisionCommandInput,
-      inputDescription: 'Provide appId, patch, and optional revision metadata.',
-      metadata: {
-        readOnly: false,
-        idempotent: false,
-        riskLevel: 'medium',
-      },
-      execute: ({getState}, input) => {
-        const state = getState();
-        const {appId, patch, metadata} =
-          input as HtmlAppWriteRevisionCommandInput;
-        const app = state.htmlApps.getApp(appId);
-        if (!app) {
-          throw new Error(`HTML app "${appId}" was not found.`);
-        }
-        const revision = state.htmlApps.commitAppRevision(
-          appId,
-          patch as HtmlAppRevisionPatch,
-          (metadata ?? {}) as CommitHtmlAppRevisionMetadata,
-        );
-        if (!revision) {
-          throw new Error(`Failed to write HTML app revision for "${appId}".`);
-        }
-        const nextApp = state.htmlApps.getApp(appId);
-        return {
-          success: true,
-          commandId: 'html-app.write-revision',
-          message: `Wrote HTML app revision "${revision.name}".`,
-          data: {
-            appId,
-            title: nextApp?.title ?? app.title,
-            revisionId: revision.id,
-            revisionName: revision.name,
-            revision,
-            filePaths: Object.keys(nextApp?.files ?? app.files),
-            diagnostics: nextApp?.diagnostics ?? app.diagnostics,
-          },
-        };
-      },
+  return createRuntimeHtmlAppRevisionCommands<RoomState>({
+    resolveCurrentAppId: (state) => {
+      const currentArtifactId = state.artifacts.config.currentArtifactId;
+      const currentArtifact = currentArtifactId
+        ? state.artifacts.config.artifactsById[currentArtifactId]
+        : undefined;
+      return currentArtifact?.type === 'html-app'
+        ? currentArtifactId
+        : undefined;
     },
-    {
-      id: 'html-app.rename',
-      name: 'Rename HTML app',
-      description:
-        'Rename an HTML app runtime and optionally commit title-updated files.',
-      group: 'HTML App',
-      keywords: ['html-app', 'rename', 'title'],
-      inputSchema: HtmlAppRenameCommandInput,
-      inputDescription: 'Provide appId, title, optional files, and metadata.',
-      metadata: {
-        readOnly: false,
-        idempotent: true,
-        riskLevel: 'low',
-      },
-      execute: ({getState}, input) => {
-        const state = getState();
-        const {appId, title, files, metadata} =
-          input as HtmlAppRenameCommandInput;
-        const app = state.htmlApps.getApp(appId);
-        if (!app) {
-          throw new Error(`HTML app "${appId}" was not found.`);
-        }
-        const trimmedTitle = title.trim();
-        if (!trimmedTitle) {
-          throw new Error('HTML app title cannot be empty.');
-        }
-        const previousTitle = app.title;
-        let revision;
-        const shouldCommitRevision =
-          files || (metadata && app.title !== trimmedTitle);
-        if (shouldCommitRevision) {
-          revision = state.htmlApps.commitAppRevision(
-            appId,
-            {
-              title: trimmedTitle,
-              ...(files ? {files, diagnostics: []} : {}),
-            },
-            (metadata ?? {}) as CommitHtmlAppRevisionMetadata,
-          );
-          if (!revision) {
-            throw new Error(`Failed to rename HTML app "${appId}".`);
-          }
-        } else if (app.title !== trimmedTitle) {
-          state.htmlApps.renameApp(appId, trimmedTitle);
-        }
-        const nextApp = state.htmlApps.getApp(appId);
-        return {
-          success: true,
-          commandId: 'html-app.rename',
-          code:
-            app.title === trimmedTitle && !files
-              ? 'html-app-title-unchanged'
-              : undefined,
-          message: `Renamed HTML app "${appId}" to "${trimmedTitle}".`,
-          data: {
-            appId,
-            previousTitle,
-            title: nextApp?.title ?? trimmedTitle,
-            revisionId: revision?.id,
-            revisionName: revision?.name,
-            revision,
-            filePaths: Object.keys(nextApp?.files ?? app.files),
-            diagnostics: nextApp?.diagnostics ?? app.diagnostics,
-          },
-        };
-      },
-    },
-    {
-      id: 'html-app.restore-revision',
-      name: 'Restore HTML app revision',
-      description: 'Restore an HTML app to a persisted source revision',
-      group: 'HTML App',
-      keywords: ['html-app', 'revision', 'restore', 'history'],
-      inputSchema: HtmlAppRestoreRevisionCommandInput,
-      inputDescription: 'Provide revisionId and optionally appId.',
-      metadata: {
-        readOnly: false,
-        idempotent: false,
-        riskLevel: 'medium',
-      },
-      execute: ({getState}, input) => {
-        const state = getState();
-        const {appId: inputAppId, revisionId} =
-          input as HtmlAppRestoreRevisionCommandInput;
-        const appId = resolveHtmlAppCommandAppId(state, inputAppId);
-        const revision = state.htmlApps.restoreAppRevision(appId, revisionId);
-        if (!revision) {
-          throw new Error(
-            `Revision "${revisionId}" was not found for HTML app "${appId}".`,
-          );
-        }
-        return {
-          success: true,
-          commandId: 'html-app.restore-revision',
-          message: `Restored HTML app revision "${revision.name}".`,
-          data: {
-            appId,
-            revisionId: revision.id,
-            revisionName: revision.name,
-          },
-        };
-      },
-    },
-    {
-      id: 'html-app.undo-revision',
-      name: 'Undo HTML app revision',
-      description: 'Move an HTML app back to its previous source revision',
-      group: 'HTML App',
-      keywords: ['html-app', 'revision', 'undo', 'history'],
-      inputSchema: HtmlAppRevisionCommandInput,
-      inputDescription: 'Optionally provide appId.',
-      metadata: {
-        readOnly: false,
-        idempotent: false,
-        riskLevel: 'medium',
-      },
-      execute: ({getState}, input) => {
-        const state = getState();
-        const {appId: inputAppId} =
-          ((input as HtmlAppRevisionCommandInput | undefined) ?? {}) || {};
-        const appId = resolveHtmlAppCommandAppId(state, inputAppId);
-        const revision = state.htmlApps.undoAppRevision(appId);
-        if (!revision) {
-          throw new Error(`HTML app "${appId}" has no revision to undo.`);
-        }
-        return {
-          success: true,
-          commandId: 'html-app.undo-revision',
-          message: `Undid to HTML app revision "${revision.name}".`,
-          data: {
-            appId,
-            revisionId: revision.id,
-            revisionName: revision.name,
-          },
-        };
-      },
-    },
-    {
-      id: 'html-app.redo-revision',
-      name: 'Redo HTML app revision',
-      description: 'Move an HTML app forward through undone source revisions',
-      group: 'HTML App',
-      keywords: ['html-app', 'revision', 'redo', 'history'],
-      inputSchema: HtmlAppRevisionCommandInput,
-      inputDescription: 'Optionally provide appId.',
-      metadata: {
-        readOnly: false,
-        idempotent: false,
-        riskLevel: 'medium',
-      },
-      execute: ({getState}, input) => {
-        const state = getState();
-        const {appId: inputAppId} =
-          ((input as HtmlAppRevisionCommandInput | undefined) ?? {}) || {};
-        const appId = resolveHtmlAppCommandAppId(state, inputAppId);
-        const revision = state.htmlApps.redoAppRevision(appId);
-        if (!revision) {
-          throw new Error(`HTML app "${appId}" has no revision to redo.`);
-        }
-        return {
-          success: true,
-          commandId: 'html-app.redo-revision',
-          message: `Redid to HTML app revision "${revision.name}".`,
-          data: {
-            appId,
-            revisionId: revision.id,
-            revisionName: revision.name,
-          },
-        };
-      },
-    },
-  ];
-}
-
-function resolveHtmlAppCommandAppId(state: RoomState, inputAppId?: string) {
-  if (inputAppId) {
-    if (!state.htmlApps.getApp(inputAppId)) {
-      throw new Error(`HTML app "${inputAppId}" was not found.`);
-    }
-    return inputAppId;
-  }
-
-  const currentArtifactId = state.artifacts.config.currentArtifactId;
-  const currentArtifact = currentArtifactId
-    ? state.artifacts.config.artifactsById[currentArtifactId]
-    : undefined;
-  if (
-    currentArtifactId &&
-    currentArtifact?.type === 'html-app' &&
-    state.htmlApps.getApp(currentArtifactId)
-  ) {
-    return currentArtifactId;
-  }
-
-  const appIds = Object.keys(state.htmlApps.config.appsById);
-  if (appIds.length === 1 && appIds[0]) {
-    return appIds[0];
-  }
-
-  throw new Error(
-    'No unambiguous HTML app target. Provide appId or select a top-level html-app artifact.',
-  );
+    getHtmlAppIds: (state) => Object.keys(state.htmlApps.config.appsById),
+    getHtmlAppState: (state, appId) => state.htmlApps.getApp(appId),
+    renameHtmlApp: (state, appId, title) =>
+      state.htmlApps.renameApp(appId, title),
+    commitHtmlAppRevision: (state, appId, patch, metadata) =>
+      state.htmlApps.commitAppRevision(
+        appId,
+        patch as HtmlAppRevisionPatch,
+        metadata as CommitHtmlAppRevisionMetadata,
+      ),
+    restoreHtmlAppRevision: (state, appId, revisionId, metadata) =>
+      state.htmlApps.restoreAppRevision(
+        appId,
+        revisionId,
+        metadata as RestoreHtmlAppRevisionMetadata,
+      ),
+    undoHtmlAppRevision: (state, appId) =>
+      state.htmlApps.undoAppRevision(appId),
+    redoHtmlAppRevision: (state, appId) =>
+      state.htmlApps.redoAppRevision(appId),
+    ambiguousTargetMessage:
+      'No unambiguous HTML app target. Provide appId or select a top-level html-app artifact.',
+  });
 }

--- a/apps/sqlrooms-cli-ui/src/createWorksheetAiAdapter.ts
+++ b/apps/sqlrooms-cli-ui/src/createWorksheetAiAdapter.ts
@@ -1,8 +1,9 @@
-import type {BlockDocumentAiAdapter} from '@sqlrooms/documents';
+import {
+  createBlockDocumentCommandAiAdapter,
+  type BlockDocumentAiAdapter,
+} from '@sqlrooms/documents';
 import type {StoreApi} from 'zustand';
 import type {RoomState} from './store-types';
-
-const WORKSHEET_APPEND_BLOCKS_COMMAND_ID = 'block-document.append-blocks';
 
 /**
  * Creates a worksheet-specific adapter for the worksheet agent.
@@ -11,67 +12,8 @@ const WORKSHEET_APPEND_BLOCKS_COMMAND_ID = 'block-document.append-blocks';
 export function createWorksheetAiAdapter(
   store: StoreApi<RoomState>,
 ): BlockDocumentAiAdapter {
-  const ensureWorksheet = (worksheetId: string) => {
-    const state = store.getState();
-
-    if (state.artifacts.getArtifact(worksheetId)?.type !== 'worksheet') {
-      throw new Error(`Artifact ${worksheetId} is not a worksheet`);
-    }
-
-    state.blockDocuments.ensureBlockDocument(worksheetId);
-  };
-
-  return {
-    setCurrentBlockDocument: (artifactId) =>
-      store.getState().artifacts.setCurrentArtifact(artifactId),
-
-    ensureBlockDocument: ensureWorksheet,
-
-    getBlocks: (worksheetId) => {
-      const state = store.getState();
-      const artifact = state.artifacts.getArtifact(worksheetId);
-      if (!artifact || artifact.type !== 'worksheet') {
-        return undefined;
-      }
-
-      const blockDocument = state.blockDocuments.config.artifacts[worksheetId];
-      if (!blockDocument) {
-        return undefined;
-      }
-
-      return blockDocument.content.content;
-    },
-
-    addBlock: async (worksheetId, block) => {
-      ensureWorksheet(worksheetId);
-
-      const result = await store.getState().commands.invokeCommand(
-        WORKSHEET_APPEND_BLOCKS_COMMAND_ID,
-        {
-          artifactId: worksheetId,
-          blocks: [block],
-        },
-        {
-          surface: 'ai',
-          actor: 'block-document-agent',
-        },
-      );
-
-      if (!result.success) {
-        throw new Error(
-          result.error ??
-            result.message ??
-            `Failed to execute ${WORKSHEET_APPEND_BLOCKS_COMMAND_ID}`,
-        );
-      }
-
-      const data = result.data as
-        | {
-            blockId?: string;
-            blockIds?: string[];
-          }
-        | undefined;
-      return data?.blockId ?? data?.blockIds?.[0] ?? block.id;
-    },
-  };
+  return createBlockDocumentCommandAiAdapter({
+    store,
+    isBlockDocumentArtifact: (artifact) => artifact.type === 'worksheet',
+  });
 }

--- a/packages/app-runtime/README.md
+++ b/packages/app-runtime/README.md
@@ -73,6 +73,27 @@ WebContainer app project records such as `appProject.config.appsByArtifactId`.
 Those projects can be migrated to `html-app` state later, but they should not
 drive the shared runtime history API.
 
+Hosts can expose revision controls through canonical room commands with
+`createHtmlAppRevisionCommands`. The runtime package owns the command IDs and
+revision operations; the host supplies callbacks for target resolution and state
+updates:
+
+```ts
+const commands = createHtmlAppRevisionCommands({
+  resolveCurrentAppId: (state) => state.currentHtmlAppId,
+  getHtmlAppIds: (state) => Object.keys(state.htmlApps.config.appsById),
+  getHtmlAppState: (state, appId) => state.htmlApps.getApp(appId),
+  renameHtmlApp: (state, appId, title) =>
+    state.htmlApps.renameApp(appId, title),
+  commitHtmlAppRevision: (state, appId, patch, metadata) =>
+    state.htmlApps.commitAppRevision(appId, patch, metadata),
+  restoreHtmlAppRevision: (state, appId, revisionId, metadata) =>
+    state.htmlApps.restoreAppRevision(appId, revisionId, metadata),
+  undoHtmlAppRevision: (state, appId) => state.htmlApps.undoAppRevision(appId),
+  redoHtmlAppRevision: (state, appId) => state.htmlApps.redoAppRevision(appId),
+});
+```
+
 ## HTML App Blocks
 
 The `html-app` block stores a small source file map instead of one opaque HTML
@@ -91,6 +112,9 @@ scripts run, so generated apps can call:
 
 `HtmlAppState.intent` can store the durable natural-language objective for a
 generated or edited app. Prefer this over storing raw model input in app state.
+
+Block-document hosts can use `createHtmlAppBlockDocumentBlock` to create the
+stateful block DTO for an owned HTML app runtime without importing CLI app code.
 
 ```js
 const {rows, columns, truncated} = await window.sqlrooms.query(

--- a/packages/app-runtime/__tests__/HtmlAppRevisionCommands.test.ts
+++ b/packages/app-runtime/__tests__/HtmlAppRevisionCommands.test.ts
@@ -1,0 +1,281 @@
+import {
+  HTML_APP_REDO_REVISION_COMMAND_ID,
+  HTML_APP_RENAME_COMMAND_ID,
+  HTML_APP_RESTORE_REVISION_COMMAND_ID,
+  HTML_APP_UNDO_REVISION_COMMAND_ID,
+  HTML_APP_WRITE_REVISION_COMMAND_ID,
+  createHtmlAppRevisionCommands,
+} from '../src/HtmlAppRevisionCommands';
+
+function createCommandContext(state: unknown) {
+  return {
+    getState: () => state as any,
+    store: {getState: () => state} as any,
+    invocation: {surface: 'unknown' as const},
+  };
+}
+
+function createState() {
+  const app: any = {
+    id: 'app-1',
+    title: 'App',
+    files: {'/index.html': '<html><title>App</title></html>'},
+    entryHtmlPath: '/index.html',
+    dependencies: [],
+    diagnostics: [],
+    revisions: [],
+    activeRevisionId: undefined,
+    redoRevisionIds: [],
+    requestedCapabilities: ['query'],
+    grantedCapabilities: ['query'],
+    createdAt: 1,
+    updatedAt: 1,
+  };
+  const revision = {
+    id: 'revision-1',
+    name: 'Initial',
+    source: 'assistant',
+    createdAt: 2,
+    files: app.files,
+    entryHtmlPath: app.entryHtmlPath,
+    dependencies: app.dependencies,
+  };
+  const state = {appsById: {'app-1': app}, currentAppId: undefined};
+  const renameHtmlApp = jest.fn((roomState, appId, title) => {
+    roomState.appsById[appId]!.title = title;
+  });
+  const commitHtmlAppRevision = jest.fn(
+    (_roomState, appId, patch, metadata) => {
+      Object.assign(state.appsById[appId]!, patch);
+      return {...revision, ...metadata};
+    },
+  );
+  const restoreHtmlAppRevision = jest.fn(() => revision);
+  const undoHtmlAppRevision = jest.fn(() => revision);
+  const redoHtmlAppRevision = jest.fn(() => revision);
+  return {
+    app,
+    revision,
+    state,
+    renameHtmlApp,
+    commitHtmlAppRevision,
+    restoreHtmlAppRevision,
+    undoHtmlAppRevision,
+    redoHtmlAppRevision,
+    commands: createHtmlAppRevisionCommands<typeof state>({
+      resolveCurrentAppId: (roomState) => roomState.currentAppId,
+      getHtmlAppIds: (roomState) => Object.keys(roomState.appsById),
+      getHtmlAppState: (roomState, appId) => roomState.appsById[appId],
+      renameHtmlApp,
+      commitHtmlAppRevision: commitHtmlAppRevision as any,
+      restoreHtmlAppRevision: restoreHtmlAppRevision as any,
+      undoHtmlAppRevision: undoHtmlAppRevision as any,
+      redoHtmlAppRevision: redoHtmlAppRevision as any,
+      ambiguousTargetMessage: 'Select a target app.',
+    }),
+  };
+}
+
+function getCommand(
+  commands: ReturnType<typeof createHtmlAppRevisionCommands>,
+  id: string,
+) {
+  const command = commands.find((candidate) => candidate.id === id);
+  if (!command) {
+    throw new Error(`Missing command "${id}".`);
+  }
+  return command;
+}
+
+describe('createHtmlAppRevisionCommands', () => {
+  it('exports canonical HTML app revision command IDs', () => {
+    const {commands} = createState();
+
+    expect(commands.map((command) => command.id)).toEqual([
+      HTML_APP_WRITE_REVISION_COMMAND_ID,
+      HTML_APP_RENAME_COMMAND_ID,
+      HTML_APP_RESTORE_REVISION_COMMAND_ID,
+      HTML_APP_UNDO_REVISION_COMMAND_ID,
+      HTML_APP_REDO_REVISION_COMMAND_ID,
+    ]);
+  });
+
+  it('writes revisions through host callbacks', async () => {
+    const {commands, state} = createState();
+
+    const result = await getCommand(
+      commands,
+      HTML_APP_WRITE_REVISION_COMMAND_ID,
+    ).execute(createCommandContext(state), {
+      appId: 'app-1',
+      patch: {title: 'Updated App'},
+      metadata: {name: 'Generated app'},
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      commandId: HTML_APP_WRITE_REVISION_COMMAND_ID,
+      data: {
+        appId: 'app-1',
+        title: 'Updated App',
+        revisionId: 'revision-1',
+        revisionName: 'Generated app',
+      },
+    });
+  });
+
+  it('renames apps directly when no revision inputs are provided', async () => {
+    const {commands, state, renameHtmlApp, commitHtmlAppRevision} =
+      createState();
+
+    const result = await getCommand(
+      commands,
+      HTML_APP_RENAME_COMMAND_ID,
+    ).execute(createCommandContext(state), {
+      appId: 'app-1',
+      title: 'Renamed App',
+    });
+
+    expect(renameHtmlApp).toHaveBeenCalledWith(state, 'app-1', 'Renamed App');
+    expect(commitHtmlAppRevision).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      success: true,
+      commandId: HTML_APP_RENAME_COMMAND_ID,
+      data: {
+        appId: 'app-1',
+        previousTitle: 'App',
+        title: 'Renamed App',
+      },
+    });
+    expect((result as any).code).toBeUndefined();
+    expect((result as any).data.revisionId).toBeUndefined();
+    expect((result as any).data.revisionName).toBeUndefined();
+  });
+
+  it('commits revision-backed renames when metadata is provided', async () => {
+    const {commands, state, renameHtmlApp, commitHtmlAppRevision} =
+      createState();
+
+    const result = await getCommand(
+      commands,
+      HTML_APP_RENAME_COMMAND_ID,
+    ).execute(createCommandContext(state), {
+      appId: 'app-1',
+      title: 'Audited App',
+      metadata: {name: 'Rename to Audited App', source: 'assistant'},
+    });
+
+    expect(renameHtmlApp).not.toHaveBeenCalled();
+    expect(commitHtmlAppRevision).toHaveBeenCalledWith(
+      state,
+      'app-1',
+      expect.objectContaining({title: 'Audited App'}),
+      expect.objectContaining({name: 'Rename to Audited App'}),
+    );
+    expect(result).toMatchObject({
+      success: true,
+      commandId: HTML_APP_RENAME_COMMAND_ID,
+      data: {
+        appId: 'app-1',
+        previousTitle: 'App',
+        title: 'Audited App',
+        revisionId: 'revision-1',
+        revisionName: 'Rename to Audited App',
+      },
+    });
+    expect((result as any).code).toBeUndefined();
+  });
+
+  it('commits revision-backed renames when files are provided without a title change', async () => {
+    const {commands, state, renameHtmlApp, commitHtmlAppRevision} =
+      createState();
+    const files = {'/index.html': '<html><title>App</title><main /></html>'};
+
+    const result = await getCommand(
+      commands,
+      HTML_APP_RENAME_COMMAND_ID,
+    ).execute(createCommandContext(state), {
+      appId: 'app-1',
+      title: 'App',
+      files,
+    });
+
+    expect(renameHtmlApp).not.toHaveBeenCalled();
+    expect(commitHtmlAppRevision).toHaveBeenCalledWith(
+      state,
+      'app-1',
+      expect.objectContaining({
+        title: 'App',
+        files,
+        diagnostics: [],
+      }),
+      expect.objectContaining({}),
+    );
+    expect(result).toMatchObject({
+      success: true,
+      commandId: HTML_APP_RENAME_COMMAND_ID,
+      data: {
+        appId: 'app-1',
+        previousTitle: 'App',
+        title: 'App',
+        revisionId: 'revision-1',
+        revisionName: 'Initial',
+      },
+    });
+    expect((result as any).code).toBeUndefined();
+  });
+
+  it('reports unchanged titles without renaming or committing revisions', async () => {
+    const {commands, state, renameHtmlApp, commitHtmlAppRevision} =
+      createState();
+
+    const result = await getCommand(
+      commands,
+      HTML_APP_RENAME_COMMAND_ID,
+    ).execute(createCommandContext(state), {
+      appId: 'app-1',
+      title: 'App',
+    });
+
+    expect(renameHtmlApp).not.toHaveBeenCalled();
+    expect(commitHtmlAppRevision).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      success: true,
+      commandId: HTML_APP_RENAME_COMMAND_ID,
+      code: 'html-app-title-unchanged',
+      data: {
+        appId: 'app-1',
+        previousTitle: 'App',
+        title: 'App',
+      },
+    });
+    expect((result as any).data.revisionId).toBeUndefined();
+    expect((result as any).data.revisionName).toBeUndefined();
+  });
+
+  it('resolves the current app for restore, undo, and redo commands', async () => {
+    const {commands, state, revision} = createState();
+    state.currentAppId = 'app-1';
+
+    for (const commandId of [
+      HTML_APP_RESTORE_REVISION_COMMAND_ID,
+      HTML_APP_UNDO_REVISION_COMMAND_ID,
+      HTML_APP_REDO_REVISION_COMMAND_ID,
+    ]) {
+      const input =
+        commandId === HTML_APP_RESTORE_REVISION_COMMAND_ID
+          ? {revisionId: revision.id}
+          : {};
+      const result = await getCommand(commands, commandId).execute(
+        createCommandContext(state),
+        input,
+      );
+
+      expect(result).toMatchObject({
+        success: true,
+        commandId,
+        data: {appId: 'app-1', revisionId: revision.id},
+      });
+    }
+  });
+});

--- a/packages/app-runtime/src/HtmlAppRevisionCommands.ts
+++ b/packages/app-runtime/src/HtmlAppRevisionCommands.ts
@@ -1,0 +1,395 @@
+import type {BaseRoomStoreState, RoomCommand} from '@sqlrooms/room-store';
+import {z} from 'zod';
+import type {
+  CommitHtmlAppRevisionMetadata,
+  HtmlAppRevision,
+  HtmlAppRevisionPatch,
+  HtmlAppState,
+  RestoreHtmlAppRevisionMetadata,
+} from './html-app';
+
+export const HTML_APP_WRITE_REVISION_COMMAND_ID = 'html-app.write-revision';
+export const HTML_APP_RENAME_COMMAND_ID = 'html-app.rename';
+export const HTML_APP_RESTORE_REVISION_COMMAND_ID = 'html-app.restore-revision';
+export const HTML_APP_UNDO_REVISION_COMMAND_ID = 'html-app.undo-revision';
+export const HTML_APP_REDO_REVISION_COMMAND_ID = 'html-app.redo-revision';
+
+export const HTML_APP_REVISION_COMMAND_IDS = {
+  writeRevision: HTML_APP_WRITE_REVISION_COMMAND_ID,
+  rename: HTML_APP_RENAME_COMMAND_ID,
+  restoreRevision: HTML_APP_RESTORE_REVISION_COMMAND_ID,
+  undoRevision: HTML_APP_UNDO_REVISION_COMMAND_ID,
+  redoRevision: HTML_APP_REDO_REVISION_COMMAND_ID,
+} as const;
+
+const HtmlAppRevisionCommandInput = z
+  .object({
+    appId: z.string().optional().describe('Target HTML app runtime id.'),
+    revisionId: z
+      .string()
+      .optional()
+      .describe('Target revision id for restore.'),
+  })
+  .default({});
+type HtmlAppRevisionCommandInput = z.infer<typeof HtmlAppRevisionCommandInput>;
+
+const HtmlAppRestoreRevisionCommandInput =
+  HtmlAppRevisionCommandInput.unwrap().extend({
+    revisionId: z.string().describe('Target revision id for restore.'),
+  });
+type HtmlAppRestoreRevisionCommandInput = z.infer<
+  typeof HtmlAppRestoreRevisionCommandInput
+>;
+
+const HtmlAppRevisionPatchInput = z.object({
+  title: z.string().optional(),
+  intent: z.string().optional(),
+  files: z.record(z.string(), z.string()).optional(),
+  entryHtmlPath: z.string().optional(),
+  dependencies: z.array(z.unknown()).optional(),
+  requestedCapabilities: z.array(z.string()).optional(),
+  grantedCapabilities: z.array(z.string()).optional(),
+  diagnostics: z.array(z.unknown()).optional(),
+});
+
+const HtmlAppRevisionMetadataInput = z
+  .object({
+    name: z.string().optional(),
+    description: z.string().optional(),
+    source: z.enum(['assistant', 'user', 'system', 'restore']).optional(),
+    sourcePrompt: z.string().optional(),
+    sessionId: z.string().optional(),
+    toolCallId: z.string().optional(),
+    commitGroupId: z.string().optional(),
+    parentRevisionId: z.string().optional(),
+    createdAt: z.number().optional(),
+    revisionId: z.string().optional(),
+    clearRedo: z.boolean().optional(),
+  })
+  .default({});
+
+const HtmlAppWriteRevisionCommandInput = z.object({
+  appId: z.string().describe('Target HTML app runtime id.'),
+  patch: HtmlAppRevisionPatchInput.describe('Durable HTML app state patch.'),
+  metadata: HtmlAppRevisionMetadataInput.optional(),
+});
+type HtmlAppWriteRevisionCommandInput = z.infer<
+  typeof HtmlAppWriteRevisionCommandInput
+>;
+
+const HtmlAppRenameCommandInput = z.object({
+  appId: z.string().describe('Target HTML app runtime id.'),
+  title: z.string().min(1).describe('New HTML app title.'),
+  files: z
+    .record(z.string(), z.string())
+    .optional()
+    .describe('Optional source files with title updates already applied.'),
+  metadata: HtmlAppRevisionMetadataInput.optional(),
+});
+type HtmlAppRenameCommandInput = z.infer<typeof HtmlAppRenameCommandInput>;
+
+export type CreateHtmlAppRevisionCommandsOptions<
+  TRoomState extends BaseRoomStoreState,
+> = {
+  /** Resolve the current host-selected HTML app id, when any. */
+  resolveCurrentAppId?: (state: TRoomState) => string | undefined;
+  /** Return all HTML app ids known to the host. */
+  getHtmlAppIds: (state: TRoomState) => string[];
+  /** Return an HTML app by id. */
+  getHtmlAppState: (
+    state: TRoomState,
+    appId: string,
+  ) => HtmlAppState | undefined;
+  /** Rename an HTML app without committing source files. */
+  renameHtmlApp: (state: TRoomState, appId: string, title: string) => void;
+  /** Commit a durable HTML app revision. */
+  commitHtmlAppRevision: (
+    state: TRoomState,
+    appId: string,
+    patch: HtmlAppRevisionPatch,
+    metadata?: CommitHtmlAppRevisionMetadata,
+  ) => HtmlAppRevision | undefined;
+  /** Restore a durable HTML app revision by id. */
+  restoreHtmlAppRevision: (
+    state: TRoomState,
+    appId: string,
+    revisionId: string,
+    metadata?: RestoreHtmlAppRevisionMetadata,
+  ) => HtmlAppRevision | undefined;
+  /** Move backward through HTML app revisions. */
+  undoHtmlAppRevision: (
+    state: TRoomState,
+    appId: string,
+  ) => HtmlAppRevision | undefined;
+  /** Move forward through undone HTML app revisions. */
+  redoHtmlAppRevision: (
+    state: TRoomState,
+    appId: string,
+  ) => HtmlAppRevision | undefined;
+  /** Error message used when no app id can be chosen unambiguously. */
+  ambiguousTargetMessage?: string;
+};
+
+function resolveHtmlAppCommandAppId<TRoomState extends BaseRoomStoreState>(
+  state: TRoomState,
+  options: CreateHtmlAppRevisionCommandsOptions<TRoomState>,
+  inputAppId?: string,
+) {
+  if (inputAppId) {
+    if (!options.getHtmlAppState(state, inputAppId)) {
+      throw new Error(`HTML app "${inputAppId}" was not found.`);
+    }
+    return inputAppId;
+  }
+
+  const currentAppId = options.resolveCurrentAppId?.(state);
+  if (currentAppId && options.getHtmlAppState(state, currentAppId)) {
+    return currentAppId;
+  }
+
+  const appIds = options.getHtmlAppIds(state);
+  if (appIds.length === 1 && appIds[0]) {
+    return appIds[0];
+  }
+
+  throw new Error(
+    options.ambiguousTargetMessage ??
+      'No unambiguous HTML app target. Provide appId.',
+  );
+}
+
+/**
+ * Create room commands for writing, renaming, restoring, undoing, and redoing
+ * HTML app revisions.
+ */
+export function createHtmlAppRevisionCommands<
+  TRoomState extends BaseRoomStoreState,
+>(
+  options: CreateHtmlAppRevisionCommandsOptions<TRoomState>,
+): RoomCommand<TRoomState>[] {
+  return [
+    {
+      id: HTML_APP_WRITE_REVISION_COMMAND_ID,
+      name: 'Write HTML app revision',
+      description: 'Commit a durable source revision for an HTML app.',
+      group: 'HTML App',
+      keywords: ['html-app', 'revision', 'write', 'commit'],
+      inputSchema: HtmlAppWriteRevisionCommandInput,
+      inputDescription: 'Provide appId, patch, and optional revision metadata.',
+      metadata: {
+        readOnly: false,
+        idempotent: false,
+        riskLevel: 'medium',
+      },
+      execute: ({getState}, input) => {
+        const state = getState();
+        const {appId, patch, metadata} =
+          input as HtmlAppWriteRevisionCommandInput;
+        const app = options.getHtmlAppState(state, appId);
+        if (!app) {
+          throw new Error(`HTML app "${appId}" was not found.`);
+        }
+        const revision = options.commitHtmlAppRevision(
+          state,
+          appId,
+          patch as HtmlAppRevisionPatch,
+          (metadata ?? {}) as CommitHtmlAppRevisionMetadata,
+        );
+        if (!revision) {
+          throw new Error(`Failed to write HTML app revision for "${appId}".`);
+        }
+        const nextApp = options.getHtmlAppState(state, appId);
+        return {
+          success: true,
+          commandId: HTML_APP_WRITE_REVISION_COMMAND_ID,
+          message: `Wrote HTML app revision "${revision.name}".`,
+          data: {
+            appId,
+            title: nextApp?.title ?? app.title,
+            revisionId: revision.id,
+            revisionName: revision.name,
+            revision,
+            filePaths: Object.keys(nextApp?.files ?? app.files),
+            diagnostics: nextApp?.diagnostics ?? app.diagnostics,
+          },
+        };
+      },
+    },
+    {
+      id: HTML_APP_RENAME_COMMAND_ID,
+      name: 'Rename HTML app',
+      description:
+        'Rename an HTML app runtime and optionally commit title-updated files.',
+      group: 'HTML App',
+      keywords: ['html-app', 'rename', 'title'],
+      inputSchema: HtmlAppRenameCommandInput,
+      inputDescription: 'Provide appId, title, optional files, and metadata.',
+      metadata: {
+        readOnly: false,
+        idempotent: false,
+        riskLevel: 'low',
+      },
+      execute: ({getState}, input) => {
+        const state = getState();
+        const {appId, title, files, metadata} =
+          input as HtmlAppRenameCommandInput;
+        const app = options.getHtmlAppState(state, appId);
+        if (!app) {
+          throw new Error(`HTML app "${appId}" was not found.`);
+        }
+        const trimmedTitle = title.trim();
+        if (!trimmedTitle) {
+          throw new Error('HTML app title cannot be empty.');
+        }
+        const previousTitle = app.title;
+        let revision;
+        const shouldCommitRevision =
+          files || (metadata && previousTitle !== trimmedTitle);
+        if (shouldCommitRevision) {
+          revision = options.commitHtmlAppRevision(
+            state,
+            appId,
+            {
+              title: trimmedTitle,
+              ...(files ? {files, diagnostics: []} : {}),
+            },
+            (metadata ?? {}) as CommitHtmlAppRevisionMetadata,
+          );
+          if (!revision) {
+            throw new Error(`Failed to rename HTML app "${appId}".`);
+          }
+        } else if (previousTitle !== trimmedTitle) {
+          options.renameHtmlApp(state, appId, trimmedTitle);
+        }
+        const nextApp = options.getHtmlAppState(state, appId);
+        return {
+          success: true,
+          commandId: HTML_APP_RENAME_COMMAND_ID,
+          code:
+            previousTitle === trimmedTitle && !files
+              ? 'html-app-title-unchanged'
+              : undefined,
+          message: `Renamed HTML app "${appId}" to "${trimmedTitle}".`,
+          data: {
+            appId,
+            previousTitle,
+            title: nextApp?.title ?? trimmedTitle,
+            revisionId: revision?.id,
+            revisionName: revision?.name,
+            revision,
+            filePaths: Object.keys(nextApp?.files ?? app.files),
+            diagnostics: nextApp?.diagnostics ?? app.diagnostics,
+          },
+        };
+      },
+    },
+    {
+      id: HTML_APP_RESTORE_REVISION_COMMAND_ID,
+      name: 'Restore HTML app revision',
+      description: 'Restore an HTML app to a persisted source revision',
+      group: 'HTML App',
+      keywords: ['html-app', 'revision', 'restore', 'history'],
+      inputSchema: HtmlAppRestoreRevisionCommandInput,
+      inputDescription: 'Provide revisionId and optionally appId.',
+      metadata: {
+        readOnly: false,
+        idempotent: false,
+        riskLevel: 'medium',
+      },
+      execute: ({getState}, input) => {
+        const state = getState();
+        const {appId: inputAppId, revisionId} =
+          input as HtmlAppRestoreRevisionCommandInput;
+        const appId = resolveHtmlAppCommandAppId(state, options, inputAppId);
+        const revision = options.restoreHtmlAppRevision(
+          state,
+          appId,
+          revisionId,
+        );
+        if (!revision) {
+          throw new Error(
+            `Revision "${revisionId}" was not found for HTML app "${appId}".`,
+          );
+        }
+        return {
+          success: true,
+          commandId: HTML_APP_RESTORE_REVISION_COMMAND_ID,
+          message: `Restored HTML app revision "${revision.name}".`,
+          data: {
+            appId,
+            revisionId: revision.id,
+            revisionName: revision.name,
+          },
+        };
+      },
+    },
+    {
+      id: HTML_APP_UNDO_REVISION_COMMAND_ID,
+      name: 'Undo HTML app revision',
+      description: 'Move an HTML app back to its previous source revision',
+      group: 'HTML App',
+      keywords: ['html-app', 'revision', 'undo', 'history'],
+      inputSchema: HtmlAppRevisionCommandInput,
+      inputDescription: 'Optionally provide appId.',
+      metadata: {
+        readOnly: false,
+        idempotent: false,
+        riskLevel: 'medium',
+      },
+      execute: ({getState}, input) => {
+        const state = getState();
+        const {appId: inputAppId} =
+          ((input as HtmlAppRevisionCommandInput | undefined) ?? {}) || {};
+        const appId = resolveHtmlAppCommandAppId(state, options, inputAppId);
+        const revision = options.undoHtmlAppRevision(state, appId);
+        if (!revision) {
+          throw new Error(`HTML app "${appId}" has no revision to undo.`);
+        }
+        return {
+          success: true,
+          commandId: HTML_APP_UNDO_REVISION_COMMAND_ID,
+          message: `Undid to HTML app revision "${revision.name}".`,
+          data: {
+            appId,
+            revisionId: revision.id,
+            revisionName: revision.name,
+          },
+        };
+      },
+    },
+    {
+      id: HTML_APP_REDO_REVISION_COMMAND_ID,
+      name: 'Redo HTML app revision',
+      description: 'Move an HTML app forward through undone source revisions',
+      group: 'HTML App',
+      keywords: ['html-app', 'revision', 'redo', 'history'],
+      inputSchema: HtmlAppRevisionCommandInput,
+      inputDescription: 'Optionally provide appId.',
+      metadata: {
+        readOnly: false,
+        idempotent: false,
+        riskLevel: 'medium',
+      },
+      execute: ({getState}, input) => {
+        const state = getState();
+        const {appId: inputAppId} =
+          ((input as HtmlAppRevisionCommandInput | undefined) ?? {}) || {};
+        const appId = resolveHtmlAppCommandAppId(state, options, inputAppId);
+        const revision = options.redoHtmlAppRevision(state, appId);
+        if (!revision) {
+          throw new Error(`HTML app "${appId}" has no revision to redo.`);
+        }
+        return {
+          success: true,
+          commandId: HTML_APP_REDO_REVISION_COMMAND_ID,
+          message: `Redid to HTML app revision "${revision.name}".`,
+          data: {
+            appId,
+            revisionId: revision.id,
+            revisionName: revision.name,
+          },
+        };
+      },
+    },
+  ];
+}

--- a/packages/app-runtime/src/html-app-block-document.ts
+++ b/packages/app-runtime/src/html-app-block-document.ts
@@ -1,0 +1,62 @@
+import {HTML_APP_BLOCK_TYPE} from './html-app';
+
+/**
+ * Block-document stateful block DTO for an owned HTML app runtime.
+ *
+ * `type` identifies the document block shape, `blockType` identifies the HTML
+ * app runtime block, `ownership` records that the document owns the runtime
+ * state, and `intent` carries the optional durable app objective.
+ */
+export type HtmlAppBlockDocumentBlock = {
+  type: 'statefulBlock';
+  id: string;
+  blockType: typeof HTML_APP_BLOCK_TYPE;
+  blockInstanceId: string;
+  ownership: 'owned';
+  intent?: string;
+  title: string;
+  caption: string;
+  height: number;
+};
+
+export type CreateHtmlAppBlockDocumentBlockOptions = {
+  /** Backing HTML app runtime id. */
+  appId: string;
+  /** Document block id. Defaults to appId. */
+  blockId?: string;
+  /** Visible app and block title. */
+  title: string;
+  /** Optional durable natural-language objective for the app block. */
+  intent?: string;
+  /** Persisted block height in pixels. */
+  height?: number;
+};
+
+/**
+ * Creates the block-document wrapper for an owned HTML app runtime.
+ */
+export function createHtmlAppBlockDocumentBlock({
+  appId,
+  blockId = appId,
+  title,
+  intent,
+  height = 560,
+}: CreateHtmlAppBlockDocumentBlockOptions): {
+  appId: string;
+  block: HtmlAppBlockDocumentBlock;
+} {
+  return {
+    appId,
+    block: {
+      type: 'statefulBlock',
+      id: blockId,
+      blockType: HTML_APP_BLOCK_TYPE,
+      blockInstanceId: appId,
+      ownership: 'owned',
+      intent,
+      title,
+      caption: title,
+      height,
+    },
+  };
+}

--- a/packages/app-runtime/src/index.ts
+++ b/packages/app-runtime/src/index.ts
@@ -55,6 +55,21 @@ export {
   type RuntimeResponseMessage as RuntimeResponseMessageType,
 } from './protocol';
 export {
+  HTML_APP_REDO_REVISION_COMMAND_ID,
+  HTML_APP_RENAME_COMMAND_ID,
+  HTML_APP_RESTORE_REVISION_COMMAND_ID,
+  HTML_APP_REVISION_COMMAND_IDS,
+  HTML_APP_UNDO_REVISION_COMMAND_ID,
+  HTML_APP_WRITE_REVISION_COMMAND_ID,
+  createHtmlAppRevisionCommands,
+  type CreateHtmlAppRevisionCommandsOptions,
+} from './HtmlAppRevisionCommands';
+export {
+  createHtmlAppBlockDocumentBlock,
+  type CreateHtmlAppBlockDocumentBlockOptions,
+  type HtmlAppBlockDocumentBlock,
+} from './html-app-block-document';
+export {
   HTML_APP_BLOCK_TYPE,
   HtmlAppBlock,
   HtmlAppDependency,

--- a/packages/documents/README.md
+++ b/packages/documents/README.md
@@ -169,8 +169,19 @@ const tools = {
 
 `BlockDocumentAiAdapter.addBlock` may return a block ID synchronously or from a
 promise. Hosts that already expose block-document mutations as room commands can
-therefore invoke the command layer from the adapter while keeping generic AI
-tools package-neutral.
+therefore use `createBlockDocumentCommandAiAdapter` to invoke the canonical
+`block-document.append-blocks` command while keeping generic AI tools
+package-neutral:
+
+```ts
+const blockDocumentAdapter = createBlockDocumentCommandAiAdapter({
+  store,
+});
+```
+
+Hosts with persisted compatibility artifact types can pass
+`isBlockDocumentArtifact` without adding that product vocabulary to the shared
+adapter API.
 
 The slice can create block documents, replace the Tiptap JSON body, and
 append/insert/update/remove/reorder top-level blocks. Supported block DTOs

--- a/packages/documents/__tests__/createBlockDocumentCommandAiAdapter.test.ts
+++ b/packages/documents/__tests__/createBlockDocumentCommandAiAdapter.test.ts
@@ -1,0 +1,168 @@
+import {
+  BLOCK_DOCUMENT_AGENT_ACTOR,
+  BLOCK_DOCUMENT_APPEND_BLOCKS_COMMAND_ID,
+  createBlockDocumentCommandAiAdapter,
+  type BlockDocumentBlock,
+} from '../src';
+
+function createMockStore({
+  artifactType = 'block-document',
+  invokeCommand,
+}: {
+  artifactType?: string;
+  invokeCommand?: (...args: any[]) => Promise<unknown>;
+} = {}) {
+  const ensureBlockDocumentCalls: unknown[][] = [];
+  const invokeCommandCalls: unknown[][] = [];
+  const setCurrentArtifactCalls: unknown[][] = [];
+  const ensureBlockDocument = (...args: unknown[]) => {
+    ensureBlockDocumentCalls.push(args);
+  };
+  const setCurrentArtifact = (...args: unknown[]) => {
+    setCurrentArtifactCalls.push(args);
+  };
+  const invokeCommandImpl =
+    invokeCommand ??
+    (async (_commandId, input: any) => ({
+      success: true,
+      commandId: BLOCK_DOCUMENT_APPEND_BLOCKS_COMMAND_ID,
+      data: {
+        blockId: input.blocks[0].id,
+      },
+    }));
+  const trackedInvokeCommand = async (...args: any[]) => {
+    invokeCommandCalls.push(args);
+    return invokeCommandImpl(...args);
+  };
+  const state = {
+    artifacts: {
+      getArtifact: (artifactId: string) =>
+        artifactId === 'doc-1'
+          ? {id: artifactId, type: artifactType, title: 'Document'}
+          : undefined,
+      setCurrentArtifact,
+    },
+    blockDocuments: {
+      ensureBlockDocument,
+      config: {
+        artifacts: {
+          'doc-1': {
+            content: {
+              content: [{id: 'existing', type: 'paragraph', text: 'Hi'}],
+            },
+          },
+        },
+      },
+    },
+    commands: {
+      invokeCommand: trackedInvokeCommand,
+    },
+  };
+
+  return {
+    store: {
+      getState: () => state,
+    } as any,
+    ensureBlockDocument,
+    ensureBlockDocumentCalls,
+    invokeCommand: trackedInvokeCommand,
+    invokeCommandCalls,
+    setCurrentArtifact,
+    setCurrentArtifactCalls,
+  };
+}
+
+describe('createBlockDocumentCommandAiAdapter', () => {
+  it('sets the current block document through the artifact slice', () => {
+    const {store, setCurrentArtifactCalls} = createMockStore();
+    const adapter = createBlockDocumentCommandAiAdapter({store});
+
+    adapter.setCurrentBlockDocument('doc-1');
+
+    expect(setCurrentArtifactCalls).toEqual([['doc-1']]);
+  });
+
+  it('appends blocks through the canonical block document command', async () => {
+    const {store, ensureBlockDocumentCalls, invokeCommandCalls} =
+      createMockStore();
+    const adapter = createBlockDocumentCommandAiAdapter({store});
+    const block: BlockDocumentBlock = {
+      id: 'paragraph-1',
+      type: 'paragraph',
+      text: 'Summary',
+    };
+
+    await expect(adapter.addBlock('doc-1', block)).resolves.toBe('paragraph-1');
+
+    expect(ensureBlockDocumentCalls).toEqual([['doc-1']]);
+    expect(invokeCommandCalls).toEqual([
+      [
+        BLOCK_DOCUMENT_APPEND_BLOCKS_COMMAND_ID,
+        {
+          artifactId: 'doc-1',
+          blocks: [block],
+        },
+        {
+          surface: 'ai',
+          actor: BLOCK_DOCUMENT_AGENT_ACTOR,
+        },
+      ],
+    ]);
+  });
+
+  it('allows hosts to recognize compatible block-document artifact types', () => {
+    const {store} = createMockStore({artifactType: 'analysis-doc'});
+    const adapter = createBlockDocumentCommandAiAdapter({
+      store,
+      isBlockDocumentArtifact: (artifact) => artifact.type === 'analysis-doc',
+    });
+
+    expect(adapter.getBlocks('doc-1')).toEqual([
+      {id: 'existing', type: 'paragraph', text: 'Hi'},
+    ]);
+  });
+
+  it('throws when ensuring an incompatible artifact type', () => {
+    const {store} = createMockStore({artifactType: 'dashboard'});
+    const adapter = createBlockDocumentCommandAiAdapter({store});
+
+    expect(() => adapter.ensureBlockDocument('doc-1')).toThrow(
+      'Artifact doc-1 is not a block document',
+    );
+  });
+
+  it('rejects addBlock before invoking commands for incompatible artifact types', async () => {
+    const {store, invokeCommandCalls} = createMockStore({
+      artifactType: 'dashboard',
+    });
+    const adapter = createBlockDocumentCommandAiAdapter({store});
+
+    await expect(
+      adapter.addBlock('doc-1', {
+        id: 'paragraph-1',
+        type: 'paragraph',
+        text: 'Summary',
+      }),
+    ).rejects.toThrow('Artifact doc-1 is not a block document');
+    expect(invokeCommandCalls).toEqual([]);
+  });
+
+  it('throws command errors when append command invocation fails', async () => {
+    const {store} = createMockStore({
+      invokeCommand: async () => ({
+        success: false,
+        commandId: BLOCK_DOCUMENT_APPEND_BLOCKS_COMMAND_ID,
+        error: 'Append failed',
+      }),
+    });
+    const adapter = createBlockDocumentCommandAiAdapter({store});
+
+    await expect(
+      adapter.addBlock('doc-1', {
+        id: 'paragraph-1',
+        type: 'paragraph',
+        text: 'Summary',
+      }),
+    ).rejects.toThrow('Append failed');
+  });
+});

--- a/packages/documents/src/createBlockDocumentCommandAiAdapter.ts
+++ b/packages/documents/src/createBlockDocumentCommandAiAdapter.ts
@@ -1,0 +1,110 @@
+import type {ArtifactMetadataType} from '@sqlrooms/artifacts';
+import type {CommandSliceState} from '@sqlrooms/room-store';
+import type {StoreApi} from 'zustand';
+import type {BlockDocumentAiAdapter} from './BlockDocumentAi';
+import type {BlockDocumentBlock} from './BlockDocumentSliceConfig';
+import type {BlockDocumentsSliceState} from './BlockDocumentsSlice';
+
+export const BLOCK_DOCUMENT_APPEND_BLOCKS_COMMAND_ID =
+  'block-document.append-blocks';
+
+export const BLOCK_DOCUMENT_AGENT_ACTOR = 'block-document-agent';
+
+type BlockDocumentCommandAiAdapterState = BlockDocumentsSliceState &
+  CommandSliceState<any> & {
+    artifacts: {
+      setCurrentArtifact: (id?: string) => void;
+      getArtifact: (id: string) => ArtifactMetadataType | undefined;
+    };
+  };
+
+export type CreateBlockDocumentCommandAiAdapterOptions<
+  TRoomState extends BlockDocumentCommandAiAdapterState,
+> = {
+  /** Store with artifacts, block documents, and command slices mounted. */
+  store: StoreApi<TRoomState>;
+  /**
+   * Optional host predicate for persisted artifact compatibility.
+   *
+   * Omit this for plain block-document artifacts. Hosts that temporarily persist
+   * another artifact type can provide a predicate without leaking that type into
+   * the reusable adapter API.
+   */
+  isBlockDocumentArtifact?: (artifact: ArtifactMetadataType) => boolean;
+};
+
+function blockIdFromAppendResult(data: unknown, block: BlockDocumentBlock) {
+  const value = data as
+    | {
+        blockId?: string;
+        blockIds?: string[];
+      }
+    | undefined;
+  return value?.blockId ?? value?.blockIds?.[0] ?? block.id;
+}
+
+/**
+ * Creates a block-document AI adapter that appends blocks through the canonical
+ * block-document command.
+ */
+export function createBlockDocumentCommandAiAdapter<
+  TRoomState extends BlockDocumentCommandAiAdapterState,
+>({
+  store,
+  isBlockDocumentArtifact = (artifact) => artifact.type === 'block-document',
+}: CreateBlockDocumentCommandAiAdapterOptions<TRoomState>): BlockDocumentAiAdapter {
+  const ensureBlockDocument = (artifactId: string) => {
+    const state = store.getState();
+    const artifact = state.artifacts.getArtifact(artifactId);
+
+    if (!artifact || !isBlockDocumentArtifact(artifact)) {
+      throw new Error(`Artifact ${artifactId} is not a block document`);
+    }
+
+    state.blockDocuments.ensureBlockDocument(artifactId);
+  };
+
+  return {
+    setCurrentBlockDocument: (artifactId) =>
+      store.getState().artifacts.setCurrentArtifact(artifactId),
+
+    ensureBlockDocument,
+
+    getBlocks: (artifactId) => {
+      const state = store.getState();
+      const artifact = state.artifacts.getArtifact(artifactId);
+      if (!artifact || !isBlockDocumentArtifact(artifact)) {
+        return undefined;
+      }
+
+      const blockDocument = state.blockDocuments.config.artifacts[artifactId];
+      return blockDocument?.content.content;
+    },
+
+    addBlock: async (artifactId, block) => {
+      ensureBlockDocument(artifactId);
+
+      const result = await store.getState().commands.invokeCommand(
+        BLOCK_DOCUMENT_APPEND_BLOCKS_COMMAND_ID,
+        {
+          artifactId,
+          blocks: [block],
+        },
+        {
+          surface: 'ai',
+          actor: BLOCK_DOCUMENT_AGENT_ACTOR,
+        },
+      );
+
+      if (!result.success) {
+        throw new Error(
+          result.error ??
+            result.message ??
+            `Failed to execute ${BLOCK_DOCUMENT_APPEND_BLOCKS_COMMAND_ID}`,
+        );
+      }
+
+      return blockIdFromAppendResult(result.data, block);
+    },
+  };
+}

--- a/packages/documents/src/index.ts
+++ b/packages/documents/src/index.ts
@@ -93,6 +93,12 @@ export {
   type CreateBlockDocumentCommandsOptions,
 } from './BlockDocumentCommands';
 export {
+  BLOCK_DOCUMENT_APPEND_BLOCKS_COMMAND_ID,
+  BLOCK_DOCUMENT_AGENT_ACTOR,
+  createBlockDocumentCommandAiAdapter,
+  type CreateBlockDocumentCommandAiAdapterOptions,
+} from './createBlockDocumentCommandAiAdapter';
+export {
   BLOCK_DOCUMENT_AGENT_TOOL_NAME,
   KnownDocumentBlockTools,
   type BlockDocumentAiAdapter,

--- a/packages/mosaic/README.md
+++ b/packages/mosaic/README.md
@@ -446,6 +446,8 @@ including chart tools, a Data Table Explorer panel tool, and an optional
 exploratory `dashboard_agent`. Client apps supply small adapters that map
 Mosaic's generic dashboard operations to their store and table metadata.
 Agent tools use `intent` for the natural-language objective they should satisfy.
+DuckDB-backed hosts can use `createDuckDbDatabaseAiAdapter(store)` for the
+database adapter.
 Mutation callbacks may return promises, so hosts can route dashboard table and
 panel writes through room commands such as `dashboard.set-selected-table`,
 `dashboard.add-panel`, `dashboard.update-panel`, and `dashboard.remove-panel`
@@ -454,18 +456,14 @@ while preserving the reusable Mosaic AI surface.
 ```ts
 import {
   createDashboardAiTools,
+  createDuckDbDatabaseAiAdapter,
   MAP_TOOL_KEY,
   type DashboardAiAdapter,
-  type DatabaseAiAdapter,
 } from '@sqlrooms/mosaic';
 
 const dashboardId = 'dashboard-1';
 
-const databaseAdapter: DatabaseAiAdapter = {
-  getTables: () => store.getState().db.tables,
-  findTable: (tableName) =>
-    store.getState().db.tables.find((table) => table.tableName === tableName),
-};
+const databaseAdapter = createDuckDbDatabaseAiAdapter(store);
 
 const dashboardAdapter: DashboardAiAdapter = {
   getSelectedTable: () =>

--- a/packages/mosaic/__tests__/createDatabaseAiAdapter.test.ts
+++ b/packages/mosaic/__tests__/createDatabaseAiAdapter.test.ts
@@ -1,0 +1,33 @@
+import {createDuckDbDatabaseAiAdapter as createDuckDbDatabaseAiAdapterFromRoot} from '../src';
+import {createDuckDbDatabaseAiAdapter} from '../src/ai';
+
+describe('createDuckDbDatabaseAiAdapter', () => {
+  it('is exported from the package root entrypoint', () => {
+    expect(createDuckDbDatabaseAiAdapterFromRoot).toBe(
+      createDuckDbDatabaseAiAdapter,
+    );
+  });
+
+  it('adapts DuckDB table catalog and lookup operations for Mosaic AI tools', () => {
+    const table = {
+      tableName: 'sales',
+      table: {schema: 'main', table: 'sales'},
+      columns: [],
+    } as any;
+    const store = {
+      getState: () => ({
+        db: {
+          tables: [table],
+          findTable: (tableName: string) =>
+            tableName === 'sales' ? table : undefined,
+        },
+      }),
+    } as any;
+
+    const adapter = createDuckDbDatabaseAiAdapter(store);
+
+    expect(adapter.getTables()).toEqual([table]);
+    expect(adapter.findTable('sales')).toBe(table);
+    expect(adapter.findTable('missing')).toBeUndefined();
+  });
+});

--- a/packages/mosaic/src/ai.ts
+++ b/packages/mosaic/src/ai.ts
@@ -5,6 +5,7 @@
 export type {ChartToolExecutionContext} from './charts/chart-types';
 export * from './ai/types';
 export * from './ai/database-types';
+export * from './ai/createDatabaseAiAdapter';
 export * from './ai/dashboard/dashboard-types';
 export * from './ai/constants';
 export * from './ai/block-document/constants';

--- a/packages/mosaic/src/ai/createDatabaseAiAdapter.ts
+++ b/packages/mosaic/src/ai/createDatabaseAiAdapter.ts
@@ -1,0 +1,15 @@
+import type {DuckDbSliceState} from '@sqlrooms/duckdb';
+import type {AiStore} from './types';
+import type {DatabaseAiAdapter} from './database-types';
+
+/**
+ * Creates a database AI adapter backed by the mounted DuckDB slice.
+ */
+export function createDuckDbDatabaseAiAdapter<TState extends DuckDbSliceState>(
+  store: AiStore<TState>,
+): DatabaseAiAdapter {
+  return {
+    getTables: () => store.getState().db.tables,
+    findTable: (tableName) => store.getState().db.findTable(tableName),
+  };
+}

--- a/packages/mosaic/src/index.ts
+++ b/packages/mosaic/src/index.ts
@@ -444,6 +444,7 @@ export type {
   AgentRunResult,
 } from './ai/types';
 export type {DatabaseAiAdapter} from './ai/database-types';
+export {createDuckDbDatabaseAiAdapter} from './ai/createDatabaseAiAdapter';
 export type {
   CreateDashboardAgentToolOptions,
   DashboardAgentResult,


### PR DESCRIPTION
## Summary

- Extract command-backed block-document AI adapter into `@sqlrooms/documents` with canonical append command and actor constants.
- Extract HTML app revision commands and HTML app block-document block construction into `@sqlrooms/app-runtime`.
- Add a DuckDB-backed Mosaic database AI adapter and rewire the CLI app to use the new package primitives.
- Leave the stateful block artifact registry in the CLI after evaluation because it is still host product surface.

## Validation

- `pnpm build`
- `pnpm --filter @sqlrooms/documents test --runInBand createBlockDocumentCommandAiAdapter.test.ts`
- `pnpm --filter @sqlrooms/app-runtime test --runInBand HtmlAppRevisionCommands.test.ts`
- `pnpm --filter @sqlrooms/mosaic test --runInBand createDatabaseAiAdapter.test.ts`
- `pnpm --filter sqlrooms-cli-app test --runInBand createWorksheetAiAdapter.test.ts createHtmlAppRevisionCommands.test.ts`
- Pre-push hook: `knip`, `turbo typecheck`, `madge --circular`, `turbo test`

The Obsidian plan checklist is updated through Stage 6; Follow-up remains unchecked as requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared HTML app revision controls (write, rename, restore, undo, redo) with canonical command IDs.
  * Introduced an AI block-document command adapter and an owned HTML app “block document” creator.
  * Added a DuckDB-backed database AI adapter factory.
* **Bug Fixes**
  * Standardized command and actor identifiers across app and worksheet AI flows.
* **Documentation**
  * Updated README/developer guidance for the shared revision and block-document workflows.
* **Tests**
  * Expanded Jest coverage for revision command behavior and canonical command payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->