### PR TITLE
fix(cli): navigate artifact on fork source links

### DIFF
--- a/apps/sqlrooms-cli-ui/src/__tests__/artifactChatHandoff.test.ts
+++ b/apps/sqlrooms-cli-ui/src/__tests__/artifactChatHandoff.test.ts
@@ -1,0 +1,251 @@
+import {jest} from '@jest/globals';
+import type {UIMessage} from 'ai';
+import {createArtifactChatHandoffController} from '../artifactChatHandoff';
+import type {RoomState} from '../store-types';
+
+const sourceArtifactId = 'source-worksheet';
+const targetArtifactId = 'target-worksheet';
+const sourceSessionId = 'source-session';
+const targetSessionId = 'target-session';
+
+function userMessage(text: string): UIMessage {
+  return {
+    id: 'user-1',
+    role: 'user',
+    parts: [{type: 'text', text}],
+  };
+}
+
+function assistantMessage(): UIMessage {
+  return {
+    id: 'assistant-1',
+    role: 'assistant',
+    parts: [{type: 'text', text: 'Done.'}],
+  };
+}
+
+function createState({
+  prompt = 'create a new worksheet with the same chart',
+  targetBlocks = [],
+  targetType = 'worksheet',
+}: {
+  prompt?: string;
+  targetBlocks?: any[];
+  targetType?: string;
+} = {}) {
+  const blocksByArtifact: Record<string, any[]> = {
+    [sourceArtifactId]: [
+      {
+        id: 'source-chart',
+        type: 'chart',
+        tableName: '"main"."cars"',
+        config: {chartType: 'scatter', settings: {x: 'Weight', y: 'MPG'}},
+        caption: 'MPG vs Weight',
+      },
+    ],
+    [targetArtifactId]: targetBlocks,
+  };
+
+  const appendBlocks = jest.fn((artifactId: string, blocks: any[]) => {
+    blocksByArtifact[artifactId] = [
+      ...(blocksByArtifact[artifactId] ?? []),
+      ...blocks,
+    ];
+  });
+  const setSessionArtifact = jest.fn();
+  const setSessionDraftContextItemIds = jest.fn();
+  const setSessionRunContext = jest.fn();
+  const selectLatestSessionForArtifact = jest.fn();
+  const forkSessionFromMessage = jest.fn(() => targetSessionId);
+  const artifactsConfig = {currentArtifactId: targetArtifactId};
+  const setCurrentArtifact = jest.fn((artifactId: string) => {
+    artifactsConfig.currentArtifactId = artifactId;
+  });
+
+  const state = {
+    ai: {
+      config: {
+        sessions: [
+          {
+            id: sourceSessionId,
+            uiMessages: [userMessage(prompt)],
+          },
+        ],
+      },
+      forkSessionFromMessage,
+      getSessionRunContext: jest.fn(() => ({
+        items: [
+          {
+            kind: 'artifact',
+            id: sourceArtifactId,
+            type: 'worksheet',
+            title: 'Source Worksheet',
+          },
+        ],
+      })),
+      setSessionDraftContextItemIds,
+      setSessionRunContext,
+    },
+    artifactAi: {
+      getSessionArtifactId: jest.fn((sessionId: string) =>
+        sessionId === sourceSessionId ? sourceArtifactId : targetArtifactId,
+      ),
+      setSessionArtifact,
+      selectLatestSessionForArtifact,
+    },
+    artifacts: {
+      config: artifactsConfig,
+      getArtifact: jest.fn((artifactId: string) => {
+        if (artifactId === sourceArtifactId) {
+          return {
+            id: sourceArtifactId,
+            type: 'worksheet',
+            title: 'Source Worksheet',
+          };
+        }
+        if (artifactId === targetArtifactId) {
+          return {
+            id: targetArtifactId,
+            type: targetType,
+            title: 'Target Worksheet',
+          };
+        }
+        return undefined;
+      }),
+      setCurrentArtifact,
+    },
+    blockDocuments: {
+      getBlocks: jest.fn((artifactId: string) => blocksByArtifact[artifactId]),
+      appendBlocks,
+    },
+  } as unknown as RoomState;
+
+  return {
+    appendBlocks,
+    blocksByArtifact,
+    forkSessionFromMessage,
+    selectLatestSessionForArtifact,
+    setCurrentArtifact,
+    setSessionArtifact,
+    setSessionDraftContextItemIds,
+    setSessionRunContext,
+    state,
+  };
+}
+
+async function triggerHandoff(state: RoomState) {
+  const controller = createArtifactChatHandoffController({
+    getState: () => state,
+  } as any);
+  await controller.commandMiddleware(
+    {id: 'block-document.create'} as any,
+    undefined,
+    {
+      getState: () => state,
+      invocation: {
+        surface: 'ai',
+        metadata: {aiSessionId: sourceSessionId},
+      },
+    } as any,
+    async () => ({
+      success: true,
+      data: {
+        artifactTargetChange: {
+          artifactId: targetArtifactId,
+          artifactType: 'worksheet',
+          title: 'Target Worksheet',
+          change: 'created',
+          shouldContinueChat: true,
+        },
+      },
+    }),
+  );
+  expect(state.artifacts.config.currentArtifactId).toBe(sourceArtifactId);
+  controller.onChatFinish({
+    sessionId: sourceSessionId,
+    messages: [
+      userMessage('create a new worksheet with the same chart'),
+      assistantMessage(),
+    ],
+  });
+}
+
+describe('createArtifactChatHandoffController', () => {
+  it('copies source chart blocks into an empty target for same-chart handoff', async () => {
+    const {
+      appendBlocks,
+      blocksByArtifact,
+      setCurrentArtifact,
+      setSessionArtifact,
+      setSessionDraftContextItemIds,
+      state,
+    } = createState();
+
+    await triggerHandoff(state);
+
+    expect(appendBlocks).toHaveBeenCalledTimes(1);
+    expect(appendBlocks).toHaveBeenCalledWith(targetArtifactId, [
+      expect.objectContaining({
+        type: 'chart',
+        tableName: '"main"."cars"',
+        caption: 'MPG vs Weight',
+      }),
+    ]);
+    expect(blocksByArtifact[targetArtifactId][0].id).not.toBe('source-chart');
+    expect(setSessionArtifact).toHaveBeenCalledWith(
+      targetSessionId,
+      targetArtifactId,
+    );
+    expect(setSessionArtifact).toHaveBeenCalledWith(
+      sourceSessionId,
+      sourceArtifactId,
+    );
+    expect(setSessionDraftContextItemIds).toHaveBeenCalledWith(
+      sourceSessionId,
+      undefined,
+    );
+    expect(setSessionDraftContextItemIds).toHaveBeenCalledWith(
+      targetSessionId,
+      undefined,
+    );
+    expect(setCurrentArtifact).toHaveBeenNthCalledWith(1, sourceArtifactId);
+    expect(setCurrentArtifact).toHaveBeenLastCalledWith(targetArtifactId);
+  });
+
+  it('does not copy chart blocks when the target was already populated', async () => {
+    const {appendBlocks, state} = createState({
+      targetBlocks: [
+        {
+          id: 'target-chart',
+          type: 'chart',
+          tableName: '"main"."cars"',
+          config: {chartType: 'scatter'},
+        },
+      ],
+    });
+
+    await triggerHandoff(state);
+
+    expect(appendBlocks).not.toHaveBeenCalled();
+  });
+
+  it('does not copy chart blocks for a non-copy prompt with an empty target', async () => {
+    const {appendBlocks, state} = createState({
+      prompt: 'what columns are in this worksheet?',
+    });
+
+    await triggerHandoff(state);
+
+    expect(appendBlocks).not.toHaveBeenCalled();
+  });
+
+  it('does not copy chart blocks into non-worksheet targets', async () => {
+    const {appendBlocks, state} = createState({
+      targetType: 'dashboard',
+    });
+
+    await triggerHandoff(state);
+
+    expect(appendBlocks).not.toHaveBeenCalled();
+  });
+});

--- a/apps/sqlrooms-cli-ui/src/ai/__tests__/createWorksheetAgentTool.test.ts
+++ b/apps/sqlrooms-cli-ui/src/ai/__tests__/createWorksheetAgentTool.test.ts
@@ -1,0 +1,200 @@
+import {jest} from '@jest/globals';
+import type {
+  BlockDocumentAiAdapter,
+  BlockDocumentBlockType,
+} from '@sqlrooms/documents';
+import type {BaseAgentToolOptions} from '@sqlrooms/mosaic/ai';
+import {tool} from 'ai';
+import {z} from 'zod';
+import {createWorksheetAgentTool} from '../createWorksheetAgentTool';
+import type {RoomState} from '../../store-types';
+
+type RunSubAgent = BaseAgentToolOptions<RoomState>['runSubAgent'];
+type WorksheetAgentToolResult = {
+  success: boolean;
+  finalOutput: string;
+  worksheetId: string;
+  metadata?: {
+    stepsExecuted: number;
+    queriesRun: number;
+  };
+};
+type TestBlockDocumentAiAdapter = BlockDocumentAiAdapter & {
+  moveBlock(
+    blockDocumentId: string,
+    blockId: string,
+    toIndex: number,
+  ): boolean | Promise<boolean>;
+};
+
+describe('createWorksheetAgentTool', () => {
+  it('retries when the sub-agent returns text without mutating the worksheet', async () => {
+    const blocks: BlockDocumentBlockType[] = [];
+    const addBlock: BlockDocumentAiAdapter['addBlock'] = async (
+      _worksheetId,
+      block,
+    ) => {
+      blocks.push(block);
+      return block.id;
+    };
+    const blockDocumentAdapter: TestBlockDocumentAiAdapter = {
+      ensureBlockDocument: jest.fn(),
+      setCurrentBlockDocument: jest.fn(),
+      getBlocks: jest.fn(() => blocks),
+      addBlock,
+      moveBlock: jest.fn(() => true),
+    };
+    const runSubAgent = jest
+      .fn<RunSubAgent>()
+      .mockImplementationOnce(async () => ({
+        finalOutput: 'I added the chart.',
+        agentToolCalls: [{toolName: 'query'}],
+      }))
+      .mockImplementationOnce(async () => {
+        blocks.push({
+          id: 'chart-1',
+          type: 'chart',
+          tableName: '"main"."cars"',
+          config: {chartType: 'scatter'},
+        });
+        return {
+          finalOutput: 'Chart added.',
+          agentToolCalls: [
+            {
+              toolName: 'create_block_document_chart_scatter',
+            },
+          ],
+        };
+      });
+
+    const worksheetAgent = createWorksheetAgentTool({
+      store: {getState: () => ({}) as any},
+      getModel: () => ({}) as any,
+      runSubAgent,
+      databaseAdapter: {
+        getTables: () => [],
+        findTable: () => undefined,
+      },
+      blockDocumentAdapter,
+      dashboardAgentTool: tool({
+        description: 'No-op dashboard agent for tests.',
+        inputSchema: z.object({}),
+        execute: async () => ({success: true}),
+      }),
+      htmlAppBlocksEnabled: false,
+      createDashboardBlock: jest.fn() as any,
+      createDataTableExplorerBlock: jest.fn() as any,
+    });
+
+    const result = (await (
+      worksheetAgent as unknown as {
+        execute: (
+          input: {
+            reasoning: string;
+            intent: string;
+            worksheetId: string;
+            maxSteps: number;
+          },
+          options: {toolCallId: string},
+        ) => Promise<WorksheetAgentToolResult>;
+      }
+    ).execute(
+      {
+        reasoning: 'test',
+        intent: 'add a scatter plot',
+        worksheetId: 'worksheet-1',
+        maxSteps: 5,
+      },
+      {toolCallId: 'parent-tool'},
+    )) as WorksheetAgentToolResult;
+
+    expect(result).toMatchObject({
+      success: true,
+      finalOutput: 'Chart added.',
+      worksheetId: 'worksheet-1',
+    });
+    expect(runSubAgent).toHaveBeenCalledTimes(2);
+    expect(runSubAgent.mock.calls[1]?.[0].prompt).toContain(
+      'did not modify the worksheet',
+    );
+    expect(result.metadata).toEqual({
+      stepsExecuted: 2,
+      queriesRun: 1,
+    });
+  });
+
+  it('allows read-only worksheet requests to return text without mutation', async () => {
+    const blocks: BlockDocumentBlockType[] = [];
+    const addBlock: BlockDocumentAiAdapter['addBlock'] = async (
+      _worksheetId,
+      block,
+    ) => {
+      blocks.push(block);
+      return block.id;
+    };
+    const blockDocumentAdapter: TestBlockDocumentAiAdapter = {
+      ensureBlockDocument: jest.fn(),
+      setCurrentBlockDocument: jest.fn(),
+      getBlocks: jest.fn(() => blocks),
+      addBlock,
+      moveBlock: jest.fn(() => true),
+    };
+    const runSubAgent = jest.fn<RunSubAgent>().mockResolvedValue({
+      finalOutput: 'The worksheet has MPG and Weight columns.',
+      agentToolCalls: [{toolName: 'query'}],
+    });
+
+    const worksheetAgent = createWorksheetAgentTool({
+      store: {getState: () => ({}) as any},
+      getModel: () => ({}) as any,
+      runSubAgent,
+      databaseAdapter: {
+        getTables: () => [],
+        findTable: () => undefined,
+      },
+      blockDocumentAdapter,
+      dashboardAgentTool: tool({
+        description: 'No-op dashboard agent for tests.',
+        inputSchema: z.object({}),
+        execute: async () => ({success: true}),
+      }),
+      htmlAppBlocksEnabled: false,
+      createDashboardBlock: jest.fn() as any,
+      createDataTableExplorerBlock: jest.fn() as any,
+    });
+
+    const result = (await (
+      worksheetAgent as unknown as {
+        execute: (
+          input: {
+            reasoning: string;
+            intent: string;
+            worksheetId: string;
+            maxSteps: number;
+          },
+          options: {toolCallId: string},
+        ) => Promise<WorksheetAgentToolResult>;
+      }
+    ).execute(
+      {
+        reasoning: 'test',
+        intent: 'what columns are in this worksheet?',
+        worksheetId: 'worksheet-1',
+        maxSteps: 5,
+      },
+      {toolCallId: 'parent-tool'},
+    )) as WorksheetAgentToolResult;
+
+    expect(result).toMatchObject({
+      success: true,
+      finalOutput: 'The worksheet has MPG and Weight columns.',
+      worksheetId: 'worksheet-1',
+      metadata: {
+        stepsExecuted: 1,
+        queriesRun: 1,
+      },
+    });
+    expect(runSubAgent).toHaveBeenCalledTimes(1);
+    expect(blocks).toEqual([]);
+  });
+});

--- a/apps/sqlrooms-cli-ui/src/ai/createWorksheetAgentTool.ts
+++ b/apps/sqlrooms-cli-ui/src/ai/createWorksheetAgentTool.ts
@@ -10,6 +10,8 @@ import {
   calculateAgentResultMetadata,
   createChartToolsInstructions,
   resolveChartTypes,
+  type AgentRunResult,
+  type AgentToolCall,
   type DatabaseAiAdapter,
 } from '@sqlrooms/mosaic/ai';
 import type {BlockDocumentAiAdapter} from '@sqlrooms/documents';
@@ -296,6 +298,48 @@ const WorksheetAgentInputSchema = z.object({
 
 type WorksheetAgentInputSchema = z.infer<typeof WorksheetAgentInputSchema>;
 
+const WORKSHEET_MUTATION_TOOL_NAMES = new Set<string>([
+  KnownWorksheetTools.add_text_block,
+  KnownWorksheetTools.add_dashboard_block,
+  KnownWorksheetTools.add_data_table_explorer,
+  KnownWorksheetTools.add_html_app_block,
+  KnownWorksheetTools.create_block_document_map_block,
+  KnownWorksheetTools.embedded_dashboard_agent,
+  KnownWorksheetTools.embedded_html_app_agent,
+]);
+
+function hasWorksheetMutationToolCall(toolCalls: AgentToolCall[] = []) {
+  for (const toolCall of toolCalls) {
+    if (
+      toolCall.toolName.startsWith(BLOCK_DOCUMENT_CHART_TOOL_PREFIX) ||
+      WORKSHEET_MUTATION_TOOL_NAMES.has(toolCall.toolName)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function shouldRequireWorksheetMutation(intent: string) {
+  const normalized = intent.toLowerCase();
+  if (
+    /^\s*(what|which|who|when|where|why|how|list|tell|describe|explain|inspect)\b/.test(
+      normalized,
+    )
+  ) {
+    return false;
+  }
+
+  return (
+    /\b(add|append|build|copy|create|delete|duplicate|edit|embed|graph|insert|make|modify|move|plot|put|remove|replace|update|visuali[sz]e)\b/.test(
+      normalized,
+    ) ||
+    /\b(chart|dashboard|data table explorer|html app|map|text block|worksheet block)\b/.test(
+      normalized,
+    )
+  );
+}
+
 /**
  * Creates the CLI worksheet artifact agent tool.
  */
@@ -366,7 +410,8 @@ IMPORTANT: IF primary artefact in run context is a worksheet, prioritize using t
 
       try {
         blockDocumentAdapter.ensureBlockDocument(worksheetId);
-        blockDocumentAdapter.setCurrentBlockDocument(worksheetId);
+        const initialBlockCount =
+          blockDocumentAdapter.getBlocks(worksheetId)?.length ?? 0;
 
         const dataTools = options.createDataTools?.({store}) ?? {};
 
@@ -399,18 +444,50 @@ IMPORTANT: IF primary artefact in run context is a worksheet, prioritize using t
             .join('\n\n'),
         });
 
-        const result = await options.runSubAgent({
-          agent,
-          prompt: intent,
-          store,
-          parentToolCallId: toolOptions?.toolCallId || '',
-          abortSignal: toolOptions?.abortSignal,
-        });
+        const runWorksheetSubAgent = (prompt: string) =>
+          options.runSubAgent({
+            agent,
+            prompt,
+            store,
+            parentToolCallId: toolOptions?.toolCallId || '',
+            abortSignal: toolOptions?.abortSignal,
+          });
 
-        const metadata = calculateAgentResultMetadata(
-          undefined,
-          result.agentToolCalls,
-        );
+        let result: AgentRunResult = await runWorksheetSubAgent(intent);
+        const allToolCalls = [...(result.agentToolCalls ?? [])];
+        const requiresWorksheetMutation =
+          shouldRequireWorksheetMutation(intent);
+        let currentBlockCount =
+          blockDocumentAdapter.getBlocks(worksheetId)?.length ?? 0;
+
+        if (
+          requiresWorksheetMutation &&
+          currentBlockCount === initialBlockCount &&
+          !hasWorksheetMutationToolCall(allToolCalls)
+        ) {
+          result = await runWorksheetSubAgent(`${intent}
+
+The previous attempt did not modify the worksheet. You must call one of the worksheet block mutation tools, such as a ${BLOCK_DOCUMENT_CHART_TOOL_PREFIX}* chart tool, ${KnownWorksheetTools.add_text_block}, ${KnownWorksheetTools.add_dashboard_block}, or another add/update worksheet block tool. Do not answer with only text.`);
+          allToolCalls.push(...(result.agentToolCalls ?? []));
+          currentBlockCount =
+            blockDocumentAdapter.getBlocks(worksheetId)?.length ?? 0;
+        }
+
+        if (
+          requiresWorksheetMutation &&
+          currentBlockCount === initialBlockCount &&
+          !hasWorksheetMutationToolCall(allToolCalls)
+        ) {
+          return {
+            success: false,
+            finalOutput:
+              'Worksheet agent did not modify the worksheet. Please retry and call a worksheet block mutation tool.',
+            worksheetId,
+            error: 'Worksheet agent completed without a worksheet mutation.',
+          };
+        }
+
+        const metadata = calculateAgentResultMetadata(undefined, allToolCalls);
 
         return {
           success: true,

--- a/apps/sqlrooms-cli-ui/src/artifactChatHandoff.ts
+++ b/apps/sqlrooms-cli-ui/src/artifactChatHandoff.ts
@@ -1,209 +1,86 @@
-import {setAiRunContextPrimaryItem} from '@sqlrooms/ai';
-import type {ArtifactTargetChange} from '@sqlrooms/artifacts/ai';
-import type {RoomCommandMiddleware} from '@sqlrooms/room-shell';
-import type {UIMessage} from 'ai';
+import {
+  createArtifactAiChatHandoffController,
+  type ArtifactAiChatHandoffTargetForkContext,
+} from '@sqlrooms/artifacts/ai';
+import {
+  createDefaultBlockDocumentBlockId,
+  type BlockDocumentBlockType,
+} from '@sqlrooms/documents';
 import type {StoreApi} from 'zustand';
 import {CLI_ARTIFACT_TYPES} from './artifactTypeIds';
 import type {RoomState} from './store-types';
 
-type PendingArtifactChatHandoff = {
-  sourceSessionId: string;
-  sourceArtifactId: string;
-  sourceUserMessageId: string;
-  target: ArtifactTargetChange;
-  commandId: string;
-};
-
 const SUPPORTED_HANDOFF_ARTIFACT_TYPES = new Set<string>(CLI_ARTIFACT_TYPES);
 
-function readArtifactTargetChange(
-  result: unknown,
-): ArtifactTargetChange | undefined {
-  if (!result || typeof result !== 'object') return undefined;
-  const data = (result as {data?: unknown}).data;
-  if (!data || typeof data !== 'object') return undefined;
-  const candidate = (data as {artifactTargetChange?: unknown})
-    .artifactTargetChange;
-  if (!candidate || typeof candidate !== 'object') return undefined;
-
-  const record = candidate as Record<string, unknown>;
-  if (
-    typeof record.artifactId !== 'string' ||
-    typeof record.artifactType !== 'string' ||
-    typeof record.title !== 'string' ||
-    (record.change !== 'created' && record.change !== 'selected')
-  ) {
-    return undefined;
-  }
-
-  return {
-    artifactId: record.artifactId,
-    artifactType: record.artifactType,
-    title: record.title,
-    change: record.change,
-    ...(typeof record.shouldContinueChat === 'boolean'
-      ? {shouldContinueChat: record.shouldContinueChat}
-      : {}),
-  };
+function isSameChartRequest(text: string) {
+  const normalized = text.toLowerCase();
+  return (
+    /\bsame\s+chart\b/.test(normalized) ||
+    /\bcopy\s+(?:the\s+)?chart\b/.test(normalized) ||
+    /\bduplicate\s+(?:the\s+)?chart\b/.test(normalized)
+  );
 }
 
-function getInvocationAiSessionId(metadata?: Record<string, unknown>) {
-  const aiSessionId = metadata?.aiSessionId;
-  return typeof aiSessionId === 'string' ? aiSessionId : undefined;
+function cloneChartBlocks(blocks: BlockDocumentBlockType[]) {
+  return blocks
+    .filter((block) => block.type === 'chart')
+    .map((block) => ({
+      ...structuredClone(block),
+      id: createDefaultBlockDocumentBlockId(),
+    })) as BlockDocumentBlockType[];
 }
 
-function getLastAssistantMessage(messages: UIMessage[]) {
-  for (let index = messages.length - 1; index >= 0; index--) {
-    const message = messages[index];
-    if (message?.role === 'assistant') {
-      return {message, index};
-    }
-  }
-  return undefined;
-}
-
-function getLastUserMessageId(
-  messages: ReadonlyArray<{id?: string; role?: string}>,
+function copySourceChartBlocksToEmptyTarget(
+  state: RoomState,
+  sourceArtifactId: string,
+  targetArtifactId: string,
 ) {
-  for (let index = messages.length - 1; index >= 0; index--) {
-    const message = messages[index];
-    if (message?.role === 'user' && typeof message.id === 'string') {
-      return message.id;
-    }
+  const targetBlocks = state.blockDocuments.getBlocks(targetArtifactId);
+  if (targetBlocks.length > 0) return;
+
+  const chartBlocks = cloneChartBlocks(
+    state.blockDocuments.getBlocks(sourceArtifactId),
+  );
+  if (chartBlocks.length === 0) return;
+
+  state.blockDocuments.appendBlocks(targetArtifactId, chartBlocks);
+}
+
+function copySourceChartBlocksForSameChartRequest({
+  state,
+  sourceArtifact,
+  sourceUserMessage,
+  targetArtifact,
+}: ArtifactAiChatHandoffTargetForkContext<RoomState>) {
+  if (!isSameChartRequest(sourceUserMessage.text)) return;
+  if (
+    sourceArtifact.type !== 'worksheet' ||
+    targetArtifact.type !== 'worksheet'
+  ) {
+    return;
   }
-  return undefined;
+
+  copySourceChartBlocksToEmptyTarget(
+    state,
+    sourceArtifact.id,
+    targetArtifact.id,
+  );
 }
 
 /**
- * Creates the command and chat-finish hooks that continue an artifact-scoped
- * AI chat when an AI-invoked command switches to another artifact.
+ * Creates the CLI policy wrapper around generic artifact AI chat handoff.
  *
- * @param store - The CLI room store used to inspect artifact and AI session state.
- * @returns Hooks for command middleware and completed chat turns.
+ * The package controller owns artifact/session handoff mechanics. The CLI app
+ * keeps worksheet-specific content behavior, such as copying chart blocks for
+ * "same chart" requests.
  */
 export function createArtifactChatHandoffController(
   store: StoreApi<RoomState>,
 ) {
-  const pendingHandoffs = new Map<string, PendingArtifactChatHandoff>();
-
-  const commandMiddleware: RoomCommandMiddleware<RoomState> = async (
-    command,
-    _input,
-    context,
-    next,
-  ) => {
-    const sourceSessionId = getInvocationAiSessionId(
-      context.invocation.metadata,
-    );
-    const sourceArtifactId = sourceSessionId
-      ? context.getState().artifactAi.getSessionArtifactId(sourceSessionId)
-      : undefined;
-
-    const result = await next();
-    if (
-      !sourceSessionId ||
-      !sourceArtifactId ||
-      context.invocation.surface !== 'ai'
-    ) {
-      return result;
-    }
-
-    const target = readArtifactTargetChange(result);
-    if (
-      !target ||
-      target.shouldContinueChat === false ||
-      target.artifactId === sourceArtifactId ||
-      !SUPPORTED_HANDOFF_ARTIFACT_TYPES.has(target.artifactType)
-    ) {
-      return result;
-    }
-
-    const nextState = store.getState();
-    const targetArtifact = nextState.artifacts.getArtifact(target.artifactId);
-    if (!targetArtifact) return result;
-    if (nextState.artifacts.config.currentArtifactId !== target.artifactId) {
-      return result;
-    }
-    const sourceSession = nextState.ai.config.sessions.find(
-      (session) => session.id === sourceSessionId,
-    );
-    const sourceUserMessageId = getLastUserMessageId(
-      sourceSession?.uiMessages ?? [],
-    );
-    if (!sourceUserMessageId) return result;
-
-    pendingHandoffs.set(sourceSessionId, {
-      sourceSessionId,
-      sourceArtifactId,
-      sourceUserMessageId,
-      target: {
-        ...target,
-        title: targetArtifact.title,
-        artifactType: targetArtifact.type,
-      },
-      commandId: command.id,
-    });
-
-    return result;
-  };
-
-  const onChatFinish = ({
-    sessionId,
-    messages,
-  }: {
-    sessionId: string;
-    messages: UIMessage[];
-  }) => {
-    const handoff = pendingHandoffs.get(sessionId);
-    if (!handoff) return;
-    pendingHandoffs.delete(sessionId);
-
-    const state = store.getState();
-    const targetArtifact = state.artifacts.getArtifact(
-      handoff.target.artifactId,
-    );
-    if (!targetArtifact) return;
-    if (
-      state.artifactAi.getSessionArtifactId(handoff.sourceSessionId) !==
-      handoff.sourceArtifactId
-    ) {
-      return;
-    }
-    if (
-      state.artifacts.config.currentArtifactId !== handoff.target.artifactId
-    ) {
-      return;
-    }
-
-    const assistantMessage = getLastAssistantMessage(messages);
-    if (!assistantMessage) return;
-    if (getLastUserMessageId(messages) !== handoff.sourceUserMessageId) {
-      return;
-    }
-
-    const targetSessionId = state.ai.forkSessionFromMessage({
-      sourceSessionId: handoff.sourceSessionId,
-      sourceMessageId: assistantMessage.message.id,
-      sourceMessageIndex: assistantMessage.index,
-      name: `Continue: ${targetArtifact.title}`,
-    });
-    if (!targetSessionId) return;
-
-    state.artifactAi.setSessionArtifact(targetSessionId, targetArtifact.id);
-    state.ai.setSessionRunContext(
-      targetSessionId,
-      setAiRunContextPrimaryItem(
-        state.ai.getSessionRunContext(targetSessionId),
-        {
-          kind: 'artifact',
-          id: targetArtifact.id,
-          type: targetArtifact.type,
-          title: targetArtifact.title,
-        },
-      ),
-    );
-    state.artifactAi.selectLatestSessionForArtifact(targetArtifact.id);
-  };
-
-  return {commandMiddleware, onChatFinish};
+  return createArtifactAiChatHandoffController<RoomState>({
+    store,
+    isSupportedArtifact: (artifact) =>
+      SUPPORTED_HANDOFF_ARTIFACT_TYPES.has(artifact.type),
+    onBeforeTargetFork: copySourceChartBlocksForSameChartRequest,
+  });
 }

--- a/apps/sqlrooms-cli-ui/src/components/AssistantChatContainer.tsx
+++ b/apps/sqlrooms-cli-ui/src/components/AssistantChatContainer.tsx
@@ -1,5 +1,8 @@
 import {Chat, isChatSessionEmpty} from '@sqlrooms/ai';
-import {isAiSessionVisibleForArtifact} from '@sqlrooms/artifacts/ai';
+import {
+  isAiSessionVisibleForArtifact,
+  switchToArtifactAiSession,
+} from '@sqlrooms/artifacts/ai';
 import {
   Button,
   ResizableHandle,
@@ -64,6 +67,13 @@ export const AssistantChatContainer: React.FC<AssistantChatContainerProps> = ({
     createArtifactScopedSession();
   }, [createArtifactScopedSession, createSessionDisabled]);
 
+  const handleSwitchToForkSource = useCallback(
+    (sourceSession: (typeof sessions)[number]) => {
+      switchToArtifactAiSession(useRoomStore, sourceSession.id);
+    },
+    [],
+  );
+
   const filterSession = useCallback(
     (session: (typeof sessions)[number]) =>
       isAiSessionVisibleForArtifact(
@@ -93,7 +103,11 @@ export const AssistantChatContainer: React.FC<AssistantChatContainerProps> = ({
   const messagesPane = (
     <div className="print-container h-full min-h-0 grow overflow-hidden">
       {isDataAvailable ? (
-        <Chat.Messages key={currentSessionId} hoistedRenderers={['chart']} />
+        <Chat.Messages
+          key={currentSessionId}
+          hoistedRenderers={['chart']}
+          onSwitchToForkSource={handleSwitchToForkSource}
+        />
       ) : (
         <div className="flex h-full w-full flex-col items-center justify-center">
           <SkeletonPane className="p-4" />
@@ -139,9 +153,7 @@ export const AssistantChatContainer: React.FC<AssistantChatContainerProps> = ({
                 filterSession={filterSession}
                 emptyLabel="No chats for this item yet"
                 onSelectChat={(sessionId) => {
-                  const switchSession =
-                    useRoomStore.getState().ai.switchSession;
-                  switchSession(sessionId);
+                  switchToArtifactAiSession(useRoomStore, sessionId);
                   setShowHistory(false);
                 }}
                 className="flex-1"

--- a/packages/ai-core/src/components/ChatMessagesContainer.tsx
+++ b/packages/ai-core/src/components/ChatMessagesContainer.tsx
@@ -11,6 +11,17 @@ import type {ErrorMessageComponentProps} from './ErrorMessage';
 import {getChatTurnsFromUiMessages} from '../chatTurns';
 import type {AiSessionForkOrigin, ChatSessionSchema} from '@sqlrooms/ai-config';
 
+/**
+ * Host callback invoked when a user chooses a fork's source chat.
+ *
+ * @param sourceSession - The source session referenced by the fork provenance.
+ * @param forkOrigin - Metadata describing how the current session was forked.
+ */
+export type ChatForkSourceSwitchHandler = (
+  sourceSession: ChatSessionSchema,
+  forkOrigin: AiSessionForkOrigin,
+) => void;
+
 function ChatForkProvenance({
   forkOrigin,
   sourceSession,
@@ -23,23 +34,23 @@ function ChatForkProvenance({
   const sourceLabel = sourceSession?.name || forkOrigin.sourceSessionNameAtFork;
 
   return (
-    <div className="text-muted-foreground my-4 flex items-center gap-3 text-sm">
-      <div className="bg-border h-px min-w-8 flex-1" />
+    <div className="text-muted-foreground my-4 flex w-full max-w-full min-w-0 items-center gap-2 text-sm">
+      <div className="bg-border h-px min-w-0 flex-1" />
       <SplitIcon className="h-4 w-4 shrink-0 rotate-90" />
       {sourceSession ? (
         <button
           type="button"
-          className="text-primary hover:text-primary/80 min-w-0 truncate underline-offset-4 hover:underline"
+          className="text-primary hover:text-primary/80 block max-w-full min-w-0 flex-shrink truncate text-left underline-offset-4 hover:underline"
           onClick={onSwitchToSource}
         >
           Forked from {sourceLabel}
         </button>
       ) : (
-        <span className="min-w-0 truncate">
+        <span className="block max-w-full min-w-0 flex-shrink truncate">
           Forked from {sourceLabel || 'deleted conversation'}
         </span>
       )}
-      <div className="bg-border h-px min-w-8 flex-1" />
+      <div className="bg-border h-px min-w-0 flex-1" />
     </div>
   );
 }
@@ -49,11 +60,13 @@ export const ChatMessagesContainer: React.FC<{
   customMarkdownComponents?: Partial<Components>;
   hoistedRenderers?: string[];
   ErrorMessageComponent?: React.ComponentType<ErrorMessageComponentProps>;
+  onSwitchToForkSource?: ChatForkSourceSwitchHandler;
 }> = ({
   className,
   customMarkdownComponents,
   hoistedRenderers,
   ErrorMessageComponent,
+  onSwitchToForkSource,
 }) => {
   const currentSession = useStoreWithAi((s) => s.ai.getCurrentSession());
   const sessionId = currentSession?.id;
@@ -118,9 +131,9 @@ export const ChatMessagesContainer: React.FC<{
     <div className={cn('relative flex h-full w-full flex-col', className)}>
       <ScrollArea
         viewportRef={containerRef}
-        className="flex w-full grow flex-col gap-5"
+        className="min-w-0 grow overflow-hidden [&_[data-radix-scroll-area-viewport]>div]:!block [&_[data-radix-scroll-area-viewport]>div]:!w-full [&_[data-radix-scroll-area-viewport]>div]:!min-w-0"
       >
-        <div className="pr-3">
+        <div className="max-w-full min-w-0 pr-3">
           {chatTurns.map((chatTurn) => (
             <React.Fragment key={chatTurn.id}>
               <ChatTurnView
@@ -134,7 +147,12 @@ export const ChatMessagesContainer: React.FC<{
                   forkOrigin={forkOrigin}
                   sourceSession={sourceSession}
                   onSwitchToSource={() => {
-                    if (sourceSession) switchSession(sourceSession.id);
+                    if (!sourceSession) return;
+                    if (onSwitchToForkSource) {
+                      onSwitchToForkSource(sourceSession, forkOrigin);
+                      return;
+                    }
+                    switchSession(sourceSession.id);
                   }}
                 />
               )}
@@ -146,6 +164,7 @@ export const ChatMessagesContainer: React.FC<{
           <div className="h-10 w-full shrink-0" />
         </div>
         <ScrollBar orientation="vertical" />
+        <ScrollBar orientation="horizontal" />
       </ScrollArea>
       <div className="pointer-events-none absolute inset-x-0 bottom-0 flex justify-center">
         <button

--- a/packages/artifacts/README.md
+++ b/packages/artifacts/README.md
@@ -228,6 +228,28 @@ Reusable helpers include:
 - `getLatestAiSessionIdForArtifact`
 - `getEmptyAiSessionIdForArtifact`
 - `getAiSessionIdsForArtifact`
+- `switchToArtifactAiSession`
+
+Use `switchToArtifactAiSession(store, sessionId)` when navigating to an
+artifact-owned chat from history or fork provenance. It selects the owning
+artifact before switching sessions so artifact/session auto-sync does not
+immediately move the chat back to the previously selected artifact.
+
+Apps that use artifact-creating commands from AI can compose
+`createArtifactAiChatHandoffController()` with command middleware and
+`ai.onChatFinish`. The controller keeps generic artifact/session handoff
+behavior in the package:
+
+- detects AI-invoked command results with `data.artifactTargetChange`
+- restores the source artifact while the current turn is still running
+- forks the finished source chat into a target artifact chat
+- binds source and target sessions to their artifacts
+- clears inherited draft context and updates artifact run context
+
+App-specific artifact content policy stays in hooks. For example, a document
+app can provide `onBeforeTargetFork` to copy selected blocks into an empty
+target artifact without teaching the package about that artifact type.
+
 - `getAiSessionGroupsByArtifact`
 - `getRunningAiSessionCountsByArtifact`
 - `getOwningArtifactRunContextItems`

--- a/packages/artifacts/__tests__/artifactAiChatHandoff.test.ts
+++ b/packages/artifacts/__tests__/artifactAiChatHandoff.test.ts
@@ -1,0 +1,310 @@
+import type {AiRunContext} from '@sqlrooms/ai-config';
+import type {UIMessage} from 'ai';
+import {
+  createArtifactAiChatHandoffController,
+  switchToArtifactAiSession,
+  type ArtifactAiChatHandoffState,
+} from '../src/ai';
+
+const sourceArtifactId = 'source-artifact';
+const targetArtifactId = 'target-artifact';
+const sourceSessionId = 'source-session';
+const targetSessionId = 'target-session';
+
+function userMessage(text: string): UIMessage {
+  return {
+    id: 'user-1',
+    role: 'user',
+    parts: [{type: 'text', text}],
+  };
+}
+
+function assistantMessage(): UIMessage {
+  return {
+    id: 'assistant-1',
+    role: 'assistant',
+    parts: [{type: 'text', text: 'Done.'}],
+  };
+}
+
+function createState({
+  sourceSessionArtifactId = sourceArtifactId,
+}: {
+  sourceSessionArtifactId?: string | null;
+} = {}) {
+  const artifactsConfig = {currentArtifactId: targetArtifactId};
+  const operationCalls: string[] = [];
+  const setCurrentArtifactCalls: string[] = [];
+  const setCurrentArtifact = (artifactId: string) => {
+    operationCalls.push(`artifact:${artifactId}`);
+    setCurrentArtifactCalls.push(artifactId);
+    artifactsConfig.currentArtifactId = artifactId;
+  };
+  const setSessionArtifactCalls: Array<[string, string]> = [];
+  const setSessionArtifact = (sessionId: string, artifactId: string) => {
+    setSessionArtifactCalls.push([sessionId, artifactId]);
+  };
+  const setSessionDraftContextItemIdsCalls: Array<
+    [string, string[] | undefined]
+  > = [];
+  const setSessionDraftContextItemIds = (
+    sessionId: string,
+    itemIds: string[] | undefined,
+  ) => {
+    setSessionDraftContextItemIdsCalls.push([sessionId, itemIds]);
+  };
+  const setSessionRunContextCalls: Array<[string, AiRunContext | undefined]> =
+    [];
+  const setSessionRunContext = (
+    sessionId: string,
+    runContext: AiRunContext | undefined,
+  ) => {
+    setSessionRunContextCalls.push([sessionId, runContext]);
+  };
+  const selectLatestSessionForArtifactCalls: string[] = [];
+  const selectLatestSessionForArtifact = (artifactId?: string) => {
+    if (artifactId) {
+      selectLatestSessionForArtifactCalls.push(artifactId);
+    }
+  };
+  const forkSessionFromMessageCalls: unknown[] = [];
+  const forkSessionFromMessage = (args: unknown) => {
+    forkSessionFromMessageCalls.push(args);
+    return targetSessionId;
+  };
+  const switchSessionCalls: string[] = [];
+  const switchSession = (sessionId: string) => {
+    operationCalls.push(`session:${sessionId}`);
+    switchSessionCalls.push(sessionId);
+  };
+
+  const state = {
+    ai: {
+      config: {
+        sessions: [
+          {
+            id: sourceSessionId,
+            uiMessages: [userMessage('create a new artifact')],
+          },
+          {
+            id: targetSessionId,
+            uiMessages: [],
+          },
+        ],
+      },
+      forkSessionFromMessage,
+      getSessionRunContext: () =>
+        ({
+          items: [
+            {
+              kind: 'artifact',
+              id: sourceArtifactId,
+              type: 'document',
+              title: 'Source Artifact',
+            },
+          ],
+          capturedAt: 1,
+        }) satisfies AiRunContext,
+      setSessionDraftContextItemIds,
+      setSessionRunContext,
+      switchSession,
+    },
+    artifactAi: {
+      getSessionArtifactId: (sessionId: string) =>
+        sessionId === sourceSessionId
+          ? (sourceSessionArtifactId ?? undefined)
+          : targetArtifactId,
+
+      setSessionArtifact,
+      selectLatestSessionForArtifact,
+    },
+    artifacts: {
+      config: artifactsConfig,
+      getArtifact: (artifactId: string) => {
+        if (artifactId === sourceArtifactId) {
+          return {
+            id: sourceArtifactId,
+            type: 'document',
+            title: 'Source Artifact',
+          };
+        }
+        if (artifactId === targetArtifactId) {
+          return {
+            id: targetArtifactId,
+            type: 'document',
+            title: 'Target Artifact',
+          };
+        }
+        return undefined;
+      },
+      setCurrentArtifact,
+    },
+  } as unknown as ArtifactAiChatHandoffState;
+
+  return {
+    forkSessionFromMessageCalls,
+    forkSessionFromMessage,
+    operationCalls,
+    selectLatestSessionForArtifactCalls,
+    selectLatestSessionForArtifact,
+    setCurrentArtifactCalls,
+    setCurrentArtifact,
+    setSessionArtifactCalls,
+    setSessionArtifact,
+    setSessionDraftContextItemIdsCalls,
+    setSessionDraftContextItemIds,
+    setSessionRunContextCalls,
+    setSessionRunContext,
+    state,
+    switchSessionCalls,
+    switchSession,
+  };
+}
+
+describe('switchToArtifactAiSession', () => {
+  it('selects the owning artifact before switching sessions', () => {
+    const {operationCalls, setCurrentArtifactCalls, state, switchSessionCalls} =
+      createState();
+
+    expect(
+      switchToArtifactAiSession({getState: () => state}, sourceSessionId),
+    ).toBe(true);
+
+    expect(setCurrentArtifactCalls).toEqual([sourceArtifactId]);
+    expect(switchSessionCalls).toEqual([sourceSessionId]);
+    expect(operationCalls).toEqual([
+      `artifact:${sourceArtifactId}`,
+      `session:${sourceSessionId}`,
+    ]);
+  });
+
+  it('does nothing for an unknown session', () => {
+    const {setCurrentArtifactCalls, state, switchSessionCalls} = createState();
+
+    expect(
+      switchToArtifactAiSession({getState: () => state}, 'missing-session'),
+    ).toBe(false);
+
+    expect(setCurrentArtifactCalls).toEqual([]);
+    expect(switchSessionCalls).toEqual([]);
+  });
+
+  it('switches the session without artifact navigation when the session is unowned', () => {
+    const {setCurrentArtifactCalls, state, switchSessionCalls} = createState({
+      sourceSessionArtifactId: null,
+    });
+
+    expect(
+      switchToArtifactAiSession({getState: () => state}, sourceSessionId),
+    ).toBe(true);
+
+    expect(setCurrentArtifactCalls).toEqual([]);
+    expect(switchSessionCalls).toEqual([sourceSessionId]);
+  });
+});
+
+describe('createArtifactAiChatHandoffController', () => {
+  it('restores the source artifact during the turn and forks to the target after finish', async () => {
+    const {
+      forkSessionFromMessageCalls,
+      selectLatestSessionForArtifactCalls,
+      setCurrentArtifactCalls,
+      setSessionArtifactCalls,
+      setSessionDraftContextItemIdsCalls,
+      setSessionRunContextCalls,
+      state,
+    } = createState();
+    const beforeSourceRestoreContexts: unknown[] = [];
+    const beforeTargetForkContexts: unknown[] = [];
+    const afterTargetForkContexts: unknown[] = [];
+    const controller = createArtifactAiChatHandoffController({
+      store: {getState: () => state},
+      onBeforeSourceRestore: (context) =>
+        beforeSourceRestoreContexts.push(context),
+      onBeforeTargetFork: (context) => beforeTargetForkContexts.push(context),
+      onAfterTargetFork: (context) => afterTargetForkContexts.push(context),
+    });
+
+    await controller.commandMiddleware(
+      {id: 'artifact.create'},
+      undefined,
+      {
+        getState: () => state,
+        invocation: {
+          surface: 'ai',
+          metadata: {aiSessionId: sourceSessionId},
+        },
+      },
+      async () => ({
+        success: true,
+        data: {
+          artifactTargetChange: {
+            artifactId: targetArtifactId,
+            artifactType: 'document',
+            title: 'Target Artifact',
+            change: 'created',
+            shouldContinueChat: true,
+          },
+        },
+      }),
+    );
+
+    expect(beforeSourceRestoreContexts).toEqual([
+      expect.objectContaining({
+        sourceArtifact: expect.objectContaining({id: sourceArtifactId}),
+        targetArtifact: expect.objectContaining({id: targetArtifactId}),
+        sourceUserMessage: {id: 'user-1', text: 'create a new artifact'},
+      }),
+    ]);
+    expect(setSessionArtifactCalls).toContainEqual([
+      sourceSessionId,
+      sourceArtifactId,
+    ]);
+    expect(setSessionDraftContextItemIdsCalls).toContainEqual([
+      sourceSessionId,
+      undefined,
+    ]);
+    expect(setSessionRunContextCalls).toContainEqual([
+      sourceSessionId,
+      expect.objectContaining({primaryItemId: sourceArtifactId}),
+    ]);
+    expect(setCurrentArtifactCalls).toContain(sourceArtifactId);
+
+    controller.onChatFinish({
+      sessionId: sourceSessionId,
+      messages: [userMessage('create a new artifact'), assistantMessage()],
+    });
+
+    expect(beforeTargetForkContexts).toEqual([
+      expect.objectContaining({
+        assistantMessage: expect.objectContaining({id: 'assistant-1'}),
+        targetArtifact: expect.objectContaining({id: targetArtifactId}),
+      }),
+    ]);
+    expect(forkSessionFromMessageCalls).toEqual([
+      {
+        sourceSessionId,
+        sourceMessageId: 'assistant-1',
+        sourceMessageIndex: 1,
+        name: 'Continue: Target Artifact',
+      },
+    ]);
+    expect(setSessionArtifactCalls).toContainEqual([
+      targetSessionId,
+      targetArtifactId,
+    ]);
+    expect(setSessionDraftContextItemIdsCalls).toContainEqual([
+      targetSessionId,
+      undefined,
+    ]);
+    expect(setSessionRunContextCalls).toContainEqual([
+      targetSessionId,
+      expect.objectContaining({primaryItemId: targetArtifactId}),
+    ]);
+    expect(setCurrentArtifactCalls.at(-1)).toBe(targetArtifactId);
+    expect(selectLatestSessionForArtifactCalls).toEqual([targetArtifactId]);
+    expect(afterTargetForkContexts).toEqual([
+      expect.objectContaining({targetSessionId}),
+    ]);
+  });
+});

--- a/packages/artifacts/src/ai/artifactAiChatHandoff.ts
+++ b/packages/artifacts/src/ai/artifactAiChatHandoff.ts
@@ -1,0 +1,448 @@
+import {
+  setAiRunContextPrimaryItem,
+  type AiRunContext,
+} from '@sqlrooms/ai-config';
+import type {UIMessage} from 'ai';
+import type {StoreApi} from 'zustand';
+import type {ArtifactMetadata} from '../ArtifactsSliceConfig';
+import type {RoomStateWithArtifactAi} from './artifactAiSlice';
+import type {ArtifactTargetChange} from './artifactTargetChange';
+
+type ForkSessionFromMessageArgs = {
+  sourceSessionId: string;
+  sourceMessageId: string;
+  sourceMessageIndex: number;
+  name?: string;
+};
+
+/**
+ * Minimal room state needed by the artifact AI chat handoff controller.
+ */
+export type ArtifactAiChatHandoffState = RoomStateWithArtifactAi & {
+  ai: RoomStateWithArtifactAi['ai'] & {
+    forkSessionFromMessage: (
+      args: ForkSessionFromMessageArgs,
+    ) => string | undefined;
+    getSessionRunContext: (sessionId: string) => AiRunContext | undefined;
+    setSessionRunContext: (
+      sessionId: string,
+      runContext: AiRunContext | undefined,
+    ) => void;
+    setSessionDraftContextItemIds: (
+      sessionId: string,
+      itemIds: string[] | undefined,
+    ) => void;
+  };
+};
+
+type ArtifactAiChatHandoffStore<TState extends ArtifactAiChatHandoffState> =
+  Pick<StoreApi<TState>, 'getState'>;
+
+type ArtifactAiCommand = {
+  id: string;
+};
+
+type ArtifactAiCommandInvocation = {
+  surface?: string;
+  metadata?: Record<string, unknown>;
+};
+
+type ArtifactAiCommandContext<TState extends ArtifactAiChatHandoffState> = {
+  getState: () => TState;
+  invocation: ArtifactAiCommandInvocation;
+};
+
+export type ArtifactAiCommandMiddleware<
+  TState extends ArtifactAiChatHandoffState,
+> = (
+  command: ArtifactAiCommand,
+  input: unknown,
+  context: ArtifactAiCommandContext<TState>,
+  next: () => Promise<unknown>,
+) => Promise<unknown>;
+
+export type ArtifactAiChatHandoffMessageSummary = {
+  id: string;
+  text: string;
+};
+
+export type ArtifactAiChatHandoffHookContext<
+  TState extends ArtifactAiChatHandoffState,
+> = {
+  state: TState;
+  commandId: string;
+  sourceArtifact: ArtifactMetadata;
+  targetArtifact: ArtifactMetadata;
+  sourceSessionId: string;
+  sourceUserMessage: ArtifactAiChatHandoffMessageSummary;
+  targetChange: ArtifactTargetChange;
+};
+
+export type ArtifactAiChatHandoffTargetForkContext<
+  TState extends ArtifactAiChatHandoffState,
+> = ArtifactAiChatHandoffHookContext<TState> & {
+  messages: UIMessage[];
+  assistantMessage: UIMessage;
+  assistantMessageIndex: number;
+};
+
+export type ArtifactAiChatHandoffAfterTargetForkContext<
+  TState extends ArtifactAiChatHandoffState,
+> = ArtifactAiChatHandoffTargetForkContext<TState> & {
+  targetSessionId: string;
+};
+
+export type CreateArtifactAiChatHandoffControllerOptions<
+  TState extends ArtifactAiChatHandoffState,
+> = {
+  /** Store containing artifact ownership and AI session state. */
+  store: ArtifactAiChatHandoffStore<TState>;
+  /** Optional predicate for apps that only support handoff for some artifacts. */
+  isSupportedArtifact?: (artifact: ArtifactMetadata) => boolean;
+  /**
+   * Optional app policy for whether an artifact target change should become a
+   * forked chat handoff.
+   */
+  shouldContinueChat?: (
+    context: ArtifactAiChatHandoffHookContext<TState> & {
+      result: unknown;
+    },
+  ) => boolean;
+  /**
+   * Runs after a pending handoff is recorded and before the source artifact is
+   * restored for the still-running turn.
+   */
+  onBeforeSourceRestore?: (
+    context: ArtifactAiChatHandoffHookContext<TState>,
+  ) => void;
+  /**
+   * Runs after the source turn finishes and before the target chat session is
+   * forked. Use this for artifact-type-specific content policy.
+   */
+  onBeforeTargetFork?: (
+    context: ArtifactAiChatHandoffTargetForkContext<TState>,
+  ) => void;
+  /** Runs after the target session is forked and bound to the target artifact. */
+  onAfterTargetFork?: (
+    context: ArtifactAiChatHandoffAfterTargetForkContext<TState>,
+  ) => void;
+};
+
+type PendingArtifactAiChatHandoff = {
+  sourceSessionId: string;
+  sourceArtifactId: string;
+  sourceUserMessage: ArtifactAiChatHandoffMessageSummary;
+  target: ArtifactTargetChange;
+  commandId: string;
+};
+
+/**
+ * Reads package-owned artifact target change metadata from a command result.
+ *
+ * @param result - Command result that may include `data.artifactTargetChange`.
+ * @returns A validated artifact target change, or `undefined`.
+ */
+export function readArtifactTargetChange(
+  result: unknown,
+): ArtifactTargetChange | undefined {
+  if (!result || typeof result !== 'object') return undefined;
+  const data = (result as {data?: unknown}).data;
+  if (!data || typeof data !== 'object') return undefined;
+  const candidate = (data as {artifactTargetChange?: unknown})
+    .artifactTargetChange;
+  if (!candidate || typeof candidate !== 'object') return undefined;
+
+  const record = candidate as Record<string, unknown>;
+  if (
+    typeof record.artifactId !== 'string' ||
+    typeof record.artifactType !== 'string' ||
+    typeof record.title !== 'string' ||
+    (record.change !== 'created' && record.change !== 'selected')
+  ) {
+    return undefined;
+  }
+
+  return {
+    artifactId: record.artifactId,
+    artifactType: record.artifactType,
+    title: record.title,
+    change: record.change,
+    ...(typeof record.shouldContinueChat === 'boolean'
+      ? {shouldContinueChat: record.shouldContinueChat}
+      : {}),
+  };
+}
+
+function getInvocationAiSessionId(metadata?: Record<string, unknown>) {
+  const aiSessionId = metadata?.aiSessionId;
+  return typeof aiSessionId === 'string' ? aiSessionId : undefined;
+}
+
+function getLastAssistantMessage(messages: UIMessage[]) {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (message?.role === 'assistant') {
+      return {message, index};
+    }
+  }
+  return undefined;
+}
+
+function getLastUserMessageId(
+  messages: ReadonlyArray<{id?: string; role?: string}>,
+) {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (message?.role === 'user' && typeof message.id === 'string') {
+      return message.id;
+    }
+  }
+  return undefined;
+}
+
+function getMessageText(message: UIMessage | undefined): string {
+  if (!message) return '';
+
+  return (
+    message.parts
+      ?.map((part) => {
+        if (
+          part &&
+          typeof part === 'object' &&
+          'text' in part &&
+          typeof part.text === 'string'
+        ) {
+          return part.text;
+        }
+        return '';
+      })
+      .join(' ') ?? ''
+  );
+}
+
+function getLastUserMessage(messages: UIMessage[]) {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (message?.role === 'user' && typeof message.id === 'string') {
+      return {
+        id: message.id,
+        text: getMessageText(message),
+      };
+    }
+  }
+  return undefined;
+}
+
+function createArtifactContextItem(artifact: ArtifactMetadata) {
+  return {
+    kind: 'artifact',
+    id: artifact.id,
+    type: artifact.type,
+    title: artifact.title,
+  };
+}
+
+/**
+ * Creates command and chat-finish hooks that continue artifact-scoped AI chats
+ * in a fork when an AI-invoked command changes the active artifact.
+ *
+ * The controller owns generic artifact/session choreography. Apps inject policy
+ * for supported artifact types and artifact-specific content behavior through
+ * hooks.
+ */
+export function createArtifactAiChatHandoffController<
+  TState extends ArtifactAiChatHandoffState,
+>({
+  store,
+  isSupportedArtifact,
+  shouldContinueChat,
+  onBeforeSourceRestore,
+  onBeforeTargetFork,
+  onAfterTargetFork,
+}: CreateArtifactAiChatHandoffControllerOptions<TState>) {
+  const pendingHandoffs = new Map<string, PendingArtifactAiChatHandoff>();
+
+  const commandMiddleware: ArtifactAiCommandMiddleware<TState> = async (
+    command,
+    _input,
+    context,
+    next,
+  ) => {
+    const sourceSessionId = getInvocationAiSessionId(
+      context.invocation.metadata,
+    );
+    const sourceArtifactId = sourceSessionId
+      ? context.getState().artifactAi.getSessionArtifactId(sourceSessionId)
+      : undefined;
+
+    const result = await next();
+    if (
+      !sourceSessionId ||
+      !sourceArtifactId ||
+      context.invocation.surface !== 'ai'
+    ) {
+      return result;
+    }
+
+    const target = readArtifactTargetChange(result);
+    if (
+      !target ||
+      target.shouldContinueChat === false ||
+      target.artifactId === sourceArtifactId
+    ) {
+      return result;
+    }
+
+    const nextState = store.getState();
+    const targetArtifact = nextState.artifacts.getArtifact(target.artifactId);
+    if (!targetArtifact) return result;
+    if (isSupportedArtifact && !isSupportedArtifact(targetArtifact)) {
+      return result;
+    }
+    const sourceArtifact = nextState.artifacts.getArtifact(sourceArtifactId);
+    if (!sourceArtifact) return result;
+    if (isSupportedArtifact && !isSupportedArtifact(sourceArtifact)) {
+      return result;
+    }
+    if (nextState.artifacts.config.currentArtifactId !== target.artifactId) {
+      return result;
+    }
+    const sourceSession = nextState.ai.config.sessions.find(
+      (session) => session.id === sourceSessionId,
+    );
+    const sourceUserMessage = getLastUserMessage(
+      (sourceSession?.uiMessages ?? []) as UIMessage[],
+    );
+    if (!sourceUserMessage?.id) return result;
+
+    const hookContext: ArtifactAiChatHandoffHookContext<TState> = {
+      state: nextState,
+      commandId: command.id,
+      sourceArtifact,
+      targetArtifact,
+      sourceSessionId,
+      sourceUserMessage,
+      targetChange: {
+        ...target,
+        title: targetArtifact.title,
+        artifactType: targetArtifact.type,
+      },
+    };
+
+    if (shouldContinueChat && !shouldContinueChat({...hookContext, result})) {
+      return result;
+    }
+
+    pendingHandoffs.set(sourceSessionId, {
+      sourceSessionId,
+      sourceArtifactId,
+      sourceUserMessage,
+      target: hookContext.targetChange,
+      commandId: command.id,
+    });
+    onBeforeSourceRestore?.(hookContext);
+
+    nextState.artifactAi.setSessionArtifact(sourceSessionId, sourceArtifactId);
+    nextState.ai.setSessionDraftContextItemIds(sourceSessionId, undefined);
+    nextState.ai.setSessionRunContext(
+      sourceSessionId,
+      setAiRunContextPrimaryItem(
+        nextState.ai.getSessionRunContext(sourceSessionId),
+        createArtifactContextItem(sourceArtifact),
+      ),
+    );
+    nextState.artifacts.setCurrentArtifact(sourceArtifactId);
+
+    return result;
+  };
+
+  const onChatFinish = ({
+    sessionId,
+    messages,
+    isError,
+  }: {
+    sessionId: string;
+    messages: UIMessage[];
+    isError?: boolean;
+  }) => {
+    const handoff = pendingHandoffs.get(sessionId);
+    if (!handoff) return;
+    pendingHandoffs.delete(sessionId);
+    if (isError) return;
+
+    const state = store.getState();
+    const sourceArtifact = state.artifacts.getArtifact(
+      handoff.sourceArtifactId,
+    );
+    if (!sourceArtifact) return;
+    const targetArtifact = state.artifacts.getArtifact(
+      handoff.target.artifactId,
+    );
+    if (!targetArtifact) return;
+    if (
+      state.artifactAi.getSessionArtifactId(handoff.sourceSessionId) !==
+      handoff.sourceArtifactId
+    ) {
+      return;
+    }
+    const currentArtifactId = state.artifacts.config.currentArtifactId;
+    if (
+      currentArtifactId !== handoff.sourceArtifactId &&
+      currentArtifactId !== handoff.target.artifactId
+    ) {
+      return;
+    }
+
+    const assistantMessage = getLastAssistantMessage(messages);
+    if (!assistantMessage) return;
+    if (getLastUserMessageId(messages) !== handoff.sourceUserMessage.id) {
+      return;
+    }
+
+    const targetForkContext: ArtifactAiChatHandoffTargetForkContext<TState> = {
+      state,
+      commandId: handoff.commandId,
+      sourceArtifact,
+      targetArtifact,
+      sourceSessionId: handoff.sourceSessionId,
+      sourceUserMessage: handoff.sourceUserMessage,
+      targetChange: {
+        ...handoff.target,
+        title: targetArtifact.title,
+        artifactType: targetArtifact.type,
+      },
+      messages,
+      assistantMessage: assistantMessage.message,
+      assistantMessageIndex: assistantMessage.index,
+    };
+
+    onBeforeTargetFork?.(targetForkContext);
+
+    const targetSessionId = state.ai.forkSessionFromMessage({
+      sourceSessionId: handoff.sourceSessionId,
+      sourceMessageId: assistantMessage.message.id,
+      sourceMessageIndex: assistantMessage.index,
+      name: `Continue: ${targetArtifact.title}`,
+    });
+    if (!targetSessionId) return;
+
+    state.artifactAi.setSessionArtifact(targetSessionId, targetArtifact.id);
+    state.ai.setSessionDraftContextItemIds(targetSessionId, undefined);
+    state.ai.setSessionRunContext(
+      targetSessionId,
+      setAiRunContextPrimaryItem(
+        state.ai.getSessionRunContext(targetSessionId),
+        createArtifactContextItem(targetArtifact),
+      ),
+    );
+    state.artifacts.setCurrentArtifact(targetArtifact.id);
+    state.artifactAi.selectLatestSessionForArtifact(targetArtifact.id);
+
+    onAfterTargetFork?.({
+      ...targetForkContext,
+      targetSessionId,
+    });
+  };
+
+  return {commandMiddleware, onChatFinish};
+}

--- a/packages/artifacts/src/ai/artifactAiNavigation.ts
+++ b/packages/artifacts/src/ai/artifactAiNavigation.ts
@@ -1,0 +1,30 @@
+import type {StoreApi} from 'zustand';
+import type {RoomStateWithArtifactAi} from './artifactAiSlice';
+
+/**
+ * Switches to an artifact-owned AI session, selecting its owning artifact first.
+ *
+ * Artifact/session auto-sync is driven by the current artifact, so switching the
+ * session before the artifact can be immediately overwritten by sync.
+ *
+ * @param store - Store containing artifact and AI session state.
+ * @param sessionId - AI session id to switch to.
+ * @returns `true` when the session exists and was selected.
+ */
+export function switchToArtifactAiSession<
+  TState extends RoomStateWithArtifactAi,
+>(store: Pick<StoreApi<TState>, 'getState'>, sessionId: string) {
+  const state = store.getState();
+  const sessionExists = state.ai.config.sessions.some(
+    (session) => session.id === sessionId,
+  );
+  if (!sessionExists) return false;
+
+  const artifactId = state.artifactAi.getSessionArtifactId(sessionId);
+  if (artifactId && state.artifacts.getArtifact(artifactId)) {
+    state.artifacts.setCurrentArtifact(artifactId);
+  }
+
+  store.getState().ai.switchSession(sessionId);
+  return true;
+}

--- a/packages/artifacts/src/ai/index.ts
+++ b/packages/artifacts/src/ai/index.ts
@@ -30,12 +30,26 @@ export {
   ArtifactAiConfigSchema,
   createArtifactAiSlice,
 } from './artifactAiSlice';
+export {
+  createArtifactAiChatHandoffController,
+  readArtifactTargetChange,
+} from './artifactAiChatHandoff';
+export {switchToArtifactAiSession} from './artifactAiNavigation';
 export type {
   ArtifactAiConfig as ArtifactAiConfigType,
   ArtifactAiSliceState,
   CreateArtifactAiSliceOptions,
   RoomStateWithArtifactAi,
 } from './artifactAiSlice';
+export type {
+  ArtifactAiChatHandoffAfterTargetForkContext,
+  ArtifactAiChatHandoffHookContext,
+  ArtifactAiChatHandoffMessageSummary,
+  ArtifactAiChatHandoffState,
+  ArtifactAiChatHandoffTargetForkContext,
+  ArtifactAiCommandMiddleware,
+  CreateArtifactAiChatHandoffControllerOptions,
+} from './artifactAiChatHandoff';
 export {
   cleanupAiSessionArtifacts,
   getAiSessionGroupsByArtifact,


### PR DESCRIPTION
## Summary

Fixes CLI artifact chat handoff navigation after an AI-created worksheet/block document fork.

- Adds an optional fork-source switch handler to shared chat messages so host apps can coordinate non-chat state when following fork provenance.
- Wires the CLI app to select the source session's owning artifact before switching to that source chat, preventing artifact/chat auto-sync from immediately switching back to the forked target.
- Adds focused coverage for the artifact-first session switch behavior.

## Root Cause

The fork provenance link only switched AI sessions. In the CLI app, artifact AI sync is driven by the current artifact. When the current artifact was still the fork target, switching to the source chat alone was immediately overwritten by sync, so the link appeared to do nothing and subsequent prompts could continue targeting the forked worksheet.

## Validation

- `pnpm --filter sqlrooms-cli-app test -- --runTestsByPath src/__tests__/artifactAiNavigation.test.ts`
- `pnpm --filter @sqlrooms/ai-core typecheck`
- `pnpm --filter sqlrooms-cli-app typecheck`
- `pnpm exec prettier --check packages/ai-core/src/components/ChatMessagesContainer.tsx apps/sqlrooms-cli-ui/src/components/AssistantChatContainer.tsx apps/sqlrooms-cli-ui/src/artifactAiNavigation.ts apps/sqlrooms-cli-ui/src/__tests__/artifactAiNavigation.test.ts`
- `pnpm build`
- Pre-push hook: `knip`, `turbo typecheck`, circular dependency check, `turbo test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added artifact-aware AI session switching so chat history can return to the correct artifact/worksheet context.
  * Enhanced artifact-scoped AI chat handoff to optionally copy source chart blocks into an empty target worksheet.
  * Added UI support for switching back to the fork source from chat provenance.
* **Bug Fixes**
  * Prevented worksheet AI runs from reporting success when no worksheet mutation occurred (with automatic retry prompting).
  * Improved fallback behavior when sessions/artifacts are missing to avoid incorrect navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->