### PR TITLE
feat: introduce dashboard skills

### DIFF
--- a/apps/sqlrooms-cli-ui/src/ai/__tests__/dashboardSkills.test.ts
+++ b/apps/sqlrooms-cli-ui/src/ai/__tests__/dashboardSkills.test.ts
@@ -1,0 +1,61 @@
+import {
+  createSqlroomsCliDashboardSkillStorage,
+  SQLROOMS_CLI_DASHBOARD_SKILL_ROOT,
+  selectSqlroomsCliDashboardSkillIds,
+} from '../dashboardSkills';
+import {DASHBOARD_SKILL_TRACES} from '../dashboardSkillTraces';
+
+describe('SQLRooms CLI dashboard skills', () => {
+  it('composes app skills before package skills', async () => {
+    const storage = createSqlroomsCliDashboardSkillStorage();
+
+    await expect(storage.listRoots()).resolves.toMatchObject([
+      SQLROOMS_CLI_DASHBOARD_SKILL_ROOT,
+      {id: 'package:@sqlrooms/mosaic'},
+    ]);
+  });
+
+  it('selects worksheet routing skills with package dashboard skills', () => {
+    expect(
+      selectSqlroomsCliDashboardSkillIds({
+        agent: 'worksheet',
+        intent: 'Add a dashboard to the current worksheet',
+      }),
+    ).toEqual([
+      'chart-selection',
+      'dashboard-design-principles',
+      'mosaic-dashboard-runtime',
+      'exploratory-dashboard',
+      'sqlrooms-cli-dashboard-routing',
+      'sqlrooms-cli-worksheet-dashboard-block',
+      'sqlrooms-cli-dashboard-polish',
+    ]);
+  });
+
+  it('keeps top-level dashboard agent selection focused on dashboard polish', () => {
+    expect(
+      selectSqlroomsCliDashboardSkillIds({
+        agent: 'dashboard',
+        intent: 'Create a KPI dashboard',
+      }),
+    ).toEqual([
+      'chart-selection',
+      'dashboard-design-principles',
+      'mosaic-dashboard-runtime',
+      'kpi-dashboard',
+      'sqlrooms-cli-dashboard-polish',
+    ]);
+  });
+
+  it.each(DASHBOARD_SKILL_TRACES)(
+    'matches expected selected skills for $id',
+    (trace) => {
+      expect(
+        selectSqlroomsCliDashboardSkillIds({
+          agent: trace.agent,
+          intent: trace.prompt,
+        }),
+      ).toEqual(trace.expectedSkillIds);
+    },
+  );
+});

--- a/apps/sqlrooms-cli-ui/src/ai/createWorksheetAgentTool.ts
+++ b/apps/sqlrooms-cli-ui/src/ai/createWorksheetAgentTool.ts
@@ -7,6 +7,7 @@ import type {
 import {
   AiAgentError,
   BLOCK_DOCUMENT_CHART_TOOL_PREFIX,
+  buildAgentSkillsInstructions,
   calculateAgentResultMetadata,
   createChartToolsInstructions,
   resolveChartTypes,
@@ -369,9 +370,21 @@ IMPORTANT: IF primary artefact in run context is a worksheet, prioritize using t
         blockDocumentAdapter.setCurrentBlockDocument(worksheetId);
 
         const dataTools = options.createDataTools?.({store}) ?? {};
+        const state = store.getState();
+        const selectedSkillIds =
+          (await options.selectSkillIds?.({
+            intent,
+            state,
+            agent: 'worksheet',
+          })) ?? [];
+        const skillContext = await buildAgentSkillsInstructions({
+          storage: options.skillStorage,
+          skillIds: selectedSkillIds,
+          heading: 'Selected Worksheet And Dashboard Skills',
+        });
 
         const agent = new ToolLoopAgent({
-          model: options.getModel({state: store.getState()}),
+          model: options.getModel({state}),
           tools: {
             ...createWorksheetBlockDocumentAiTools({
               databaseAdapter,
@@ -393,6 +406,7 @@ IMPORTANT: IF primary artefact in run context is a worksheet, prioritize using t
           stopWhen: [stepCountIs(Math.max(5, Math.min(50, maxSteps ?? 20)))],
           instructions: [
             options.instructions ?? getWorksheetAgentInstructions(options),
+            skillContext.instructions,
             options.additionalInstructions,
           ]
             .filter(Boolean)
@@ -411,6 +425,7 @@ IMPORTANT: IF primary artefact in run context is a worksheet, prioritize using t
           undefined,
           result.agentToolCalls,
         );
+        metadata.skillsApplied = skillContext.appliedSkills;
 
         return {
           success: true,

--- a/apps/sqlrooms-cli-ui/src/ai/dashboardSkillTraces.ts
+++ b/apps/sqlrooms-cli-ui/src/ai/dashboardSkillTraces.ts
@@ -1,0 +1,148 @@
+/**
+ * Expected dashboard-skill traces for the first SQLRooms CLI dashboard slice.
+ */
+export type DashboardSkillTrace = {
+  id: string;
+  prompt: string;
+  agent: 'dashboard' | 'worksheet';
+  expectedSkillIds: string[];
+  expectedAgentPath: string;
+  expectedDurableActions: string[];
+  expectedResult: string;
+  unacceptableOutcomes: string[];
+};
+
+/**
+ * Small deterministic trace suite used to guard skill selection and routing
+ * expectations before adding more skill families.
+ */
+export const DASHBOARD_SKILL_TRACES: DashboardSkillTrace[] = [
+  {
+    id: 'exploratory-dashboard',
+    prompt: 'Create an exploratory dashboard for this table.',
+    agent: 'dashboard',
+    expectedSkillIds: [
+      'chart-selection',
+      'dashboard-design-principles',
+      'mosaic-dashboard-runtime',
+      'exploratory-dashboard',
+      'sqlrooms-cli-dashboard-polish',
+    ],
+    expectedAgentPath: 'dashboard_agent -> dashboard panel tools',
+    expectedDurableActions: [
+      'dashboard.set-selected-table',
+      'dashboard.add-panel',
+    ],
+    expectedResult: '3-5 complementary dashboard panels',
+    unacceptableOutcomes: ['chat-only charts', 'no durable dashboard panels'],
+  },
+  {
+    id: 'kpi-dashboard',
+    prompt: 'Create a KPI dashboard.',
+    agent: 'dashboard',
+    expectedSkillIds: [
+      'chart-selection',
+      'dashboard-design-principles',
+      'mosaic-dashboard-runtime',
+      'kpi-dashboard',
+      'sqlrooms-cli-dashboard-polish',
+    ],
+    expectedAgentPath: 'dashboard_agent -> query -> dashboard panel tools',
+    expectedDurableActions: [
+      'dashboard.set-selected-table',
+      'dashboard.add-panel',
+    ],
+    expectedResult: 'headline metric trend and useful breakdown panels',
+    unacceptableOutcomes: ['raw counts without context', 'text-only answer'],
+  },
+  {
+    id: 'diagnostic-dashboard',
+    prompt: 'Explain why revenue changed.',
+    agent: 'dashboard',
+    expectedSkillIds: [
+      'chart-selection',
+      'dashboard-design-principles',
+      'mosaic-dashboard-runtime',
+      'kpi-dashboard',
+      'diagnostic-dashboard',
+      'sqlrooms-cli-dashboard-polish',
+    ],
+    expectedAgentPath: 'dashboard_agent -> query -> dashboard panel tools',
+    expectedDurableActions: [
+      'dashboard.set-selected-table',
+      'dashboard.add-panel',
+    ],
+    expectedResult: 'comparison and segment-driver panels with uncertainty',
+    unacceptableOutcomes: ['unsupported causal claims', 'no comparison frame'],
+  },
+  {
+    id: 'worksheet-dashboard-block',
+    prompt: 'Add a dashboard to the current worksheet.',
+    agent: 'worksheet',
+    expectedSkillIds: [
+      'chart-selection',
+      'dashboard-design-principles',
+      'mosaic-dashboard-runtime',
+      'exploratory-dashboard',
+      'sqlrooms-cli-dashboard-routing',
+      'sqlrooms-cli-worksheet-dashboard-block',
+      'sqlrooms-cli-dashboard-polish',
+    ],
+    expectedAgentPath:
+      'worksheet_agent -> add_dashboard_block -> embedded_dashboard_agent',
+    expectedDurableActions: [
+      'block-document.add-dashboard-block',
+      'dashboard.add-panel',
+    ],
+    expectedResult: 'worksheet dashboard block populated with panels',
+    unacceptableOutcomes: [
+      'top-level dashboard artifact',
+      'standalone chat chart',
+    ],
+  },
+  {
+    id: 'map-heavy-dashboard',
+    prompt: 'Add a map-heavy dashboard.',
+    agent: 'worksheet',
+    expectedSkillIds: [
+      'chart-selection',
+      'dashboard-design-principles',
+      'mosaic-dashboard-runtime',
+      'exploratory-dashboard',
+      'sqlrooms-cli-dashboard-routing',
+      'sqlrooms-cli-worksheet-dashboard-block',
+      'sqlrooms-cli-dashboard-polish',
+    ],
+    expectedAgentPath:
+      'worksheet_agent -> worksheet map tool or embedded_dashboard_agent',
+    expectedDurableActions: [
+      'block-document.add-map-block or block-document.add-dashboard-block',
+      'dashboard.add-panel when routed through a dashboard',
+    ],
+    expectedResult: 'map-centered worksheet or dashboard with supporting views',
+    unacceptableOutcomes: ['markdown-only map', 'unsupported map panel claim'],
+  },
+  {
+    id: 'refine-existing-dashboard',
+    prompt: 'Refine this existing dashboard.',
+    agent: 'dashboard',
+    expectedSkillIds: [
+      'chart-selection',
+      'dashboard-design-principles',
+      'mosaic-dashboard-runtime',
+      'exploratory-dashboard',
+      'sqlrooms-cli-dashboard-polish',
+    ],
+    expectedAgentPath:
+      'dashboard_agent -> list_dashboard_panels -> panel tools',
+    expectedDurableActions: [
+      'dashboard.update-panel',
+      'dashboard.add-panel when needed',
+    ],
+    expectedResult: 'targeted dashboard refinement preserving existing intent',
+    unacceptableOutcomes: [
+      'blind duplicate dashboard',
+      'untargeted panel edits',
+    ],
+  },
+];

--- a/apps/sqlrooms-cli-ui/src/ai/dashboardSkills.ts
+++ b/apps/sqlrooms-cli-ui/src/ai/dashboardSkills.ts
@@ -1,0 +1,142 @@
+import {
+  BundledSkillStorage,
+  CompositeSkillStorage,
+  type BundledSkillDefinition,
+  type SkillStorage,
+} from '@sqlrooms/ai';
+import {
+  MOSAIC_DASHBOARD_SKILLS,
+  MOSAIC_DASHBOARD_SKILL_ROOT,
+  selectMosaicDashboardSkillIds,
+} from '@sqlrooms/mosaic/ai';
+
+/**
+ * Read-only skill root for SQLRooms CLI dashboard and worksheet policy.
+ */
+export const SQLROOMS_CLI_DASHBOARD_SKILL_ROOT = {
+  id: 'app:sqlrooms-cli-ui',
+  label: 'SQLRooms CLI dashboard skills',
+  writable: false,
+} as const;
+
+/**
+ * App-owned skills that specialize reusable Mosaic dashboard guidance for the
+ * SQLRooms CLI artifact and worksheet surfaces.
+ */
+export const SQLROOMS_CLI_DASHBOARD_SKILLS = [
+  {
+    id: 'sqlrooms-cli-dashboard-routing',
+    manifest: {
+      id: 'sqlrooms-cli-dashboard-routing',
+      version: '0.1.0',
+      name: 'SQLRooms CLI Dashboard Routing',
+      description:
+        'Choose between dashboard artifacts, worksheet dashboard blocks, chart blocks, and embedded agents.',
+    },
+    instructions: `
+Use this skill inside the SQLRooms CLI app when deciding how dashboard work should be routed.
+
+- If the primary artifact is a worksheet, prefer worksheet blocks and worksheet-scoped tools.
+- If the user explicitly asks for an interactive dashboard inside a worksheet, create or reuse a dashboard block, then call the embedded dashboard agent.
+- If the primary artifact is a dashboard artifact, call the dashboard agent directly.
+- If the user asks for one or two simple worksheet charts, create chart blocks directly instead of creating a dashboard block.
+- If the request is exploratory, multi-view, map-heavy, or benefits from coordinated filters, prefer a dashboard block or dashboard artifact.
+- If targeting is ambiguous across multiple existing stateful blocks, inspect blocks before mutating one.
+
+This skill does not grant tools. Use command-backed worksheet and dashboard operations for durable changes.
+`.trim(),
+  },
+  {
+    id: 'sqlrooms-cli-worksheet-dashboard-block',
+    manifest: {
+      id: 'sqlrooms-cli-worksheet-dashboard-block',
+      version: '0.1.0',
+      name: 'SQLRooms CLI Worksheet Dashboard Block',
+      description:
+        'Guide creation, reuse, and follow-up edits for dashboard blocks embedded in worksheets.',
+    },
+    instructions: `
+Use this skill when a dashboard lives inside a SQLRooms worksheet.
+
+- Create the dashboard block container before populating it with the embedded dashboard agent.
+- Reuse an existing dashboard block when the user's request is a follow-up or refinement.
+- Pass the dashboard block's stateful block instance id as dashboardId to the embedded dashboard agent.
+- Keep worksheet surrounding text short: headings or captions should orient the dashboard, not duplicate every panel.
+- For map requests without direct worksheet map tools, route through a dashboard block that can host map panels.
+- For follow-up edits, inspect worksheet blocks and existing dashboard panels before adding a new dashboard.
+
+Do not bypass worksheet commands or mutate block document state through hidden mechanisms.
+`.trim(),
+  },
+  {
+    id: 'sqlrooms-cli-dashboard-polish',
+    manifest: {
+      id: 'sqlrooms-cli-dashboard-polish',
+      version: '0.1.0',
+      name: 'SQLRooms CLI Dashboard Polish',
+      description:
+        'Apply SQLRooms CLI defaults for dashboard titles, captions, summaries, and follow-up behavior.',
+    },
+    instructions: `
+Use this skill for SQLRooms CLI dashboard presentation defaults.
+
+- Use concise dashboard and panel titles that match the user's artifact context.
+- Prefer practical first drafts over exhaustive dashboards; users can refine interactively.
+- Add brief summary text around worksheet dashboard blocks only when it helps the worksheet read naturally.
+- Preserve existing dashboard intent when editing unless the user clearly asks to repurpose it.
+- Keep user-facing summaries honest about uncertainty and unsupported runtime capabilities.
+- Prefer visible command/tool paths over hidden agent-only state changes.
+
+Do not duplicate Mosaic chart-selection guidance here; defer chart theory to package-owned Mosaic skills.
+`.trim(),
+  },
+] satisfies ReadonlyArray<BundledSkillDefinition>;
+
+/**
+ * Build the SQLRooms CLI skill catalog in priority order:
+ * workspace, user, app bundled skills, then package bundled skills.
+ */
+export function createSqlroomsCliDashboardSkillStorage({
+  workspaceStorage,
+  userStorage,
+}: {
+  workspaceStorage?: SkillStorage;
+  userStorage?: SkillStorage;
+} = {}): SkillStorage {
+  const storages = [
+    workspaceStorage,
+    userStorage,
+    new BundledSkillStorage(
+      SQLROOMS_CLI_DASHBOARD_SKILL_ROOT,
+      SQLROOMS_CLI_DASHBOARD_SKILLS,
+    ),
+    new BundledSkillStorage(
+      MOSAIC_DASHBOARD_SKILL_ROOT,
+      MOSAIC_DASHBOARD_SKILLS,
+    ),
+  ].filter((storage): storage is SkillStorage => Boolean(storage));
+
+  return new CompositeSkillStorage(storages);
+}
+
+/**
+ * Select app and package dashboard skills for a single CLI agent run.
+ */
+export function selectSqlroomsCliDashboardSkillIds({
+  agent,
+  intent,
+}: {
+  agent: 'dashboard' | 'worksheet';
+  intent: string;
+}): ReadonlyArray<string> {
+  const skillIds = new Set<string>(selectMosaicDashboardSkillIds(intent));
+
+  if (agent === 'worksheet') {
+    skillIds.add('sqlrooms-cli-dashboard-routing');
+    skillIds.add('sqlrooms-cli-worksheet-dashboard-block');
+  }
+
+  skillIds.add('sqlrooms-cli-dashboard-polish');
+
+  return [...skillIds];
+}

--- a/apps/sqlrooms-cli-ui/src/createDashboardAgent.ts
+++ b/apps/sqlrooms-cli-ui/src/createDashboardAgent.ts
@@ -8,6 +8,10 @@ import {
 import type {StoreApi} from 'zustand';
 import type {RoomState} from './store-types';
 import {createDatabaseAiAdapter} from './createDatabaseAiAdapter';
+import {
+  createSqlroomsCliDashboardSkillStorage,
+  selectSqlroomsCliDashboardSkillIds,
+} from './ai/dashboardSkills';
 
 export function dashboardAgentTool(
   store: StoreApi<RoomState>,
@@ -37,6 +41,9 @@ export function dashboardAgentTool(
       createDefaultAiTools(store, {query: {}, tables: true, commands: false}),
     runSubAgent: ({agent, prompt, parentToolCallId, abortSignal}) =>
       streamSubAgent(agent, prompt, store, parentToolCallId, abortSignal),
+    skillStorage: createSqlroomsCliDashboardSkillStorage(),
+    selectSkillIds: ({agent, intent}) =>
+      selectSqlroomsCliDashboardSkillIds({agent, intent}),
   };
 
   return deckMapsEnabled

--- a/apps/sqlrooms-cli-ui/src/createWorksheetAgent.ts
+++ b/apps/sqlrooms-cli-ui/src/createWorksheetAgent.ts
@@ -19,6 +19,10 @@ import {
   KnownWorksheetTools,
 } from './ai/constants';
 import {WorksheetMapBlockToolParameters} from './createWorksheetCommands';
+import {
+  createSqlroomsCliDashboardSkillStorage,
+  selectSqlroomsCliDashboardSkillIds,
+} from './ai/dashboardSkills';
 
 const WorksheetMapBlockToolInput = WorksheetMapBlockToolParameters.omit({
   worksheetId: true,
@@ -103,6 +107,9 @@ export function worksheetAgentTool(
       createDefaultAiTools(store, {query: {}, tables: true, commands: false}),
     runSubAgent: ({agent, prompt, parentToolCallId, abortSignal}) =>
       streamSubAgent(agent, prompt, store, parentToolCallId, abortSignal),
+    skillStorage: createSqlroomsCliDashboardSkillStorage(),
+    selectSkillIds: ({agent, intent}) =>
+      selectSqlroomsCliDashboardSkillIds({agent, intent}),
   };
 
   const dashboardAgentTool = (

--- a/dev-docs/contributing/skills.md
+++ b/dev-docs/contributing/skills.md
@@ -1,0 +1,59 @@
+# SQLRooms Skills Pattern
+
+Skills are reusable instruction sets that shape agent judgment without becoming
+new mutation paths. Agents still execute through typed tools, commands, stores,
+and adapters.
+
+## Ownership
+
+Put a skill next to the owner of the judgment it encodes:
+
+- Package skills describe reusable package capabilities and constraints.
+- App skills describe product routing, host defaults, and artifact policy.
+- User and workspace skills describe local preferences and recurring workflows.
+
+For dashboards, `@sqlrooms/mosaic` owns reusable dashboard guidance such as
+chart selection and runtime constraints. `apps/sqlrooms-cli-ui` owns worksheet
+and artifact routing policy.
+
+## Priority
+
+Compose skill roots in this order:
+
+```text
+workspace skills
+user skills
+app bundled skills
+package bundled skills
+```
+
+Higher-priority roots can intentionally shadow lower-priority skill ids.
+Preserve root ids in traces so selected guidance remains inspectable.
+
+## Agent Use
+
+Agents should:
+
+- select a small relevant skill set for the current request;
+- append selected skill text to the agent prompt;
+- keep tool schemas, command ids, targeting rules, and result shapes in code;
+- record selected `{id, rootId}` pairs in metadata or devtools traces;
+- keep working when no skills are available.
+
+Skills must not grant tools, bypass command schemas, or mutate state directly.
+
+## Skill Cards
+
+Before adding a new skill, write a short card:
+
+- Skill
+- Owner
+- Purpose
+- Runtime tools allowed
+- Commands/actions it may invoke
+- State it may mutate
+- Expected traces
+- Why this belongs in a skill
+- Why this is safe to override
+
+Use concrete, reviewable skills before building broader ranking or authoring UI.

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -336,6 +336,47 @@ const unsubscribe = storage.subscribe(() => {
 // later: unsubscribe();
 ```
 
+### Bundled storage
+
+`BundledSkillStorage` exposes read-only skills shipped inside a package or app
+bundle. Use it for baseline product or package guidance, then compose it below
+workspace and user roots:
+
+```tsx
+import {BundledSkillStorage, CompositeSkillStorage} from '@sqlrooms/ai';
+
+const packageSkills = new BundledSkillStorage(
+  {
+    id: 'package:@sqlrooms/mosaic',
+    label: '@sqlrooms/mosaic skills',
+    writable: false,
+  },
+  [
+    {
+      id: 'chart-selection',
+      manifest: {
+        id: 'chart-selection',
+        version: '0.1.0',
+        name: 'Chart Selection',
+        description: 'Choose chart types from intent and data shape.',
+      },
+      instructions: 'Prefer histograms for one numeric distribution.',
+    },
+  ],
+);
+
+const storage = new CompositeSkillStorage([
+  workspaceStorage,
+  userStorage,
+  appBundledSkills,
+  packageSkills,
+]);
+```
+
+Bundled roots reject `writeSkill` and `deleteSkill`. Their root ids are retained
+in `SkillRef`, so agent traces can show whether selected guidance came from a
+workspace, user, app, or package root.
+
 ### Manifest utilities
 
 - `parseSkillManifest(raw)` — parse and validate a skill manifest (Zod-backed, throws `SkillManifestError` on failure)

--- a/packages/ai/__tests__/bundledSkillStorage.test.ts
+++ b/packages/ai/__tests__/bundledSkillStorage.test.ts
@@ -1,0 +1,68 @@
+import {
+  BundledSkillStorage,
+  SkillNotFoundError,
+  SkillRootReadOnlyError,
+} from '../src';
+
+const root = {
+  id: 'package:test',
+  label: 'Test bundled skills',
+  writable: false,
+};
+
+const skills = [
+  {
+    id: 'test-skill',
+    manifest: {
+      id: 'test-skill',
+      version: '0.1.0',
+      name: 'Test Skill',
+      description: 'A bundled test skill.',
+    },
+    instructions: 'Use the test skill carefully.',
+  },
+];
+
+describe('BundledSkillStorage', () => {
+  it('lists and reads bundled skills from a read-only root', async () => {
+    const storage = new BundledSkillStorage(root, skills);
+
+    await expect(storage.listRoots()).resolves.toEqual([root]);
+    await expect(storage.listSkills()).resolves.toEqual([
+      {
+        ref: {rootId: 'package:test', id: 'test-skill'},
+        manifest: skills[0].manifest,
+      },
+    ]);
+    await expect(
+      storage.readSkill({rootId: 'package:test', id: 'test-skill'}),
+    ).resolves.toMatchObject({
+      ref: {rootId: 'package:test', id: 'test-skill'},
+      instructions: 'Use the test skill carefully.',
+    });
+  });
+
+  it('resolves bare ids within the bundled root', async () => {
+    const storage = new BundledSkillStorage(root, skills);
+
+    await expect(storage.resolveSkillId('test-skill')).resolves.toEqual({
+      rootId: 'package:test',
+      id: 'test-skill',
+    });
+    await expect(storage.resolveSkillId('missing')).resolves.toBeNull();
+  });
+
+  it('rejects reads and writes outside the bundled catalog', async () => {
+    const storage = new BundledSkillStorage(root, skills);
+
+    await expect(
+      storage.readSkill({rootId: 'package:test', id: 'missing'}),
+    ).rejects.toBeInstanceOf(SkillNotFoundError);
+    await expect(
+      storage.writeSkill('package:test', 'test-skill', {
+        manifest: skills[0].manifest,
+        instructions: 'Updated',
+      }),
+    ).rejects.toBeInstanceOf(SkillRootReadOnlyError);
+  });
+});

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -88,8 +88,9 @@ export {
   serializeSkillManifest,
   loadSkillFromFiles,
   CompositeSkillStorage,
+  BundledSkillStorage,
 } from './skills';
-export type {SkillManifest} from './skills';
+export type {BundledSkillDefinition, SkillManifest} from './skills';
 export type {
   SkillStorage,
   SkillRoot,

--- a/packages/ai/src/skills/bundled.ts
+++ b/packages/ai/src/skills/bundled.ts
@@ -1,0 +1,99 @@
+import {SkillNotFoundError, SkillRootReadOnlyError} from './errors';
+import type {SkillManifest} from './manifest';
+import type {
+  SkillFile,
+  SkillListing,
+  SkillRecord,
+  SkillRef,
+  SkillRoot,
+  SkillStorage,
+  SkillWriteContent,
+} from './storage';
+
+/**
+ * Definition for a skill bundled directly into package or app source.
+ */
+export type BundledSkillDefinition = {
+  /** Skill id within the bundled root. */
+  id: string;
+  /** Parsed skill manifest. */
+  manifest: SkillManifest;
+  /** Markdown instructions shown to an agent when the skill is selected. */
+  instructions: string;
+  /** Optional files that conceptually live alongside `SKILL.md`. */
+  extraFiles?: SkillFile[];
+};
+
+/**
+ * Read-only `SkillStorage` for skills shipped with a package or app bundle.
+ *
+ * Hosts can combine multiple bundled roots with user/workspace roots via
+ * `CompositeSkillStorage` while preserving root ids in listings and traces.
+ */
+export class BundledSkillStorage implements SkillStorage {
+  private readonly skillsById: ReadonlyMap<string, BundledSkillDefinition>;
+
+  constructor(
+    private readonly root: SkillRoot,
+    skills: ReadonlyArray<BundledSkillDefinition>,
+  ) {
+    this.skillsById = new Map(skills.map((skill) => [skill.id, skill]));
+  }
+
+  async listRoots(): Promise<SkillRoot[]> {
+    return [{...this.root, writable: false}];
+  }
+
+  async listSkills(rootId?: string): Promise<SkillListing[]> {
+    if (rootId !== undefined && rootId !== this.root.id) return [];
+    return [...this.skillsById.values()].map((skill) => ({
+      ref: {rootId: this.root.id, id: skill.id},
+      manifest: skill.manifest,
+    }));
+  }
+
+  async readSkill(ref: SkillRef): Promise<SkillRecord> {
+    if (ref.rootId !== this.root.id) {
+      throw new SkillNotFoundError(
+        `Unknown bundled skill root "${ref.rootId}"`,
+        {
+          ref,
+        },
+      );
+    }
+
+    const skill = this.skillsById.get(ref.id);
+    if (!skill) {
+      throw new SkillNotFoundError(`Unknown bundled skill "${ref.id}"`, {ref});
+    }
+
+    return {
+      ref,
+      manifest: skill.manifest,
+      instructions: skill.instructions,
+      extraFiles: skill.extraFiles ?? [],
+    };
+  }
+
+  async writeSkill(
+    rootId: string,
+    id: string,
+    _content: SkillWriteContent,
+  ): Promise<SkillRef> {
+    throw new SkillRootReadOnlyError(
+      `Bundled skill root "${rootId}" is read-only`,
+      {rootId, extras: {id}},
+    );
+  }
+
+  async deleteSkill(ref: SkillRef): Promise<void> {
+    throw new SkillRootReadOnlyError(
+      `Bundled skill root "${ref.rootId}" is read-only`,
+      {ref},
+    );
+  }
+
+  async resolveSkillId(id: string): Promise<SkillRef | null> {
+    return this.skillsById.has(id) ? {rootId: this.root.id, id} : null;
+  }
+}

--- a/packages/ai/src/skills/index.ts
+++ b/packages/ai/src/skills/index.ts
@@ -2,4 +2,5 @@ export * from './errors';
 export * from './manifest';
 export * from './storage';
 export * from './composite';
+export * from './bundled';
 export * from './authoring';

--- a/packages/mosaic/README.md
+++ b/packages/mosaic/README.md
@@ -520,6 +520,19 @@ dashboard prompts and tool registration stay aligned. When host tools need
 specialized agent guidance, pass `additionalInstructions` to append that
 guidance after the built-in agent workflow without replacing it.
 
+Dashboard agents can also receive selected skill instructions through
+`skillStorage` and `selectSkillIds`. The package exports reusable Mosaic
+dashboard skill definitions via `MOSAIC_DASHBOARD_SKILLS`,
+`MOSAIC_DASHBOARD_SKILL_ROOT`, and `selectMosaicDashboardSkillIds`. These
+skills cover chart selection, dashboard design, exploratory/KPI/diagnostic
+patterns, and Mosaic runtime constraints. They are advisory prompt context only:
+tool schemas, command contracts, and durable mutations remain in code.
+
+When selected skills are available, `dashboard_agent` appends their text to the
+agent instructions and echoes `{id, rootId}` entries in
+`metadata.skillsApplied`. If no skill storage is provided, the agent still runs
+with its built-in instructions.
+
 Block-document agents can also accept host tools through `extraTools`. Host
 tool factories should receive the active block document ID alongside the block
 document and database adapters, so apps can add scoped tools such as embedded

--- a/packages/mosaic/__tests__/dashboardSkills.test.ts
+++ b/packages/mosaic/__tests__/dashboardSkills.test.ts
@@ -1,0 +1,59 @@
+import {
+  buildAgentSkillsInstructions,
+  MOSAIC_DASHBOARD_SKILLS,
+  MOSAIC_DASHBOARD_SKILL_ROOT,
+  selectMosaicDashboardSkillIds,
+} from '../src/ai';
+
+describe('dashboard skills', () => {
+  it('selects baseline and exploratory skills for open-ended dashboard requests', () => {
+    expect(
+      selectMosaicDashboardSkillIds('Create an overview dashboard'),
+    ).toEqual([
+      'chart-selection',
+      'dashboard-design-principles',
+      'mosaic-dashboard-runtime',
+      'exploratory-dashboard',
+    ]);
+  });
+
+  it('selects KPI and diagnostic skills when the intent asks for metric drivers', () => {
+    expect(
+      selectMosaicDashboardSkillIds('Explain why revenue changed last quarter'),
+    ).toEqual([
+      'chart-selection',
+      'dashboard-design-principles',
+      'mosaic-dashboard-runtime',
+      'kpi-dashboard',
+      'diagnostic-dashboard',
+    ]);
+  });
+
+  it('renders selected skill instructions with root ids for traces', async () => {
+    const storage = {
+      resolveSkillId: async (id: string) =>
+        id === 'chart-selection'
+          ? {rootId: MOSAIC_DASHBOARD_SKILL_ROOT.id, id}
+          : null,
+      readSkill: async () => ({
+        ref: {rootId: MOSAIC_DASHBOARD_SKILL_ROOT.id, id: 'chart-selection'},
+        manifest: MOSAIC_DASHBOARD_SKILLS[0].manifest,
+        instructions: MOSAIC_DASHBOARD_SKILLS[0].instructions,
+      }),
+    };
+
+    const result = await buildAgentSkillsInstructions({
+      storage,
+      skillIds: ['chart-selection', 'missing-skill'],
+      heading: 'Selected Dashboard Skills',
+    });
+
+    expect(result.appliedSkills).toEqual([
+      {rootId: MOSAIC_DASHBOARD_SKILL_ROOT.id, id: 'chart-selection'},
+    ]);
+    expect(result.instructions).toContain('## Selected Dashboard Skills');
+    expect(result.instructions).toContain(
+      `Root: ${MOSAIC_DASHBOARD_SKILL_ROOT.id}`,
+    );
+  });
+});

--- a/packages/mosaic/src/ai.ts
+++ b/packages/mosaic/src/ai.ts
@@ -4,8 +4,10 @@
  */
 export type {ChartToolExecutionContext} from './charts/chart-types';
 export * from './ai/types';
+export * from './ai/skills';
 export * from './ai/database-types';
 export * from './ai/dashboard/dashboard-types';
+export * from './ai/dashboard/dashboardSkills';
 export * from './ai/constants';
 export * from './ai/block-document/constants';
 export {AiAgentError} from './ai/errors';

--- a/packages/mosaic/src/ai/dashboard/createDashboardAgentTool.ts
+++ b/packages/mosaic/src/ai/dashboard/createDashboardAgentTool.ts
@@ -15,6 +15,8 @@ import {createChartToolsInstructions} from '../../charts/chart-types/createChart
 import {DASHBOARD_CHART_TOOL_PREFIX, KnownDashboardTools} from './constants';
 import {AgentIntentSchemaFields} from '../agentIntent';
 import {getTableIdentity} from '@sqlrooms/db';
+import {buildAgentSkillsInstructions} from '../skills';
+import {selectMosaicDashboardSkillIds} from './dashboardSkills';
 
 function getDashboardAgentInstructions<TState>(
   options: CreateDashboardAgentToolOptions<TState>,
@@ -186,6 +188,17 @@ IMPORTANT: IF primary artefact in run context is a dashboard, prioritize using t
         );
 
         const dataTools = options.createDataTools?.({store}) ?? {};
+        const selectedSkillIds =
+          (await options.selectSkillIds?.({
+            intent,
+            state,
+            agent: 'dashboard',
+          })) ?? selectMosaicDashboardSkillIds(intent);
+        const skillContext = await buildAgentSkillsInstructions({
+          storage: options.skillStorage,
+          skillIds: selectedSkillIds,
+          heading: 'Selected Dashboard Skills',
+        });
 
         const agent = new ToolLoopAgent({
           model: options.getModel({state}),
@@ -201,6 +214,7 @@ IMPORTANT: IF primary artefact in run context is a dashboard, prioritize using t
           stopWhen: [stepCountIs(Math.max(5, Math.min(50, maxSteps ?? 20)))],
           instructions: [
             options.instructions ?? getDashboardAgentInstructions(options),
+            skillContext.instructions,
             options.additionalInstructions,
           ]
             .filter(Boolean)
@@ -219,6 +233,7 @@ IMPORTANT: IF primary artefact in run context is a dashboard, prioritize using t
           tableName,
           result.agentToolCalls,
         );
+        metadata.skillsApplied = skillContext.appliedSkills;
 
         return {
           success: true,

--- a/packages/mosaic/src/ai/dashboard/dashboardSkills.ts
+++ b/packages/mosaic/src/ai/dashboard/dashboardSkills.ts
@@ -1,0 +1,175 @@
+/**
+ * Read-only skill root for dashboard guidance owned by `@sqlrooms/mosaic`.
+ */
+export const MOSAIC_DASHBOARD_SKILL_ROOT = {
+  id: 'package:@sqlrooms/mosaic',
+  label: '@sqlrooms/mosaic dashboard skills',
+  writable: false,
+} as const;
+
+/**
+ * Package-owned dashboard skills. These describe reusable Mosaic dashboard
+ * judgment without SQLRooms CLI artifact policy.
+ */
+export const MOSAIC_DASHBOARD_SKILLS = [
+  {
+    id: 'chart-selection',
+    manifest: {
+      id: 'chart-selection',
+      version: '0.1.0',
+      name: 'Chart Selection',
+      description:
+        'Choose Mosaic chart and panel types from analytical intent and data shape.',
+    },
+    instructions: `
+Use this skill when deciding which dashboard panel best matches a question.
+
+- Prefer histograms for one numeric distribution.
+- Prefer count plots for categorical frequency or ranking when the category count is modest.
+- Prefer line charts for ordered time or sequence trends; aggregate before plotting large tables.
+- Prefer scatter plots for relationships between two numeric measures only when row count is manageable.
+- Prefer heatmaps for dense relationships, binned numeric comparisons, or high-row-count scatter alternatives.
+- Prefer box plots for comparing numeric distributions across groups.
+- Prefer data table explorer panels when users need raw records, column summaries, or sortable detail.
+- Prefer map panels only when the host provides a map tool and the data has spatial fields.
+
+Do not use this skill to invent unsupported panel types. If the runtime lacks the needed panel, choose the closest supported chart or explain the limitation.
+`.trim(),
+  },
+  {
+    id: 'dashboard-design-principles',
+    manifest: {
+      id: 'dashboard-design-principles',
+      version: '0.1.0',
+      name: 'Dashboard Design Principles',
+      description:
+        'Design coherent Mosaic dashboards with useful density, grouping, labels, and filters.',
+    },
+    instructions: `
+Use this skill when arranging multiple Mosaic panels into a dashboard.
+
+- Build a coherent analytical path: overview first, then breakdowns, then detail.
+- Keep exploratory dashboards to 3-5 strong panels before adding refinements.
+- Use short, specific panel titles that name the measure and grouping.
+- Avoid chart soup: each panel should answer a different question.
+- Put related panels near each other and avoid duplicating the same encoding repeatedly.
+- Prefer durable dashboard state changes through commands or tools; skills provide guidance only.
+- When a dashboard already exists, inspect panels before updating so edits target the intended panel.
+
+Do not use this skill to override tool schemas, command contracts, or selected-table runtime behavior.
+`.trim(),
+  },
+  {
+    id: 'exploratory-dashboard',
+    manifest: {
+      id: 'exploratory-dashboard',
+      version: '0.1.0',
+      name: 'Exploratory Dashboard',
+      description:
+        'Create a compact set of coordinated views that reveal dataset structure.',
+    },
+    instructions: `
+Use this skill when the user asks to explore, understand, profile, or get a high-level view of a dataset.
+
+- Start with broad shape: row count, important ranges, common categories, and missing-looking dimensions.
+- Create 3-5 panels that cover complementary aspects: distribution, trend, relationship, segment, and detail.
+- Use aggregated charts for large tables before considering row-level encodings.
+- Include a data table explorer panel when field summaries or raw-detail inspection would help the user continue.
+- Stop once the dashboard has a useful first pass; follow-up edits can refine the layout.
+
+Do not spend the whole run querying without creating panels.
+`.trim(),
+  },
+  {
+    id: 'kpi-dashboard',
+    manifest: {
+      id: 'kpi-dashboard',
+      version: '0.1.0',
+      name: 'KPI Dashboard',
+      description:
+        'Build metrics-first dashboards with headline measures, trends, breakdowns, and guardrails.',
+    },
+    instructions: `
+Use this skill when the user asks for KPI, metric, performance, scorecard, revenue, growth, retention, or operational tracking.
+
+- Identify the headline metric, its time grain, and the most useful denominators or guardrails.
+- Show a trend before detailed segmentation when time fields exist.
+- Add one or two breakdowns that explain movement by segment, category, region, channel, or product.
+- Use clear aggregation in titles, such as "Monthly Revenue" or "Orders by Region".
+- Include a detail or table panel only when it helps audit the metric.
+
+Do not present raw counts as KPIs when a rate, denominator, or time window is required but unavailable.
+`.trim(),
+  },
+  {
+    id: 'diagnostic-dashboard',
+    manifest: {
+      id: 'diagnostic-dashboard',
+      version: '0.1.0',
+      name: 'Diagnostic Dashboard',
+      description:
+        'Compare periods, segment drivers, decompose changes, and surface anomalies or detail records.',
+    },
+    instructions: `
+Use this skill when the user asks why a metric changed, what drove an anomaly, or how two periods or segments differ.
+
+- Establish the comparison frame first: period, cohort, segment, or baseline.
+- Create panels that isolate drivers: trend, segment contribution, distribution shift, and outlier/detail.
+- Prefer grouped or faceted views when comparing a small number of categories.
+- Use queries to confirm candidate drivers before creating durable panels.
+- Surface uncertainty when the available fields do not support causal interpretation.
+
+Do not claim root cause from correlation alone.
+`.trim(),
+  },
+  {
+    id: 'mosaic-dashboard-runtime',
+    manifest: {
+      id: 'mosaic-dashboard-runtime',
+      version: '0.1.0',
+      name: 'Mosaic Dashboard Runtime',
+      description:
+        'Respect Mosaic dashboard constraints, selected-table behavior, filters, panel limits, and query cost.',
+    },
+    instructions: `
+Use this skill whenever creating or editing a Mosaic dashboard.
+
+- A dashboard has a selected table; use the provided tableName or the dashboard selected table.
+- Inspect existing panels before modifying, replacing, or adding related panels.
+- Keep durable mutations in tools and commands. Skills never grant tools and never mutate state directly.
+- Respect panel validation errors and runtime issues; adjust chart type, fields, or aggregation when needed.
+- Limit expensive exploration. Prefer summaries, grouping, and limits before high-cardinality row-level views.
+- Use host-provided map tools only when present; otherwise choose a supported non-map panel or explain the limitation.
+
+Do not rely on hidden state or app-specific artifact rules from a reusable package skill.
+`.trim(),
+  },
+] as const;
+
+const KPI_TERMS =
+  /\b(kpi|metric|scorecard|revenue|sales|growth|retention|churn|conversion|performance)\b/i;
+const DIAGNOSTIC_TERMS =
+  /\b(why|changed|change|driver|diagnos|anomal|compare|period|difference|decompos|explain)\b/i;
+const EXPLORATORY_TERMS =
+  /\b(explore|exploratory|overview|understand|profile|summar|insight|comprehensive|high-level)\b/i;
+
+/**
+ * Select a compact package-owned skill set for a dashboard request.
+ */
+export function selectMosaicDashboardSkillIds(
+  intent: string,
+): ReadonlyArray<string> {
+  const ids = new Set<string>([
+    'chart-selection',
+    'dashboard-design-principles',
+    'mosaic-dashboard-runtime',
+  ]);
+
+  if (KPI_TERMS.test(intent)) ids.add('kpi-dashboard');
+  if (DIAGNOSTIC_TERMS.test(intent)) ids.add('diagnostic-dashboard');
+  if (EXPLORATORY_TERMS.test(intent) || ids.size === 3) {
+    ids.add('exploratory-dashboard');
+  }
+
+  return [...ids];
+}

--- a/packages/mosaic/src/ai/skills.ts
+++ b/packages/mosaic/src/ai/skills.ts
@@ -1,0 +1,70 @@
+/**
+ * Minimal skill record shape consumed by Mosaic agents.
+ *
+ * This intentionally stays structural so hosts can pass `@sqlrooms/ai`
+ * `SkillStorage` implementations without making Mosaic depend on that package.
+ */
+export type AgentSkillStorage = {
+  resolveSkillId(id: string): Promise<{rootId: string; id: string} | null>;
+  readSkill(ref: {rootId: string; id: string}): Promise<{
+    ref: {rootId: string; id: string};
+    manifest: {name: string; description: string};
+    instructions: string;
+  }>;
+};
+
+/**
+ * Skill selection metadata included in agent results for traceability.
+ */
+export type AppliedAgentSkill = {
+  id: string;
+  rootId: string;
+};
+
+/**
+ * Resolve skill ids against a storage root and render them as an agent prompt
+ * section. Missing skills are ignored so package agents keep working when a
+ * host does not provide bundled or user skills.
+ */
+export async function buildAgentSkillsInstructions({
+  storage,
+  skillIds,
+  heading,
+}: {
+  storage?: AgentSkillStorage;
+  skillIds: ReadonlyArray<string>;
+  heading: string;
+}): Promise<{
+  instructions?: string;
+  appliedSkills: AppliedAgentSkill[];
+}> {
+  if (!storage || skillIds.length === 0) {
+    return {appliedSkills: []};
+  }
+
+  const sections: string[] = [];
+  const appliedSkills: AppliedAgentSkill[] = [];
+
+  for (const skillId of skillIds) {
+    const ref = await storage.resolveSkillId(skillId);
+    if (!ref) continue;
+    const skill = await storage.readSkill(ref);
+    appliedSkills.push({id: skill.ref.id, rootId: skill.ref.rootId});
+    sections.push(
+      `### ${skill.manifest.name}\n` +
+        `Skill: ${skill.ref.id}\n` +
+        `Root: ${skill.ref.rootId}\n` +
+        `Purpose: ${skill.manifest.description}\n\n` +
+        skill.instructions.trim(),
+    );
+  }
+
+  if (sections.length === 0) {
+    return {appliedSkills};
+  }
+
+  return {
+    appliedSkills,
+    instructions: `## ${heading}\n\n${sections.join('\n\n')}`,
+  };
+}

--- a/packages/mosaic/src/ai/tool-types.ts
+++ b/packages/mosaic/src/ai/tool-types.ts
@@ -49,4 +49,8 @@ export type AgentResultMetadata = {
   tableName?: string;
   stepsExecuted: number;
   queriesRun: number;
+  skillsApplied?: Array<{
+    id: string;
+    rootId: string;
+  }>;
 };

--- a/packages/mosaic/src/ai/types.ts
+++ b/packages/mosaic/src/ai/types.ts
@@ -1,6 +1,7 @@
 import type {LanguageModel, Tool, ToolLoopAgent} from 'ai';
 import type {DataTable} from '@sqlrooms/db';
 import type {ChartTypeDefinition} from '../charts/chart-types/base-types';
+import type {AgentSkillStorage} from './skills';
 
 /**
  * Common types used by Mosaic AI agents and tool composition.
@@ -63,5 +64,19 @@ export type BaseAgentToolOptions<TState> = {
    * usage guidance while preserving the base workflow.
    */
   additionalInstructions?: string;
+  /**
+   * Optional catalog of package, app, user, or workspace skills available to
+   * this agent. Agents remain executable without skills.
+   */
+  skillStorage?: AgentSkillStorage;
+  /**
+   * Optional deterministic selector that returns the skill ids relevant to a
+   * single agent run. Selected root ids are echoed in result metadata.
+   */
+  selectSkillIds?: (args: {
+    intent: string;
+    state: TState;
+    agent: 'dashboard' | 'worksheet';
+  }) => ReadonlyArray<string> | Promise<ReadonlyArray<string>>;
   chartToolsOptions?: ChartToolsOptions;
 };


### PR DESCRIPTION
## Summary

- Add read-only bundled skill storage for package/app-provided skills.
- Add package-owned Mosaic dashboard skills plus deterministic selection and prompt rendering.
- Add SQLRooms CLI dashboard/worksheet skill roots, trace fixtures, and agent wiring that records applied `{id, rootId}` metadata.
- Document the skills pattern in package READMEs and contributing docs.

## Validation

- `pnpm install`
- `pnpm build`
- `pnpm --filter @sqlrooms/ai test --runInBand -- bundledSkillStorage.test.ts`
- `pnpm --filter @sqlrooms/mosaic test --runInBand -- dashboardSkills.test.ts`
- `pnpm --filter sqlrooms-cli-app test --runInBand -- dashboardSkills.test.ts`
- `pnpm --filter sqlrooms-cli-app build`
- Push hook: `knip`, `turbo typecheck`, `madge --circular packages/*/src/index.ts`, `turbo test`

## Notes

- Obsidian plan stages were updated to implemented.
- Related Obsidian assessment notes were linked back to the dashboard skills introduction plan.