### PR TITLE
feat(documents): add block reorder AI tool

### DIFF
--- a/apps/sqlrooms-cli-ui/src/ai/__tests__/createWorksheetBlockDocumentAiTools.test.ts
+++ b/apps/sqlrooms-cli-ui/src/ai/__tests__/createWorksheetBlockDocumentAiTools.test.ts
@@ -15,6 +15,7 @@ describe('createWorksheetBlockDocumentAiTools', () => {
       ensureBlockDocument: () => {},
       getBlocks: () => [],
       addBlock: (_blockDocumentId, block) => block.id,
+      moveBlock: () => true,
     };
   }
 
@@ -27,6 +28,7 @@ describe('createWorksheetBlockDocumentAiTools', () => {
 
   function createOptions(
     overrides: {
+      blockDocumentAdapter?: BlockDocumentAiAdapter;
       extraTools?: () => Record<string, Tool>;
       htmlAppBlocksEnabled?: boolean;
     } = {},
@@ -75,6 +77,31 @@ describe('createWorksheetBlockDocumentAiTools', () => {
 
     expect(tools[KnownWorksheetTools.add_html_app_block]).toBeUndefined();
     expect(tools[KnownWorksheetTools.embedded_html_app_agent]).toBeUndefined();
+  });
+
+  it('registers a built-in worksheet block move tool', async () => {
+    const blockDocumentAdapter = createBlockDocumentAdapter();
+    const moveBlock = jest.spyOn(blockDocumentAdapter, 'moveBlock');
+    const tools = createWorksheetBlockDocumentAiTools(
+      createOptions({blockDocumentAdapter}),
+    );
+
+    expect(tools[KnownWorksheetTools.move_block]).toBeDefined();
+
+    const result = await (tools[KnownWorksheetTools.move_block] as any).execute(
+      {
+        blockId: 'paragraph-1',
+        toIndex: 0,
+      },
+    );
+
+    expect(result).toEqual({
+      success: true,
+      blockId: 'paragraph-1',
+      toIndex: 0,
+      message: 'Moved block paragraph-1 to index 0',
+    });
+    expect(moveBlock).toHaveBeenCalledWith('worksheet-1', 'paragraph-1', 0);
   });
 
   it('rejects HTML app block tools when the embedded app agent is unavailable', () => {

--- a/apps/sqlrooms-cli-ui/src/ai/__tests__/createWorksheetBlockDocumentAiTools.test.ts
+++ b/apps/sqlrooms-cli-ui/src/ai/__tests__/createWorksheetBlockDocumentAiTools.test.ts
@@ -2,6 +2,7 @@ import {jest} from '@jest/globals';
 import {tool, type Tool} from 'ai';
 import type {
   BlockDocumentAiAdapter,
+  BlockDocumentMoveBlockAiAdapter,
   BlockDocumentStatefulBlockBlock,
 } from '@sqlrooms/documents';
 import type {DatabaseAiAdapter} from '@sqlrooms/mosaic/ai';
@@ -9,7 +10,8 @@ import {createWorksheetBlockDocumentAiTools} from '../createWorksheetBlockDocume
 import {KnownWorksheetTools} from '../constants';
 
 describe('createWorksheetBlockDocumentAiTools', () => {
-  function createBlockDocumentAdapter(): BlockDocumentAiAdapter {
+  function createBlockDocumentAdapter(): BlockDocumentAiAdapter &
+    BlockDocumentMoveBlockAiAdapter {
     return {
       setCurrentBlockDocument: () => {},
       ensureBlockDocument: () => {},
@@ -28,7 +30,8 @@ describe('createWorksheetBlockDocumentAiTools', () => {
 
   function createOptions(
     overrides: {
-      blockDocumentAdapter?: BlockDocumentAiAdapter;
+      blockDocumentAdapter?: BlockDocumentAiAdapter &
+        BlockDocumentMoveBlockAiAdapter;
       extraTools?: () => Record<string, Tool>;
       htmlAppBlocksEnabled?: boolean;
     } = {},

--- a/apps/sqlrooms-cli-ui/src/ai/createWorksheetAgentTool.ts
+++ b/apps/sqlrooms-cli-ui/src/ai/createWorksheetAgentTool.ts
@@ -102,9 +102,9 @@ ${htmlAppBlocksEnabled ? `8. If the user asks for an HTML app, D3 app, Chart.js 
 ### Existing Blocks
 Before updating a worksheet dashboard${
     htmlAppBlocksEnabled ? ', updating an existing worksheet HTML app,' : ''
-  } or adding a map to an existing worksheet, call ${KnownWorksheetTools.list_blocks} to find existing dashboard${
+  }, adding a map to an existing worksheet, or reordering blocks, call ${KnownWorksheetTools.list_blocks} to find existing dashboard${
     htmlAppBlocksEnabled ? '/html-app' : ''
-  } blocks and their resource IDs. For stateful blocks, use statefulBlock.blockType to identify the surface and statefulBlock.blockInstanceId as dashboardId, appId, or mapId for the matching embedded tool.
+  } blocks and their resource IDs. For stateful blocks, use statefulBlock.blockType to identify the surface and statefulBlock.blockInstanceId as dashboardId, appId, or mapId for the matching embedded tool. For reorder requests, use blockId and index from ${KnownWorksheetTools.list_blocks}, then call ${KnownWorksheetTools.move_block}; moving a block to the top means toIndex 0.
 
 ### Chart Blocks
 To create a chart block in a worksheet, call one of the chart generation tools:
@@ -254,6 +254,7 @@ When user asks for "comprehensive analysis" or "high-level insights":
   - For line charts: use GROUP BY with time buckets or aggregations
   - Histograms and count plots are always safe (they aggregate automatically)
 - **Validate columns:** Chart generation tools will validate column existence and types
+- **Reorder existing blocks:** Use ${KnownWorksheetTools.list_blocks} to identify the target block ID, then ${KnownWorksheetTools.move_block} with the desired zero-based destination index
 - **Handle errors gracefully:** If a query or chart creation fails, try alternative approach
 
 Common mistakes to avoid:
@@ -349,6 +350,10 @@ IF user requests an HTML/D3/Chart.js/browser app in a worksheet:
 `
     : ''
 }
+
+IF user asks to reorder or move worksheet content:
+1. Call ${KnownWorksheetTools.list_blocks} to identify the target blockId
+2. Call ${KnownWorksheetTools.move_block} with the target blockId and zero-based toIndex
 
 Otherwise, create chart and text blocks directly using ${BLOCK_DOCUMENT_CHART_TOOL_PREFIX}* tools.
 

--- a/apps/sqlrooms-cli-ui/src/ai/createWorksheetAgentTool.ts
+++ b/apps/sqlrooms-cli-ui/src/ai/createWorksheetAgentTool.ts
@@ -12,7 +12,10 @@ import {
   resolveChartTypes,
   type DatabaseAiAdapter,
 } from '@sqlrooms/mosaic/ai';
-import type {BlockDocumentAiAdapter} from '@sqlrooms/documents';
+import type {
+  BlockDocumentAiAdapter,
+  BlockDocumentMoveBlockAiAdapter,
+} from '@sqlrooms/documents';
 import type {RoomState} from '../store-types';
 import {
   createWorksheetBlockDocumentAiTools,
@@ -37,7 +40,8 @@ export type WorksheetAgentResult = {
 
 export type CreateWorksheetAgentToolOptions =
   BaseAgentToolOptions<RoomState> & {
-    blockDocumentAdapter: BlockDocumentAiAdapter;
+    blockDocumentAdapter: BlockDocumentAiAdapter &
+      BlockDocumentMoveBlockAiAdapter;
     databaseAdapter: DatabaseAiAdapter;
     dashboardAgentTool: Tool;
     chartToolsOptions?: ChartToolsOptions;

--- a/apps/sqlrooms-cli-ui/src/ai/createWorksheetBlockDocumentAiTools.ts
+++ b/apps/sqlrooms-cli-ui/src/ai/createWorksheetBlockDocumentAiTools.ts
@@ -2,6 +2,7 @@ import type {Tool} from 'ai';
 import {
   createAddBlockDocumentTextBlockTool,
   createListBlockDocumentBlocksTool,
+  createMoveBlockDocumentBlockTool,
   type BlockDocumentAiAdapter,
   type BlockDocumentStatefulBlockBlock,
 } from '@sqlrooms/documents';
@@ -154,6 +155,11 @@ export function createWorksheetBlockDocumentAiTools({
     }`,
   });
 
+  const moveBlockTool = createMoveBlockDocumentBlockTool({
+    blockDocumentAdapter,
+    blockDocumentId: worksheetId,
+  });
+
   const additionalTools =
     extraTools?.({
       worksheetId,
@@ -174,6 +180,7 @@ export function createWorksheetBlockDocumentAiTools({
   const builtInTools: Record<string, Tool> = {
     ...chartTools,
     [KnownWorksheetTools.list_blocks]: listBlocksTool,
+    [KnownWorksheetTools.move_block]: moveBlockTool,
     [KnownWorksheetTools.add_text_block]: addTextBlockTool,
     [KnownWorksheetTools.add_dashboard_block]: addDashboardBlockTool,
     [KnownWorksheetTools.add_data_table_explorer]: addDataTableExplorerTool,

--- a/apps/sqlrooms-cli-ui/src/ai/createWorksheetBlockDocumentAiTools.ts
+++ b/apps/sqlrooms-cli-ui/src/ai/createWorksheetBlockDocumentAiTools.ts
@@ -4,6 +4,7 @@ import {
   createListBlockDocumentBlocksTool,
   createMoveBlockDocumentBlockTool,
   type BlockDocumentAiAdapter,
+  type BlockDocumentMoveBlockAiAdapter,
   type BlockDocumentStatefulBlockBlock,
 } from '@sqlrooms/documents';
 import {
@@ -33,7 +34,8 @@ export type ExtraWorksheetAiToolsFactory = (
  */
 export type CreateWorksheetBlockDocumentAiToolsOptions = {
   databaseAdapter: DatabaseAiAdapter;
-  blockDocumentAdapter: BlockDocumentAiAdapter;
+  blockDocumentAdapter: BlockDocumentAiAdapter &
+    BlockDocumentMoveBlockAiAdapter;
   dashboardAgentTool: Tool;
   chartToolsOptions?: ChartToolsOptions;
   worksheetId: string;

--- a/apps/sqlrooms-cli-ui/src/createWorksheetAiAdapter.ts
+++ b/apps/sqlrooms-cli-ui/src/createWorksheetAiAdapter.ts
@@ -1,6 +1,7 @@
 import {
   createBlockDocumentCommandAiAdapter,
   type BlockDocumentAiAdapter,
+  type BlockDocumentMoveBlockAiAdapter,
 } from '@sqlrooms/documents';
 import type {StoreApi} from 'zustand';
 import type {RoomState} from './store-types';
@@ -11,7 +12,7 @@ import type {RoomState} from './store-types';
  */
 export function createWorksheetAiAdapter(
   store: StoreApi<RoomState>,
-): BlockDocumentAiAdapter {
+): BlockDocumentAiAdapter & BlockDocumentMoveBlockAiAdapter {
   return createBlockDocumentCommandAiAdapter({
     store,
     isBlockDocumentArtifact: (artifact) => artifact.type === 'worksheet',

--- a/packages/documents/README.md
+++ b/packages/documents/README.md
@@ -132,6 +132,7 @@ import {
   createAddBlockDocumentTextBlockTool,
   createBlockDocumentFeatureSlices,
   createListBlockDocumentBlocksTool,
+  createMoveBlockDocumentBlockTool,
 } from '@sqlrooms/documents';
 
 const roomStore = createRoomStore(
@@ -151,8 +152,8 @@ const roomStore = createRoomStore(
 
 Generic AI helpers use the same block DTOs as commands and the editor. Hosts
 provide a small `BlockDocumentAiAdapter` that ensures a document, lists its
-blocks, and appends new blocks; feature packages or apps can then compose these
-tools with their own stateful-block tools:
+blocks, appends new blocks, and reorders top-level blocks; feature packages or
+apps can then compose these tools with their own stateful-block tools:
 
 ```ts
 const tools = {
@@ -164,14 +165,18 @@ const tools = {
     blockDocumentAdapter,
     blockDocumentId,
   }),
+  move_block_document_block: createMoveBlockDocumentBlockTool({
+    blockDocumentAdapter,
+    blockDocumentId,
+  }),
 };
 ```
 
 `BlockDocumentAiAdapter.addBlock` may return a block ID synchronously or from a
 promise. Hosts that already expose block-document mutations as room commands can
 therefore use `createBlockDocumentCommandAiAdapter` to invoke the canonical
-`block-document.append-blocks` command while keeping generic AI tools
-package-neutral:
+`block-document.append-blocks` and `block-document.move-block` commands while
+keeping generic AI tools package-neutral:
 
 ```ts
 const blockDocumentAdapter = createBlockDocumentCommandAiAdapter({

--- a/packages/documents/README.md
+++ b/packages/documents/README.md
@@ -152,8 +152,9 @@ const roomStore = createRoomStore(
 
 Generic AI helpers use the same block DTOs as commands and the editor. Hosts
 provide a small `BlockDocumentAiAdapter` that ensures a document, lists its
-blocks, appends new blocks, and reorders top-level blocks; feature packages or
-apps can then compose these tools with their own stateful-block tools:
+blocks, and appends new blocks; feature packages or apps can then compose these
+tools with their own stateful-block tools. Reorder tools require the narrower
+`BlockDocumentMoveBlockAiAdapter` capability:
 
 ```ts
 const tools = {

--- a/packages/documents/__tests__/BlockDocumentAi.test.ts
+++ b/packages/documents/__tests__/BlockDocumentAi.test.ts
@@ -3,6 +3,7 @@ import {
   createBlockDocumentCommandIds,
   createAddBlockDocumentTextBlockTool,
   createListBlockDocumentBlocksTool,
+  createMoveBlockDocumentBlockTool,
   type BlockDocumentAiAdapter,
   type BlockDocumentBlock,
 } from '../src';
@@ -34,6 +35,7 @@ describe('block document AI helpers', () => {
         addedBlocks.push(block);
         return block.id;
       },
+      moveBlock: () => true,
     };
 
     const tool = createAddBlockDocumentTextBlockTool({
@@ -74,6 +76,7 @@ describe('block document AI helpers', () => {
         addBlockCalled = true;
         return block.id;
       },
+      moveBlock: () => true,
     };
 
     const tool = createAddBlockDocumentTextBlockTool({
@@ -104,6 +107,7 @@ describe('block document AI helpers', () => {
         addedBlocks.push(block);
         return `command:${block.id}`;
       },
+      moveBlock: () => true,
     };
 
     const tool = createAddBlockDocumentTextBlockTool({
@@ -153,6 +157,7 @@ describe('block document AI helpers', () => {
         }),
       ],
       addBlock: (_blockDocumentId, block) => block.id,
+      moveBlock: () => true,
     };
 
     const tool = createListBlockDocumentBlocksTool({
@@ -167,6 +172,7 @@ describe('block document AI helpers', () => {
       blocks: [
         {
           blockId: 'block-1',
+          index: 0,
           type: 'statefulBlock',
           caption: 'Dashboard',
           statefulBlock: {
@@ -177,6 +183,7 @@ describe('block document AI helpers', () => {
         },
         {
           blockId: 'block-2',
+          index: 1,
           type: 'statefulBlock',
           title: 'Country Explorer',
           statefulBlock: {
@@ -188,5 +195,67 @@ describe('block document AI helpers', () => {
     });
     expect(result.blocks[0]).not.toHaveProperty('dashboardId');
     expect(result.blocks[1]).not.toHaveProperty('htmlAppId');
+  });
+
+  it('moves a top-level block through the block document adapter', async () => {
+    const moveCalls: unknown[][] = [];
+    const ensuredBlockDocumentIds: string[] = [];
+    const blockDocumentAdapter: BlockDocumentAiAdapter = {
+      setCurrentBlockDocument: () => {},
+      ensureBlockDocument: (blockDocumentId) => {
+        ensuredBlockDocumentIds.push(blockDocumentId);
+      },
+      getBlocks: () => [],
+      addBlock: (_blockDocumentId, block) => block.id,
+      moveBlock: (blockDocumentId, blockId, toIndex) => {
+        moveCalls.push([blockDocumentId, blockId, toIndex]);
+        return true;
+      },
+    };
+
+    const moveTool = createMoveBlockDocumentBlockTool({
+      blockDocumentAdapter,
+      blockDocumentId: 'document-1',
+    });
+
+    const result = await (moveTool as any).execute({
+      reasoning: 'Move the joke to the top.',
+      blockId: 'joke-block',
+      toIndex: 0,
+    });
+
+    expect(result).toEqual({
+      success: true,
+      blockId: 'joke-block',
+      toIndex: 0,
+      message: 'Moved block joke-block to index 0',
+    });
+    expect(ensuredBlockDocumentIds).toEqual(['document-1']);
+    expect(moveCalls).toEqual([['document-1', 'joke-block', 0]]);
+  });
+
+  it('reports missing blocks when the adapter cannot move a block', async () => {
+    const blockDocumentAdapter: BlockDocumentAiAdapter = {
+      setCurrentBlockDocument: () => {},
+      ensureBlockDocument: () => {},
+      getBlocks: () => [],
+      addBlock: (_blockDocumentId, block) => block.id,
+      moveBlock: () => false,
+    };
+
+    const moveTool = createMoveBlockDocumentBlockTool({
+      blockDocumentAdapter,
+      blockDocumentId: 'document-1',
+    });
+
+    const result = await (moveTool as any).execute({
+      blockId: 'missing-block',
+      toIndex: 0,
+    });
+
+    expect(result).toEqual({
+      success: false,
+      errorMessage: 'Block "missing-block" was not found.',
+    });
   });
 });

--- a/packages/documents/__tests__/BlockDocumentAi.test.ts
+++ b/packages/documents/__tests__/BlockDocumentAi.test.ts
@@ -6,6 +6,7 @@ import {
   createMoveBlockDocumentBlockTool,
   type BlockDocumentAiAdapter,
   type BlockDocumentBlock,
+  type BlockDocumentMoveBlockAiAdapter,
 } from '../src';
 
 describe('block document AI helpers', () => {
@@ -35,7 +36,6 @@ describe('block document AI helpers', () => {
         addedBlocks.push(block);
         return block.id;
       },
-      moveBlock: () => true,
     };
 
     const tool = createAddBlockDocumentTextBlockTool({
@@ -76,7 +76,6 @@ describe('block document AI helpers', () => {
         addBlockCalled = true;
         return block.id;
       },
-      moveBlock: () => true,
     };
 
     const tool = createAddBlockDocumentTextBlockTool({
@@ -107,7 +106,6 @@ describe('block document AI helpers', () => {
         addedBlocks.push(block);
         return `command:${block.id}`;
       },
-      moveBlock: () => true,
     };
 
     const tool = createAddBlockDocumentTextBlockTool({
@@ -157,7 +155,6 @@ describe('block document AI helpers', () => {
         }),
       ],
       addBlock: (_blockDocumentId, block) => block.id,
-      moveBlock: () => true,
     };
 
     const tool = createListBlockDocumentBlocksTool({
@@ -200,13 +197,10 @@ describe('block document AI helpers', () => {
   it('moves a top-level block through the block document adapter', async () => {
     const moveCalls: unknown[][] = [];
     const ensuredBlockDocumentIds: string[] = [];
-    const blockDocumentAdapter: BlockDocumentAiAdapter = {
-      setCurrentBlockDocument: () => {},
+    const blockDocumentAdapter: BlockDocumentMoveBlockAiAdapter = {
       ensureBlockDocument: (blockDocumentId) => {
         ensuredBlockDocumentIds.push(blockDocumentId);
       },
-      getBlocks: () => [],
-      addBlock: (_blockDocumentId, block) => block.id,
       moveBlock: (blockDocumentId, blockId, toIndex) => {
         moveCalls.push([blockDocumentId, blockId, toIndex]);
         return true;
@@ -234,12 +228,28 @@ describe('block document AI helpers', () => {
     expect(moveCalls).toEqual([['document-1', 'joke-block', 0]]);
   });
 
-  it('reports missing blocks when the adapter cannot move a block', async () => {
-    const blockDocumentAdapter: BlockDocumentAiAdapter = {
-      setCurrentBlockDocument: () => {},
+  it('rejects negative move indexes at the tool schema boundary', () => {
+    const blockDocumentAdapter: BlockDocumentMoveBlockAiAdapter = {
       ensureBlockDocument: () => {},
-      getBlocks: () => [],
-      addBlock: (_blockDocumentId, block) => block.id,
+      moveBlock: () => true,
+    };
+
+    const moveTool = createMoveBlockDocumentBlockTool({
+      blockDocumentAdapter,
+      blockDocumentId: 'document-1',
+    });
+
+    expect(
+      (moveTool as any).inputSchema.safeParse({
+        blockId: 'joke-block',
+        toIndex: -1,
+      }).success,
+    ).toBe(false);
+  });
+
+  it('reports missing blocks when the adapter cannot move a block', async () => {
+    const blockDocumentAdapter: BlockDocumentMoveBlockAiAdapter = {
+      ensureBlockDocument: () => {},
       moveBlock: () => false,
     };
 

--- a/packages/documents/__tests__/createBlockDocumentCommandAiAdapter.test.ts
+++ b/packages/documents/__tests__/createBlockDocumentCommandAiAdapter.test.ts
@@ -1,6 +1,7 @@
 import {
   BLOCK_DOCUMENT_AGENT_ACTOR,
   BLOCK_DOCUMENT_APPEND_BLOCKS_COMMAND_ID,
+  BLOCK_DOCUMENT_MOVE_BLOCK_COMMAND_ID,
   createBlockDocumentCommandAiAdapter,
   type BlockDocumentBlock,
 } from '../src';
@@ -23,12 +24,15 @@ function createMockStore({
   };
   const invokeCommandImpl =
     invokeCommand ??
-    (async (_commandId, input: any) => ({
+    (async (commandId, input: any) => ({
       success: true,
-      commandId: BLOCK_DOCUMENT_APPEND_BLOCKS_COMMAND_ID,
-      data: {
-        blockId: input.blocks[0].id,
-      },
+      commandId,
+      data:
+        commandId === BLOCK_DOCUMENT_APPEND_BLOCKS_COMMAND_ID
+          ? {
+              blockId: input.blocks[0].id,
+            }
+          : {},
     }));
   const trackedInvokeCommand = async (...args: any[]) => {
     invokeCommandCalls.push(args);
@@ -110,6 +114,32 @@ describe('createBlockDocumentCommandAiAdapter', () => {
     ]);
   });
 
+  it('moves blocks through the canonical block document command', async () => {
+    const {store, ensureBlockDocumentCalls, invokeCommandCalls} =
+      createMockStore();
+    const adapter = createBlockDocumentCommandAiAdapter({store});
+
+    await expect(adapter.moveBlock('doc-1', 'paragraph-1', 0)).resolves.toBe(
+      true,
+    );
+
+    expect(ensureBlockDocumentCalls).toEqual([['doc-1']]);
+    expect(invokeCommandCalls).toEqual([
+      [
+        BLOCK_DOCUMENT_MOVE_BLOCK_COMMAND_ID,
+        {
+          artifactId: 'doc-1',
+          blockId: 'paragraph-1',
+          toIndex: 0,
+        },
+        {
+          surface: 'ai',
+          actor: BLOCK_DOCUMENT_AGENT_ACTOR,
+        },
+      ],
+    ]);
+  });
+
   it('allows hosts to recognize compatible block-document artifact types', () => {
     const {store} = createMockStore({artifactType: 'analysis-doc'});
     const adapter = createBlockDocumentCommandAiAdapter({
@@ -164,5 +194,20 @@ describe('createBlockDocumentCommandAiAdapter', () => {
         text: 'Summary',
       }),
     ).rejects.toThrow('Append failed');
+  });
+
+  it('throws command errors when move command invocation fails', async () => {
+    const {store} = createMockStore({
+      invokeCommand: async () => ({
+        success: false,
+        commandId: BLOCK_DOCUMENT_MOVE_BLOCK_COMMAND_ID,
+        error: 'Move failed',
+      }),
+    });
+    const adapter = createBlockDocumentCommandAiAdapter({store});
+
+    await expect(adapter.moveBlock('doc-1', 'paragraph-1', 0)).rejects.toThrow(
+      'Move failed',
+    );
   });
 });

--- a/packages/documents/src/BlockDocumentAi.ts
+++ b/packages/documents/src/BlockDocumentAi.ts
@@ -9,6 +9,7 @@ export const BLOCK_DOCUMENT_AGENT_TOOL_NAME = 'block_document_agent';
 export const KnownDocumentBlockTools = {
   add_text_block: 'add_block_document_text_block',
   list_blocks: 'list_block_document_blocks',
+  move_block: 'move_block_document_block',
 } as const;
 
 /**
@@ -26,6 +27,12 @@ export type BlockDocumentAiAdapter = {
     blockDocumentId: string,
     block: BlockDocumentBlock,
   ): string | Promise<string>;
+  /** Move a top-level block to a new zero-based index. */
+  moveBlock(
+    blockDocumentId: string,
+    blockId: string,
+    toIndex: number,
+  ): boolean | Promise<boolean>;
 };
 
 /**
@@ -33,6 +40,7 @@ export type BlockDocumentAiAdapter = {
  */
 export type BlockDocumentBlockSummary = {
   blockId: string;
+  index: number;
   type: string;
   title?: string;
   caption?: string;

--- a/packages/documents/src/BlockDocumentAi.ts
+++ b/packages/documents/src/BlockDocumentAi.ts
@@ -27,6 +27,15 @@ export type BlockDocumentAiAdapter = {
     blockDocumentId: string,
     block: BlockDocumentBlock,
   ): string | Promise<string>;
+};
+
+/**
+ * Narrow adapter for tools that reorder top-level block document blocks.
+ */
+export type BlockDocumentMoveBlockAiAdapter = Pick<
+  BlockDocumentAiAdapter,
+  'ensureBlockDocument'
+> & {
   /** Move a top-level block to a new zero-based index. */
   moveBlock(
     blockDocumentId: string,

--- a/packages/documents/src/createBlockDocumentCommandAiAdapter.ts
+++ b/packages/documents/src/createBlockDocumentCommandAiAdapter.ts
@@ -1,7 +1,10 @@
 import type {ArtifactMetadataType} from '@sqlrooms/artifacts';
 import type {CommandSliceState} from '@sqlrooms/room-store';
 import type {StoreApi} from 'zustand';
-import type {BlockDocumentAiAdapter} from './BlockDocumentAi';
+import type {
+  BlockDocumentAiAdapter,
+  BlockDocumentMoveBlockAiAdapter,
+} from './BlockDocumentAi';
 import type {BlockDocumentBlock} from './BlockDocumentSliceConfig';
 import type {BlockDocumentsSliceState} from './BlockDocumentsSlice';
 
@@ -45,15 +48,16 @@ function blockIdFromAppendResult(data: unknown, block: BlockDocumentBlock) {
 }
 
 /**
- * Creates a block-document AI adapter that appends blocks through the canonical
- * block-document command.
+ * Creates a block-document AI adapter that mutates blocks through canonical
+ * block-document commands.
  */
 export function createBlockDocumentCommandAiAdapter<
   TRoomState extends BlockDocumentCommandAiAdapterState,
 >({
   store,
   isBlockDocumentArtifact = (artifact) => artifact.type === 'block-document',
-}: CreateBlockDocumentCommandAiAdapterOptions<TRoomState>): BlockDocumentAiAdapter {
+}: CreateBlockDocumentCommandAiAdapterOptions<TRoomState>): BlockDocumentAiAdapter &
+  BlockDocumentMoveBlockAiAdapter {
   const ensureBlockDocument = (artifactId: string) => {
     const state = store.getState();
     const artifact = state.artifacts.getArtifact(artifactId);

--- a/packages/documents/src/createBlockDocumentCommandAiAdapter.ts
+++ b/packages/documents/src/createBlockDocumentCommandAiAdapter.ts
@@ -7,6 +7,7 @@ import type {BlockDocumentsSliceState} from './BlockDocumentsSlice';
 
 export const BLOCK_DOCUMENT_APPEND_BLOCKS_COMMAND_ID =
   'block-document.append-blocks';
+export const BLOCK_DOCUMENT_MOVE_BLOCK_COMMAND_ID = 'block-document.move-block';
 
 export const BLOCK_DOCUMENT_AGENT_ACTOR = 'block-document-agent';
 
@@ -105,6 +106,33 @@ export function createBlockDocumentCommandAiAdapter<
       }
 
       return blockIdFromAppendResult(result.data, block);
+    },
+
+    moveBlock: async (artifactId, blockId, toIndex) => {
+      ensureBlockDocument(artifactId);
+
+      const result = await store.getState().commands.invokeCommand(
+        BLOCK_DOCUMENT_MOVE_BLOCK_COMMAND_ID,
+        {
+          artifactId,
+          blockId,
+          toIndex,
+        },
+        {
+          surface: 'ai',
+          actor: BLOCK_DOCUMENT_AGENT_ACTOR,
+        },
+      );
+
+      if (!result.success) {
+        throw new Error(
+          result.error ??
+            result.message ??
+            `Failed to execute ${BLOCK_DOCUMENT_MOVE_BLOCK_COMMAND_ID}`,
+        );
+      }
+
+      return true;
     },
   };
 }

--- a/packages/documents/src/createListBlockDocumentBlocksTool.ts
+++ b/packages/documents/src/createListBlockDocumentBlocksTool.ts
@@ -39,12 +39,14 @@ export type CreateListBlockDocumentBlocksToolOptions = {
 
 function summarizeBlock(
   block: ReturnType<typeof blockDocumentNodeToBlock>,
+  index: number,
 ): BlockDocumentBlockSummary | undefined {
   if (!block) return undefined;
 
   if (block.type === 'statefulBlock') {
     return {
       blockId: block.id,
+      index,
       type: block.type,
       ...(block.title !== undefined ? {title: block.title} : {}),
       ...(block.caption !== undefined ? {caption: block.caption} : {}),
@@ -61,6 +63,7 @@ function summarizeBlock(
   if (block.type === 'chart') {
     return {
       blockId: block.id,
+      index,
       type: block.type,
       tableName: block.tableName,
       ...(block.caption !== undefined ? {caption: block.caption} : {}),
@@ -69,6 +72,7 @@ function summarizeBlock(
 
   return {
     blockId: block.id,
+    index,
     type: block.type,
     ...('text' in block ? {title: block.text} : {}),
     ...('caption' in block && block.caption !== undefined
@@ -104,7 +108,9 @@ export function createListBlockDocumentBlocksTool({
         return {
           success: true,
           blocks: blocks
-            .map((node) => summarizeBlock(blockDocumentNodeToBlock(node)))
+            .map((node, index) =>
+              summarizeBlock(blockDocumentNodeToBlock(node), index),
+            )
             .filter(
               (block): block is BlockDocumentBlockSummary =>
                 block !== undefined,

--- a/packages/documents/src/createMoveBlockDocumentBlockTool.ts
+++ b/packages/documents/src/createMoveBlockDocumentBlockTool.ts
@@ -1,0 +1,85 @@
+import {tool} from 'ai';
+import {z} from 'zod';
+import type {BlockDocumentAiAdapter} from './BlockDocumentAi';
+
+const MoveBlockDocumentBlockToolInput = z.object({
+  reasoning: z
+    .string()
+    .optional()
+    .describe('Brief rationale for moving this block.'),
+  blockId: z.string().describe('ID of the top-level block to move.'),
+  toIndex: z
+    .number()
+    .int()
+    .describe('Zero-based destination index among top-level blocks.'),
+});
+
+type MoveBlockDocumentBlockToolInput = z.infer<
+  typeof MoveBlockDocumentBlockToolInput
+>;
+
+type BlockDocumentToolOutput<T> =
+  | ({success: true} & T)
+  | {success: false; errorMessage: string};
+
+type MoveBlockDocumentBlockToolOutput = BlockDocumentToolOutput<{
+  blockId?: string;
+  toIndex?: number;
+  message?: string;
+}>;
+
+/**
+ * Options for creating a generic block-document move tool.
+ */
+export type CreateMoveBlockDocumentBlockToolOptions = {
+  /** Adapter for block document operations. */
+  blockDocumentAdapter: BlockDocumentAiAdapter;
+  /** ID of the block document where blocks will be reordered. */
+  blockDocumentId: string;
+};
+
+/**
+ * Creates a tool for reordering one top-level block in a block document.
+ */
+export function createMoveBlockDocumentBlockTool({
+  blockDocumentAdapter,
+  blockDocumentId,
+}: CreateMoveBlockDocumentBlockToolOptions) {
+  return tool<
+    MoveBlockDocumentBlockToolInput,
+    MoveBlockDocumentBlockToolOutput
+  >({
+    description: `Move a top-level block in the block document to a new index.
+Use this after listing blocks when the user asks to reorder worksheet content, such as moving a paragraph to the top.`,
+    inputSchema: MoveBlockDocumentBlockToolInput,
+    execute: async ({blockId, toIndex}) => {
+      try {
+        blockDocumentAdapter.ensureBlockDocument(blockDocumentId);
+        const moved = await blockDocumentAdapter.moveBlock(
+          blockDocumentId,
+          blockId,
+          toIndex,
+        );
+
+        if (!moved) {
+          return {
+            success: false,
+            errorMessage: `Block "${blockId}" was not found.`,
+          };
+        }
+
+        return {
+          success: true,
+          blockId,
+          toIndex,
+          message: `Moved block ${blockId} to index ${toIndex}`,
+        };
+      } catch (error) {
+        return {
+          success: false,
+          errorMessage: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
+  });
+}

--- a/packages/documents/src/createMoveBlockDocumentBlockTool.ts
+++ b/packages/documents/src/createMoveBlockDocumentBlockTool.ts
@@ -1,6 +1,6 @@
 import {tool} from 'ai';
 import {z} from 'zod';
-import type {BlockDocumentAiAdapter} from './BlockDocumentAi';
+import type {BlockDocumentMoveBlockAiAdapter} from './BlockDocumentAi';
 
 const MoveBlockDocumentBlockToolInput = z.object({
   reasoning: z
@@ -11,6 +11,7 @@ const MoveBlockDocumentBlockToolInput = z.object({
   toIndex: z
     .number()
     .int()
+    .nonnegative()
     .describe('Zero-based destination index among top-level blocks.'),
 });
 
@@ -33,7 +34,7 @@ type MoveBlockDocumentBlockToolOutput = BlockDocumentToolOutput<{
  */
 export type CreateMoveBlockDocumentBlockToolOptions = {
   /** Adapter for block document operations. */
-  blockDocumentAdapter: BlockDocumentAiAdapter;
+  blockDocumentAdapter: BlockDocumentMoveBlockAiAdapter;
   /** ID of the block document where blocks will be reordered. */
   blockDocumentId: string;
 };

--- a/packages/documents/src/index.ts
+++ b/packages/documents/src/index.ts
@@ -95,6 +95,7 @@ export {
 export {
   BLOCK_DOCUMENT_APPEND_BLOCKS_COMMAND_ID,
   BLOCK_DOCUMENT_AGENT_ACTOR,
+  BLOCK_DOCUMENT_MOVE_BLOCK_COMMAND_ID,
   createBlockDocumentCommandAiAdapter,
   type CreateBlockDocumentCommandAiAdapterOptions,
 } from './createBlockDocumentCommandAiAdapter';
@@ -117,6 +118,10 @@ export {
   createListBlockDocumentBlocksTool,
   type CreateListBlockDocumentBlocksToolOptions,
 } from './createListBlockDocumentBlocksTool';
+export {
+  createMoveBlockDocumentBlockTool,
+  type CreateMoveBlockDocumentBlockToolOptions,
+} from './createMoveBlockDocumentBlockTool';
 export {BlockDocumentEditor} from './BlockDocumentEditor';
 export {
   BlockDocumentEditorRoot,

--- a/packages/documents/src/index.ts
+++ b/packages/documents/src/index.ts
@@ -106,6 +106,7 @@ export {
   type BlockDocumentAgentPlanStep,
   type BlockDocumentAgentResult,
   type BlockDocumentBlockSummary,
+  type BlockDocumentMoveBlockAiAdapter,
   type ExtraBlockDocumentAiToolsFactory,
   type ExtraBlockDocumentAiToolsParams,
 } from './BlockDocumentAi';

--- a/packages/mosaic/__tests__/block-document-ai.test.ts
+++ b/packages/mosaic/__tests__/block-document-ai.test.ts
@@ -36,7 +36,6 @@ describe('Mosaic block-document AI tools', () => {
         addedBlocks.push(block);
         return block.id;
       },
-      moveBlock: () => true,
     };
 
     return {blockDocumentAdapter, addedBlocks};
@@ -127,7 +126,6 @@ describe('Mosaic block-document AI tools', () => {
       },
       getBlocks: () => [],
       addBlock: jest.fn((_blockDocumentId, block) => block.id),
-      moveBlock: () => true,
     };
 
     const tool = createAddMosaicDashboardBlockTool({
@@ -220,7 +218,6 @@ describe('Mosaic block-document AI tools', () => {
       },
       getBlocks: () => [],
       addBlock: jest.fn((_blockDocumentId, block) => block.id),
-      moveBlock: () => true,
     };
 
     const dataTableTool = createBlockDocumentDataTableExplorerTool({

--- a/packages/mosaic/__tests__/block-document-ai.test.ts
+++ b/packages/mosaic/__tests__/block-document-ai.test.ts
@@ -29,12 +29,14 @@ describe('Mosaic block-document AI tools', () => {
   function createMockBlockDocumentAdapter() {
     const addedBlocks: BlockDocumentBlock[] = [];
     const blockDocumentAdapter: BlockDocumentAiAdapter = {
+      setCurrentBlockDocument: () => {},
       ensureBlockDocument: () => {},
       getBlocks: () => [],
       addBlock: (_blockDocumentId, block) => {
         addedBlocks.push(block);
         return block.id;
       },
+      moveBlock: () => true,
     };
 
     return {blockDocumentAdapter, addedBlocks};
@@ -119,11 +121,13 @@ describe('Mosaic block-document AI tools', () => {
       } satisfies BlockDocumentStatefulBlockBlock,
     }));
     const blockDocumentAdapter: BlockDocumentAiAdapter = {
+      setCurrentBlockDocument: () => {},
       ensureBlockDocument: () => {
         throw new Error('Block document was deleted');
       },
       getBlocks: () => [],
       addBlock: jest.fn((_blockDocumentId, block) => block.id),
+      moveBlock: () => true,
     };
 
     const tool = createAddMosaicDashboardBlockTool({
@@ -210,11 +214,13 @@ describe('Mosaic block-document AI tools', () => {
       }),
     );
     const blockDocumentAdapter: BlockDocumentAiAdapter = {
+      setCurrentBlockDocument: () => {},
       ensureBlockDocument: () => {
         throw new Error('Block document was deleted');
       },
       getBlocks: () => [],
       addBlock: jest.fn((_blockDocumentId, block) => block.id),
+      moveBlock: () => true,
     };
 
     const dataTableTool = createBlockDocumentDataTableExplorerTool({


### PR DESCRIPTION
## Summary

- Add a generic `move_block_document_block` AI tool for reordering top-level block document blocks by block ID and destination index.
- Route command-backed AI adapters through the existing canonical `block-document.move-block` command.
- Include block indexes in `list_block_document_blocks` summaries and teach the worksheet agent to use list-then-move for reorder requests.
- Cover the new adapter/tool behavior in documents, worksheet, and mosaic tests and update the documents README.

## Why

Block documents already had a slice-level and room-command move operation, but the worksheet/block-document agent toolset only exposed listing and append-style mutations. Agents could inspect blocks but had no AI-facing reorder tool, so requests like moving an existing paragraph to the top failed even though the underlying command existed.

## Validation

- `pnpm build`
- `pnpm --filter @sqlrooms/documents test --runInBand`
- `pnpm --filter sqlrooms-cli-app test --runInBand createWorksheetBlockDocumentAiTools`
- `pnpm --filter @sqlrooms/mosaic test --runInBand block-document-ai`
- `pnpm --filter @sqlrooms/documents typecheck`
- `pnpm --filter sqlrooms-cli-app typecheck`
- Pre-push hooks: `knip`, full `turbo typecheck`, circular dependency check, full `turbo test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for moving and reordering blocks within worksheet and block documents.
  * Block listings now show each block’s position, making it easier to identify where content sits.
  * AI-assisted workflows can now guide users through reordering existing content.

* **Bug Fixes**
  * Improved handling for move/reorder actions, including clearer success and error responses when a block can’t be moved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->