### PR TITLE
feat(mosaic): add count plot metric controls

### DIFF
--- a/packages/mosaic/README.md
+++ b/packages/mosaic/README.md
@@ -231,8 +231,14 @@ aggregate a numeric `valueField` per category:
 - `aggregate`: `"sum"`, `"avg"`, `"min"`, or `"max"`; defaults to `"sum"`.
 - `sort`: `"value-desc"`, `"value-asc"`, `"label-asc"`, or `"label-desc"`;
   defaults to `"value-desc"`.
+- `maxBars`: maximum number of displayed category bars; defaults to `10`.
+- `barMaxHeight`: target maximum bar height in pixels; defaults to `32`.
 - `leftMargin`: optional manual left margin in pixels. When omitted, SQLRooms
   derives a bounded left margin from chart metadata.
+
+Count plots cap the visible categories instead of folding the hidden tail into
+`Others` so the generated vgplot spec continues to cross-filter against the
+source table without a separate pre-aggregation query client.
 
 For the common case, prefer the compound `DataTableExplorer` API.
 `useDataTableExplorer` is still available when you need direct access to the

--- a/packages/mosaic/README.md
+++ b/packages/mosaic/README.md
@@ -240,6 +240,8 @@ Count plots cap the visible categories instead of folding the hidden tail into
 source table without pre-aggregating the rendered values.
 At runtime, count plots query the category cardinality and size the rendered
 chart to the number of visible categories, capped by `maxBars`.
+Bars use fixed row geometry; the chart grows or scrolls rather than stretching
+or squeezing bar thickness.
 
 For the common case, prefer the compound `DataTableExplorer` API.
 `useDataTableExplorer` is still available when you need direct access to the

--- a/packages/mosaic/README.md
+++ b/packages/mosaic/README.md
@@ -221,6 +221,19 @@ function CodeView({value}: {value: string}) {
 }
 ```
 
+### Count Plot Settings
+
+`count-plot` chart configs support categorical counts by default and can also
+aggregate a numeric `valueField` per category:
+
+- `metric`: `"count"` or `"aggregate"`; defaults to `"count"`.
+- `valueField`: numeric column required when `metric` is `"aggregate"`.
+- `aggregate`: `"sum"`, `"avg"`, `"min"`, or `"max"`; defaults to `"sum"`.
+- `sort`: `"value-desc"`, `"value-asc"`, `"label-asc"`, or `"label-desc"`;
+  defaults to `"value-desc"`.
+- `leftMargin`: optional manual left margin in pixels. When omitted, SQLRooms
+  derives a bounded left margin from chart metadata.
+
 For the common case, prefer the compound `DataTableExplorer` API.
 `useDataTableExplorer` is still available when you need direct access to the
 explorer state for custom layout, sizing, or advanced composition.

--- a/packages/mosaic/README.md
+++ b/packages/mosaic/README.md
@@ -232,13 +232,14 @@ aggregate a numeric `valueField` per category:
 - `sort`: `"value-desc"`, `"value-asc"`, `"label-asc"`, or `"label-desc"`;
   defaults to `"value-desc"`.
 - `maxBars`: maximum number of displayed category bars; defaults to `10`.
-- `barMaxHeight`: target maximum bar height in pixels; defaults to `32`.
 - `leftMargin`: optional manual left margin in pixels. When omitted, SQLRooms
   derives a bounded left margin from chart metadata.
 
 Count plots cap the visible categories instead of folding the hidden tail into
 `Others` so the generated vgplot spec continues to cross-filter against the
-source table without a separate pre-aggregation query client.
+source table without pre-aggregating the rendered values.
+At runtime, count plots query the category cardinality and size the rendered
+chart to the number of visible categories, capped by `maxBars`.
 
 For the common case, prefer the compound `DataTableExplorer` API.
 `useDataTableExplorer` is still available when you need direct access to the

--- a/packages/mosaic/__tests__/chart-types/count-plot-category-count-client.test.ts
+++ b/packages/mosaic/__tests__/chart-types/count-plot-category-count-client.test.ts
@@ -1,0 +1,46 @@
+import {makeQualifiedTableName} from '@sqlrooms/duckdb';
+import {CountPlotCategoryCountClient} from '../../src/charts/chart-types/count-plot/renderer/CountPlotCategoryCountClient';
+
+describe('CountPlotCategoryCountClient', () => {
+  it('builds a category count query that includes null as a category', () => {
+    const client = new CountPlotCategoryCountClient({
+      field: 'origin',
+      onStateChange: () => {},
+      table: makeQualifiedTableName({
+        database: 'local',
+        schema: 'main',
+        table: 'cars',
+        defaultDatabase: 'local',
+      }),
+    });
+
+    const sql = client.query([]).toString();
+
+    expect(sql).toContain('COUNT(DISTINCT "origin")');
+    expect(sql).toContain(
+      'COALESCE(MAX(CASE WHEN "origin" IS NULL THEN 1 ELSE 0 END), 0)',
+    );
+    expect(sql).toContain('FROM "main"."cars"');
+    expect(sql).not.toContain('FROM "local"."main"."cars"');
+  });
+
+  it('publishes count state from query results', () => {
+    let latest: any;
+    const client = new CountPlotCategoryCountClient({
+      field: 'origin',
+      onStateChange: (state) => {
+        latest = state;
+      },
+      table: makeQualifiedTableName({
+        schema: 'main',
+        table: 'cars',
+      }),
+    });
+
+    client.queryResult({
+      toArray: () => [{count: 3}],
+    });
+
+    expect(latest).toEqual({count: 3, isLoading: false});
+  });
+});

--- a/packages/mosaic/__tests__/chart-types/count-plot-spec.test.ts
+++ b/packages/mosaic/__tests__/chart-types/count-plot-spec.test.ts
@@ -30,10 +30,10 @@ describe('createCountPlotSpec', () => {
     }) as any;
 
     expect(spec.plot[0].x).toEqual({count: null});
-    expect(spec.plot[0].y).toEqual({
-      column: 'class',
-      sort: {x: 'sum', order: 'desc', limit: 10},
-    });
+    for (const mark of spec.plot.slice(0, 3)) {
+      expect(mark.y).toBe('class');
+      expect(mark.sort).toEqual({y: '-x', limit: 10});
+    }
     expect(spec.xLabel).toBe('Count');
     expect(spec.height).toBe(400);
     expect(spec.yPaddingInner).toBe(0.7);
@@ -51,11 +51,7 @@ describe('createCountPlotSpec', () => {
       settings,
     }) as any;
 
-    expect(spec.plot[0].y.sort).toEqual({
-      x: 'sum',
-      order: 'asc',
-      limit: 10,
-    });
+    expect(spec.plot[0].sort).toEqual({y: 'x', limit: 10});
   });
 
   it('can sort categories by label', () => {
@@ -69,11 +65,7 @@ describe('createCountPlotSpec', () => {
       settings,
     }) as any;
 
-    expect(spec.plot[0].y.sort).toEqual({
-      y: 'min',
-      order: 'asc',
-      limit: 10,
-    });
+    expect(spec.plot[0].sort).toEqual({y: 'y', limit: 10});
   });
 
   it('can aggregate a numeric value column', () => {
@@ -91,11 +83,7 @@ describe('createCountPlotSpec', () => {
 
     expect(spec.plot[0].x).toEqual({avg: 'length_m'});
     expect(spec.plot[2].text).toEqual({avg: 'length_m'});
-    expect(spec.plot[0].y.sort).toEqual({
-      x: 'avg',
-      order: 'desc',
-      limit: 10,
-    });
+    expect(spec.plot[0].sort).toEqual({y: '-x', limit: 10});
     expect(spec.xLabel).toBe('AVG length_m');
   });
 
@@ -111,11 +99,7 @@ describe('createCountPlotSpec', () => {
       settings,
     }) as any;
 
-    expect(spec.plot[0].y.sort).toEqual({
-      x: 'sum',
-      order: 'desc',
-      limit: 6,
-    });
+    expect(spec.plot[0].sort).toEqual({y: '-x', limit: 6});
     expect(spec.height).toBe(286);
   });
 

--- a/packages/mosaic/__tests__/chart-types/count-plot-spec.test.ts
+++ b/packages/mosaic/__tests__/chart-types/count-plot-spec.test.ts
@@ -38,6 +38,7 @@ describe('createCountPlotSpec', () => {
     expect(spec.height).toBe(512);
     expect(spec.yPaddingInner).toBeCloseTo(10 / 42);
     expect(spec.margins.left).toBeGreaterThan(50);
+    expect(spec.plot[3]).toEqual({select: 'intervalY', as: '$brush'});
   });
 
   it('applies ascending value sorting', () => {

--- a/packages/mosaic/__tests__/chart-types/count-plot-spec.test.ts
+++ b/packages/mosaic/__tests__/chart-types/count-plot-spec.test.ts
@@ -1,0 +1,113 @@
+import {makeQualifiedTableName, type DataTable} from '@sqlrooms/duckdb';
+import {createCountPlotSpec} from '../../src/charts/chart-types/count-plot/spec';
+import type {CountPlotChartSettings} from '../../src/charts/chart-types/count-plot/schema';
+
+describe('createCountPlotSpec', () => {
+  const mockDataTable: DataTable = {
+    table: makeQualifiedTableName({
+      database: 'attached',
+      schema: 'main',
+      table: 'roads',
+    }),
+    tableName: 'roads',
+    schema: 'main',
+    isView: false,
+    columns: [
+      {name: 'class', type: 'VARCHAR'},
+      {name: 'length_m', type: 'DOUBLE'},
+    ],
+  };
+
+  it('generates a count plot with auto-derived left margin by default', () => {
+    const settings: CountPlotChartSettings = {
+      field: 'class',
+    };
+
+    const spec = createCountPlotSpec({
+      dataTable: mockDataTable,
+      settings,
+      selectionName: 'test_selection',
+    }) as any;
+
+    expect(spec.plot[0].x).toEqual({count: null});
+    expect(spec.plot[0].y).toEqual({
+      column: 'class',
+      sort: {x: 'sum', order: 'desc', limit: 100},
+    });
+    expect(spec.xLabel).toBe('Count');
+    expect(spec.margins.left).toBeGreaterThan(50);
+  });
+
+  it('applies ascending value sorting', () => {
+    const settings: CountPlotChartSettings = {
+      field: 'class',
+      sort: 'value-asc',
+    };
+
+    const spec = createCountPlotSpec({
+      dataTable: mockDataTable,
+      settings,
+    }) as any;
+
+    expect(spec.plot[0].y.sort).toEqual({
+      x: 'sum',
+      order: 'asc',
+      limit: 100,
+    });
+  });
+
+  it('can sort categories by label', () => {
+    const settings: CountPlotChartSettings = {
+      field: 'class',
+      sort: 'label-asc',
+    };
+
+    const spec = createCountPlotSpec({
+      dataTable: mockDataTable,
+      settings,
+    }) as any;
+
+    expect(spec.plot[0].y.sort).toEqual({
+      y: 'min',
+      order: 'asc',
+      limit: 100,
+    });
+  });
+
+  it('can aggregate a numeric value column', () => {
+    const settings: CountPlotChartSettings = {
+      field: 'class',
+      metric: 'aggregate',
+      valueField: 'length_m',
+      aggregate: 'avg',
+    };
+
+    const spec = createCountPlotSpec({
+      dataTable: mockDataTable,
+      settings,
+    }) as any;
+
+    expect(spec.plot[0].x).toEqual({avg: 'length_m'});
+    expect(spec.plot[2].text).toEqual({avg: 'length_m'});
+    expect(spec.plot[0].y.sort).toEqual({
+      x: 'avg',
+      order: 'desc',
+      limit: 100,
+    });
+    expect(spec.xLabel).toBe('AVG length_m');
+  });
+
+  it('uses manual left margin when provided', () => {
+    const settings: CountPlotChartSettings = {
+      field: 'class',
+      leftMargin: 140,
+    };
+
+    const spec = createCountPlotSpec({
+      dataTable: mockDataTable,
+      settings,
+    }) as any;
+
+    expect(spec.margins.left).toBe(140);
+  });
+});

--- a/packages/mosaic/__tests__/chart-types/count-plot-spec.test.ts
+++ b/packages/mosaic/__tests__/chart-types/count-plot-spec.test.ts
@@ -35,8 +35,8 @@ describe('createCountPlotSpec', () => {
       expect(mark.sort).toEqual({y: '-x', limit: 10});
     }
     expect(spec.xLabel).toBe('Count');
-    expect(spec.height).toBe(400);
-    expect(spec.yPaddingInner).toBe(0.7);
+    expect(spec.height).toBe(512);
+    expect(spec.yPaddingInner).toBeCloseTo(10 / 42);
     expect(spec.margins.left).toBeGreaterThan(50);
   });
 
@@ -99,7 +99,7 @@ describe('createCountPlotSpec', () => {
     }) as any;
 
     expect(spec.plot[0].sort).toEqual({y: '-x', limit: 6});
-    expect(spec.height).toBe(286);
+    expect(spec.height).toBe(344);
   });
 
   it('uses visible category count for plot height when provided', () => {
@@ -115,7 +115,24 @@ describe('createCountPlotSpec', () => {
     }) as any;
 
     expect(spec.plot[0].sort).toEqual({y: '-x', limit: 10});
-    expect(spec.height).toBe(180);
+    expect(spec.height).toBe(218);
+  });
+
+  it('keeps the same row geometry for a single visible category', () => {
+    const settings: CountPlotChartSettings = {
+      field: 'class',
+      maxBars: 10,
+    };
+
+    const spec = createCountPlotSpec({
+      dataTable: mockDataTable,
+      settings,
+      visibleCategoryCount: 1,
+    }) as any;
+
+    expect(spec.height).toBe(134);
+    expect(spec.yPaddingInner).toBeCloseTo(10 / 42);
+    expect(spec.yPaddingOuter).toBeCloseTo(16 / 42);
   });
 
   it('uses manual left margin when provided', () => {

--- a/packages/mosaic/__tests__/chart-types/count-plot-spec.test.ts
+++ b/packages/mosaic/__tests__/chart-types/count-plot-spec.test.ts
@@ -32,9 +32,11 @@ describe('createCountPlotSpec', () => {
     expect(spec.plot[0].x).toEqual({count: null});
     expect(spec.plot[0].y).toEqual({
       column: 'class',
-      sort: {x: 'sum', order: 'desc', limit: 100},
+      sort: {x: 'sum', order: 'desc', limit: 10},
     });
     expect(spec.xLabel).toBe('Count');
+    expect(spec.height).toBe(400);
+    expect(spec.yPaddingInner).toBe(0.7);
     expect(spec.margins.left).toBeGreaterThan(50);
   });
 
@@ -52,7 +54,7 @@ describe('createCountPlotSpec', () => {
     expect(spec.plot[0].y.sort).toEqual({
       x: 'sum',
       order: 'asc',
-      limit: 100,
+      limit: 10,
     });
   });
 
@@ -70,7 +72,7 @@ describe('createCountPlotSpec', () => {
     expect(spec.plot[0].y.sort).toEqual({
       y: 'min',
       order: 'asc',
-      limit: 100,
+      limit: 10,
     });
   });
 
@@ -92,9 +94,29 @@ describe('createCountPlotSpec', () => {
     expect(spec.plot[0].y.sort).toEqual({
       x: 'avg',
       order: 'desc',
-      limit: 100,
+      limit: 10,
     });
     expect(spec.xLabel).toBe('AVG length_m');
+  });
+
+  it('uses maxBars for category limiting and plot height', () => {
+    const settings: CountPlotChartSettings = {
+      field: 'class',
+      maxBars: 6,
+      barMaxHeight: 32,
+    };
+
+    const spec = createCountPlotSpec({
+      dataTable: mockDataTable,
+      settings,
+    }) as any;
+
+    expect(spec.plot[0].y.sort).toEqual({
+      x: 'sum',
+      order: 'desc',
+      limit: 6,
+    });
+    expect(spec.height).toBe(286);
   });
 
   it('uses manual left margin when provided', () => {

--- a/packages/mosaic/__tests__/chart-types/count-plot-spec.test.ts
+++ b/packages/mosaic/__tests__/chart-types/count-plot-spec.test.ts
@@ -91,7 +91,6 @@ describe('createCountPlotSpec', () => {
     const settings: CountPlotChartSettings = {
       field: 'class',
       maxBars: 6,
-      barMaxHeight: 32,
     };
 
     const spec = createCountPlotSpec({
@@ -101,6 +100,22 @@ describe('createCountPlotSpec', () => {
 
     expect(spec.plot[0].sort).toEqual({y: '-x', limit: 6});
     expect(spec.height).toBe(286);
+  });
+
+  it('uses visible category count for plot height when provided', () => {
+    const settings: CountPlotChartSettings = {
+      field: 'class',
+      maxBars: 10,
+    };
+
+    const spec = createCountPlotSpec({
+      dataTable: mockDataTable,
+      settings,
+      visibleCategoryCount: 3,
+    }) as any;
+
+    expect(spec.plot[0].sort).toEqual({y: '-x', limit: 10});
+    expect(spec.height).toBe(180);
   });
 
   it('uses manual left margin when provided', () => {

--- a/packages/mosaic/__tests__/chartTypes.test.ts
+++ b/packages/mosaic/__tests__/chartTypes.test.ts
@@ -1,4 +1,4 @@
-import {boxPlotChartType} from '../src';
+import {boxPlotChartType, countPlotChartType} from '../src';
 
 describe('chart type definitions', () => {
   it('box-plot uses renderer pattern', () => {
@@ -8,5 +8,10 @@ describe('chart type definitions', () => {
     expect(boxPlotChartType.outputKind).toBeUndefined();
     expect(boxPlotChartType.createSpec).toBeUndefined();
     expect(boxPlotChartType.createOutput).toBeUndefined();
+  });
+
+  it('count-plot uses renderer pattern for runtime sizing', () => {
+    expect(countPlotChartType.renderer).toBeDefined();
+    expect(countPlotChartType.createSpec).toBeUndefined();
   });
 });

--- a/packages/mosaic/src/charts/MosaicChartView.tsx
+++ b/packages/mosaic/src/charts/MosaicChartView.tsx
@@ -130,6 +130,7 @@ export const MosaicChartView: FC<MosaicChartViewProps> = ({
     return (
       <div className={cn('h-full w-full', className)}>
         {createElement(renderContext.renderer, {
+          dataTable: renderContext.dataTable,
           table: renderContext.dataTable.table,
           config,
           coordinator: connection.coordinator,

--- a/packages/mosaic/src/charts/MosaicChartView.tsx
+++ b/packages/mosaic/src/charts/MosaicChartView.tsx
@@ -135,6 +135,7 @@ export const MosaicChartView: FC<MosaicChartViewProps> = ({
           config,
           coordinator: connection.coordinator,
           params,
+          selectionName,
           retention,
           dataPolicy,
           runtimeIssueContext,

--- a/packages/mosaic/src/charts/chart-types/base-types.ts
+++ b/packages/mosaic/src/charts/chart-types/base-types.ts
@@ -153,6 +153,8 @@ export interface ChartRendererProps<TConfig extends ChartConfig = ChartConfig> {
    * Keys are param names (without $), values are Param or Selection instances.
    */
   params?: BrushSelectionParams;
+  /** Optional shared selection name used to add chart-local brush interactors. */
+  selectionName?: string;
   /**
    * Optional retention adapter for preserving the underlying vgplot
    * instance across temporary unmount/remount cycles.

--- a/packages/mosaic/src/charts/chart-types/base-types.ts
+++ b/packages/mosaic/src/charts/chart-types/base-types.ts
@@ -134,6 +134,8 @@ export type BrushSelectionParams = Map<string, Selection>;
  * helper instead of reconstructing table references from display names.
  */
 export interface ChartRendererProps<TConfig extends ChartConfig = ChartConfig> {
+  /** Resolved table metadata for the chart's data source. */
+  dataTable: DataTable;
   /** Canonical qualified table identity for the chart's data source. */
   table: QualifiedTableName;
   /** Validated chart configuration for this renderer. */

--- a/packages/mosaic/src/charts/chart-types/count-plot/CountPlotSettings.tsx
+++ b/packages/mosaic/src/charts/chart-types/count-plot/CountPlotSettings.tsx
@@ -1,10 +1,59 @@
 import {type FC} from 'react';
+import {Combobox, Input} from '@sqlrooms/ui';
 import {Field} from '../../../components/Field';
 import {ColumnSelector} from '../../../components/ColumnSelector';
+import {AggregationSelector} from '../../../components/AggregationSelector';
 import {useMosaicChartSettingsContext} from '../../chart-settings/MosaicChartSettingsContext';
+import type {CountPlotMetric, CountPlotSort} from './schema';
+
+const METRIC_OPTIONS = [
+  {value: 'count', label: 'Count'},
+  {value: 'aggregate', label: 'Aggregate'},
+] as const satisfies readonly {value: CountPlotMetric; label: string}[];
+
+const SORT_OPTIONS = [
+  {value: 'value-desc', label: 'Value descending'},
+  {value: 'value-asc', label: 'Value ascending'},
+  {value: 'label-asc', label: 'Label A-Z'},
+  {value: 'label-desc', label: 'Label Z-A'},
+] as const satisfies readonly {value: CountPlotSort; label: string}[];
+
+type OptionSelectorProps<TValue extends string> = {
+  value: TValue;
+  options: readonly {value: TValue; label: string}[];
+  onChange: (value: TValue) => void;
+};
+
+function OptionSelector<TValue extends string>({
+  value,
+  options,
+  onChange,
+}: OptionSelectorProps<TValue>) {
+  const selectedOption = options.find((option) => option.value === value);
+
+  return (
+    <Combobox
+      value={value}
+      onChange={(newValue) => onChange(newValue as TValue)}
+    >
+      <Combobox.Trigger className="shadow-none">
+        <span>{selectedOption?.label ?? value}</span>
+      </Combobox.Trigger>
+      <Combobox.Content>
+        {options.map((option) => (
+          <Combobox.Item key={option.value} value={option.value}>
+            <span className="text-xs">{option.label}</span>
+          </Combobox.Item>
+        ))}
+      </Combobox.Content>
+    </Combobox>
+  );
+}
 
 export const CountPlotSettingsComponent: FC = () => {
   const {onChangeConfig, config} = useMosaicChartSettingsContext('count-plot');
+  const metric = config.settings.metric ?? 'count';
+  const sort = config.settings.sort ?? 'value-desc';
 
   return (
     <div className="space-y-4">
@@ -12,6 +61,54 @@ export const CountPlotSettingsComponent: FC = () => {
         <ColumnSelector.Categorical
           value={config.settings.field}
           onChange={(field) => onChangeConfig('field', field)}
+        />
+      </Field>
+      <Field label="Metric">
+        <OptionSelector
+          value={metric}
+          options={METRIC_OPTIONS}
+          onChange={(value) => onChangeConfig('metric', value)}
+        />
+      </Field>
+      {metric === 'aggregate' && (
+        <Field label="Value field" required>
+          <div className="flex items-end gap-2">
+            <ColumnSelector.Numeric
+              className="flex-1"
+              value={config.settings.valueField}
+              onChange={(valueField) =>
+                onChangeConfig('valueField', valueField)
+              }
+            />
+            <AggregationSelector
+              value={config.settings.aggregate ?? 'sum'}
+              onChange={(aggregate) => onChangeConfig('aggregate', aggregate)}
+            />
+          </div>
+        </Field>
+      )}
+      <Field label="Sort">
+        <OptionSelector
+          value={sort}
+          options={SORT_OPTIONS}
+          onChange={(value) => onChangeConfig('sort', value)}
+        />
+      </Field>
+      <Field label="Left padding">
+        <Input
+          type="number"
+          min={0}
+          max={320}
+          value={config.settings.leftMargin ?? ''}
+          className="no-spinner"
+          onChange={(event) => {
+            const value = event.target.value;
+            onChangeConfig(
+              'leftMargin',
+              value === '' ? undefined : parseInt(value, 10),
+            );
+          }}
+          placeholder="Auto"
         />
       </Field>
     </div>

--- a/packages/mosaic/src/charts/chart-types/count-plot/CountPlotSettings.tsx
+++ b/packages/mosaic/src/charts/chart-types/count-plot/CountPlotSettings.tsx
@@ -4,7 +4,16 @@ import {Field} from '../../../components/Field';
 import {ColumnSelector} from '../../../components/ColumnSelector';
 import {AggregationSelector} from '../../../components/AggregationSelector';
 import {useMosaicChartSettingsContext} from '../../chart-settings/MosaicChartSettingsContext';
-import type {CountPlotMetric, CountPlotSort} from './schema';
+import {
+  DEFAULT_COUNT_PLOT_BAR_MAX_HEIGHT,
+  DEFAULT_COUNT_PLOT_MAX_BARS,
+  MAX_COUNT_PLOT_BAR_MAX_HEIGHT,
+  MAX_COUNT_PLOT_MAX_BARS,
+  MIN_COUNT_PLOT_BAR_MAX_HEIGHT,
+  MIN_COUNT_PLOT_MAX_BARS,
+  type CountPlotMetric,
+  type CountPlotSort,
+} from './schema';
 
 const METRIC_OPTIONS = [
   {value: 'count', label: 'Count'},
@@ -92,6 +101,44 @@ export const CountPlotSettingsComponent: FC = () => {
           value={sort}
           options={SORT_OPTIONS}
           onChange={(value) => onChangeConfig('sort', value)}
+        />
+      </Field>
+      <Field label="Max bars">
+        <Input
+          type="number"
+          min={MIN_COUNT_PLOT_MAX_BARS}
+          max={MAX_COUNT_PLOT_MAX_BARS}
+          value={config.settings.maxBars ?? DEFAULT_COUNT_PLOT_MAX_BARS}
+          className="no-spinner"
+          onChange={(event) => {
+            const value = event.target.value;
+            onChangeConfig(
+              'maxBars',
+              value === '' ? DEFAULT_COUNT_PLOT_MAX_BARS : parseInt(value, 10),
+            );
+          }}
+          placeholder={String(DEFAULT_COUNT_PLOT_MAX_BARS)}
+        />
+      </Field>
+      <Field label="Bar height">
+        <Input
+          type="number"
+          min={MIN_COUNT_PLOT_BAR_MAX_HEIGHT}
+          max={MAX_COUNT_PLOT_BAR_MAX_HEIGHT}
+          value={
+            config.settings.barMaxHeight ?? DEFAULT_COUNT_PLOT_BAR_MAX_HEIGHT
+          }
+          className="no-spinner"
+          onChange={(event) => {
+            const value = event.target.value;
+            onChangeConfig(
+              'barMaxHeight',
+              value === ''
+                ? DEFAULT_COUNT_PLOT_BAR_MAX_HEIGHT
+                : parseInt(value, 10),
+            );
+          }}
+          placeholder={String(DEFAULT_COUNT_PLOT_BAR_MAX_HEIGHT)}
         />
       </Field>
       <Field label="Left padding">

--- a/packages/mosaic/src/charts/chart-types/count-plot/CountPlotSettings.tsx
+++ b/packages/mosaic/src/charts/chart-types/count-plot/CountPlotSettings.tsx
@@ -5,11 +5,8 @@ import {ColumnSelector} from '../../../components/ColumnSelector';
 import {AggregationSelector} from '../../../components/AggregationSelector';
 import {useMosaicChartSettingsContext} from '../../chart-settings/MosaicChartSettingsContext';
 import {
-  DEFAULT_COUNT_PLOT_BAR_MAX_HEIGHT,
   DEFAULT_COUNT_PLOT_MAX_BARS,
-  MAX_COUNT_PLOT_BAR_MAX_HEIGHT,
   MAX_COUNT_PLOT_MAX_BARS,
-  MIN_COUNT_PLOT_BAR_MAX_HEIGHT,
   MIN_COUNT_PLOT_MAX_BARS,
   type CountPlotMetric,
   type CountPlotSort,
@@ -118,27 +115,6 @@ export const CountPlotSettingsComponent: FC = () => {
             );
           }}
           placeholder={String(DEFAULT_COUNT_PLOT_MAX_BARS)}
-        />
-      </Field>
-      <Field label="Bar height">
-        <Input
-          type="number"
-          min={MIN_COUNT_PLOT_BAR_MAX_HEIGHT}
-          max={MAX_COUNT_PLOT_BAR_MAX_HEIGHT}
-          value={
-            config.settings.barMaxHeight ?? DEFAULT_COUNT_PLOT_BAR_MAX_HEIGHT
-          }
-          className="no-spinner"
-          onChange={(event) => {
-            const value = event.target.value;
-            onChangeConfig(
-              'barMaxHeight',
-              value === ''
-                ? DEFAULT_COUNT_PLOT_BAR_MAX_HEIGHT
-                : parseInt(value, 10),
-            );
-          }}
-          placeholder={String(DEFAULT_COUNT_PLOT_BAR_MAX_HEIGHT)}
         />
       </Field>
       <Field label="Left padding">

--- a/packages/mosaic/src/charts/chart-types/count-plot/definition.ts
+++ b/packages/mosaic/src/charts/chart-types/count-plot/definition.ts
@@ -13,7 +13,7 @@ export const countPlotChartType: SpecChartTypeDefinition<CountPlotChartConfig> =
     id: 'count-plot',
     label: 'Count Plot',
     description: DESCRIPTION,
-    aiDescription: `${DESCRIPTION} - frequency of categorical values (always safe, aggregates automatically)`,
+    aiDescription: `${DESCRIPTION} - frequency of categorical values or numeric aggregates by category (aggregates automatically)`,
     icon: BarChartHorizontal,
     schema: CountPlotChartSettings,
     settingsComponent: CountPlotSettingsComponent,

--- a/packages/mosaic/src/charts/chart-types/count-plot/definition.ts
+++ b/packages/mosaic/src/charts/chart-types/count-plot/definition.ts
@@ -1,14 +1,14 @@
-import type {SpecChartTypeDefinition} from '../base-types';
+import type {ComponentChartTypeDefinition} from '../base-types';
 import {CountPlotChartConfig, CountPlotChartSettings} from './schema';
 import {titleFromDescription} from '../../../chart-builders/chartTypeUtils';
 import {CountPlotSettingsComponent} from './CountPlotSettings';
 import {createCountPlotAiTool} from './tool';
 import {BarChartHorizontal} from 'lucide-react';
-import {createCountPlotSpec} from './spec';
+import {CountPlotPanelRenderer} from './renderer/CountPlotPanelRenderer';
 
 const DESCRIPTION = 'Create a count plot of a field';
 
-export const countPlotChartType: SpecChartTypeDefinition<CountPlotChartConfig> =
+export const countPlotChartType: ComponentChartTypeDefinition<CountPlotChartConfig> =
   {
     id: 'count-plot',
     label: 'Count Plot',
@@ -19,5 +19,5 @@ export const countPlotChartType: SpecChartTypeDefinition<CountPlotChartConfig> =
     settingsComponent: CountPlotSettingsComponent,
     buildTitle: titleFromDescription(DESCRIPTION),
     createTool: createCountPlotAiTool,
-    createSpec: createCountPlotSpec,
+    renderer: CountPlotPanelRenderer,
   };

--- a/packages/mosaic/src/charts/chart-types/count-plot/renderer/CountPlotCategoryCountClient.ts
+++ b/packages/mosaic/src/charts/chart-types/count-plot/renderer/CountPlotCategoryCountClient.ts
@@ -1,0 +1,76 @@
+import {MosaicClient} from '@uwdata/mosaic-core';
+import {column, Query, sql} from '@uwdata/mosaic-sql';
+import type {QualifiedTableName} from '@sqlrooms/duckdb';
+import {getMosaicSqlTableReference} from '../../../../mosaicTableReference';
+import {readCountData} from '../../../../data-table-explorer/utils';
+
+export type CountPlotCategoryCountState = {
+  count?: number;
+  error?: Error;
+  isLoading: boolean;
+};
+
+type CountPlotCategoryCountClientOptions = {
+  field: string;
+  onStateChange: (state: CountPlotCategoryCountState) => void;
+  table: QualifiedTableName;
+};
+
+/**
+ * Mosaic client that counts possible count-plot categories for sizing.
+ */
+export class CountPlotCategoryCountClient extends MosaicClient {
+  private count?: number;
+  private error?: Error;
+  private readonly field: string;
+  private readonly onStateChange: (state: CountPlotCategoryCountState) => void;
+  private readonly table: QualifiedTableName;
+
+  constructor(options: CountPlotCategoryCountClientOptions) {
+    super();
+    this.field = options.field;
+    this.onStateChange = options.onStateChange;
+    this.table = options.table;
+  }
+
+  override get filterStable(): boolean {
+    return true;
+  }
+
+  override queryPending(): this {
+    this.onStateChange({
+      count: this.count,
+      error: this.error,
+      isLoading: true,
+    });
+    return this;
+  }
+
+  override query(): Query {
+    const fieldColumn = column(this.field);
+
+    return Query.from(getMosaicSqlTableReference(this.table)).select({
+      count: sql`COUNT(DISTINCT ${fieldColumn}) + COALESCE(MAX(CASE WHEN ${fieldColumn} IS NULL THEN 1 ELSE 0 END), 0)`,
+    });
+  }
+
+  override queryResult(data: unknown): this {
+    this.count = readCountData(data);
+    this.error = undefined;
+    this.onStateChange({
+      count: this.count,
+      isLoading: false,
+    });
+    return this;
+  }
+
+  override queryError(error: Error): this {
+    this.error = error;
+    this.onStateChange({
+      count: this.count,
+      error,
+      isLoading: false,
+    });
+    return this;
+  }
+}

--- a/packages/mosaic/src/charts/chart-types/count-plot/renderer/CountPlotPanelRenderer.tsx
+++ b/packages/mosaic/src/charts/chart-types/count-plot/renderer/CountPlotPanelRenderer.tsx
@@ -20,6 +20,7 @@ export const CountPlotPanelRenderer: FC<
   retention,
   runtimeIssueContext,
   runtimeIssueReporter,
+  selectionName,
   table,
 }) => {
   const field =
@@ -37,6 +38,7 @@ export const CountPlotPanelRenderer: FC<
       return {
         spec: createCountPlotSpec({
           dataTable,
+          selectionName,
           settings: config.settings,
           visibleCategoryCount: categoryCount.count,
         }),
@@ -44,7 +46,7 @@ export const CountPlotPanelRenderer: FC<
     } catch (error) {
       return {error: error instanceof Error ? error : new Error(String(error))};
     }
-  }, [categoryCount.count, config.settings, dataTable]);
+  }, [categoryCount.count, config.settings, dataTable, selectionName]);
 
   if (specResult.error) {
     return (

--- a/packages/mosaic/src/charts/chart-types/count-plot/renderer/CountPlotPanelRenderer.tsx
+++ b/packages/mosaic/src/charts/chart-types/count-plot/renderer/CountPlotPanelRenderer.tsx
@@ -1,0 +1,74 @@
+import type {FC} from 'react';
+import {useMemo} from 'react';
+import {VgPlotChart} from '../../../../VgPlotChart';
+import type {ChartRendererProps} from '../../base-types';
+import type {CountPlotChartConfig} from '../schema';
+import {createCountPlotSpec} from '../spec';
+import {useCountPlotCategoryCount} from './useCountPlotCategoryCount';
+
+/**
+ * Count plot renderer that sizes the vgplot chart to runtime category count.
+ */
+export const CountPlotPanelRenderer: FC<
+  ChartRendererProps<CountPlotChartConfig>
+> = ({
+  config,
+  coordinator,
+  dataPolicy,
+  dataTable,
+  params,
+  retention,
+  runtimeIssueContext,
+  runtimeIssueReporter,
+  table,
+}) => {
+  const field =
+    typeof config.settings.field === 'string'
+      ? config.settings.field
+      : undefined;
+  const categoryCount = useCountPlotCategoryCount({
+    coordinator,
+    field,
+    table,
+  });
+
+  const specResult = useMemo(() => {
+    try {
+      return {
+        spec: createCountPlotSpec({
+          dataTable,
+          settings: config.settings,
+          visibleCategoryCount: categoryCount.count,
+        }),
+      };
+    } catch (error) {
+      return {error: error instanceof Error ? error : new Error(String(error))};
+    }
+  }, [categoryCount.count, config.settings, dataTable]);
+
+  if (specResult.error) {
+    return (
+      <div className="text-muted-foreground flex h-full flex-col items-center justify-center text-sm">
+        {specResult.error.message}
+      </div>
+    );
+  }
+
+  const specHeight = (specResult.spec as {height?: unknown}).height;
+  const height = typeof specHeight === 'number' ? specHeight : 240;
+
+  return (
+    <div className="flex h-full min-h-0 w-full overflow-auto">
+      <div className="my-auto w-full shrink-0" style={{height}}>
+        <VgPlotChart
+          spec={specResult.spec}
+          params={params}
+          retention={retention}
+          dataPolicy={dataPolicy}
+          runtimeIssueContext={runtimeIssueContext}
+          runtimeIssueReporter={runtimeIssueReporter}
+        />
+      </div>
+    </div>
+  );
+};

--- a/packages/mosaic/src/charts/chart-types/count-plot/renderer/useCountPlotCategoryCount.ts
+++ b/packages/mosaic/src/charts/chart-types/count-plot/renderer/useCountPlotCategoryCount.ts
@@ -1,0 +1,52 @@
+import type {Coordinator} from '@uwdata/mosaic-core';
+import type {QualifiedTableName} from '@sqlrooms/duckdb';
+import {useEffect, useState} from 'react';
+import {
+  CountPlotCategoryCountClient,
+  type CountPlotCategoryCountState,
+} from './CountPlotCategoryCountClient';
+
+type CountPlotCategoryCountHookState = CountPlotCategoryCountState & {
+  field?: string;
+};
+
+/**
+ * Connects the count-plot category-count client for runtime chart sizing.
+ */
+export function useCountPlotCategoryCount(args: {
+  coordinator: Coordinator;
+  field: string | undefined;
+  table: QualifiedTableName;
+}): CountPlotCategoryCountState {
+  const {coordinator, field, table} = args;
+  const [state, setState] = useState<CountPlotCategoryCountHookState>({
+    isLoading: false,
+  });
+
+  useEffect(() => {
+    if (!field) {
+      return;
+    }
+
+    const client = new CountPlotCategoryCountClient({
+      field,
+      onStateChange: (nextState) => setState({...nextState, field}),
+      table,
+    });
+    coordinator.connect(client);
+
+    return () => {
+      client.destroy();
+    };
+  }, [coordinator, field, table]);
+
+  if (!field) {
+    return {isLoading: false};
+  }
+
+  if (state.field !== field) {
+    return {isLoading: true};
+  }
+
+  return state;
+}

--- a/packages/mosaic/src/charts/chart-types/count-plot/schema.ts
+++ b/packages/mosaic/src/charts/chart-types/count-plot/schema.ts
@@ -16,9 +16,6 @@ export type CountPlotSort = z.infer<typeof CountPlotSort>;
 export const DEFAULT_COUNT_PLOT_MAX_BARS = 10;
 export const MIN_COUNT_PLOT_MAX_BARS = 1;
 export const MAX_COUNT_PLOT_MAX_BARS = 100;
-export const DEFAULT_COUNT_PLOT_BAR_MAX_HEIGHT = 32;
-export const MIN_COUNT_PLOT_BAR_MAX_HEIGHT = 8;
-export const MAX_COUNT_PLOT_BAR_MAX_HEIGHT = 64;
 
 export const CountPlotChartSettings = z.object({
   field: z
@@ -46,14 +43,6 @@ export const CountPlotChartSettings = z.object({
     .optional()
     .default(DEFAULT_COUNT_PLOT_MAX_BARS)
     .describe('Maximum number of category bars to display'),
-  barMaxHeight: z
-    .number()
-    .int()
-    .min(MIN_COUNT_PLOT_BAR_MAX_HEIGHT)
-    .max(MAX_COUNT_PLOT_BAR_MAX_HEIGHT)
-    .optional()
-    .default(DEFAULT_COUNT_PLOT_BAR_MAX_HEIGHT)
-    .describe('Target maximum bar height in pixels'),
   leftMargin: z
     .number()
     .int()

--- a/packages/mosaic/src/charts/chart-types/count-plot/schema.ts
+++ b/packages/mosaic/src/charts/chart-types/count-plot/schema.ts
@@ -13,6 +13,13 @@ export const CountPlotSort = z.enum([
 ]);
 export type CountPlotSort = z.infer<typeof CountPlotSort>;
 
+export const DEFAULT_COUNT_PLOT_MAX_BARS = 10;
+export const MIN_COUNT_PLOT_MAX_BARS = 1;
+export const MAX_COUNT_PLOT_MAX_BARS = 100;
+export const DEFAULT_COUNT_PLOT_BAR_MAX_HEIGHT = 32;
+export const MIN_COUNT_PLOT_BAR_MAX_HEIGHT = 8;
+export const MAX_COUNT_PLOT_BAR_MAX_HEIGHT = 64;
+
 export const CountPlotChartSettings = z.object({
   field: z
     .string()
@@ -31,6 +38,22 @@ export const CountPlotChartSettings = z.object({
   sort: CountPlotSort.optional()
     .default('value-desc')
     .describe('Sort categories by metric value or label'),
+  maxBars: z
+    .number()
+    .int()
+    .min(MIN_COUNT_PLOT_MAX_BARS)
+    .max(MAX_COUNT_PLOT_MAX_BARS)
+    .optional()
+    .default(DEFAULT_COUNT_PLOT_MAX_BARS)
+    .describe('Maximum number of category bars to display'),
+  barMaxHeight: z
+    .number()
+    .int()
+    .min(MIN_COUNT_PLOT_BAR_MAX_HEIGHT)
+    .max(MAX_COUNT_PLOT_BAR_MAX_HEIGHT)
+    .optional()
+    .default(DEFAULT_COUNT_PLOT_BAR_MAX_HEIGHT)
+    .describe('Target maximum bar height in pixels'),
   leftMargin: z
     .number()
     .int()

--- a/packages/mosaic/src/charts/chart-types/count-plot/schema.ts
+++ b/packages/mosaic/src/charts/chart-types/count-plot/schema.ts
@@ -1,11 +1,43 @@
 import {z} from 'zod';
 import {ChartDataPolicyOverrideConfig} from '../data-policy-schema';
+import {AggregateFunction} from '../../../schemas';
+
+export const CountPlotMetric = z.enum(['count', 'aggregate']);
+export type CountPlotMetric = z.infer<typeof CountPlotMetric>;
+
+export const CountPlotSort = z.enum([
+  'value-desc',
+  'value-asc',
+  'label-asc',
+  'label-desc',
+]);
+export type CountPlotSort = z.infer<typeof CountPlotSort>;
 
 export const CountPlotChartSettings = z.object({
   field: z
     .string()
     .optional()
     .describe('Categorical column to count frequency of values'),
+  metric: CountPlotMetric.optional()
+    .default('count')
+    .describe('Use row count or aggregate a numeric value column per category'),
+  valueField: z
+    .string()
+    .optional()
+    .describe('Numeric column to aggregate when metric is aggregate'),
+  aggregate: AggregateFunction.optional()
+    .default('sum')
+    .describe('Aggregation function for valueField'),
+  sort: CountPlotSort.optional()
+    .default('value-desc')
+    .describe('Sort categories by metric value or label'),
+  leftMargin: z
+    .number()
+    .int()
+    .min(0)
+    .max(320)
+    .optional()
+    .describe('Manual left margin in pixels; omit to auto-size from metadata'),
 });
 
 export type CountPlotChartSettings = z.infer<typeof CountPlotChartSettings>;

--- a/packages/mosaic/src/charts/chart-types/count-plot/spec.ts
+++ b/packages/mosaic/src/charts/chart-types/count-plot/spec.ts
@@ -1,5 +1,14 @@
 import type {Spec} from '@uwdata/mosaic-spec';
-import {CountPlotChartSettings, CountPlotSort} from './schema';
+import {
+  CountPlotChartSettings,
+  CountPlotSort,
+  DEFAULT_COUNT_PLOT_BAR_MAX_HEIGHT,
+  DEFAULT_COUNT_PLOT_MAX_BARS,
+  MAX_COUNT_PLOT_BAR_MAX_HEIGHT,
+  MAX_COUNT_PLOT_MAX_BARS,
+  MIN_COUNT_PLOT_BAR_MAX_HEIGHT,
+  MIN_COUNT_PLOT_MAX_BARS,
+} from './schema';
 import {CreateSpecOptions, getChartTableReference} from '../base-types';
 import {validateCountPlotSettings} from './validation';
 import type {AggregateFunction} from '../../../schemas';
@@ -7,11 +16,29 @@ import type {TableColumn} from '@sqlrooms/duckdb';
 
 const BG_COLOR = 'var(--color-chart-overlay)';
 const FG_COLOR = 'var(--color-chart-1)';
-const CATEGORY_LIMIT = 100;
 const MIN_AUTO_LEFT_MARGIN = 72;
 const MAX_AUTO_LEFT_MARGIN = 220;
 const LABEL_CHARACTER_WIDTH = 8;
 const AXIS_GUTTER_WIDTH = 40;
+const HEIGHT_MARGINS = {top: 20, bottom: 50};
+const MIN_COUNT_PLOT_HEIGHT = 180;
+const MAX_COUNT_PLOT_HEIGHT = 400;
+const ROW_GAP = 4;
+const DEFAULT_Y_PADDING_INNER = 0.7;
+const DEFAULT_Y_PADDING_OUTER = 0.2;
+
+function clampInteger(
+  value: number | undefined,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return fallback;
+  }
+
+  return Math.max(min, Math.min(max, Math.round(value)));
+}
 
 function clampMargin(value: number): number {
   return Math.max(0, Math.min(320, Math.round(value)));
@@ -54,18 +81,19 @@ function getSortConfig(
   sort: CountPlotSort | undefined,
   metric: 'count' | 'aggregate',
   aggregate: AggregateFunction,
+  maxBars: number,
 ): unknown {
   const sortOption = sort ?? 'value-desc';
   const order = sortOption.endsWith('asc') ? 'asc' : 'desc';
 
   if (sortOption.startsWith('label')) {
-    return {y: 'min', order, limit: CATEGORY_LIMIT};
+    return {y: 'min', order, limit: maxBars};
   }
 
   return {
     x: metric === 'count' ? 'sum' : aggregate,
     order,
-    limit: CATEGORY_LIMIT,
+    limit: maxBars,
   };
 }
 
@@ -81,6 +109,18 @@ function getValueLabel(
   return `${aggregate.toUpperCase()} ${valueColumn.name}`;
 }
 
+function getPlotHeight(maxBars: number, barMaxHeight: number): number {
+  const height =
+    HEIGHT_MARGINS.top +
+    HEIGHT_MARGINS.bottom +
+    maxBars * (barMaxHeight + ROW_GAP);
+
+  return Math.max(
+    MIN_COUNT_PLOT_HEIGHT,
+    Math.min(MAX_COUNT_PLOT_HEIGHT, height),
+  );
+}
+
 export function createCountPlotSpec(
   options: CreateSpecOptions<CountPlotChartSettings>,
 ): Spec {
@@ -90,9 +130,21 @@ export function createCountPlotSpec(
     validateCountPlotSettings(options);
   const tableReference = getChartTableReference(dataTable);
   const metricChannel = getMetricChannel(metric, aggregate, valueColumn);
+  const maxBars = clampInteger(
+    settings.maxBars,
+    DEFAULT_COUNT_PLOT_MAX_BARS,
+    MIN_COUNT_PLOT_MAX_BARS,
+    MAX_COUNT_PLOT_MAX_BARS,
+  );
+  const barMaxHeight = clampInteger(
+    settings.barMaxHeight,
+    DEFAULT_COUNT_PLOT_BAR_MAX_HEIGHT,
+    MIN_COUNT_PLOT_BAR_MAX_HEIGHT,
+    MAX_COUNT_PLOT_BAR_MAX_HEIGHT,
+  );
   const yChannel = {
     column: fieldColumn.name,
-    sort: getSortConfig(settings.sort, metric, aggregate),
+    sort: getSortConfig(settings.sort, metric, aggregate, maxBars),
   };
 
   // Count plot shows categorical frequency as horizontal bars
@@ -135,13 +187,14 @@ export function createCountPlotSpec(
     plot,
     xLabel: getValueLabel(metric, aggregate, valueColumn),
     yLabel: fieldColumn.name,
-    height: 400,
+    height: getPlotHeight(maxBars, barMaxHeight),
     width: 380,
+    yPaddingInner: DEFAULT_Y_PADDING_INNER,
+    yPaddingOuter: DEFAULT_Y_PADDING_OUTER,
     margins: {
       left: deriveLeftMargin(fieldColumn, settings.leftMargin),
       right: 50,
-      top: 20,
-      bottom: 50,
+      ...HEIGHT_MARGINS,
     },
     params: {brush: {select: 'crossfilter'}},
   } as Spec;

--- a/packages/mosaic/src/charts/chart-types/count-plot/spec.ts
+++ b/packages/mosaic/src/charts/chart-types/count-plot/spec.ts
@@ -1,18 +1,99 @@
 import type {Spec} from '@uwdata/mosaic-spec';
-import {CountPlotChartSettings} from './schema';
+import {CountPlotChartSettings, CountPlotSort} from './schema';
 import {CreateSpecOptions, getChartTableReference} from '../base-types';
 import {validateCountPlotSettings} from './validation';
+import type {AggregateFunction} from '../../../schemas';
+import type {TableColumn} from '@sqlrooms/duckdb';
 
 const BG_COLOR = 'var(--color-chart-overlay)';
 const FG_COLOR = 'var(--color-chart-1)';
+const CATEGORY_LIMIT = 100;
+const MIN_AUTO_LEFT_MARGIN = 72;
+const MAX_AUTO_LEFT_MARGIN = 220;
+const LABEL_CHARACTER_WIDTH = 8;
+const AXIS_GUTTER_WIDTH = 40;
+
+function clampMargin(value: number): number {
+  return Math.max(0, Math.min(320, Math.round(value)));
+}
+
+function deriveLeftMargin(
+  fieldColumn: TableColumn,
+  manualLeftMargin: number | undefined,
+): number {
+  if (manualLeftMargin !== undefined) {
+    return clampMargin(manualLeftMargin);
+  }
+
+  const estimatedLabelWidth =
+    fieldColumn.name.length * LABEL_CHARACTER_WIDTH + AXIS_GUTTER_WIDTH;
+
+  return Math.max(
+    MIN_AUTO_LEFT_MARGIN,
+    Math.min(MAX_AUTO_LEFT_MARGIN, Math.round(estimatedLabelWidth)),
+  );
+}
+
+function getMetricChannel(
+  metric: 'count' | 'aggregate',
+  aggregate: AggregateFunction,
+  valueColumn: TableColumn | undefined,
+): Record<string, string | null> {
+  if (metric === 'count') {
+    return {count: null};
+  }
+
+  if (!valueColumn) {
+    return {count: null};
+  }
+
+  return {[aggregate]: valueColumn.name};
+}
+
+function getSortConfig(
+  sort: CountPlotSort | undefined,
+  metric: 'count' | 'aggregate',
+  aggregate: AggregateFunction,
+): unknown {
+  const sortOption = sort ?? 'value-desc';
+  const order = sortOption.endsWith('asc') ? 'asc' : 'desc';
+
+  if (sortOption.startsWith('label')) {
+    return {y: 'min', order, limit: CATEGORY_LIMIT};
+  }
+
+  return {
+    x: metric === 'count' ? 'sum' : aggregate,
+    order,
+    limit: CATEGORY_LIMIT,
+  };
+}
+
+function getValueLabel(
+  metric: 'count' | 'aggregate',
+  aggregate: AggregateFunction,
+  valueColumn: TableColumn | undefined,
+): string {
+  if (metric === 'count' || !valueColumn) {
+    return 'Count';
+  }
+
+  return `${aggregate.toUpperCase()} ${valueColumn.name}`;
+}
 
 export function createCountPlotSpec(
   options: CreateSpecOptions<CountPlotChartSettings>,
 ): Spec {
-  const {dataTable, selectionName} = options;
+  const {dataTable, selectionName, settings} = options;
 
-  const {fieldColumn} = validateCountPlotSettings(options);
+  const {aggregate, fieldColumn, metric, valueColumn} =
+    validateCountPlotSettings(options);
   const tableReference = getChartTableReference(dataTable);
+  const metricChannel = getMetricChannel(metric, aggregate, valueColumn);
+  const yChannel = {
+    column: fieldColumn.name,
+    sort: getSortConfig(settings.sort, metric, aggregate),
+  };
 
   // Count plot shows categorical frequency as horizontal bars
   // Categories on Y-axis, counts on X-axis
@@ -20,34 +101,25 @@ export function createCountPlotSpec(
     {
       mark: 'barX',
       data: {from: tableReference},
-      x: {count: null},
-      y: {
-        column: fieldColumn.name,
-        sort: {x: 'sum', order: 'desc', limit: 100},
-      },
+      x: metricChannel,
+      y: yChannel,
       fill: BG_COLOR,
       inset: 0.5,
     },
     {
       mark: 'barX',
       data: {from: tableReference, filterBy: '$brush'},
-      x: {count: null},
-      y: {
-        column: fieldColumn.name,
-        sort: {x: 'sum', order: 'desc', limit: 100},
-      },
+      x: metricChannel,
+      y: yChannel,
       fill: FG_COLOR,
       inset: 0.5,
     },
     {
       mark: 'text',
       data: {from: tableReference, filterBy: '$brush'},
-      x: {count: null},
-      y: {
-        column: fieldColumn.name,
-        sort: {x: 'sum', order: 'desc', limit: 100},
-      },
-      text: {count: null},
+      x: metricChannel,
+      y: yChannel,
+      text: metricChannel,
       dx: 5,
       textAnchor: 'start',
       fill: 'currentColor',
@@ -61,11 +133,16 @@ export function createCountPlotSpec(
 
   return {
     plot,
-    xLabel: 'Count',
+    xLabel: getValueLabel(metric, aggregate, valueColumn),
     yLabel: fieldColumn.name,
     height: 400,
     width: 380,
-    margins: {left: 50, right: 50, top: 20, bottom: 50},
+    margins: {
+      left: deriveLeftMargin(fieldColumn, settings.leftMargin),
+      right: 50,
+      top: 20,
+      bottom: 50,
+    },
     params: {brush: {select: 'crossfilter'}},
   } as Spec;
 }

--- a/packages/mosaic/src/charts/chart-types/count-plot/spec.ts
+++ b/packages/mosaic/src/charts/chart-types/count-plot/spec.ts
@@ -18,12 +18,12 @@ const MAX_AUTO_LEFT_MARGIN = 220;
 const LABEL_CHARACTER_WIDTH = 8;
 const AXIS_GUTTER_WIDTH = 40;
 const HEIGHT_MARGINS = {top: 20, bottom: 50};
-const MIN_COUNT_PLOT_HEIGHT = 180;
-const MAX_COUNT_PLOT_HEIGHT = 400;
-const COUNT_PLOT_BAR_MAX_HEIGHT = 32;
-const ROW_GAP = 4;
-const DEFAULT_Y_PADDING_INNER = 0.7;
-const DEFAULT_Y_PADDING_OUTER = 0.2;
+const COUNT_PLOT_BAR_HEIGHT = 32;
+const COUNT_PLOT_ROW_GAP = 10;
+const COUNT_PLOT_OUTER_GAP = 16;
+const COUNT_PLOT_ROW_STEP = COUNT_PLOT_BAR_HEIGHT + COUNT_PLOT_ROW_GAP;
+const DEFAULT_Y_PADDING_INNER = COUNT_PLOT_ROW_GAP / COUNT_PLOT_ROW_STEP;
+const DEFAULT_Y_PADDING_OUTER = COUNT_PLOT_OUTER_GAP / COUNT_PLOT_ROW_STEP;
 
 type CountPlotMarkSort = {
   y: 'x' | '-x' | 'y' | '-y';
@@ -113,14 +113,12 @@ function getValueLabel(
 }
 
 function getPlotHeight(maxBars: number): number {
-  const height =
+  return (
     HEIGHT_MARGINS.top +
     HEIGHT_MARGINS.bottom +
-    maxBars * (COUNT_PLOT_BAR_MAX_HEIGHT + ROW_GAP);
-
-  return Math.max(
-    MIN_COUNT_PLOT_HEIGHT,
-    Math.min(MAX_COUNT_PLOT_HEIGHT, height),
+    maxBars * COUNT_PLOT_BAR_HEIGHT +
+    Math.max(0, maxBars - 1) * COUNT_PLOT_ROW_GAP +
+    2 * COUNT_PLOT_OUTER_GAP
   );
 }
 

--- a/packages/mosaic/src/charts/chart-types/count-plot/spec.ts
+++ b/packages/mosaic/src/charts/chart-types/count-plot/spec.ts
@@ -27,6 +27,11 @@ const ROW_GAP = 4;
 const DEFAULT_Y_PADDING_INNER = 0.7;
 const DEFAULT_Y_PADDING_OUTER = 0.2;
 
+type CountPlotMarkSort = {
+  y: 'x' | '-x' | 'y' | '-y';
+  limit: number;
+};
+
 function clampInteger(
   value: number | undefined,
   fallback: number,
@@ -79,22 +84,13 @@ function getMetricChannel(
 
 function getSortConfig(
   sort: CountPlotSort | undefined,
-  metric: 'count' | 'aggregate',
-  aggregate: AggregateFunction,
   maxBars: number,
-): unknown {
+): CountPlotMarkSort {
   const sortOption = sort ?? 'value-desc';
-  const order = sortOption.endsWith('asc') ? 'asc' : 'desc';
+  const channel = sortOption.startsWith('label') ? 'y' : 'x';
+  const descending = sortOption.endsWith('desc');
 
-  if (sortOption.startsWith('label')) {
-    return {y: 'min', order, limit: maxBars};
-  }
-
-  return {
-    x: metric === 'count' ? 'sum' : aggregate,
-    order,
-    limit: maxBars,
-  };
+  return {y: `${descending ? '-' : ''}${channel}`, limit: maxBars};
 }
 
 function getValueLabel(
@@ -142,10 +138,8 @@ export function createCountPlotSpec(
     MIN_COUNT_PLOT_BAR_MAX_HEIGHT,
     MAX_COUNT_PLOT_BAR_MAX_HEIGHT,
   );
-  const yChannel = {
-    column: fieldColumn.name,
-    sort: getSortConfig(settings.sort, metric, aggregate, maxBars),
-  };
+  const yChannel = fieldColumn.name;
+  const markSort = getSortConfig(settings.sort, maxBars);
 
   // Count plot shows categorical frequency as horizontal bars
   // Categories on Y-axis, counts on X-axis
@@ -155,6 +149,7 @@ export function createCountPlotSpec(
       data: {from: tableReference},
       x: metricChannel,
       y: yChannel,
+      sort: markSort,
       fill: BG_COLOR,
       inset: 0.5,
     },
@@ -163,6 +158,7 @@ export function createCountPlotSpec(
       data: {from: tableReference, filterBy: '$brush'},
       x: metricChannel,
       y: yChannel,
+      sort: markSort,
       fill: FG_COLOR,
       inset: 0.5,
     },
@@ -171,6 +167,7 @@ export function createCountPlotSpec(
       data: {from: tableReference, filterBy: '$brush'},
       x: metricChannel,
       y: yChannel,
+      sort: markSort,
       text: metricChannel,
       dx: 5,
       textAnchor: 'start',

--- a/packages/mosaic/src/charts/chart-types/count-plot/spec.ts
+++ b/packages/mosaic/src/charts/chart-types/count-plot/spec.ts
@@ -2,11 +2,8 @@ import type {Spec} from '@uwdata/mosaic-spec';
 import {
   CountPlotChartSettings,
   CountPlotSort,
-  DEFAULT_COUNT_PLOT_BAR_MAX_HEIGHT,
   DEFAULT_COUNT_PLOT_MAX_BARS,
-  MAX_COUNT_PLOT_BAR_MAX_HEIGHT,
   MAX_COUNT_PLOT_MAX_BARS,
-  MIN_COUNT_PLOT_BAR_MAX_HEIGHT,
   MIN_COUNT_PLOT_MAX_BARS,
 } from './schema';
 import {CreateSpecOptions, getChartTableReference} from '../base-types';
@@ -23,6 +20,7 @@ const AXIS_GUTTER_WIDTH = 40;
 const HEIGHT_MARGINS = {top: 20, bottom: 50};
 const MIN_COUNT_PLOT_HEIGHT = 180;
 const MAX_COUNT_PLOT_HEIGHT = 400;
+const COUNT_PLOT_BAR_MAX_HEIGHT = 32;
 const ROW_GAP = 4;
 const DEFAULT_Y_PADDING_INNER = 0.7;
 const DEFAULT_Y_PADDING_OUTER = 0.2;
@@ -31,6 +29,15 @@ type CountPlotMarkSort = {
   y: 'x' | '-x' | 'y' | '-y';
   limit: number;
 };
+
+export type CreateCountPlotSpecOptions =
+  CreateSpecOptions<CountPlotChartSettings> & {
+    /**
+     * Number of categories expected to render after applying the count plot
+     * category cap. When omitted, the chart sizes itself for `maxBars`.
+     */
+    visibleCategoryCount?: number;
+  };
 
 function clampInteger(
   value: number | undefined,
@@ -105,11 +112,11 @@ function getValueLabel(
   return `${aggregate.toUpperCase()} ${valueColumn.name}`;
 }
 
-function getPlotHeight(maxBars: number, barMaxHeight: number): number {
+function getPlotHeight(maxBars: number): number {
   const height =
     HEIGHT_MARGINS.top +
     HEIGHT_MARGINS.bottom +
-    maxBars * (barMaxHeight + ROW_GAP);
+    maxBars * (COUNT_PLOT_BAR_MAX_HEIGHT + ROW_GAP);
 
   return Math.max(
     MIN_COUNT_PLOT_HEIGHT,
@@ -117,9 +124,21 @@ function getPlotHeight(maxBars: number, barMaxHeight: number): number {
   );
 }
 
-export function createCountPlotSpec(
-  options: CreateSpecOptions<CountPlotChartSettings>,
-): Spec {
+function getVisibleBarCount(
+  visibleCategoryCount: number | undefined,
+  maxBars: number,
+): number {
+  if (
+    visibleCategoryCount === undefined ||
+    !Number.isFinite(visibleCategoryCount)
+  ) {
+    return maxBars;
+  }
+
+  return Math.max(1, Math.min(maxBars, Math.ceil(visibleCategoryCount)));
+}
+
+export function createCountPlotSpec(options: CreateCountPlotSpecOptions): Spec {
   const {dataTable, selectionName, settings} = options;
 
   const {aggregate, fieldColumn, metric, valueColumn} =
@@ -132,14 +151,12 @@ export function createCountPlotSpec(
     MIN_COUNT_PLOT_MAX_BARS,
     MAX_COUNT_PLOT_MAX_BARS,
   );
-  const barMaxHeight = clampInteger(
-    settings.barMaxHeight,
-    DEFAULT_COUNT_PLOT_BAR_MAX_HEIGHT,
-    MIN_COUNT_PLOT_BAR_MAX_HEIGHT,
-    MAX_COUNT_PLOT_BAR_MAX_HEIGHT,
-  );
   const yChannel = fieldColumn.name;
   const markSort = getSortConfig(settings.sort, maxBars);
+  const visibleBarCount = getVisibleBarCount(
+    options.visibleCategoryCount,
+    maxBars,
+  );
 
   // Count plot shows categorical frequency as horizontal bars
   // Categories on Y-axis, counts on X-axis
@@ -184,7 +201,7 @@ export function createCountPlotSpec(
     plot,
     xLabel: getValueLabel(metric, aggregate, valueColumn),
     yLabel: fieldColumn.name,
-    height: getPlotHeight(maxBars, barMaxHeight),
+    height: getPlotHeight(visibleBarCount),
     width: 380,
     yPaddingInner: DEFAULT_Y_PADDING_INNER,
     yPaddingOuter: DEFAULT_Y_PADDING_OUTER,

--- a/packages/mosaic/src/charts/chart-types/count-plot/tool.ts
+++ b/packages/mosaic/src/charts/chart-types/count-plot/tool.ts
@@ -29,6 +29,7 @@ Example queries: "count by land use type", "how many features per administrative
 Required: field must be categorical/text (${CATEGORICAL_COLUMN_TYPES.join(', ')}).
 Optional aggregation: set metric to "aggregate", valueField to a numeric column, and aggregate to one of ${AGGREGATE_FUNCTIONS.join(', ')}.
 Optional sorting: sort can be "value-desc", "value-asc", "label-asc", or "label-desc".
+Optional density: maxBars caps the number of displayed categories; barMaxHeight controls the target maximum bar height in pixels.
 
 NOTE: Count plots aggregate by counting unique values, so they handle large datasets efficiently (no data point limit).
 

--- a/packages/mosaic/src/charts/chart-types/count-plot/tool.ts
+++ b/packages/mosaic/src/charts/chart-types/count-plot/tool.ts
@@ -29,7 +29,7 @@ Example queries: "count by land use type", "how many features per administrative
 Required: field must be categorical/text (${CATEGORICAL_COLUMN_TYPES.join(', ')}).
 Optional aggregation: set metric to "aggregate", valueField to a numeric column, and aggregate to one of ${AGGREGATE_FUNCTIONS.join(', ')}.
 Optional sorting: sort can be "value-desc", "value-asc", "label-asc", or "label-desc".
-Optional density: maxBars caps the number of displayed categories; barMaxHeight controls the target maximum bar height in pixels.
+Optional density: maxBars caps the number of displayed categories.
 
 NOTE: Count plots aggregate by counting unique values, so they handle large datasets efficiently (no data point limit).
 

--- a/packages/mosaic/src/charts/chart-types/count-plot/tool.ts
+++ b/packages/mosaic/src/charts/chart-types/count-plot/tool.ts
@@ -6,6 +6,9 @@ import {CATEGORICAL_COLUMN_TYPES} from '../../../column-types-utils';
 import {ChartToolParams, ChartToolOutput} from '../tool-types';
 import {validateCountPlotSettings} from './validation';
 import {ensureTable} from '../../../ai/tool-helpers';
+import {AggregateFunction} from '../../../schemas';
+
+const AGGREGATE_FUNCTIONS = AggregateFunction.options;
 
 export const CountPlotToolInput = BaseChartToolInput.extend({
   settings: CountPlotChartSettings.required(),
@@ -18,12 +21,14 @@ export function createCountPlotAiTool({
   addChart,
 }: ChartToolParams) {
   return tool<CountPlotToolInput, ChartToolOutput<CountPlotChartConfig>>({
-    description: `Count plot: horizontal bar chart showing frequency of categorical/text values. Counts how many times each unique value appears.
+    description: `Count plot: horizontal bar chart showing frequency of categorical/text values. By default, counts how many times each unique value appears. Can alternatively aggregate a numeric value column per category.
 
 Use when: user asks to "count", "frequency of", "how many", "breakdown by category", "distribution of [text/category column]".
-Example queries: "count by land use type", "how many features per administrative region", "frequency of terrain types", "breakdown by zone classification", "count parcels by ownership type".
+Example queries: "count by land use type", "how many features per administrative region", "frequency of terrain types", "breakdown by zone classification", "count parcels by ownership type", "total length by road class".
 
 Required: field must be categorical/text (${CATEGORICAL_COLUMN_TYPES.join(', ')}).
+Optional aggregation: set metric to "aggregate", valueField to a numeric column, and aggregate to one of ${AGGREGATE_FUNCTIONS.join(', ')}.
+Optional sorting: sort can be "value-desc", "value-asc", "label-asc", or "label-desc".
 
 NOTE: Count plots aggregate by counting unique values, so they handle large datasets efficiently (no data point limit).
 

--- a/packages/mosaic/src/charts/chart-types/count-plot/validation.ts
+++ b/packages/mosaic/src/charts/chart-types/count-plot/validation.ts
@@ -5,16 +5,20 @@ import {
   MissingColumnsError,
   RequiredFieldsError,
 } from '../errors';
-import {isCategoricalType} from '../../../column-types-utils';
+import {isCategoricalType, isNumericType} from '../../../column-types-utils';
 import {TableColumn} from '@sqlrooms/duckdb';
+import {AggregateFunction} from '../../../schemas';
 
 export type ValidatedCountPlotSettings = {
   fieldColumn: TableColumn;
+  metric: 'count' | 'aggregate';
+  valueColumn?: TableColumn;
+  aggregate: AggregateFunction;
 };
 
 export function validateCountPlotSettings({
   dataTable,
-  settings: {field},
+  settings: {aggregate = 'sum', field, metric = 'count', valueField},
 }: ValidateSpecOptions<CountPlotChartSettings>): ValidatedCountPlotSettings {
   // Basic validation for required fields
   if (!field) {
@@ -32,7 +36,32 @@ export function validateCountPlotSettings({
     throw new InvalidColumnTypeError(fieldColumn.name, 'categorical');
   }
 
+  if (metric === 'count') {
+    return {
+      fieldColumn,
+      aggregate,
+      metric,
+    };
+  }
+
+  if (!valueField) {
+    throw new RequiredFieldsError('Value field');
+  }
+
+  const valueColumn = dataTable.columns.find((col) => col.name === valueField);
+
+  if (!valueColumn) {
+    throw new MissingColumnsError(valueField);
+  }
+
+  if (!isNumericType(valueColumn.type)) {
+    throw new InvalidColumnTypeError(valueColumn.name, 'numeric');
+  }
+
   return {
+    aggregate,
     fieldColumn,
+    metric,
+    valueColumn,
   };
 }


### PR DESCRIPTION
## Summary

- Add Count Plot settings for metric mode, numeric aggregation, sort order, and manual left padding.
- Auto-derive a bounded left margin from chart metadata when no manual value is set.
- Extend count plot validation, AI tool guidance, README docs, and spec coverage.

## Validation

- `pnpm build`
- `pnpm --filter @sqlrooms/mosaic test -- --runTestsByPath packages/mosaic/__tests__/chart-types/count-plot-spec.test.ts`
- `pnpm --filter @sqlrooms/mosaic typecheck`
- Pre-push hook: `knip`, `turbo typecheck`, circular dependency scan, `turbo test`