### PR TITLE
fix(deck): pass custom num rows; detect missing columns fix

### DIFF
--- a/packages/deck/src/dashboard.tsx
+++ b/packages/deck/src/dashboard.tsx
@@ -140,8 +140,11 @@ function detectMissingColumns(
 
       if (typeof propValue === 'string' && propValue.startsWith('@@=')) {
         const expression = propValue.slice(3).trim();
-        if (/^[A-Za-z_$][\w$]*$/.test(expression)) {
-          check(expression);
+        const identifiers = expression.match(/\b[A-Za-z_$][\w$]*\b/g);
+        if (identifiers) {
+          for (const id of identifiers) {
+            check(id);
+          }
         }
       }
       // Check @@function colorScale/scale field references
@@ -293,7 +296,7 @@ function DeckMapDashboardDatasetClient({
       ? (source.transformSql ?? '')
       : '';
   const {data, error, isLoading, client} = useMosaicClient({
-    id: `${panel.id}:${datasetId}:${sourceKey}:${sourceQueryKey}`,
+    id: `${panel.id}:${datasetId}:${sourceKey}:${sourceQueryKey}:${maxRows}`,
     selectionName,
     query,
     queryError,

--- a/packages/deck/src/dashboard.tsx
+++ b/packages/deck/src/dashboard.tsx
@@ -139,7 +139,10 @@ function detectMissingColumns(
       if (propName === 'getElevation' && !layerObj.extruded) continue;
 
       if (typeof propValue === 'string' && propValue.startsWith('@@=')) {
-        check(propValue.slice(3).trim());
+        const expression = propValue.slice(3).trim();
+        if (/^[A-Za-z_$][\w$]*$/.test(expression)) {
+          check(expression);
+        }
       }
       // Check @@function colorScale/scale field references
       if (
@@ -509,6 +512,9 @@ function DeckMapDashboardRenderer({
     [mapConfig, datasetStates],
   );
 
+  const maxRows =
+    mapConfig?.dataPolicy?.maxRows ?? DEFAULT_DECK_MAP_MAX_DATA_POINTS;
+
   const mapContent = !mapConfig ? (
     <div className="text-muted-foreground flex h-full items-center justify-center p-4 text-sm">
       Invalid map panel config.
@@ -531,7 +537,7 @@ function DeckMapDashboardRenderer({
           runtimeIssueContext={runtimeIssueContext}
           runtimeIssueReporter={runtimeIssueReporter}
           selectionName={selectionName}
-          maxRows={DEFAULT_DECK_MAP_MAX_DATA_POINTS}
+          maxRows={maxRows}
         />
       ))}
       {issue ? (
@@ -551,10 +557,7 @@ function DeckMapDashboardRenderer({
           {Object.values(datasetStates).some((s) => s.isSampled) &&
             !sampledDismissed && (
               <div className="bg-background/80 text-muted-foreground absolute top-2 left-2 z-10 flex items-center gap-1.5 rounded px-2 py-1 text-xs shadow">
-                <span>
-                  Data sampled to{' '}
-                  {DEFAULT_DECK_MAP_MAX_DATA_POINTS.toLocaleString()} rows
-                </span>
+                <span>Data sampled to {maxRows.toLocaleString()} rows</span>
                 <button
                   className="text-muted-foreground/60 hover:text-foreground -mr-0.5 ml-0.5"
                   onClick={() => setSampledDismissed(true)}

--- a/packages/deck/src/json/compileColorScale.ts
+++ b/packages/deck/src/json/compileColorScale.ts
@@ -85,6 +85,16 @@ function getGeoArrowOrRowValue(options: {
       return batch.getChild(batchFieldName)?.get(objectInfo.index);
     }
 
+    if (batch) {
+      // Batch is present (GeoArrow path) but the field wasn't found in it.
+      // The index is batch-local and cannot be safely used against the global
+      // vector which spans all batches. Return undefined so the mapper
+      // applies nullColor rather than reading the wrong row.
+      return undefined;
+    }
+
+    // No batch context (e.g. GeoJSON binary path): the index is global,
+    // so using the table-level vector is safe.
     return vector.get(objectInfo.index);
   }
 

--- a/packages/deck/src/json/rewriteGeoArrowAccessors.ts
+++ b/packages/deck/src/json/rewriteGeoArrowAccessors.ts
@@ -56,11 +56,11 @@ export function rewriteGeoArrowAccessors(options: {
         continue;
       }
       if (!vector) {
+        // Column not found — fall through to compileGeoArrowAccessor which
+        // handles missing bindings gracefully (returns undefined per row).
         console.warn(
-          `Column "${expression.trim()}" not found in dataset for accessor "${propName}". Skipping accessor.`,
+          `Column "${expression.trim()}" not found in dataset for accessor "${propName}".`,
         );
-        delete nextProps[propName];
-        continue;
       }
     }
 


### PR DESCRIPTION
1. dataPolicy.maxRows override now respected
2. detectMissingColumns no longer reports false-positives for expressions:
- Before checking a @@= accessor reference, validates it's a simple identifier (/^[A-Za-z_$][\w$]*$/)
- Complex expressions like @@=population * 10 or @@=[255, val, 0] are now skipped instead of being incorrectly flagged as missing columns
3. Now, when a column isn't found, instead of deleting the prop or guessing a fallback, it falls through to compileGeoArrowAccessor which already handles missing columns properly
4. return undefined when we have a batch but can't resolve the field in it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved missing-column detection for complex binding expressions to prevent incorrect warnings.
  * Fixed GeoArrow field lookup to avoid mixing data across batches when a field can’t be resolved.
  * Adjusted GeoArrow accessor behavior so absent columns compile to per-row `undefined` instead of being removed.

* **New Features**
  * Updated map data sampling to respect the configured maximum row limit, including updating the “data sampled” notice to reflect the applied value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->