### PR TITLE
fix: focus nearest text block from document background

### DIFF
--- a/packages/documents/src/BlockDocumentEditor/BlockDocumentEditorContent.tsx
+++ b/packages/documents/src/BlockDocumentEditor/BlockDocumentEditorContent.tsx
@@ -1,6 +1,7 @@
 import {cn, ScrollArea} from '@sqlrooms/ui';
-import {EditorContent} from '@tiptap/react';
-import type {FC} from 'react';
+import {TextSelection} from '@tiptap/pm/state';
+import {EditorContent, type Editor} from '@tiptap/react';
+import type {FC, MouseEvent as ReactMouseEvent} from 'react';
 import {useCallback, useState} from 'react';
 import {BlockDocumentBlockControls} from './BlockDocumentBlockControls';
 import {useBlockDocumentEditorContext} from './BlockDocumentEditorContext';
@@ -10,10 +11,187 @@ export type BlockDocumentEditorContentProps = {
   className?: string;
 };
 
+type ClosestTextBlock = {
+  element: HTMLElement;
+  pos: number;
+  nodeSize: number;
+};
+
+function getDirectNodePos(editor: Editor, element: HTMLElement) {
+  try {
+    const pos = editor.view.posAtDOM(element, 0);
+    const resolvedPos = editor.state.doc.resolve(pos);
+    for (let depth = resolvedPos.depth; depth > 0; depth -= 1) {
+      if (resolvedPos.node(depth).isTextblock) {
+        return resolvedPos.before(depth);
+      }
+    }
+    return resolvedPos.depth > 0 ? resolvedPos.before(1) : pos;
+  } catch {
+    return null;
+  }
+}
+
+function getTextBlockFromElement(
+  editor: Editor,
+  element: HTMLElement,
+): ClosestTextBlock | null {
+  const pos = getDirectNodePos(editor, element);
+  const node = pos == null ? null : editor.state.doc.nodeAt(pos);
+  if (pos == null || !node?.isTextblock) return null;
+  return {element, pos, nodeSize: node.nodeSize};
+}
+
+function getTextBlockFromClickTarget(
+  editor: Editor,
+  target: EventTarget | null,
+): ClosestTextBlock | null {
+  if (!(target instanceof HTMLElement)) return null;
+
+  const editorElement = editor.view.dom as HTMLElement;
+  let element: HTMLElement | null = target;
+  while (element && element !== editorElement) {
+    const block = getTextBlockFromElement(editor, element);
+    if (block) return block;
+    element = element.parentElement;
+  }
+
+  return null;
+}
+
+function getClosestTextBlockAtY(
+  editor: Editor,
+  editorElement: HTMLElement,
+  clientY: number,
+): ClosestTextBlock | null {
+  const blockRows = Array.from(editorElement.children)
+    .filter((child): child is HTMLElement => child instanceof HTMLElement)
+    .map((element) => {
+      const pos = getDirectNodePos(editor, element);
+      const node = pos == null ? null : editor.state.doc.nodeAt(pos);
+      return pos != null && node
+        ? {element, node, pos, rect: element.getBoundingClientRect()}
+        : null;
+    })
+    .filter(
+      (
+        row,
+      ): row is {
+        element: HTMLElement;
+        node: NonNullable<ReturnType<Editor['state']['doc']['nodeAt']>>;
+        pos: number;
+        rect: DOMRect;
+      } => row != null,
+    );
+
+  for (let index = 0; index < blockRows.length; index += 1) {
+    const row = blockRows[index]!;
+    const previousRow = blockRows[index - 1];
+    const nextRow = blockRows[index + 1];
+    const topBoundary = previousRow
+      ? (previousRow.rect.bottom + row.rect.top) / 2
+      : Number.NEGATIVE_INFINITY;
+    const bottomBoundary = nextRow
+      ? (row.rect.bottom + nextRow.rect.top) / 2
+      : Number.POSITIVE_INFINITY;
+
+    if (clientY >= topBoundary && clientY <= bottomBoundary) {
+      return row.node.isTextblock
+        ? {element: row.element, pos: row.pos, nodeSize: row.node.nodeSize}
+        : null;
+    }
+  }
+
+  return null;
+}
+
+function getTextBlockForClick(
+  editor: Editor,
+  event: ReactMouseEvent,
+): ClosestTextBlock | null {
+  const editorElement = editor.view.dom as HTMLElement;
+  return (
+    getTextBlockFromClickTarget(editor, event.target) ??
+    getClosestTextBlockAtY(editor, editorElement, event.clientY)
+  );
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(value, max));
+}
+
+function getTextSelectionPos(
+  editor: Editor,
+  block: ClosestTextBlock,
+  event: ReactMouseEvent,
+) {
+  const contentStart = block.pos + 1;
+  const contentEnd = block.pos + block.nodeSize - 1;
+  const rect = block.element.getBoundingClientRect();
+  const y =
+    rect.height > 2
+      ? clamp(event.clientY, rect.top + 1, rect.bottom - 1)
+      : event.clientY;
+  const coordsPos = editor.view.posAtCoords({
+    left: event.clientX,
+    top: y,
+  })?.pos;
+
+  if (
+    coordsPos != null &&
+    coordsPos >= contentStart &&
+    coordsPos <= contentEnd
+  ) {
+    return coordsPos;
+  }
+
+  return event.clientY >= rect.top + rect.height / 2
+    ? contentEnd
+    : contentStart;
+}
+
+function focusClosestTextBlock(editor: Editor, event: ReactMouseEvent) {
+  const block = getTextBlockForClick(editor, event);
+  if (!block) return;
+
+  const selectionPos = getTextSelectionPos(editor, block, event);
+  const selection = TextSelection.near(editor.state.doc.resolve(selectionPos));
+  editor.view.dispatch(editor.state.tr.setSelection(selection));
+  editor.view.focus();
+}
+
+function isInteractiveClickTarget(target: HTMLElement) {
+  return Boolean(
+    target.closest(
+      [
+        'a[href]',
+        'button',
+        'input',
+        'select',
+        'textarea',
+        '[contenteditable="false"]',
+        '[role="button"]',
+        '[role="menu"]',
+        '[role="menuitem"]',
+      ].join(','),
+    ),
+  );
+}
+
+function isSelectionPreservingClick(event: ReactMouseEvent) {
+  return (
+    event.shiftKey ||
+    event.metaKey ||
+    event.ctrlKey ||
+    event.altKey ||
+    event.detail > 1
+  );
+}
+
 export const BlockDocumentEditorContent: FC<
   BlockDocumentEditorContentProps
 > = ({className}) => {
-  const {editor} = useBlockDocumentEditorContext();
+  const {editor, readOnly} = useBlockDocumentEditorContext();
   const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(
     null,
   );
@@ -22,14 +200,22 @@ export const BlockDocumentEditorContent: FC<
   );
 
   const handleClick = useCallback(
-    (e: React.MouseEvent) => {
-      // Clear selection if clicking on the editor background (not on a block)
+    (e: ReactMouseEvent) => {
+      // Clear custom block selection if clicking in editable document space.
       const target = e.target as HTMLElement;
-      if (target.classList.contains('ProseMirror')) {
+      if (
+        editor &&
+        scrollElement?.contains(target) &&
+        !isSelectionPreservingClick(e) &&
+        !isInteractiveClickTarget(target)
+      ) {
         clearSelection?.();
+        if (!readOnly) {
+          focusClosestTextBlock(editor, e);
+        }
       }
     },
-    [clearSelection],
+    [clearSelection, editor, readOnly, scrollElement],
   );
 
   return (


### PR DESCRIPTION
## What changed

- Added document-space click handling for `BlockDocumentEditor.Content` so clicks on empty ProseMirror background, direct text block rows, or viewport whitespace below blocks focus the nearest text block.
- Preserves existing block-selection clearing behavior and ignores interactive controls/non-editable embedded content, so buttons, menus, inputs, charts, and media blocks do not steal focus.

## Why

Clicking empty space in a Worksheet/BlockDocument previously cleared selection without placing the cursor. The running app has three relevant click targets: the empty text block itself, the ProseMirror background, and the scroll viewport wrapper below the document content. This update handles all three.

## Validation

- `pnpm --filter @sqlrooms/documents typecheck`
- `pnpm --filter @sqlrooms/documents build`
- Browser verification on `http://localhost:3100/`: from a blurred top-bar input state, clicking 50px below the last text block focuses the ProseMirror editor and places selection in the empty paragraph.
- Browser verification on `http://localhost:3100/`: clicking whitespace to the right of the empty paragraph focuses the ProseMirror editor.
- Pre-push hook: `knip`, `turbo typecheck`, circular dependency check, and `turbo test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved click handling in the block editor so the cursor is placed more reliably in the nearest text area.
  * Better maps clicks across blocks of different sizes and positions, including edge cases near block boundaries.
  * Preserves selection when clicking interactive elements such as links, buttons, and form controls.
  * Prevents selection from being cleared when the click looks intentional (e.g., modifier/repeated clicks), and focuses the correct block when editing is allowed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->