### PR TITLE
fix(documents): flip slash menu near viewport edge

### DIFF
--- a/packages/documents/src/BlockDocumentEditor/BlockDocumentBlockControls.tsx
+++ b/packages/documents/src/BlockDocumentEditor/BlockDocumentBlockControls.tsx
@@ -1589,7 +1589,14 @@ export const BlockDocumentBlockControls: FC<
           ) : null}
           <div
             className="pointer-events-none absolute z-30 h-px w-px"
-            style={{top: blockTypeSearch.menuTop, left: blockTypeSearch.left}}
+            style={{
+              height: Math.max(
+                1,
+                blockTypeSearch.menuTop - blockTypeSearch.top - 4,
+              ),
+              left: blockTypeSearch.left,
+              top: blockTypeSearch.top,
+            }}
           >
             <Popover
               open={blockTypeSearchMenuOpen && !handleMenuOpen}
@@ -1602,7 +1609,7 @@ export const BlockDocumentBlockControls: FC<
               }}
             >
               <PopoverAnchor asChild>
-                <span className="pointer-events-none block h-px w-px" />
+                <span className="pointer-events-none block h-full w-px" />
               </PopoverAnchor>
               <PopoverContent
                 align="start"

--- a/packages/documents/src/BlockDocumentEditor/BlockDocumentBlockControls.tsx
+++ b/packages/documents/src/BlockDocumentEditor/BlockDocumentBlockControls.tsx
@@ -128,7 +128,7 @@ const DRAG_SCROLL_EDGE_THRESHOLD = 80;
 const DRAG_SCROLL_MAX_STEP = 28;
 const BLOCK_TYPE_SEARCH_MENU_MAX_HEIGHT = 300;
 const BLOCK_TYPE_SEARCH_MENU_LIST_MAX_HEIGHT = 240;
-const BLOCK_TYPE_SEARCH_MENU_BOTTOM_MARGIN = 16;
+const BLOCK_TYPE_SEARCH_MENU_VIEWPORT_PADDING = 16;
 const BLOCK_DOCUMENT_CONTENT_LEFT_GUTTER = 96;
 const EMPTY_BLOCK_PLACEHOLDER = "Press '/' to change block type";
 const SLASH_SEARCH_PLACEHOLDER = 'Type to search';
@@ -1608,16 +1608,15 @@ export const BlockDocumentBlockControls: FC<
                 align="start"
                 side="bottom"
                 sideOffset={4}
-                avoidCollisions={false}
                 collisionPadding={{
-                  bottom: BLOCK_TYPE_SEARCH_MENU_BOTTOM_MARGIN,
+                  bottom: BLOCK_TYPE_SEARCH_MENU_VIEWPORT_PADDING,
                   left: 8,
                   right: 8,
-                  top: 8,
+                  top: BLOCK_TYPE_SEARCH_MENU_VIEWPORT_PADDING,
                 }}
                 className="flex w-72 flex-col overflow-hidden p-1"
                 style={{
-                  maxHeight: `min(${BLOCK_TYPE_SEARCH_MENU_MAX_HEIGHT}px, calc(var(--radix-popover-content-available-height) - ${BLOCK_TYPE_SEARCH_MENU_BOTTOM_MARGIN}px))`,
+                  maxHeight: `min(${BLOCK_TYPE_SEARCH_MENU_MAX_HEIGHT}px, var(--radix-popover-content-available-height))`,
                 }}
                 onOpenAutoFocus={(event) => event.preventDefault()}
                 onCloseAutoFocus={(event) => event.preventDefault()}


### PR DESCRIPTION
## Summary

Fixes the block document slash menu when it is opened near the bottom of the viewport. The menu now lets Radix Popover collision handling choose the available side, so it can flip above the active text block instead of being clipped below the window.

## Root Cause

The slash menu popover explicitly disabled collision handling with `avoidCollisions={false}`, forcing it to render below the block even when there was not enough viewport space. After enabling flipping, the anchor was still a 1px point below the block, so the flipped menu could overlap the text row. The anchor now spans the focused block row, allowing top placement to sit above the row and bottom placement to sit below it.

## Validation

- `pnpm build`
- `pnpm --filter @sqlrooms/documents typecheck`
- Browser check in `sqlrooms-cli-app`: opened a worksheet near the bottom of the viewport and confirmed the slash menu rendered with `data-side="top"`, was not clipped, and did not overlap the slash text block (`gap: 4`, `overlapsSlashBlock: false`).
- Pre-push hook: `knip`, `turbo typecheck`, circular dependency check, `turbo test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the positioning and sizing of the block type search popover for better on-screen alignment.
  * Made the active search indicator adapt to the available space, preventing awkward spacing or clipping.
  * Updated the popover’s display height handling so it better fits within the viewport.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->