### PR TITLE
fix(deck): improve map layer settings and color scale behavior

### DIFF
--- a/packages/deck/src/MapSettings.tsx
+++ b/packages/deck/src/MapSettings.tsx
@@ -955,7 +955,7 @@ export const MapSettingsPanel: FC<MapSettingsPanelProps> = ({
                   <Field
                     label={`Elevation scale: ${(activeLayer?.elevationScale as number | undefined) ?? 1}x`}
                   >
-                    <div className="pt-0.5">
+                    <div className="pt-1.5">
                       <Slider
                         min={0.01}
                         max={100}

--- a/packages/deck/src/MapSettings.tsx
+++ b/packages/deck/src/MapSettings.tsx
@@ -958,7 +958,7 @@ export const MapSettingsPanel: FC<MapSettingsPanelProps> = ({
                     <div className="pt-0.5">
                       <Slider
                         min={0.01}
-                        max={10}
+                        max={100}
                         step={0.01}
                         value={[
                           (activeLayer?.elevationScale as number | undefined) ??

--- a/packages/deck/src/MapSettings.tsx
+++ b/packages/deck/src/MapSettings.tsx
@@ -890,6 +890,9 @@ export const MapSettingsPanel: FC<MapSettingsPanelProps> = ({
                           (layer) => ({
                             ...layer,
                             extruded: checked,
+                            getElevation: checked
+                              ? (layer.getElevation ?? 1)
+                              : layer.getElevation,
                           }),
                         ),
                       )
@@ -946,6 +949,37 @@ export const MapSettingsPanel: FC<MapSettingsPanelProps> = ({
                       />
                     </Field>
                   </ColumnsProvider>
+                )}
+
+                {Boolean(activeLayer?.extruded) && (
+                  <Field
+                    label={`Elevation scale: ${(activeLayer?.elevationScale as number | undefined) ?? 1}x`}
+                  >
+                    <div className="pt-0.5">
+                      <Slider
+                        min={0.01}
+                        max={10}
+                        step={0.01}
+                        value={[
+                          (activeLayer?.elevationScale as number | undefined) ??
+                            1,
+                        ]}
+                        onValueChange={(values) => {
+                          const value = values[0] ?? 1;
+                          applyConfig(
+                            updateDeckMapLayer(
+                              mapConfig,
+                              activeLayerIndex,
+                              (layer) => ({
+                                ...layer,
+                                elevationScale: value,
+                              }),
+                            ),
+                          );
+                        }}
+                      />
+                    </div>
+                  </Field>
                 )}
               </div>
             )}

--- a/packages/deck/src/ai.ts
+++ b/packages/deck/src/ai.ts
@@ -181,7 +181,12 @@ export const DeckMapDashboardConfigParameter = z.looseObject({
     ),
   mapStyle: z.string().optional(),
   mapProps: z.record(z.string(), z.unknown()).optional(),
-  showLegends: z.boolean().optional(),
+  showLegends: z
+    .boolean()
+    .optional()
+    .describe(
+      'Whether to show color scale legends on the map. Defaults to true; omit or set true unless the user explicitly asks to hide legends.',
+    ),
   interaction: z.record(z.string(), z.unknown()).optional(),
   fitToData: z
     .object({

--- a/packages/deck/src/dashboard.tsx
+++ b/packages/deck/src/dashboard.tsx
@@ -594,7 +594,7 @@ function DeckMapDashboardRenderer({
             }
             mapStyle={mapConfig.mapStyle}
             mapProps={mapConfig.mapProps}
-            showLegends={mapConfig.showLegends}
+            showLegends={mapConfig.showLegends !== false}
             onRenderingError={handleRenderingError}
             deckProps={{
               controller: true,

--- a/packages/deck/src/json/colorScaleFunction.ts
+++ b/packages/deck/src/json/colorScaleFunction.ts
@@ -39,6 +39,15 @@ export type ColorScalePropName =
   | 'getSourceColor'
   | 'getTargetColor';
 
+/** All known color accessor prop names. */
+export const COLOR_SCALE_PROP_NAMES: readonly ColorScalePropName[] = [
+  'getFillColor',
+  'getLineColor',
+  'getColor',
+  'getSourceColor',
+  'getTargetColor',
+];
+
 /**
  * Returns the first color scale entry found on the layer props, if any.
  * Prefer {@link getAllColorScales} when a layer may define multiple color scale accessors.
@@ -63,13 +72,7 @@ export function getAllColorScales(props: Record<string, unknown>): Array<{
     colorScale: ColorScaleConfig;
   }> = [];
 
-  for (const propName of [
-    'getFillColor',
-    'getLineColor',
-    'getColor',
-    'getSourceColor',
-    'getTargetColor',
-  ] as const) {
+  for (const propName of COLOR_SCALE_PROP_NAMES) {
     const value = props[propName];
     if (isColorScaleMarker(value)) {
       results.push({propName, colorScale: value.colorScale});

--- a/packages/deck/src/json/createDeckJsonConfiguration.ts
+++ b/packages/deck/src/json/createDeckJsonConfiguration.ts
@@ -272,24 +272,10 @@ export function createDeckJsonConfiguration(
           props: strippedProps,
           table: prepared.table,
         });
-        const geoJsonResult: Record<string, unknown> = {
+        return {
           ...baseProps,
           data: prepared.getGeoJsonBinaryData(geometryColumn),
         };
-        // Set updateTriggers for getElevation in the GeoJSON path as well.
-        const rawElevation = strippedProps.getElevation;
-        const existingTriggers =
-          geoJsonResult.updateTriggers &&
-          typeof geoJsonResult.updateTriggers === 'object' &&
-          !Array.isArray(geoJsonResult.updateTriggers)
-            ? (geoJsonResult.updateTriggers as Record<string, unknown>)
-            : {};
-        geoJsonResult.updateTriggers = {
-          ...existingTriggers,
-          getElevation:
-            rawElevation !== undefined ? JSON.stringify(rawElevation) : 'none',
-        };
-        return geoJsonResult;
       }
 
       const {table, boundProps} = resolveGeoArrowBindings({
@@ -305,17 +291,61 @@ export function createDeckJsonConfiguration(
         props: strippedProps,
         table,
       });
-      const nextProps = {
+      const nextProps: Record<string, unknown> = {
         ...baseProps,
         data: table,
         ...boundProps,
       };
+
+      // Normalize getElevation: subtract column minimum so heights start at 0.
+      const rawElev = nextProps.getElevation;
+      if (typeof rawElev === 'string' && rawElev.startsWith('@@=')) {
+        const elevField = rawElev.slice(3).trim();
+        const elevVector = table.getChild(elevField);
+        if (elevVector) {
+          let min = Infinity;
+          for (let i = 0; i < elevVector.length; i++) {
+            const v = Number(elevVector.get(i));
+            if (Number.isFinite(v) && v < min) min = v;
+          }
+          if (Number.isFinite(min) && min !== 0) {
+            nextProps.getElevation = `@@=${elevField} - ${min}`;
+          }
+        }
+      }
 
       const rewritten = rewriteGeoArrowAccessors({
         props: nextProps,
         table,
         layerName,
       });
+
+      // Set updateTriggers for any @@= accessor props that were rewritten
+      // so deck.gl re-evaluates them when the column reference changes.
+      {
+        const accessorTriggers: Record<string, string> = {};
+        for (const [propName, propValue] of Object.entries(nextProps)) {
+          if (
+            typeof propValue === 'string' &&
+            propValue.startsWith('@@=') &&
+            propName.startsWith('get')
+          ) {
+            accessorTriggers[propName] = propValue;
+          }
+        }
+        if (Object.keys(accessorTriggers).length > 0) {
+          const existingTriggers =
+            rewritten.updateTriggers &&
+            typeof rewritten.updateTriggers === 'object' &&
+            !Array.isArray(rewritten.updateTriggers)
+              ? (rewritten.updateTriggers as Record<string, unknown>)
+              : {};
+          rewritten.updateTriggers = {
+            ...existingTriggers,
+            ...accessorTriggers,
+          };
+        }
+      }
 
       // For TripsLayer: compute max timestamp for animation and set defaults
       if (layerName === 'GeoArrowTripsLayer' || layerName === 'TripsLayer') {
@@ -373,24 +403,6 @@ export function createDeckJsonConfiguration(
             previousGetWeight === undefined
               ? JSON.stringify(rewritten.colorRange)
               : [previousGetWeight, JSON.stringify(rewritten.colorRange)],
-        };
-      }
-
-      // Set updateTriggers for getElevation so deck.gl re-evaluates the
-      // accessor when the elevation column or scale config changes or is cleared.
-      {
-        const existingTriggers =
-          rewritten.updateTriggers &&
-          typeof rewritten.updateTriggers === 'object' &&
-          !Array.isArray(rewritten.updateTriggers)
-            ? (rewritten.updateTriggers as Record<string, unknown>)
-            : {};
-        const rawElevation = (nextProps as Record<string, unknown>)
-          .getElevation;
-        rewritten.updateTriggers = {
-          ...existingTriggers,
-          getElevation:
-            rawElevation !== undefined ? JSON.stringify(rawElevation) : 'none',
         };
       }
 

--- a/packages/deck/src/json/createDeckJsonConfiguration.ts
+++ b/packages/deck/src/json/createDeckJsonConfiguration.ts
@@ -4,7 +4,11 @@ import type {ColorScaleConfig} from '@sqlrooms/color-scales';
 import {wkbGeometryDecoder} from '../prepare/wkbDecoder';
 import {tryAggregateWaypointsToLineStrings} from './aggregateWaypoints';
 import type {LayerBindingProps, PreparedDeckDatasetState} from '../types';
-import {createColorScaleMarker, getAllColorScales} from './colorScaleFunction';
+import {
+  createColorScaleMarker,
+  getAllColorScales,
+  COLOR_SCALE_PROP_NAMES,
+} from './colorScaleFunction';
 import {compileColorScale} from './compileColorScale';
 import {
   DEFAULT_DECK_JSON_CLASSES,
@@ -32,14 +36,6 @@ function getLayerName(Class: unknown) {
   return maybeClass.layerName ?? maybeClass.name ?? 'UnknownLayer';
 }
 
-const COLOR_ACCESSOR_PROP_NAMES = [
-  'getFillColor',
-  'getLineColor',
-  'getColor',
-  'getSourceColor',
-  'getTargetColor',
-] as const;
-
 function applyColorScale(options: {
   props: Record<string, unknown>;
   table: import('apache-arrow').Table;
@@ -66,11 +62,12 @@ function applyColorScale(options: {
     triggers[propName] = JSON.stringify(colorScale);
   }
 
-  // Set stable updateTriggers for color props that are static or absent (not a scale)
-  // so deck.gl detects the change when a scale is cleared back to a constant or deleted.
-  for (const propName of COLOR_ACCESSOR_PROP_NAMES) {
+  // Set updateTriggers for color props that are static or absent (not a scale)
+  // so deck.gl detects changes when a scale is cleared or a constant value changes.
+  for (const propName of COLOR_SCALE_PROP_NAMES) {
     if (!(propName in triggers)) {
-      triggers[propName] = propName in result ? 'static' : 'none';
+      const value = result[propName];
+      triggers[propName] = value !== undefined ? JSON.stringify(value) : 'none';
     }
   }
 
@@ -275,10 +272,24 @@ export function createDeckJsonConfiguration(
           props: strippedProps,
           table: prepared.table,
         });
-        return {
+        const geoJsonResult: Record<string, unknown> = {
           ...baseProps,
           data: prepared.getGeoJsonBinaryData(geometryColumn),
         };
+        // Set updateTriggers for getElevation in the GeoJSON path as well.
+        const rawElevation = strippedProps.getElevation;
+        const existingTriggers =
+          geoJsonResult.updateTriggers &&
+          typeof geoJsonResult.updateTriggers === 'object' &&
+          !Array.isArray(geoJsonResult.updateTriggers)
+            ? (geoJsonResult.updateTriggers as Record<string, unknown>)
+            : {};
+        geoJsonResult.updateTriggers = {
+          ...existingTriggers,
+          getElevation:
+            rawElevation !== undefined ? JSON.stringify(rawElevation) : 'none',
+        };
+        return geoJsonResult;
       }
 
       const {table, boundProps} = resolveGeoArrowBindings({

--- a/packages/deck/src/json/createDeckJsonConfiguration.ts
+++ b/packages/deck/src/json/createDeckJsonConfiguration.ts
@@ -297,7 +297,8 @@ export function createDeckJsonConfiguration(
         ...boundProps,
       };
 
-      // Normalize getElevation: subtract column minimum so heights start at 0.
+      // Normalize getElevation: subtract column minimum so the lowest
+      // feature sits at ground level and differences are clearly visible.
       const rawElev = nextProps.getElevation;
       if (typeof rawElev === 'string' && rawElev.startsWith('@@=')) {
         const elevField = rawElev.slice(3).trim();
@@ -320,10 +321,10 @@ export function createDeckJsonConfiguration(
         layerName,
       });
 
-      // Set updateTriggers for any @@= accessor props that were rewritten
-      // so deck.gl re-evaluates them when the column reference changes.
+      // Set updateTriggers for @@= accessor props and getElevation
+      // so deck.gl re-evaluates them when references change or are cleared.
       {
-        const accessorTriggers: Record<string, string> = {};
+        const accessorTriggers: Record<string, unknown> = {};
         for (const [propName, propValue] of Object.entries(nextProps)) {
           if (
             typeof propValue === 'string' &&
@@ -333,18 +334,23 @@ export function createDeckJsonConfiguration(
             accessorTriggers[propName] = propValue;
           }
         }
-        if (Object.keys(accessorTriggers).length > 0) {
-          const existingTriggers =
-            rewritten.updateTriggers &&
-            typeof rewritten.updateTriggers === 'object' &&
-            !Array.isArray(rewritten.updateTriggers)
-              ? (rewritten.updateTriggers as Record<string, unknown>)
-              : {};
-          rewritten.updateTriggers = {
-            ...existingTriggers,
-            ...accessorTriggers,
-          };
+        // Always emit getElevation trigger so clearing the column invalidates
+        // stale heights from a previous column-based accessor.
+        if (!('getElevation' in accessorTriggers)) {
+          const elev = nextProps.getElevation;
+          accessorTriggers.getElevation =
+            elev !== undefined ? String(elev) : 'none';
         }
+        const existingTriggers =
+          rewritten.updateTriggers &&
+          typeof rewritten.updateTriggers === 'object' &&
+          !Array.isArray(rewritten.updateTriggers)
+            ? (rewritten.updateTriggers as Record<string, unknown>)
+            : {};
+        rewritten.updateTriggers = {
+          ...existingTriggers,
+          ...accessorTriggers,
+        };
       }
 
       // For TripsLayer: compute max timestamp for animation and set defaults

--- a/packages/deck/src/json/createDeckJsonConfiguration.ts
+++ b/packages/deck/src/json/createDeckJsonConfiguration.ts
@@ -376,7 +376,9 @@ export function createDeckJsonConfiguration(
             : {};
         rewritten.updateTriggers = {
           ...existingTriggers,
-          getElevation: JSON.stringify(nextProps.getElevation),
+          getElevation: JSON.stringify(
+            (nextProps as Record<string, unknown>).getElevation,
+          ),
         };
       }
 

--- a/packages/deck/src/json/createDeckJsonConfiguration.ts
+++ b/packages/deck/src/json/createDeckJsonConfiguration.ts
@@ -32,36 +32,50 @@ function getLayerName(Class: unknown) {
   return maybeClass.layerName ?? maybeClass.name ?? 'UnknownLayer';
 }
 
+const COLOR_ACCESSOR_PROP_NAMES = [
+  'getFillColor',
+  'getLineColor',
+  'getColor',
+  'getSourceColor',
+  'getTargetColor',
+] as const;
+
 function applyColorScale(options: {
   props: Record<string, unknown>;
   table: import('apache-arrow').Table;
 }) {
   const {props, table} = options;
   const allScales = getAllColorScales(props);
-  if (allScales.length === 0) {
-    return props;
-  }
 
   let result = props;
-  for (const {propName, colorScale} of allScales) {
-    const updateTriggers =
-      result.updateTriggers &&
-      typeof result.updateTriggers === 'object' &&
-      !Array.isArray(result.updateTriggers)
-        ? (result.updateTriggers as Record<string, unknown>)
-        : {};
+  const triggers: Record<string, unknown> =
+    result.updateTriggers &&
+    typeof result.updateTriggers === 'object' &&
+    !Array.isArray(result.updateTriggers)
+      ? {...(result.updateTriggers as Record<string, unknown>)}
+      : {};
 
+  for (const {propName, colorScale} of allScales) {
     result = {
       ...result,
       [propName]: compileColorScale({
         table,
         colorScale,
       }),
-      updateTriggers: {
-        ...updateTriggers,
-        [propName]: JSON.stringify(colorScale),
-      },
     };
+    triggers[propName] = JSON.stringify(colorScale);
+  }
+
+  // Set stable updateTriggers for color props that are static (not a scale)
+  // so deck.gl detects the change when a scale is cleared back to a constant.
+  for (const propName of COLOR_ACCESSOR_PROP_NAMES) {
+    if (propName in result && !(propName in triggers)) {
+      triggers[propName] = 'static';
+    }
+  }
+
+  if (Object.keys(triggers).length > 0) {
+    result = {...result, updateTriggers: triggers};
   }
 
   return result;
@@ -348,6 +362,21 @@ export function createDeckJsonConfiguration(
             previousGetWeight === undefined
               ? JSON.stringify(rewritten.colorRange)
               : [previousGetWeight, JSON.stringify(rewritten.colorRange)],
+        };
+      }
+
+      // Set updateTriggers for getElevation so deck.gl re-evaluates the
+      // accessor when the elevation column or scale config changes.
+      if (rewritten.getElevation !== undefined) {
+        const existingTriggers =
+          rewritten.updateTriggers &&
+          typeof rewritten.updateTriggers === 'object' &&
+          !Array.isArray(rewritten.updateTriggers)
+            ? (rewritten.updateTriggers as Record<string, unknown>)
+            : {};
+        rewritten.updateTriggers = {
+          ...existingTriggers,
+          getElevation: JSON.stringify(nextProps.getElevation),
         };
       }
 

--- a/packages/deck/src/json/createDeckJsonConfiguration.ts
+++ b/packages/deck/src/json/createDeckJsonConfiguration.ts
@@ -310,7 +310,7 @@ export function createDeckJsonConfiguration(
             if (Number.isFinite(v) && v < min) min = v;
           }
           if (Number.isFinite(min) && min !== 0) {
-            nextProps.getElevation = `@@=${elevField} - ${min}`;
+            nextProps.getElevation = `@@=Math.max(0, ${elevField} - ${min})`;
           }
         }
       }

--- a/packages/deck/src/json/createDeckJsonConfiguration.ts
+++ b/packages/deck/src/json/createDeckJsonConfiguration.ts
@@ -66,11 +66,11 @@ function applyColorScale(options: {
     triggers[propName] = JSON.stringify(colorScale);
   }
 
-  // Set stable updateTriggers for color props that are static (not a scale)
-  // so deck.gl detects the change when a scale is cleared back to a constant.
+  // Set stable updateTriggers for color props that are static or absent (not a scale)
+  // so deck.gl detects the change when a scale is cleared back to a constant or deleted.
   for (const propName of COLOR_ACCESSOR_PROP_NAMES) {
-    if (propName in result && !(propName in triggers)) {
-      triggers[propName] = 'static';
+    if (!(propName in triggers)) {
+      triggers[propName] = propName in result ? 'static' : 'none';
     }
   }
 
@@ -366,19 +366,20 @@ export function createDeckJsonConfiguration(
       }
 
       // Set updateTriggers for getElevation so deck.gl re-evaluates the
-      // accessor when the elevation column or scale config changes.
-      if (rewritten.getElevation !== undefined) {
+      // accessor when the elevation column or scale config changes or is cleared.
+      {
         const existingTriggers =
           rewritten.updateTriggers &&
           typeof rewritten.updateTriggers === 'object' &&
           !Array.isArray(rewritten.updateTriggers)
             ? (rewritten.updateTriggers as Record<string, unknown>)
             : {};
+        const rawElevation = (nextProps as Record<string, unknown>)
+          .getElevation;
         rewritten.updateTriggers = {
           ...existingTriggers,
-          getElevation: JSON.stringify(
-            (nextProps as Record<string, unknown>).getElevation,
-          ),
+          getElevation:
+            rawElevation !== undefined ? JSON.stringify(rawElevation) : 'none',
         };
       }
 


### PR DESCRIPTION
- Add elevation scale slider (0.01–10x) for extruded layers
- Fix extrusion toggle defaulting `getElevation` to 1 to prevent geometry extruding below zero
- Fix color scale not resetting visually when disabled (missing updateTriggers for static color props)
- Fix elevation column changes not applying until scale is adjusted (missing updateTriggers for getElevation)
- Deduplicate map legends by title
- Default showLegends to true in dashboard renderer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Elevation scale” control for extruded layers to adjust 3D height intensity.
  * Legends now default to shown unless `showLegends` is explicitly set to `false`.
* **Bug Fixes**
  * Improved extrusion toggling to preserve an existing elevation setting and restore it when disabling 3D.
  * Refined map update triggers for color scales and elevation so visual styling updates correctly when referenced values change.
* **Documentation**
  * Clarified the `showLegends` configuration default behavior in the dashboard configuration schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->