### PR TITLE
chore: workspace block-document renames

### DIFF
--- a/apps/sqlrooms-cli-ui/src/__tests__/createCliBlockDocumentAiAdapter.test.ts
+++ b/apps/sqlrooms-cli-ui/src/__tests__/createCliBlockDocumentAiAdapter.test.ts
@@ -5,7 +5,7 @@ import {
   type BlockDocumentBlock,
 } from '@sqlrooms/documents';
 import type {StoreApi} from 'zustand';
-import {createWorksheetAiAdapter} from '../createWorksheetAiAdapter';
+import {createCliBlockDocumentAiAdapter} from '../createCliBlockDocumentAiAdapter';
 import type {RoomState} from '../store-types';
 
 function createMockStore({
@@ -50,10 +50,10 @@ function createMockStore({
   };
 }
 
-describe('createWorksheetAiAdapter', () => {
-  it('adds worksheet blocks through the block document append command', async () => {
+describe('createCliBlockDocumentAiAdapter', () => {
+  it('adds blocks through the block document append command', async () => {
     const {store, ensureBlockDocument, invokeCommand} = createMockStore();
-    const adapter = createWorksheetAiAdapter(store);
+    const adapter = createCliBlockDocumentAiAdapter(store);
     const block: BlockDocumentBlock = {
       id: 'paragraph-1',
       type: 'paragraph',
@@ -86,7 +86,7 @@ describe('createWorksheetAiAdapter', () => {
         error: 'Command failed',
       })),
     });
-    const adapter = createWorksheetAiAdapter(store);
+    const adapter = createCliBlockDocumentAiAdapter(store);
 
     await expect(
       adapter.addBlock('worksheet-1', {

--- a/apps/sqlrooms-cli-ui/src/__tests__/createCliBlockDocumentCommands.test.ts
+++ b/apps/sqlrooms-cli-ui/src/__tests__/createCliBlockDocumentCommands.test.ts
@@ -2,7 +2,7 @@ import {jest} from '@jest/globals';
 import {DECK_MAP_DASHBOARD_PANEL_TYPE} from '@sqlrooms/deck';
 import {makeQualifiedTableName} from '@sqlrooms/duckdb';
 import type {MosaicDashboardPanelConfigType} from '@sqlrooms/mosaic';
-import {createWorksheetCommands} from '../createWorksheetCommands';
+import {createCliBlockDocumentCommands} from '../createCliBlockDocumentCommands';
 
 const earthquakesTable = {
   table: makeQualifiedTableName({schema: 'main', table: 'earthquakes'}),
@@ -22,7 +22,7 @@ function createCommandContext(state: unknown) {
 }
 
 function getCommand(id: string) {
-  const command = createWorksheetCommands().find(
+  const command = createCliBlockDocumentCommands().find(
     (candidate) => candidate.id === id,
   );
   if (!command) {
@@ -57,12 +57,14 @@ function createState() {
     }
     return {success: true, commandId, data: input};
   });
-  const updateBlock = jest.fn((worksheetId: string, blockId: string, block) => {
-    const index = blocks.findIndex((candidate) => candidate.id === blockId);
-    if (worksheetId !== 'worksheet-1' || index < 0) return false;
-    blocks[index] = block;
-    return true;
-  });
+  const updateBlock = jest.fn(
+    (blockDocumentId: string, blockId: string, block) => {
+      const index = blocks.findIndex((candidate) => candidate.id === blockId);
+      if (blockDocumentId !== 'worksheet-1' || index < 0) return false;
+      blocks[index] = block;
+      return true;
+    },
+  );
 
   return {
     blocks,
@@ -97,9 +99,11 @@ function createState() {
   };
 }
 
-describe('createWorksheetCommands', () => {
+describe('createCliBlockDocumentCommands', () => {
   it('registers the block document command IDs for worksheet stateful blocks', () => {
-    expect(createWorksheetCommands().map((command) => command.id)).toEqual([
+    expect(
+      createCliBlockDocumentCommands().map((command) => command.id),
+    ).toEqual([
       'block-document.add-dashboard-block',
       'block-document.add-data-table-block',
       'block-document.add-html-app-block',
@@ -108,12 +112,12 @@ describe('createWorksheetCommands', () => {
     ]);
   });
 
-  it('adds dashboard blocks through worksheet and dashboard commands', async () => {
+  it('adds dashboard blocks through block document and dashboard commands', async () => {
     const {state, invokeCommand} = createState();
     const result = await getCommand(
       'block-document.add-dashboard-block',
     ).execute(createCommandContext(state), {
-      worksheetId: 'worksheet-1',
+      blockDocumentId: 'worksheet-1',
       title: 'Dashboard',
       tableName: 'earthquakes',
       intent: 'show trends',
@@ -122,7 +126,7 @@ describe('createWorksheetCommands', () => {
     expect(result).toMatchObject({
       success: true,
       data: {
-        worksheetId: 'worksheet-1',
+        blockDocumentId: 'worksheet-1',
         blockId: 'dashboard-block',
         dashboardId: 'dashboard-id',
         selectedTable: earthquakesTableIdentity,
@@ -144,14 +148,14 @@ describe('createWorksheetCommands', () => {
     );
   });
 
-  it('adds data table and HTML app blocks through worksheet commands', async () => {
+  it('adds data table and HTML app blocks through block document commands', async () => {
     const {state, invokeCommand} = createState();
 
     await expect(
       getCommand('block-document.add-data-table-block').execute(
         createCommandContext(state),
         {
-          worksheetId: 'worksheet-1',
+          blockDocumentId: 'worksheet-1',
           title: 'Profile',
           tableName: 'earthquakes',
         },
@@ -178,7 +182,7 @@ describe('createWorksheetCommands', () => {
       getCommand('block-document.add-html-app-block').execute(
         createCommandContext(state),
         {
-          worksheetId: 'worksheet-1',
+          blockDocumentId: 'worksheet-1',
           title: 'Explorer App',
         },
       ),
@@ -195,7 +199,7 @@ describe('createWorksheetCommands', () => {
       getCommand('block-document.add-map-block').execute(
         createCommandContext(state),
         {
-          worksheetId: 'worksheet-1',
+          blockDocumentId: 'worksheet-1',
           title: 'Map',
           mapId: 'map-1',
           tableName: 'earthquakes',
@@ -223,13 +227,13 @@ describe('createWorksheetCommands', () => {
     );
   });
 
-  it('updates worksheet block metadata through the block document slice', async () => {
+  it('updates block document block metadata through the block document slice', async () => {
     const {state, updateBlock} = createState();
 
     const result = await getCommand(
       'block-document.update-block-metadata',
     ).execute(createCommandContext(state), {
-      worksheetId: 'worksheet-1',
+      blockDocumentId: 'worksheet-1',
       blockId: 'block-1',
       title: 'Updated Map',
       caption: 'Updated Map',
@@ -238,7 +242,7 @@ describe('createWorksheetCommands', () => {
     expect(result).toMatchObject({
       success: true,
       data: {
-        worksheetId: 'worksheet-1',
+        blockDocumentId: 'worksheet-1',
         blockId: 'block-1',
         title: 'Updated Map',
         caption: 'Updated Map',
@@ -279,7 +283,7 @@ describe('createWorksheetCommands', () => {
       getCommand('block-document.add-map-block').execute(
         createCommandContext(state),
         {
-          worksheetId: 'worksheet-1',
+          blockDocumentId: 'worksheet-1',
           title: 'Map',
           reasoning: 'show earthquake points',
           config: {
@@ -341,7 +345,7 @@ describe('createWorksheetCommands', () => {
     const result = await getCommand('block-document.add-map-block').execute(
       createCommandContext(state),
       {
-        worksheetId: 'worksheet-1',
+        blockDocumentId: 'worksheet-1',
         title: 'Map',
         reasoning: 'show earthquake points',
         config: {

--- a/apps/sqlrooms-cli-ui/src/ai/__tests__/createCliBlockDocumentAiTools.test.ts
+++ b/apps/sqlrooms-cli-ui/src/ai/__tests__/createCliBlockDocumentAiTools.test.ts
@@ -6,10 +6,10 @@ import type {
   BlockDocumentStatefulBlockBlock,
 } from '@sqlrooms/documents';
 import type {DatabaseAiAdapter} from '@sqlrooms/mosaic/ai';
-import {createWorksheetBlockDocumentAiTools} from '../createWorksheetBlockDocumentAiTools';
-import {KnownWorksheetTools} from '../constants';
+import {createCliBlockDocumentAiTools} from '../createCliBlockDocumentAiTools';
+import {KnownBlockDocumentTools} from '../constants';
 
-describe('createWorksheetBlockDocumentAiTools', () => {
+describe('createCliBlockDocumentAiTools', () => {
   function createBlockDocumentAdapter(): BlockDocumentAiAdapter &
     BlockDocumentMoveBlockAiAdapter {
     return {
@@ -45,7 +45,7 @@ describe('createWorksheetBlockDocumentAiTools', () => {
         execute: async () => ({success: true}),
       }),
       chartToolsOptions: {chartTypes: []},
-      worksheetId: 'worksheet-1',
+      blockDocumentId: 'worksheet-1',
       createDashboardBlock: ({title}: {title: string}) => ({
         dashboardId: 'dashboard-1',
         block: {
@@ -76,27 +76,29 @@ describe('createWorksheetBlockDocumentAiTools', () => {
   }
 
   it('does not register HTML app block tools by default', () => {
-    const tools = createWorksheetBlockDocumentAiTools(createOptions());
+    const tools = createCliBlockDocumentAiTools(createOptions());
 
-    expect(tools[KnownWorksheetTools.add_html_app_block]).toBeUndefined();
-    expect(tools[KnownWorksheetTools.embedded_html_app_agent]).toBeUndefined();
+    expect(tools[KnownBlockDocumentTools.add_html_app_block]).toBeUndefined();
+    expect(
+      tools[KnownBlockDocumentTools.embedded_html_app_agent],
+    ).toBeUndefined();
   });
 
-  it('registers a built-in worksheet block move tool', async () => {
+  it('registers a built-in block document block move tool', async () => {
     const blockDocumentAdapter = createBlockDocumentAdapter();
     const moveBlock = jest.spyOn(blockDocumentAdapter, 'moveBlock');
-    const tools = createWorksheetBlockDocumentAiTools(
+    const tools = createCliBlockDocumentAiTools(
       createOptions({blockDocumentAdapter}),
     );
 
-    expect(tools[KnownWorksheetTools.move_block]).toBeDefined();
+    expect(tools[KnownBlockDocumentTools.move_block]).toBeDefined();
 
-    const result = await (tools[KnownWorksheetTools.move_block] as any).execute(
-      {
-        blockId: 'paragraph-1',
-        toIndex: 0,
-      },
-    );
+    const result = await (
+      tools[KnownBlockDocumentTools.move_block] as any
+    ).execute({
+      blockId: 'paragraph-1',
+      toIndex: 0,
+    });
 
     expect(result).toEqual({
       success: true,
@@ -109,7 +111,7 @@ describe('createWorksheetBlockDocumentAiTools', () => {
 
   it('rejects HTML app block tools when the embedded app agent is unavailable', () => {
     expect(() =>
-      createWorksheetBlockDocumentAiTools(
+      createCliBlockDocumentAiTools(
         createOptions({htmlAppBlocksEnabled: true}),
       ),
     ).toThrow(
@@ -124,17 +126,18 @@ describe('createWorksheetBlockDocumentAiTools', () => {
       execute: async () => ({success: true}),
     });
 
-    const tools = createWorksheetBlockDocumentAiTools(
+    const tools = createCliBlockDocumentAiTools(
       createOptions({
         htmlAppBlocksEnabled: true,
         extraTools: jest.fn(() => ({
-          [KnownWorksheetTools.embedded_html_app_agent]: embeddedHtmlAppAgent,
+          [KnownBlockDocumentTools.embedded_html_app_agent]:
+            embeddedHtmlAppAgent,
         })),
       }),
     );
 
-    expect(tools[KnownWorksheetTools.add_html_app_block]).toBeDefined();
-    expect(tools[KnownWorksheetTools.embedded_html_app_agent]).toBe(
+    expect(tools[KnownBlockDocumentTools.add_html_app_block]).toBeDefined();
+    expect(tools[KnownBlockDocumentTools.embedded_html_app_agent]).toBe(
       embeddedHtmlAppAgent,
     );
   });

--- a/apps/sqlrooms-cli-ui/src/ai/constants.ts
+++ b/apps/sqlrooms-cli-ui/src/ai/constants.ts
@@ -4,9 +4,10 @@ import {
 } from '@sqlrooms/documents';
 import {KnownMosaicBlockDocumentTools} from '@sqlrooms/mosaic/ai';
 
-export const WORKSHEET_AGENT_TOOL_NAME = BLOCK_DOCUMENT_AGENT_TOOL_NAME;
+export const CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME =
+  BLOCK_DOCUMENT_AGENT_TOOL_NAME;
 
-export const KnownWorksheetTools = {
+export const KnownBlockDocumentTools = {
   ...KnownDocumentBlockTools,
   ...KnownMosaicBlockDocumentTools,
   add_html_app_block: 'add_html_app_block',
@@ -15,7 +16,7 @@ export const KnownWorksheetTools = {
   create_block_document_map_block: 'create_block_document_map_block',
 } as const;
 
-export const EXPERIMENTAL_WORKSHEET_AGENT_INSTRUCTIONS = `Direct worksheet map blocks are available in this CLI app.
+export const EXPERIMENTAL_BLOCK_DOCUMENT_AGENT_INSTRUCTIONS = `Direct worksheet map blocks are available in this CLI app.
 In this app, a Worksheet is a block document artifact, and direct map blocks are block-document map blocks.
-For worksheet map requests, call ${KnownWorksheetTools.create_block_document_map_block}. Do not create a dashboard block just to hold a map.
-If updating an existing worksheet map, call list_block_document_blocks first and pass its statefulBlock.blockInstanceId as mapId to ${KnownWorksheetTools.create_block_document_map_block}.`;
+For worksheet map requests, call ${KnownBlockDocumentTools.create_block_document_map_block}. Do not create a dashboard block just to hold a map.
+If updating an existing worksheet map, call list_block_document_blocks first and pass its statefulBlock.blockInstanceId as mapId to ${KnownBlockDocumentTools.create_block_document_map_block}.`;

--- a/apps/sqlrooms-cli-ui/src/ai/constants.ts
+++ b/apps/sqlrooms-cli-ui/src/ai/constants.ts
@@ -19,4 +19,4 @@ export const KnownBlockDocumentTools = {
 export const EXPERIMENTAL_BLOCK_DOCUMENT_AGENT_INSTRUCTIONS = `Direct worksheet map blocks are available in this CLI app.
 In this app, a Worksheet is a block document artifact, and direct map blocks are block-document map blocks.
 For worksheet map requests, call ${KnownBlockDocumentTools.create_block_document_map_block}. Do not create a dashboard block just to hold a map.
-If updating an existing worksheet map, call list_block_document_blocks first and pass its statefulBlock.blockInstanceId as mapId to ${KnownBlockDocumentTools.create_block_document_map_block}.`;
+If updating an existing worksheet map, call ${KnownBlockDocumentTools.list_blocks} first and pass its statefulBlock.blockInstanceId as mapId to ${KnownBlockDocumentTools.create_block_document_map_block}.`;

--- a/apps/sqlrooms-cli-ui/src/ai/createCliBlockDocumentAgentTool.ts
+++ b/apps/sqlrooms-cli-ui/src/ai/createCliBlockDocumentAgentTool.ts
@@ -439,7 +439,7 @@ IMPORTANT: IF primary artefact in run context is a worksheet, prioritize using t
         const friendlyMessage =
           error instanceof AiAgentError
             ? errorMessage
-            : 'Block document agent execution failed.';
+            : 'Worksheet update failed.';
 
         return {
           success: false,

--- a/apps/sqlrooms-cli-ui/src/ai/createCliBlockDocumentAgentTool.ts
+++ b/apps/sqlrooms-cli-ui/src/ai/createCliBlockDocumentAgentTool.ts
@@ -18,10 +18,13 @@ import type {
 } from '@sqlrooms/documents';
 import type {RoomState} from '../store-types';
 import {
-  createWorksheetBlockDocumentAiTools,
-  type ExtraWorksheetAiToolsFactory,
-} from './createWorksheetBlockDocumentAiTools';
-import {KnownWorksheetTools, WORKSHEET_AGENT_TOOL_NAME} from './constants';
+  createCliBlockDocumentAiTools,
+  type ExtraBlockDocumentAiToolsFactory,
+} from './createCliBlockDocumentAiTools';
+import {
+  KnownBlockDocumentTools,
+  CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME,
+} from './constants';
 
 const AgentIntentSchemaFields = {
   intent: z
@@ -30,15 +33,15 @@ const AgentIntentSchemaFields = {
     .describe('The natural-language objective for the agent to satisfy.'),
 };
 
-export type WorksheetAgentResult = {
+export type BlockDocumentAgentResult = {
   success: boolean;
   finalOutput: string;
-  worksheetId: string;
+  blockDocumentId: string;
   error?: string;
   metadata?: ReturnType<typeof calculateAgentResultMetadata>;
 };
 
-export type CreateWorksheetAgentToolOptions =
+export type CreateCliBlockDocumentAgentToolOptions =
   BaseAgentToolOptions<RoomState> & {
     blockDocumentAdapter: BlockDocumentAiAdapter &
       BlockDocumentMoveBlockAiAdapter;
@@ -47,29 +50,29 @@ export type CreateWorksheetAgentToolOptions =
     chartToolsOptions?: ChartToolsOptions;
     htmlAppBlocksEnabled?: boolean;
     mapBlocksEnabled?: boolean;
-    extraTools?: ExtraWorksheetAiToolsFactory;
+    extraTools?: ExtraBlockDocumentAiToolsFactory;
     createDashboardBlock: Parameters<
-      typeof createWorksheetBlockDocumentAiTools
+      typeof createCliBlockDocumentAiTools
     >[0]['createDashboardBlock'];
     createDataTableExplorerBlock: Parameters<
-      typeof createWorksheetBlockDocumentAiTools
+      typeof createCliBlockDocumentAiTools
     >[0]['createDataTableExplorerBlock'];
     createHtmlAppBlock?: Parameters<
-      typeof createWorksheetBlockDocumentAiTools
+      typeof createCliBlockDocumentAiTools
     >[0]['createHtmlAppBlock'];
     addDashboardBlock?: Parameters<
-      typeof createWorksheetBlockDocumentAiTools
+      typeof createCliBlockDocumentAiTools
     >[0]['addDashboardBlock'];
     addDataTableExplorerBlock?: Parameters<
-      typeof createWorksheetBlockDocumentAiTools
+      typeof createCliBlockDocumentAiTools
     >[0]['addDataTableExplorerBlock'];
     addHtmlAppBlock?: Parameters<
-      typeof createWorksheetBlockDocumentAiTools
+      typeof createCliBlockDocumentAiTools
     >[0]['addHtmlAppBlock'];
   };
 
-function getWorksheetAgentInstructions(
-  options: CreateWorksheetAgentToolOptions,
+function getBlockDocumentAgentInstructions(
+  options: CreateCliBlockDocumentAgentToolOptions,
 ): string {
   const chartTools = resolveChartTypes(options.chartToolsOptions?.chartTypes);
   const htmlAppBlocksEnabled = options.htmlAppBlocksEnabled !== false;
@@ -97,31 +100,31 @@ CRITICAL RULES:
 7. ${
     mapBlocksEnabled
       ? 'If the user asks to add a map or geospatial visualization to a worksheet, use the available direct worksheet map block tool; do not create a dashboard block solely to hold a map.'
-      : `If the user asks to add a map or geospatial visualization to a worksheet dashboard, use a dashboard block and ${KnownWorksheetTools.embedded_dashboard_agent}; worksheet chart tools cannot create map panels.`
+      : `If the user asks to add a map or geospatial visualization to a worksheet dashboard, use a dashboard block and ${KnownBlockDocumentTools.embedded_dashboard_agent}; worksheet chart tools cannot create map panels.`
   }
-${htmlAppBlocksEnabled ? `8. If the user asks for an HTML app, D3 app, Chart.js app, browser app, custom interactive visualization, or generated app inside a worksheet, use ${KnownWorksheetTools.add_html_app_block} + ${KnownWorksheetTools.embedded_html_app_agent}. Do not create a top-level html-app artifact from inside ${WORKSHEET_AGENT_TOOL_NAME}.` : ''}
+${htmlAppBlocksEnabled ? `8. If the user asks for an HTML app, D3 app, Chart.js app, browser app, custom interactive visualization, or generated app inside a worksheet, use ${KnownBlockDocumentTools.add_html_app_block} + ${KnownBlockDocumentTools.embedded_html_app_agent}. Do not create a top-level html-app artifact from inside ${CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME}.` : ''}
 
 ## Creating Blocks
 
 ### Existing Blocks
 Before updating a worksheet dashboard${
     htmlAppBlocksEnabled ? ', updating an existing worksheet HTML app,' : ''
-  }, adding a map to an existing worksheet, or reordering blocks, call ${KnownWorksheetTools.list_blocks} to find existing dashboard${
+  }, adding a map to an existing worksheet, or reordering blocks, call ${KnownBlockDocumentTools.list_blocks} to find existing dashboard${
     htmlAppBlocksEnabled ? '/html-app' : ''
-  } blocks and their resource IDs. For stateful blocks, use statefulBlock.blockType to identify the surface and statefulBlock.blockInstanceId as dashboardId, appId, or mapId for the matching embedded tool. For reorder requests, use blockId and index from ${KnownWorksheetTools.list_blocks}, then call ${KnownWorksheetTools.move_block}; moving a block to the top means toIndex 0.
+  } blocks and their resource IDs. For stateful blocks, use statefulBlock.blockType to identify the surface and statefulBlock.blockInstanceId as dashboardId, appId, or mapId for the matching embedded tool. For reorder requests, use blockId and index from ${KnownBlockDocumentTools.list_blocks}, then call ${KnownBlockDocumentTools.move_block}; moving a block to the top means toIndex 0.
 
 ### Chart Blocks
 To create a chart block in a worksheet, call one of the chart generation tools:
 ${chartToolsInstructions}
 
 ### Text Blocks
-To add text context or summaries, use the ${KnownWorksheetTools.add_text_block} tool:
+To add text context or summaries, use the ${KnownBlockDocumentTools.add_text_block} tool:
 - Type "heading" (level 1-3) - for section titles
 - Type "paragraph" - for explanatory text
 - Type "list" (ordered/unordered) - for key points or findings
 
 ### Data Table Explorer Blocks
-To add a data table explorer block, use the ${KnownWorksheetTools.add_data_table_explorer} tool:
+To add a data table explorer block, use the ${KnownBlockDocumentTools.add_data_table_explorer} tool:
 - Provide a title for the block
 - Provide the dataset (table name) to explore
 - Provide intent when the request includes a durable purpose for the block
@@ -132,18 +135,18 @@ To add a data table explorer block, use the ${KnownWorksheetTools.add_data_table
 To create an interactive dashboard block for data exploration, use a TWO-STEP workflow:
 
 If the worksheet already has a dashboard block that matches the request, reuse it:
-- Call ${KnownWorksheetTools.list_blocks}
-- Use the dashboard block's statefulBlock.blockInstanceId as dashboardId when calling ${KnownWorksheetTools.embedded_dashboard_agent}
+- Call ${KnownBlockDocumentTools.list_blocks}
+- Use the dashboard block's statefulBlock.blockInstanceId as dashboardId when calling ${KnownBlockDocumentTools.embedded_dashboard_agent}
 
 STEP 1: Create the empty dashboard block container
-- Call ${KnownWorksheetTools.add_dashboard_block} with:
+- Call ${KnownBlockDocumentTools.add_dashboard_block} with:
   - dashboardTitle: title for the dashboard
   - tableName: the dataset to analyze
   - intent: durable purpose for this dashboard block
 - This returns a dashboardId
 
 STEP 2: Populate the dashboard with charts and panels
-- Call ${KnownWorksheetTools.embedded_dashboard_agent} with:
+- Call ${KnownBlockDocumentTools.embedded_dashboard_agent} with:
   - dashboardId: the ID from step 1
   - tableName: the dataset to analyze
   - intent: what insights or charts to create
@@ -162,17 +165,17 @@ ${
 To create a custom embedded browser app inside the worksheet, use a TWO-STEP workflow:
 
 If the worksheet already has an html-app block that matches the request, reuse it:
-- Call ${KnownWorksheetTools.list_blocks}
-- Use the html-app block's statefulBlock.blockInstanceId as appId when calling ${KnownWorksheetTools.embedded_html_app_agent}
+- Call ${KnownBlockDocumentTools.list_blocks}
+- Use the html-app block's statefulBlock.blockInstanceId as appId when calling ${KnownBlockDocumentTools.embedded_html_app_agent}
 
 STEP 1: Create the empty html-app block container
-- Call ${KnownWorksheetTools.add_html_app_block} with:
+- Call ${KnownBlockDocumentTools.add_html_app_block} with:
   - appTitle: title for the app
   - intent: durable purpose for this app block
 - This returns an appId
 
 STEP 2: Write the app files and observe runtime diagnostics
-- Call ${KnownWorksheetTools.embedded_html_app_agent} with:
+- Call ${KnownBlockDocumentTools.embedded_html_app_agent} with:
   - appId: the ID from step 1
   - intent: what app or visualization to create
 
@@ -181,7 +184,7 @@ Use html-app blocks when:
 - The requested interaction is not well represented by built-in worksheet chart blocks or dashboard panels
 - The app should call SQLRooms through window.sqlrooms.query(...) or window.sqlrooms.queryRows(...)
 
-If updating an existing worksheet app, first call ${KnownWorksheetTools.list_blocks}, find an html-app block, and pass its statefulBlock.blockInstanceId as appId to ${KnownWorksheetTools.embedded_html_app_agent}.
+If updating an existing worksheet app, first call ${KnownBlockDocumentTools.list_blocks}, find an html-app block, and pass its statefulBlock.blockInstanceId as appId to ${KnownBlockDocumentTools.embedded_html_app_agent}.
 For incremental edits to an existing worksheet app, such as changing title, labels, colors, styles, layout, controls, or interactions, do not inspect tables or schemas first unless the user explicitly asks to change the app's data/query behavior.
 `
     : ''
@@ -197,16 +200,16 @@ When user asks for specific charts (e.g., "create histogram of depth and magnitu
 4. Done after ALL requested charts are created
 
 **Exception:** If user explicitly requests a dashboard ("add dashboard for X dataset"), use the TWO-STEP workflow:
-1. Call ${KnownWorksheetTools.add_dashboard_block} to create the container
-2. Call ${KnownWorksheetTools.embedded_dashboard_agent} with the returned dashboardId to populate it
+1. Call ${KnownBlockDocumentTools.add_dashboard_block} to create the container
+2. Call ${KnownBlockDocumentTools.embedded_dashboard_agent} with the returned dashboardId to populate it
 
 **Map requests:** ${
     mapBlocksEnabled
-      ? `If user asks to add a map to a worksheet, use the direct worksheet map block tool. If updating an existing worksheet map, call ${KnownWorksheetTools.list_blocks} first and pass the map resource ID to the map tool.`
-      : `If user asks to add a map to an existing worksheet/dashboard, call ${KnownWorksheetTools.list_blocks}. If a dashboard block exists, call ${KnownWorksheetTools.embedded_dashboard_agent} with that dashboardId and an intent to create or update a map panel. If no dashboard block exists, create one first with ${KnownWorksheetTools.add_dashboard_block}.`
+      ? `If user asks to add a map to a worksheet, use the direct worksheet map block tool. If updating an existing worksheet map, call ${KnownBlockDocumentTools.list_blocks} first and pass the map resource ID to the map tool.`
+      : `If user asks to add a map to an existing worksheet/dashboard, call ${KnownBlockDocumentTools.list_blocks}. If a dashboard block exists, call ${KnownBlockDocumentTools.embedded_dashboard_agent} with that dashboardId and an intent to create or update a map panel. If no dashboard block exists, create one first with ${KnownBlockDocumentTools.add_dashboard_block}.`
   }
 
-${htmlAppBlocksEnabled ? `**HTML app requests:** If user asks to create a new app inside the worksheet, call ${KnownWorksheetTools.add_html_app_block}, then call ${KnownWorksheetTools.embedded_html_app_agent} with the returned appId. If modifying an existing app, call ${KnownWorksheetTools.list_blocks} first and pass the target statefulBlock.blockInstanceId as appId.` : ''}
+${htmlAppBlocksEnabled ? `**HTML app requests:** If user asks to create a new app inside the worksheet, call ${KnownBlockDocumentTools.add_html_app_block}, then call ${KnownBlockDocumentTools.embedded_html_app_agent} with the returned appId. If modifying an existing app, call ${KnownBlockDocumentTools.list_blocks} first and pass the target statefulBlock.blockInstanceId as appId.` : ''}
 
 ### Exploratory Requests
 When user asks for "comprehensive analysis" or "high-level insights":
@@ -228,8 +231,8 @@ When user asks for "comprehensive analysis" or "high-level insights":
 - Analysis benefits from seeing multiple related views together in one interactive dashboard
 
 **To create dashboard blocks:**
-1. Call ${KnownWorksheetTools.add_dashboard_block} to create the container (get dashboardId)
-2. Call ${KnownWorksheetTools.embedded_dashboard_agent} with dashboardId to populate it with charts
+1. Call ${KnownBlockDocumentTools.add_dashboard_block} to create the container (get dashboardId)
+2. Call ${KnownBlockDocumentTools.embedded_dashboard_agent} with dashboardId to populate it with charts
 
 ## Query Guidelines
 
@@ -252,13 +255,13 @@ When user asks for "comprehensive analysis" or "high-level insights":
 - **SUMMARIZE THE INSIGHTS:** If you create a text block, make it a 1-2 sentence summary of the key insight from the charts, not a long narrative.
 - **Multiple charts for exploratory tasks:** "Comprehensive worksheet" = 3-5+ charts showing different aspects
 - **Diverse visualizations:** Mix histogram, count plot, scatter, heatmap - don't create 5 of the same type
-- **Dashboard blocks for multi-faceted exploration:** When the dataset has multiple related dimensions (e.g., region, category, time period), use the two-step workflow: call ${KnownWorksheetTools.add_dashboard_block} to create the container, then call ${KnownWorksheetTools.embedded_dashboard_agent} to populate it with interactive panels
+- **Dashboard blocks for multi-faceted exploration:** When the dataset has multiple related dimensions (e.g., region, category, time period), use the two-step workflow: call ${KnownBlockDocumentTools.add_dashboard_block} to create the container, then call ${KnownBlockDocumentTools.embedded_dashboard_agent} to populate it with interactive panels
 - **Avoid unaggregated charts for large datasets:** For datasets >10k rows, DO NOT use scatter charts or line charts without aggregations:
   - For scatter plots: use heatmap or binned aggregations
   - For line charts: use GROUP BY with time buckets or aggregations
   - Histograms and count plots are always safe (they aggregate automatically)
 - **Validate columns:** Chart generation tools will validate column existence and types
-- **Reorder existing blocks:** Use ${KnownWorksheetTools.list_blocks} to identify the target block ID, then ${KnownWorksheetTools.move_block} with the desired zero-based destination index
+- **Reorder existing blocks:** Use ${KnownBlockDocumentTools.list_blocks} to identify the target block ID, then ${KnownBlockDocumentTools.move_block} with the desired zero-based destination index
 - **Handle errors gracefully:** If a query or chart creation fails, try alternative approach
 
 Common mistakes to avoid:
@@ -274,24 +277,24 @@ Success patterns:
 - Create 3-5+ diverse chart blocks for exploratory requests
 - Call ${BLOCK_DOCUMENT_CHART_TOOL_PREFIX}* tools to automatically create charts
 - Mix different chart types to show different patterns
-- Use ${KnownWorksheetTools.add_dashboard_block} + ${KnownWorksheetTools.embedded_dashboard_agent} (two-step) when user explicitly asks for dashboard or when coordinated multi-view analysis would enhance exploration
+- Use ${KnownBlockDocumentTools.add_dashboard_block} + ${KnownBlockDocumentTools.embedded_dashboard_agent} (two-step) when user explicitly asks for dashboard or when coordinated multi-view analysis would enhance exploration
 ${
   mapBlocksEnabled
-    ? `- For map requests, use the direct worksheet map block tool; call ${KnownWorksheetTools.list_blocks} first when updating an existing map and pass its statefulBlock.blockInstanceId as mapId`
-    : `- For map requests, use ${KnownWorksheetTools.list_blocks} then ${KnownWorksheetTools.embedded_dashboard_agent} so the map is added as a dashboard panel`
+    ? `- For map requests, use the direct worksheet map block tool; call ${KnownBlockDocumentTools.list_blocks} first when updating an existing map and pass its statefulBlock.blockInstanceId as mapId`
+    : `- For map requests, use ${KnownBlockDocumentTools.list_blocks} then ${KnownBlockDocumentTools.embedded_dashboard_agent} so the map is added as a dashboard panel`
 }
-${htmlAppBlocksEnabled ? `- For worksheet app requests, use ${KnownWorksheetTools.add_html_app_block} + ${KnownWorksheetTools.embedded_html_app_agent} so the app is embedded in the worksheet` : ''}
+${htmlAppBlocksEnabled ? `- For worksheet app requests, use ${KnownBlockDocumentTools.add_html_app_block} + ${KnownBlockDocumentTools.embedded_html_app_agent} so the app is embedded in the worksheet` : ''}
 - Charts are created immediately when you call the ${BLOCK_DOCUMENT_CHART_TOOL_PREFIX}* tools`;
 }
 
-const WorksheetAgentInputSchema = z.object({
+const BlockDocumentAgentInputSchema = z.object({
   reasoning: z
     .string()
-    .describe('Reasoning for why the worksheet agent is being called'),
+    .describe('Reasoning for why the block-document agent is being called'),
   ...AgentIntentSchemaFields,
-  worksheetId: z
+  blockDocumentId: z
     .string()
-    .describe('Target worksheet ID where blocks will be added.'),
+    .describe('Target block document artifact ID where blocks will be added.'),
   maxSteps: z
     .number()
     .optional()
@@ -299,13 +302,15 @@ const WorksheetAgentInputSchema = z.object({
     .describe('Maximum exploration steps (default: 20, range: 5-50)'),
 });
 
-type WorksheetAgentInputSchema = z.infer<typeof WorksheetAgentInputSchema>;
+type BlockDocumentAgentInputSchema = z.infer<
+  typeof BlockDocumentAgentInputSchema
+>;
 
 /**
- * Creates the CLI worksheet artifact agent tool.
+ * Creates the CLI block-document artifact agent tool.
  */
-export function createWorksheetAgentTool(
-  options: CreateWorksheetAgentToolOptions,
+export function createCliBlockDocumentAgentTool(
+  options: CreateCliBlockDocumentAgentToolOptions,
 ): Tool {
   const {
     store,
@@ -332,32 +337,32 @@ export function createWorksheetAgentTool(
 ${htmlAppBlocksEnabled ? '- HTML APP BLOCKS (custom browser apps powered by window.sqlrooms.query/queryRows)' : ''}
 
 IF user requests DASHBOARD:
-1. Call ${KnownWorksheetTools.add_dashboard_block} to create the container (get dashboardId)
-2. Call ${KnownWorksheetTools.embedded_dashboard_agent} with dashboardId to populate it with charts
+1. Call ${KnownBlockDocumentTools.add_dashboard_block} to create the container (get dashboardId)
+2. Call ${KnownBlockDocumentTools.embedded_dashboard_agent} with dashboardId to populate it with charts
 
 IF user requests a MAP in a worksheet:
 ${
   mapBlocksEnabled
-    ? `1. For a new map, call ${KnownWorksheetTools.create_block_document_map_block} directly
-2. For an existing map, call ${KnownWorksheetTools.list_blocks} and pass statefulBlock.blockInstanceId as mapId to create_block_document_map_block`
-    : `1. Call ${KnownWorksheetTools.list_blocks} to find an existing dashboard block
-2. Reuse an existing dashboardId if available, otherwise call ${KnownWorksheetTools.add_dashboard_block}
-3. Call ${KnownWorksheetTools.embedded_dashboard_agent} with an intent to add a map panel`
+    ? `1. For a new map, call ${KnownBlockDocumentTools.create_block_document_map_block} directly
+2. For an existing map, call ${KnownBlockDocumentTools.list_blocks} and pass statefulBlock.blockInstanceId as mapId to create_block_document_map_block`
+    : `1. Call ${KnownBlockDocumentTools.list_blocks} to find an existing dashboard block
+2. Reuse an existing dashboardId if available, otherwise call ${KnownBlockDocumentTools.add_dashboard_block}
+3. Call ${KnownBlockDocumentTools.embedded_dashboard_agent} with an intent to add a map panel`
 }
 
 ${
   htmlAppBlocksEnabled
     ? `
 IF user requests an HTML/D3/Chart.js/browser app in a worksheet:
-1. For a new app, call ${KnownWorksheetTools.add_html_app_block} to create the container, then call ${KnownWorksheetTools.embedded_html_app_agent} with the returned appId
-2. For an existing app, call ${KnownWorksheetTools.list_blocks}, then call ${KnownWorksheetTools.embedded_html_app_agent} with statefulBlock.blockInstanceId as appId
+1. For a new app, call ${KnownBlockDocumentTools.add_html_app_block} to create the container, then call ${KnownBlockDocumentTools.embedded_html_app_agent} with the returned appId
+2. For an existing app, call ${KnownBlockDocumentTools.list_blocks}, then call ${KnownBlockDocumentTools.embedded_html_app_agent} with statefulBlock.blockInstanceId as appId
 `
     : ''
 }
 
 IF user asks to reorder or move worksheet content:
-1. Call ${KnownWorksheetTools.list_blocks} to identify the target blockId
-2. Call ${KnownWorksheetTools.move_block} with the target blockId and zero-based toIndex
+1. Call ${KnownBlockDocumentTools.list_blocks} to identify the target blockId
+2. Call ${KnownBlockDocumentTools.move_block} with the target blockId and zero-based toIndex
 
 Otherwise, create chart and text blocks directly using ${BLOCK_DOCUMENT_CHART_TOOL_PREFIX}* tools.
 
@@ -368,24 +373,24 @@ Use this for:
 ${htmlAppBlocksEnabled ? '- App requests in worksheets: "create an app", "make a D3 visualization", "build a browser widget"' : ''}
 
 IMPORTANT: IF primary artefact in run context is a worksheet, prioritize using this tool for any queries or data analysis tasks.`,
-    inputSchema: WorksheetAgentInputSchema,
-    execute: async (params, toolOptions): Promise<WorksheetAgentResult> => {
-      const {worksheetId, maxSteps} = params;
+    inputSchema: BlockDocumentAgentInputSchema,
+    execute: async (params, toolOptions): Promise<BlockDocumentAgentResult> => {
+      const {blockDocumentId, maxSteps} = params;
       const {intent} = params;
 
       try {
-        blockDocumentAdapter.ensureBlockDocument(worksheetId);
-        blockDocumentAdapter.setCurrentBlockDocument(worksheetId);
+        blockDocumentAdapter.ensureBlockDocument(blockDocumentId);
+        blockDocumentAdapter.setCurrentBlockDocument(blockDocumentId);
 
         const dataTools = options.createDataTools?.({store}) ?? {};
 
         const agent = new ToolLoopAgent({
           model: options.getModel({state: store.getState()}),
           tools: {
-            ...createWorksheetBlockDocumentAiTools({
+            ...createCliBlockDocumentAiTools({
               databaseAdapter,
               blockDocumentAdapter,
-              worksheetId,
+              blockDocumentId,
               chartToolsOptions,
               dashboardAgentTool,
               extraTools,
@@ -401,7 +406,7 @@ IMPORTANT: IF primary artefact in run context is a worksheet, prioritize using t
           },
           stopWhen: [stepCountIs(Math.max(5, Math.min(50, maxSteps ?? 20)))],
           instructions: [
-            options.instructions ?? getWorksheetAgentInstructions(options),
+            options.instructions ?? getBlockDocumentAgentInstructions(options),
             options.additionalInstructions,
           ]
             .filter(Boolean)
@@ -424,7 +429,7 @@ IMPORTANT: IF primary artefact in run context is a worksheet, prioritize using t
         return {
           success: true,
           finalOutput: result.finalOutput || 'Worksheet created successfully.',
-          worksheetId,
+          blockDocumentId,
           metadata,
         };
       } catch (error) {
@@ -434,12 +439,12 @@ IMPORTANT: IF primary artefact in run context is a worksheet, prioritize using t
         const friendlyMessage =
           error instanceof AiAgentError
             ? errorMessage
-            : 'Worksheet agent execution failed.';
+            : 'Block document agent execution failed.';
 
         return {
           success: false,
           finalOutput: friendlyMessage,
-          worksheetId,
+          blockDocumentId,
           error: errorMessage,
         };
       }

--- a/apps/sqlrooms-cli-ui/src/ai/createCliBlockDocumentAiTools.ts
+++ b/apps/sqlrooms-cli-ui/src/ai/createCliBlockDocumentAiTools.ts
@@ -15,31 +15,30 @@ import {
   type DatabaseAiAdapter,
 } from '@sqlrooms/mosaic/ai';
 import {createAddHtmlAppBlockDocumentBlockTool} from './createAddHtmlAppBlockDocumentBlockTool';
-import {KnownWorksheetTools} from './constants';
+import {KnownBlockDocumentTools} from './constants';
 
-export type ExtraWorksheetAiToolsParams = {
-  /** ID of the worksheet artifact being edited. */
-  worksheetId: string;
+export type ExtraBlockDocumentAiToolsParams = {
+  /** ID of the block document artifact being edited. */
   blockDocumentId: string;
   blockDocumentAdapter: BlockDocumentAiAdapter;
   databaseAdapter: DatabaseAiAdapter;
 };
 
-export type ExtraWorksheetAiToolsFactory = (
-  params: ExtraWorksheetAiToolsParams,
+export type ExtraBlockDocumentAiToolsFactory = (
+  params: ExtraBlockDocumentAiToolsParams,
 ) => Record<string, Tool>;
 
 /**
- * Options for creating worksheet block-document AI tools in the CLI app.
+ * Options for creating block-document AI tools in the CLI app.
  */
-export type CreateWorksheetBlockDocumentAiToolsOptions = {
+export type CreateCliBlockDocumentAiToolsOptions = {
   databaseAdapter: DatabaseAiAdapter;
   blockDocumentAdapter: BlockDocumentAiAdapter &
     BlockDocumentMoveBlockAiAdapter;
   dashboardAgentTool: Tool;
   chartToolsOptions?: ChartToolsOptions;
-  worksheetId: string;
-  extraTools?: ExtraWorksheetAiToolsFactory;
+  blockDocumentId: string;
+  extraTools?: ExtraBlockDocumentAiToolsFactory;
   htmlAppBlocksEnabled?: boolean;
   createDashboardBlock: (params: {
     title: string;
@@ -62,19 +61,19 @@ export type CreateWorksheetBlockDocumentAiToolsOptions = {
     | {appId: string; block: BlockDocumentStatefulBlockBlock}
     | Promise<{appId: string; block: BlockDocumentStatefulBlockBlock}>;
   addDashboardBlock?: (params: {
-    worksheetId: string;
+    blockDocumentId: string;
     title: string;
     tableName: string;
     intent?: string;
   }) => Promise<{dashboardId: string; blockId: string}>;
   addDataTableExplorerBlock?: (params: {
-    worksheetId: string;
+    blockDocumentId: string;
     title: string;
     tableName: string;
     intent?: string;
   }) => Promise<unknown>;
   addHtmlAppBlock?: (params: {
-    worksheetId: string;
+    blockDocumentId: string;
     title: string;
     intent?: string;
   }) => Promise<{appId: string; blockId: string}>;
@@ -90,7 +89,7 @@ function ensureNoOverride(
 
   if (duplicates.length > 0) {
     throw new Error(
-      `Custom worksheet AI tools cannot override built-in tools: ${duplicates.join(
+      `Custom block-document AI tools cannot override built-in tools: ${duplicates.join(
         ', ',
       )}`,
     );
@@ -98,14 +97,14 @@ function ensureNoOverride(
 }
 
 /**
- * Creates the CLI worksheet tool collection by composing generic document
+ * Creates the CLI block-document tool collection by composing generic document
  * tools with Mosaic and HTML app integration tools.
  */
-export function createWorksheetBlockDocumentAiTools({
+export function createCliBlockDocumentAiTools({
   blockDocumentAdapter,
   databaseAdapter,
   chartToolsOptions,
-  worksheetId,
+  blockDocumentId,
   dashboardAgentTool,
   extraTools,
   htmlAppBlocksEnabled = false,
@@ -115,24 +114,24 @@ export function createWorksheetBlockDocumentAiTools({
   addDashboardBlock,
   addDataTableExplorerBlock,
   addHtmlAppBlock,
-}: CreateWorksheetBlockDocumentAiToolsOptions): Record<string, Tool> {
+}: CreateCliBlockDocumentAiToolsOptions): Record<string, Tool> {
   const chartTools = createBlockDocumentChartTools({
     databaseAdapter,
     blockDocumentAdapter,
     chartToolsOptions,
-    blockDocumentId: worksheetId,
+    blockDocumentId,
   });
 
   const addTextBlockTool = createAddBlockDocumentTextBlockTool({
     blockDocumentAdapter,
-    blockDocumentId: worksheetId,
+    blockDocumentId,
   });
 
   const addDashboardBlockTool = createAddMosaicDashboardBlockTool({
     blockDocumentAdapter,
-    blockDocumentId: worksheetId,
+    blockDocumentId,
     addDashboardBlock: addDashboardBlock
-      ? (params) => addDashboardBlock({worksheetId, ...params})
+      ? (params) => addDashboardBlock({blockDocumentId, ...params})
       : undefined,
     createDashboardBlock,
   });
@@ -140,61 +139,60 @@ export function createWorksheetBlockDocumentAiTools({
   const addDataTableExplorerTool = createBlockDocumentDataTableExplorerTool({
     databaseAdapter,
     blockDocumentAdapter,
-    blockDocumentId: worksheetId,
+    blockDocumentId,
     addDataTableExplorerBlock: addDataTableExplorerBlock
-      ? (params) => addDataTableExplorerBlock({worksheetId, ...params})
+      ? (params) => addDataTableExplorerBlock({blockDocumentId, ...params})
       : undefined,
     createDataTableExplorerBlock,
   });
 
   const listBlocksTool = createListBlockDocumentBlocksTool({
     blockDocumentAdapter,
-    blockDocumentId: worksheetId,
-    usageHint: `Use this before updating an existing worksheet dashboard, map, or app block. Stateful blocks include statefulBlock.blockType and statefulBlock.blockInstanceId. For dashboard blocks, pass statefulBlock.blockInstanceId to ${KnownWorksheetTools.embedded_dashboard_agent} as dashboardId. For map blocks, pass statefulBlock.blockInstanceId to a direct worksheet map tool when available.${
+    blockDocumentId,
+    usageHint: `Use this before updating an existing worksheet dashboard, map, or app block. Stateful blocks include statefulBlock.blockType and statefulBlock.blockInstanceId. For dashboard blocks, pass statefulBlock.blockInstanceId to ${KnownBlockDocumentTools.embedded_dashboard_agent} as dashboardId. For map blocks, pass statefulBlock.blockInstanceId to a direct worksheet map tool when available.${
       htmlAppBlocksEnabled
-        ? ` For html-app blocks, pass statefulBlock.blockInstanceId to ${KnownWorksheetTools.embedded_html_app_agent} as appId. For a new worksheet HTML app, use ${KnownWorksheetTools.add_html_app_block} first.`
+        ? ` For html-app blocks, pass statefulBlock.blockInstanceId to ${KnownBlockDocumentTools.embedded_html_app_agent} as appId. For a new worksheet HTML app, use ${KnownBlockDocumentTools.add_html_app_block} first.`
         : ''
     }`,
   });
 
   const moveBlockTool = createMoveBlockDocumentBlockTool({
     blockDocumentAdapter,
-    blockDocumentId: worksheetId,
+    blockDocumentId,
   });
 
   const additionalTools =
     extraTools?.({
-      worksheetId,
-      blockDocumentId: worksheetId,
+      blockDocumentId,
       blockDocumentAdapter,
       databaseAdapter,
     }) ?? {};
 
   if (
     htmlAppBlocksEnabled &&
-    !additionalTools[KnownWorksheetTools.embedded_html_app_agent]
+    !additionalTools[KnownBlockDocumentTools.embedded_html_app_agent]
   ) {
     throw new Error(
-      `${KnownWorksheetTools.add_html_app_block} requires ${KnownWorksheetTools.embedded_html_app_agent} in extraTools when htmlAppBlocksEnabled is true.`,
+      `${KnownBlockDocumentTools.add_html_app_block} requires ${KnownBlockDocumentTools.embedded_html_app_agent} in extraTools when htmlAppBlocksEnabled is true.`,
     );
   }
 
   const builtInTools: Record<string, Tool> = {
     ...chartTools,
-    [KnownWorksheetTools.list_blocks]: listBlocksTool,
-    [KnownWorksheetTools.move_block]: moveBlockTool,
-    [KnownWorksheetTools.add_text_block]: addTextBlockTool,
-    [KnownWorksheetTools.add_dashboard_block]: addDashboardBlockTool,
-    [KnownWorksheetTools.add_data_table_explorer]: addDataTableExplorerTool,
-    [KnownWorksheetTools.embedded_dashboard_agent]: dashboardAgentTool,
+    [KnownBlockDocumentTools.list_blocks]: listBlocksTool,
+    [KnownBlockDocumentTools.move_block]: moveBlockTool,
+    [KnownBlockDocumentTools.add_text_block]: addTextBlockTool,
+    [KnownBlockDocumentTools.add_dashboard_block]: addDashboardBlockTool,
+    [KnownBlockDocumentTools.add_data_table_explorer]: addDataTableExplorerTool,
+    [KnownBlockDocumentTools.embedded_dashboard_agent]: dashboardAgentTool,
     ...(htmlAppBlocksEnabled
       ? {
-          [KnownWorksheetTools.add_html_app_block]:
+          [KnownBlockDocumentTools.add_html_app_block]:
             createAddHtmlAppBlockDocumentBlockTool({
               blockDocumentAdapter,
-              blockDocumentId: worksheetId,
+              blockDocumentId,
               addHtmlAppBlock: addHtmlAppBlock
-                ? (params) => addHtmlAppBlock({worksheetId, ...params})
+                ? (params) => addHtmlAppBlock({blockDocumentId, ...params})
                 : undefined,
               createHtmlAppBlock,
             }),

--- a/apps/sqlrooms-cli-ui/src/components/useLocalFileLoader.ts
+++ b/apps/sqlrooms-cli-ui/src/components/useLocalFileLoader.ts
@@ -16,7 +16,9 @@ export const LOCAL_DATA_ACCEPTED_FORMATS = {
   'application/geo+json': ['.geojson'],
 };
 
-function getCurrentOrFirstWorksheetId(state: RoomState): string | undefined {
+function getCurrentOrFirstWorksheetArtifactId(
+  state: RoomState,
+): string | undefined {
   const currentArtifactId = state.artifacts.config.currentArtifactId;
   const currentArtifact = currentArtifactId
     ? state.artifacts.config.artifactsById[currentArtifactId]
@@ -34,20 +36,20 @@ function getCurrentOrFirstWorksheetId(state: RoomState): string | undefined {
 
 function ensureImportWorksheetForTable(tableName: string) {
   const state = useRoomStore.getState();
-  const worksheetId =
-    getCurrentOrFirstWorksheetId(state) ??
+  const worksheetArtifactId =
+    getCurrentOrFirstWorksheetArtifactId(state) ??
     state.artifacts.createArtifact({
       type: 'worksheet',
       title: 'Worksheet',
     });
 
-  state.artifacts.setCurrentArtifact(worksheetId);
-  state.blockDocuments.ensureBlockDocument(worksheetId);
+  state.artifacts.setCurrentArtifact(worksheetArtifactId);
+  state.blockDocuments.ensureBlockDocument(worksheetArtifactId);
 
   const nextState = useRoomStore.getState();
   const existingBlocks =
-    nextState.blockDocuments.config.artifacts[worksheetId]?.content.content ??
-    [];
+    nextState.blockDocuments.config.artifacts[worksheetArtifactId]?.content
+      .content ?? [];
   const hasDataTableExplorer = existingBlocks.some(
     (block) =>
       block.type === 'statefulBlock' &&
@@ -69,7 +71,7 @@ function ensureImportWorksheetForTable(tableName: string) {
     intent: `Initial profile for imported table ${tableName}`,
   };
 
-  nextState.blockDocuments.appendBlocks(worksheetId, [block]);
+  nextState.blockDocuments.appendBlocks(worksheetArtifactId, [block]);
 }
 
 export function useLocalFileLoader() {

--- a/apps/sqlrooms-cli-ui/src/createBlockDocumentAgent.ts
+++ b/apps/sqlrooms-cli-ui/src/createBlockDocumentAgent.ts
@@ -5,41 +5,43 @@ import {tool, type Tool} from 'ai';
 import {createDashboardAgentTool} from '@sqlrooms/mosaic/ai';
 import type {StoreApi} from 'zustand';
 import type {RoomState} from './store-types';
-import {createWorksheetAiAdapter} from './createWorksheetAiAdapter';
+import {createCliBlockDocumentAiAdapter} from './createCliBlockDocumentAiAdapter';
 import {createDatabaseAiAdapter} from './createDatabaseAiAdapter';
 import {createDashboardAgentToolWithDeckMaps} from '@sqlrooms/deck';
 import {htmlAppAgentTool} from './createHtmlAppAgent';
 import {createDefaultBlockDocumentBlockId} from '@sqlrooms/documents';
 import {
-  createWorksheetAgentTool,
-  type CreateWorksheetAgentToolOptions,
-} from './ai/createWorksheetAgentTool';
+  createCliBlockDocumentAgentTool,
+  type CreateCliBlockDocumentAgentToolOptions,
+} from './ai/createCliBlockDocumentAgentTool';
 import {
-  EXPERIMENTAL_WORKSHEET_AGENT_INSTRUCTIONS,
-  KnownWorksheetTools,
+  EXPERIMENTAL_BLOCK_DOCUMENT_AGENT_INSTRUCTIONS,
+  KnownBlockDocumentTools,
 } from './ai/constants';
-import {WorksheetMapBlockToolParameters} from './createWorksheetCommands';
+import {BlockDocumentMapBlockToolParameters} from './createCliBlockDocumentCommands';
 
-const WorksheetMapBlockToolInput = WorksheetMapBlockToolParameters.omit({
-  worksheetId: true,
-});
+const BlockDocumentMapBlockToolInput = BlockDocumentMapBlockToolParameters.omit(
+  {
+    blockDocumentId: true,
+  },
+);
 
-function createWorksheetMapBlockTool(
+function createBlockDocumentMapBlockTool(
   store: StoreApi<RoomState>,
-  worksheetId: string,
+  blockDocumentId: string,
 ): Tool {
   return tool({
     description: `Create or update a direct worksheet map block from a native Deck JSON map config.
 
 Use this for map, geospatial, spatial, longitude/latitude, geometry, H3, route, or location visualizations inside a worksheet. This creates a worksheet map block directly; do not create a dashboard block just to show a map.`,
-    inputSchema: WorksheetMapBlockToolInput,
+    inputSchema: BlockDocumentMapBlockToolInput,
     execute: async (params) => {
       try {
         const result = await store
           .getState()
           .commands.invokeCommand(
             'block-document.add-map-block',
-            {worksheetId, ...params},
+            {blockDocumentId, ...params},
             {surface: 'ai', actor: 'block-document-agent'},
           );
         if (!result.success) {
@@ -74,7 +76,7 @@ Use this for map, geospatial, spatial, longitude/latitude, geometry, H3, route, 
   });
 }
 
-export function worksheetAgentTool(
+export function blockDocumentAgentTool(
   store: StoreApi<RoomState>,
   {
     experimentalEnabled = false,
@@ -82,7 +84,7 @@ export function worksheetAgentTool(
     experimentalEnabled?: boolean;
   } = {},
 ) {
-  const worksheetAdapter = createWorksheetAiAdapter(store);
+  const blockDocumentAdapter = createCliBlockDocumentAiAdapter(store);
   const databaseAdapter = createDatabaseAiAdapter(store);
 
   const baseOptions: BaseAgentToolOptions<RoomState> = {
@@ -114,19 +116,19 @@ export function worksheetAgentTool(
     databaseAdapter,
   });
 
-  const worksheetAgentOptions: CreateWorksheetAgentToolOptions = {
+  const blockDocumentAgentOptions: CreateCliBlockDocumentAgentToolOptions = {
     ...baseOptions,
     databaseAdapter,
-    blockDocumentAdapter: worksheetAdapter,
+    blockDocumentAdapter,
     dashboardAgentTool,
     htmlAppBlocksEnabled: experimentalEnabled,
     mapBlocksEnabled: experimentalEnabled,
-    addDashboardBlock: async ({worksheetId, title, tableName, intent}) => {
+    addDashboardBlock: async ({blockDocumentId, title, tableName, intent}) => {
       const result = await store
         .getState()
         .commands.invokeCommand(
           'block-document.add-dashboard-block',
-          {worksheetId, title, tableName, intent},
+          {blockDocumentId, title, tableName, intent},
           {surface: 'ai', actor: 'block-document-agent'},
         );
       if (!result.success) {
@@ -143,7 +145,7 @@ export function worksheetAgentTool(
       return {dashboardId: data.dashboardId, blockId: data.blockId};
     },
     addDataTableExplorerBlock: async ({
-      worksheetId,
+      blockDocumentId,
       title,
       tableName,
       intent,
@@ -152,7 +154,7 @@ export function worksheetAgentTool(
         .getState()
         .commands.invokeCommand(
           'block-document.add-data-table-block',
-          {worksheetId, title, tableName, intent},
+          {blockDocumentId, title, tableName, intent},
           {surface: 'ai', actor: 'block-document-agent'},
         );
       if (!result.success) {
@@ -162,12 +164,12 @@ export function worksheetAgentTool(
       }
       return result.data;
     },
-    addHtmlAppBlock: async ({worksheetId, title, intent}) => {
+    addHtmlAppBlock: async ({blockDocumentId, title, intent}) => {
       const result = await store
         .getState()
         .commands.invokeCommand(
           'block-document.add-html-app-block',
-          {worksheetId, title, intent},
+          {blockDocumentId, title, intent},
           {surface: 'ai', actor: 'block-document-agent'},
         );
       if (!result.success) {
@@ -211,15 +213,15 @@ export function worksheetAgentTool(
       caption: title,
     }),
     additionalInstructions: experimentalEnabled
-      ? EXPERIMENTAL_WORKSHEET_AGENT_INSTRUCTIONS
+      ? EXPERIMENTAL_BLOCK_DOCUMENT_AGENT_INSTRUCTIONS
       : undefined,
-    extraTools: ({worksheetId}) => {
+    extraTools: ({blockDocumentId}) => {
       if (experimentalEnabled) {
         return {
-          [KnownWorksheetTools.embedded_html_app_agent]:
+          [KnownBlockDocumentTools.embedded_html_app_agent]:
             htmlAppAgentTool(store),
-          [KnownWorksheetTools.create_block_document_map_block]:
-            createWorksheetMapBlockTool(store, worksheetId),
+          [KnownBlockDocumentTools.create_block_document_map_block]:
+            createBlockDocumentMapBlockTool(store, blockDocumentId),
         };
       }
 
@@ -227,5 +229,5 @@ export function worksheetAgentTool(
     },
   };
 
-  return createWorksheetAgentTool(worksheetAgentOptions);
+  return createCliBlockDocumentAgentTool(blockDocumentAgentOptions);
 }

--- a/apps/sqlrooms-cli-ui/src/createCliBlockDocumentAiAdapter.ts
+++ b/apps/sqlrooms-cli-ui/src/createCliBlockDocumentAiAdapter.ts
@@ -6,11 +6,8 @@ import {
 import type {StoreApi} from 'zustand';
 import type {RoomState} from './store-types';
 
-/**
- * Creates a worksheet-specific adapter for the worksheet agent.
- * Worksheets are block documents, not dashboards.
- */
-export function createWorksheetAiAdapter(
+/** Creates the CLI block-document adapter for Worksheet artifacts. */
+export function createCliBlockDocumentAiAdapter(
   store: StoreApi<RoomState>,
 ): BlockDocumentAiAdapter & BlockDocumentMoveBlockAiAdapter {
   return createBlockDocumentCommandAiAdapter({

--- a/apps/sqlrooms-cli-ui/src/createCliBlockDocumentCommands.ts
+++ b/apps/sqlrooms-cli-ui/src/createCliBlockDocumentCommands.ts
@@ -13,35 +13,36 @@ import type {RoomCommand} from '@sqlrooms/room-shell';
 import {z} from 'zod';
 import type {RoomState} from './store-types';
 
-export const CLI_WORKSHEET_COMMAND_OWNER = '@sqlrooms-cli-ui/block-document';
+export const CLI_BLOCK_DOCUMENT_COMMAND_OWNER =
+  '@sqlrooms-cli-ui/block-document';
 
-const WORKSHEET_CREATE_STATEFUL_BLOCK_COMMAND_ID =
+const BLOCK_DOCUMENT_CREATE_STATEFUL_BLOCK_COMMAND_ID =
   'block-document.create-stateful-block';
-const WORKSHEET_ADD_DASHBOARD_BLOCK_COMMAND_ID =
+const BLOCK_DOCUMENT_ADD_DASHBOARD_BLOCK_COMMAND_ID =
   'block-document.add-dashboard-block';
-const WORKSHEET_ADD_DATA_TABLE_BLOCK_COMMAND_ID =
+const BLOCK_DOCUMENT_ADD_DATA_TABLE_BLOCK_COMMAND_ID =
   'block-document.add-data-table-block';
-const WORKSHEET_ADD_HTML_APP_BLOCK_COMMAND_ID =
+const BLOCK_DOCUMENT_ADD_HTML_APP_BLOCK_COMMAND_ID =
   'block-document.add-html-app-block';
-const WORKSHEET_UPDATE_BLOCK_METADATA_COMMAND_ID =
+const BLOCK_DOCUMENT_UPDATE_BLOCK_METADATA_COMMAND_ID =
   'block-document.update-block-metadata';
-const WORKSHEET_ADD_MAP_BLOCK_COMMAND_ID = 'block-document.add-map-block';
+const BLOCK_DOCUMENT_ADD_MAP_BLOCK_COMMAND_ID = 'block-document.add-map-block';
 const DASHBOARD_SET_SELECTED_TABLE_COMMAND_ID = 'dashboard.set-selected-table';
 
-const WorksheetIdInput = z.object({
-  worksheetId: z.string().describe('Target worksheet artifact ID.'),
+const BlockDocumentIdInput = z.object({
+  blockDocumentId: z.string().describe('Target block document artifact ID.'),
 });
 
-const WorksheetAddDashboardBlockInput = WorksheetIdInput.extend({
+const BlockDocumentAddDashboardBlockInput = BlockDocumentIdInput.extend({
   title: z.string().default('Dashboard').describe('Dashboard block title.'),
   tableName: z.string().describe('Selected table for the dashboard.'),
   intent: z
     .string()
     .optional()
-    .describe('Optional durable purpose for this worksheet block.'),
+    .describe('Optional durable purpose for this block document block.'),
 });
 
-const WorksheetAddDataTableBlockInput = WorksheetIdInput.extend({
+const BlockDocumentAddDataTableBlockInput = BlockDocumentIdInput.extend({
   title: z
     .string()
     .default('Data Table Explorer')
@@ -50,39 +51,39 @@ const WorksheetAddDataTableBlockInput = WorksheetIdInput.extend({
   intent: z
     .string()
     .optional()
-    .describe('Optional durable purpose for this worksheet block.'),
+    .describe('Optional durable purpose for this block document block.'),
 });
 
-const WorksheetAddHtmlAppBlockInput = WorksheetIdInput.extend({
+const BlockDocumentAddHtmlAppBlockInput = BlockDocumentIdInput.extend({
   title: z.string().default('HTML App').describe('HTML app block title.'),
   intent: z
     .string()
     .optional()
-    .describe('Optional durable purpose for this worksheet block.'),
+    .describe('Optional durable purpose for this block document block.'),
 });
 
-const WorksheetUpdateBlockMetadataInput = WorksheetIdInput.extend({
-  blockId: z.string().describe('Worksheet document block ID to update.'),
+const BlockDocumentUpdateBlockMetadataInput = BlockDocumentIdInput.extend({
+  blockId: z.string().describe('Block document block ID to update.'),
   title: z.string().optional().describe('Updated block title.'),
   caption: z.string().optional().describe('Updated block caption.'),
   height: z.number().positive().optional().describe('Updated block height.'),
 });
 
-export const WorksheetMapBlockToolParameters =
+export const BlockDocumentMapBlockToolParameters =
   DeckMapDashboardToolParameters.extend({
-    worksheetId: z.string().describe('Target worksheet artifact ID.'),
+    blockDocumentId: z.string().describe('Target block document artifact ID.'),
     mapId: z
       .string()
       .optional()
-      .describe('Existing worksheet map block resource ID to update.'),
+      .describe('Existing block document map block resource ID to update.'),
     intent: z
       .string()
       .optional()
-      .describe('Durable purpose for this worksheet map block.'),
+      .describe('Durable purpose for this block document map block.'),
   });
 
-type WorksheetMapBlockToolParameters = z.infer<
-  typeof WorksheetMapBlockToolParameters
+type BlockDocumentMapBlockToolParameters = z.infer<
+  typeof BlockDocumentMapBlockToolParameters
 >;
 
 function getFirstDatasetSourceTableName(
@@ -117,12 +118,17 @@ function hasSqlOnlyDatasetSource(
   });
 }
 
-function resolveWorksheet(state: RoomState, worksheetId: string) {
-  const artifact = state.artifacts.getArtifact(worksheetId);
+function resolveBlockDocumentArtifact(
+  state: RoomState,
+  blockDocumentId: string,
+) {
+  const artifact = state.artifacts.getArtifact(blockDocumentId);
   if (!artifact || artifact.type !== 'worksheet') {
-    throw new Error(`Artifact ${worksheetId} is not a worksheet`);
+    throw new Error(
+      `Artifact ${blockDocumentId} is not a Worksheet block document`,
+    );
   }
-  state.blockDocuments.ensureBlockDocument(worksheetId);
+  state.blockDocuments.ensureBlockDocument(blockDocumentId);
   return artifact;
 }
 
@@ -160,12 +166,12 @@ function statefulBlockFromCommandData(data: unknown): {
 
 function findStatefulBlock(
   state: RoomState,
-  worksheetId: string,
+  blockDocumentId: string,
   blockInstanceId: string,
   blockType: string,
 ) {
   return state.blockDocuments
-    .getBlocks(worksheetId)
+    .getBlocks(blockDocumentId)
     .find((block: unknown): block is BlockDocumentStatefulBlockBlock => {
       if (typeof block !== 'object' || block === null) {
         return false;
@@ -194,22 +200,22 @@ function findMapPanel(state: RoomState, mapId: string, panelId?: string) {
   );
 }
 
-export function createWorksheetCommands(): RoomCommand<RoomState>[] {
+export function createCliBlockDocumentCommands(): RoomCommand<RoomState>[] {
   return [
     {
-      id: WORKSHEET_ADD_DASHBOARD_BLOCK_COMMAND_ID,
-      name: 'Add worksheet dashboard block',
-      description: 'Add an owned dashboard block to a worksheet.',
+      id: BLOCK_DOCUMENT_ADD_DASHBOARD_BLOCK_COMMAND_ID,
+      name: 'Add block document dashboard block',
+      description: 'Add an owned dashboard block to a block document.',
       group: 'Worksheet',
-      keywords: ['worksheet', 'dashboard', 'block', 'add'],
-      inputSchema: WorksheetAddDashboardBlockInput,
+      keywords: ['block document', 'dashboard', 'block', 'add'],
+      inputSchema: BlockDocumentAddDashboardBlockInput,
       metadata: {readOnly: false, idempotent: false, riskLevel: 'medium'},
       execute: async ({getState}, input) => {
-        const {worksheetId, title, tableName, intent} = input as z.infer<
-          typeof WorksheetAddDashboardBlockInput
+        const {blockDocumentId, title, tableName, intent} = input as z.infer<
+          typeof BlockDocumentAddDashboardBlockInput
         >;
         const state = getState();
-        resolveWorksheet(state, worksheetId);
+        resolveBlockDocumentArtifact(state, blockDocumentId);
         const table = state.db.findTable(tableName);
         if (!table) {
           throw new Error(`Table ${tableName} was not found`);
@@ -217,9 +223,9 @@ export function createWorksheetCommands(): RoomCommand<RoomState>[] {
         const tableIdentity = getTableIdentity(table.table);
         const result = await invokeRequiredCommand(
           state,
-          WORKSHEET_CREATE_STATEFUL_BLOCK_COMMAND_ID,
+          BLOCK_DOCUMENT_CREATE_STATEFUL_BLOCK_COMMAND_ID,
           {
-            artifactId: worksheetId,
+            artifactId: blockDocumentId,
             blockType: 'dashboard',
             intent,
             title,
@@ -236,10 +242,10 @@ export function createWorksheetCommands(): RoomCommand<RoomState>[] {
         );
         return {
           success: true,
-          commandId: WORKSHEET_ADD_DASHBOARD_BLOCK_COMMAND_ID,
+          commandId: BLOCK_DOCUMENT_ADD_DASHBOARD_BLOCK_COMMAND_ID,
           message: `Added worksheet dashboard block "${title}".`,
           data: {
-            worksheetId,
+            blockDocumentId,
             blockId,
             dashboardId,
             selectedTable: tableIdentity,
@@ -248,19 +254,19 @@ export function createWorksheetCommands(): RoomCommand<RoomState>[] {
       },
     },
     {
-      id: WORKSHEET_ADD_DATA_TABLE_BLOCK_COMMAND_ID,
-      name: 'Add worksheet data table block',
-      description: 'Add a data table explorer block to a worksheet.',
+      id: BLOCK_DOCUMENT_ADD_DATA_TABLE_BLOCK_COMMAND_ID,
+      name: 'Add block document data table block',
+      description: 'Add a data table explorer block to a block document.',
       group: 'Worksheet',
-      keywords: ['worksheet', 'data table', 'block', 'add'],
-      inputSchema: WorksheetAddDataTableBlockInput,
+      keywords: ['block document', 'data table', 'block', 'add'],
+      inputSchema: BlockDocumentAddDataTableBlockInput,
       metadata: {readOnly: false, idempotent: false, riskLevel: 'medium'},
       execute: async ({getState}, input) => {
-        const {worksheetId, title, tableName, intent} = input as z.infer<
-          typeof WorksheetAddDataTableBlockInput
+        const {blockDocumentId, title, tableName, intent} = input as z.infer<
+          typeof BlockDocumentAddDataTableBlockInput
         >;
         const state = getState();
-        resolveWorksheet(state, worksheetId);
+        resolveBlockDocumentArtifact(state, blockDocumentId);
         const table = state.db.findTable(tableName);
         if (!table) {
           throw new Error(`Table ${tableName} was not found`);
@@ -268,9 +274,9 @@ export function createWorksheetCommands(): RoomCommand<RoomState>[] {
         const tableIdentity = getTableIdentity(table.table);
         const result = await invokeRequiredCommand(
           state,
-          WORKSHEET_CREATE_STATEFUL_BLOCK_COMMAND_ID,
+          BLOCK_DOCUMENT_CREATE_STATEFUL_BLOCK_COMMAND_ID,
           {
-            artifactId: worksheetId,
+            artifactId: blockDocumentId,
             blockType: 'data-table',
             intent,
             title: tableIdentity,
@@ -283,10 +289,10 @@ export function createWorksheetCommands(): RoomCommand<RoomState>[] {
         );
         return {
           success: true,
-          commandId: WORKSHEET_ADD_DATA_TABLE_BLOCK_COMMAND_ID,
+          commandId: BLOCK_DOCUMENT_ADD_DATA_TABLE_BLOCK_COMMAND_ID,
           message: `Added worksheet data table block "${title}".`,
           data: {
-            worksheetId,
+            blockDocumentId,
             blockId,
             dataTableId: blockInstanceId,
             selectedTable: tableIdentity,
@@ -295,24 +301,24 @@ export function createWorksheetCommands(): RoomCommand<RoomState>[] {
       },
     },
     {
-      id: WORKSHEET_ADD_HTML_APP_BLOCK_COMMAND_ID,
-      name: 'Add worksheet HTML app block',
-      description: 'Add an owned HTML app block to a worksheet.',
+      id: BLOCK_DOCUMENT_ADD_HTML_APP_BLOCK_COMMAND_ID,
+      name: 'Add block document HTML app block',
+      description: 'Add an owned HTML app block to a block document.',
       group: 'Worksheet',
-      keywords: ['worksheet', 'html', 'app', 'block', 'add'],
-      inputSchema: WorksheetAddHtmlAppBlockInput,
+      keywords: ['block document', 'html', 'app', 'block', 'add'],
+      inputSchema: BlockDocumentAddHtmlAppBlockInput,
       metadata: {readOnly: false, idempotent: false, riskLevel: 'medium'},
       execute: async ({getState}, input) => {
-        const {worksheetId, title, intent} = input as z.infer<
-          typeof WorksheetAddHtmlAppBlockInput
+        const {blockDocumentId, title, intent} = input as z.infer<
+          typeof BlockDocumentAddHtmlAppBlockInput
         >;
         const state = getState();
-        resolveWorksheet(state, worksheetId);
+        resolveBlockDocumentArtifact(state, blockDocumentId);
         const result = await invokeRequiredCommand(
           state,
-          WORKSHEET_CREATE_STATEFUL_BLOCK_COMMAND_ID,
+          BLOCK_DOCUMENT_CREATE_STATEFUL_BLOCK_COMMAND_ID,
           {
-            artifactId: worksheetId,
+            artifactId: blockDocumentId,
             blockType: 'html-app',
             intent,
             title,
@@ -325,63 +331,67 @@ export function createWorksheetCommands(): RoomCommand<RoomState>[] {
         );
         return {
           success: true,
-          commandId: WORKSHEET_ADD_HTML_APP_BLOCK_COMMAND_ID,
+          commandId: BLOCK_DOCUMENT_ADD_HTML_APP_BLOCK_COMMAND_ID,
           message: `Added worksheet HTML app block "${title}".`,
-          data: {worksheetId, blockId, appId},
+          data: {blockDocumentId, blockId, appId},
         };
       },
     },
     {
-      id: WORKSHEET_UPDATE_BLOCK_METADATA_COMMAND_ID,
-      name: 'Update worksheet block metadata',
-      description: 'Update title, caption, or height for a worksheet block.',
+      id: BLOCK_DOCUMENT_UPDATE_BLOCK_METADATA_COMMAND_ID,
+      name: 'Update block document block metadata',
+      description:
+        'Update title, caption, or height for a block document block.',
       group: 'Worksheet',
-      keywords: ['worksheet', 'block', 'metadata', 'update'],
-      inputSchema: WorksheetUpdateBlockMetadataInput,
+      keywords: ['block document', 'block', 'metadata', 'update'],
+      inputSchema: BlockDocumentUpdateBlockMetadataInput,
       metadata: {readOnly: false, idempotent: false, riskLevel: 'medium'},
       execute: ({getState}, input) => {
-        const {worksheetId, blockId, title, caption, height} = input as z.infer<
-          typeof WorksheetUpdateBlockMetadataInput
-        >;
+        const {blockDocumentId, blockId, title, caption, height} =
+          input as z.infer<typeof BlockDocumentUpdateBlockMetadataInput>;
         const state = getState();
-        resolveWorksheet(state, worksheetId);
+        resolveBlockDocumentArtifact(state, blockDocumentId);
         const existing = state.blockDocuments
-          .getBlocks(worksheetId)
+          .getBlocks(blockDocumentId)
           .find((block: {id?: string}) => block.id === blockId);
         if (!existing) {
           throw new Error(
-            `Worksheet block ${blockId} was not found in worksheet ${worksheetId}`,
+            `Block document block ${blockId} was not found in ${blockDocumentId}`,
           );
         }
-        const updated = state.blockDocuments.updateBlock(worksheetId, blockId, {
-          ...existing,
-          ...(title !== undefined ? {title} : {}),
-          ...(caption !== undefined ? {caption} : {}),
-          ...(height !== undefined ? {height} : {}),
-        });
+        const updated = state.blockDocuments.updateBlock(
+          blockDocumentId,
+          blockId,
+          {
+            ...existing,
+            ...(title !== undefined ? {title} : {}),
+            ...(caption !== undefined ? {caption} : {}),
+            ...(height !== undefined ? {height} : {}),
+          },
+        );
         if (!updated) {
-          throw new Error(`Failed to update worksheet block ${blockId}`);
+          throw new Error(`Failed to update block document block ${blockId}`);
         }
         return {
           success: true,
-          commandId: WORKSHEET_UPDATE_BLOCK_METADATA_COMMAND_ID,
+          commandId: BLOCK_DOCUMENT_UPDATE_BLOCK_METADATA_COMMAND_ID,
           message: `Updated worksheet block "${blockId}".`,
-          data: {worksheetId, blockId, title, caption, height},
+          data: {blockDocumentId, blockId, title, caption, height},
         };
       },
     },
     {
-      id: WORKSHEET_ADD_MAP_BLOCK_COMMAND_ID,
-      name: 'Add or update worksheet map block',
-      description: 'Create or update a direct worksheet map block.',
+      id: BLOCK_DOCUMENT_ADD_MAP_BLOCK_COMMAND_ID,
+      name: 'Add or update block document map block',
+      description: 'Create or update a direct block document map block.',
       group: 'Worksheet',
-      keywords: ['worksheet', 'map', 'deck', 'block', 'add', 'update'],
-      inputSchema: WorksheetMapBlockToolParameters,
+      keywords: ['block document', 'map', 'deck', 'block', 'add', 'update'],
+      inputSchema: BlockDocumentMapBlockToolParameters,
       metadata: {readOnly: false, idempotent: false, riskLevel: 'medium'},
       execute: async ({getState}, input) => {
-        const params = input as WorksheetMapBlockToolParameters;
+        const params = input as BlockDocumentMapBlockToolParameters;
         const state = getState();
-        resolveWorksheet(state, params.worksheetId);
+        resolveBlockDocumentArtifact(state, params.blockDocumentId);
 
         const tableName =
           params.tableName ?? getFirstDatasetSourceTableName(params.config);
@@ -391,7 +401,7 @@ export function createWorksheetCommands(): RoomCommand<RoomState>[] {
           hasSqlOnlyDatasetSource(params.config)
         ) {
           throw new Error(
-            'tableName is required when updating a worksheet map block with SQL-only dataset sources',
+            'tableName is required when updating a block document map block with SQL-only dataset sources',
           );
         }
         const table = tableName ? state.db.findTable(tableName) : undefined;
@@ -403,11 +413,16 @@ export function createWorksheetCommands(): RoomCommand<RoomState>[] {
         const mapId = params.mapId ?? createDefaultBlockDocumentBlockId();
         const title = params.title || 'Map';
         const existingMapBlock = params.mapId
-          ? findStatefulBlock(state, params.worksheetId, params.mapId, 'map')
+          ? findStatefulBlock(
+              state,
+              params.blockDocumentId,
+              params.mapId,
+              'map',
+            )
           : undefined;
         if (params.mapId && !existingMapBlock) {
           throw new Error(
-            `Worksheet map block ${params.mapId} was not found in worksheet ${params.worksheetId}`,
+            `Block document map block ${params.mapId} was not found in ${params.blockDocumentId}`,
           );
         }
 
@@ -422,9 +437,9 @@ export function createWorksheetCommands(): RoomCommand<RoomState>[] {
         } else {
           const result = await invokeRequiredCommand(
             state,
-            WORKSHEET_CREATE_STATEFUL_BLOCK_COMMAND_ID,
+            BLOCK_DOCUMENT_CREATE_STATEFUL_BLOCK_COMMAND_ID,
             {
-              artifactId: params.worksheetId,
+              artifactId: params.blockDocumentId,
               blockType: 'map',
               blockInstanceId: mapId,
               intent: params.intent,
@@ -466,9 +481,9 @@ export function createWorksheetCommands(): RoomCommand<RoomState>[] {
         if (existingMapBlock) {
           await invokeRequiredCommand(
             state,
-            WORKSHEET_UPDATE_BLOCK_METADATA_COMMAND_ID,
+            BLOCK_DOCUMENT_UPDATE_BLOCK_METADATA_COMMAND_ID,
             {
-              worksheetId: params.worksheetId,
+              blockDocumentId: params.blockDocumentId,
               blockId: existingMapBlock.id,
               title,
               caption: title,
@@ -478,12 +493,12 @@ export function createWorksheetCommands(): RoomCommand<RoomState>[] {
 
         return {
           success: true,
-          commandId: WORKSHEET_ADD_MAP_BLOCK_COMMAND_ID,
+          commandId: BLOCK_DOCUMENT_ADD_MAP_BLOCK_COMMAND_ID,
           message: params.mapId
             ? `Updated worksheet map block "${title}".`
             : `Added worksheet map block "${title}".`,
           data: {
-            worksheetId: params.worksheetId,
+            blockDocumentId: params.blockDocumentId,
             blockId,
             mapId,
             panelId: existingPanel?.id ?? panel.id,

--- a/apps/sqlrooms-cli-ui/src/store.ts
+++ b/apps/sqlrooms-cli-ui/src/store.ts
@@ -105,7 +105,7 @@ import {toast} from '@sqlrooms/ui';
 import {createArtifactChatHandoffController} from './artifactChatHandoff';
 import {createCliArtifactTypes} from './artifactTypes';
 import {addCliDatabaseInitializationDiagnostics} from './cliDatabaseInitialization';
-import {worksheetAgentTool} from './createWorksheetAgent';
+import {blockDocumentAgentTool} from './createBlockDocumentAgent';
 import {createArtifactContextAiTools} from './context/createArtifactContextAiTools';
 import {formatRunContextInstructions} from './context/formatRunContextInstructions';
 import {getRunContext} from './context/getRunContext';
@@ -138,33 +138,36 @@ import {
 import {dashboardAgentTool} from './createDashboardAgent';
 import {htmlAppAgentTool} from './createHtmlAppAgent';
 import {
-  CLI_WORKSHEET_COMMAND_OWNER,
-  createWorksheetCommands,
-} from './createWorksheetCommands';
-import {KnownWorksheetTools, WORKSHEET_AGENT_TOOL_NAME} from './ai/constants';
+  CLI_BLOCK_DOCUMENT_COMMAND_OWNER,
+  createCliBlockDocumentCommands,
+} from './createCliBlockDocumentCommands';
+import {
+  KnownBlockDocumentTools,
+  CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME,
+} from './ai/constants';
 
 export type {RoomState} from './store-types';
 
 const DOCUMENT_COMMAND_OWNER = '@sqlrooms/documents';
 const MOSAIC_DASHBOARD_COMMAND_OWNER = '@sqlrooms/mosaic/dashboard';
-const WORKSHEET_COMMAND_OWNER = '@sqlrooms/documents/block-document';
-const WORKSHEET_PYTHON_COMMAND_OWNER = '@sqlrooms/python/block-document';
+const BLOCK_DOCUMENT_COMMAND_OWNER = '@sqlrooms/documents/block-document';
+const BLOCK_DOCUMENT_PYTHON_COMMAND_OWNER = '@sqlrooms/python/block-document';
 const AI_SETTINGS_SAVE_FAILED_TOAST_ID = 'ai-settings-save-failed';
 const STABLE_SQLROOMS_CLI_AI_INSTRUCTIONS = `
 In the SQLRooms CLI app, a Worksheet is a block document artifact. When the user asks to create, edit, inspect, or add content to a worksheet, target the current worksheet artifact using block-document commands and block-document agent tools. Use the word Worksheet in user-facing replies, but use block-document tool names and command IDs when invoking tools. The artifact type may still be "worksheet"; its editable content model is a block document.
 
 When the user's primary context artifact is a worksheet or dashboard and they ask to add, update, or create a visualization, chart, or dashboard surface, mutate that artifact through the appropriate agent tool instead of creating a separate artifact, chat-only chart, or markdown image.
 
-- Use ${WORKSHEET_AGENT_TOOL_NAME} when the primary artifact is a worksheet, or when the user explicitly asks to create/edit a top-level worksheet artifact.
+- Use ${CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME} when the primary artifact is a worksheet, or when the user explicitly asks to create/edit a top-level worksheet artifact.
 - For dashboard artifacts, call dashboard_agent.
 - Use the standalone chart and chart_image_for_markdown tools only when the user wants an inline chat visualization or no target artifact is available.
 `;
 const EXPERIMENTAL_SQLROOMS_CLI_AI_INSTRUCTIONS = `
 Experimental SQLRooms tools are available in this session. Use them for app, map, and generated interactive visualization requests when they match the user's target artifact.
 
-- If the primary artifact is a worksheet and the user asks for an app, HTML app, D3 app, Chart.js app, browser app, or generated interactive visualization inside it, call ${WORKSHEET_AGENT_TOOL_NAME}. The worksheet agent should create/reuse the worksheet html-app block, then call ${KnownWorksheetTools.embedded_html_app_agent} with the block's appId.
+- If the primary artifact is a worksheet and the user asks for an app, HTML app, D3 app, Chart.js app, browser app, or generated interactive visualization inside it, call ${CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME}. The worksheet agent should create/reuse the worksheet html-app block, then call ${KnownBlockDocumentTools.embedded_html_app_agent} with the block's appId.
 - Do not use top-level html_app_agent to populate worksheet stateful blocks inside worksheets.
-- For worksheet map requests, call ${WORKSHEET_AGENT_TOOL_NAME}. It should add or reuse a direct worksheet map block, not create a dashboard block just to hold the map.
+- For worksheet map requests, call ${CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME}. It should add or reuse a direct worksheet map block, not create a dashboard block just to hold the map.
 - For generated HTML, D3, Chart.js, or browser app visualizations only when the primary artifact is an html-app artifact or no worksheet/dashboard artifact is the requested target, write through html_app_agent. html_app_agent requires appId and never creates artifacts or worksheet blocks.
 - If the primary artifact is an html-app artifact, call html_app_agent with appId set to the current artifact id and update it instead of creating a new html-app artifact.
 - For incremental edits to an existing html-app artifact, such as changing title, labels, colors, styles, layout, controls, or interactions, call html_app_agent directly with the current appId and the user's edit request. Do not inspect tables or schemas first unless the user explicitly asks to change the app's data/query behavior.
@@ -173,13 +176,13 @@ Experimental SQLRooms tools are available in this session. Use them for app, map
 - If an embedded worksheet HTML app target is ambiguous, ask the user to select the app/block or provide appId instead of mutating a guessed app.
 `;
 
-const WORKSHEET_BLOCK_DOCUMENT_OPTIONS = {
+const BLOCK_DOCUMENT_OPTIONS = {
   artifactType: 'worksheet',
   artifactLabel: 'Worksheet',
   commandNamespace: 'block-document',
   commandGroup: 'Worksheet',
   defaultTitle: 'Worksheet',
-  blockDocumentAgentToolName: WORKSHEET_AGENT_TOOL_NAME,
+  blockDocumentAgentToolName: CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME,
 } as const;
 
 export const runtimeConfig = await fetchRuntimeConfig();
@@ -763,9 +766,9 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
           }
           registerCommandsForOwner(
             store,
-            WORKSHEET_COMMAND_OWNER,
+            BLOCK_DOCUMENT_COMMAND_OWNER,
             createBlockDocumentCommands<RoomState>({
-              ...WORKSHEET_BLOCK_DOCUMENT_OPTIONS,
+              ...BLOCK_DOCUMENT_OPTIONS,
               statefulBlockTypes: createStatefulBlockCommandTypes({
                 experimentalEnabled,
               }),
@@ -773,19 +776,18 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
           );
           registerCommandsForOwner(
             store,
-            CLI_WORKSHEET_COMMAND_OWNER,
-            createWorksheetCommands(),
+            CLI_BLOCK_DOCUMENT_COMMAND_OWNER,
+            createCliBlockDocumentCommands(),
           );
           if (experimentalEnabled) {
             registerCommandsForOwner(
               store,
-              WORKSHEET_PYTHON_COMMAND_OWNER,
+              BLOCK_DOCUMENT_PYTHON_COMMAND_OWNER,
               createPythonBlockCommands<RoomState>({
-                artifactType: WORKSHEET_BLOCK_DOCUMENT_OPTIONS.artifactType,
-                artifactLabel: WORKSHEET_BLOCK_DOCUMENT_OPTIONS.artifactLabel,
-                commandNamespace:
-                  WORKSHEET_BLOCK_DOCUMENT_OPTIONS.commandNamespace,
-                commandGroup: WORKSHEET_BLOCK_DOCUMENT_OPTIONS.commandGroup,
+                artifactType: BLOCK_DOCUMENT_OPTIONS.artifactType,
+                artifactLabel: BLOCK_DOCUMENT_OPTIONS.artifactLabel,
+                commandNamespace: BLOCK_DOCUMENT_OPTIONS.commandNamespace,
+                commandGroup: BLOCK_DOCUMENT_OPTIONS.commandGroup,
               }),
             );
             registerCommandsForOwner(
@@ -799,9 +801,12 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
           unregisterCommandsForOwner(store, DASHBOARD_COMMAND_OWNER);
           unregisterCommandsForOwner(store, MOSAIC_DASHBOARD_COMMAND_OWNER);
           unregisterCommandsForOwner(store, DOCUMENT_COMMAND_OWNER);
-          unregisterCommandsForOwner(store, WORKSHEET_COMMAND_OWNER);
-          unregisterCommandsForOwner(store, CLI_WORKSHEET_COMMAND_OWNER);
-          unregisterCommandsForOwner(store, WORKSHEET_PYTHON_COMMAND_OWNER);
+          unregisterCommandsForOwner(store, BLOCK_DOCUMENT_COMMAND_OWNER);
+          unregisterCommandsForOwner(store, CLI_BLOCK_DOCUMENT_COMMAND_OWNER);
+          unregisterCommandsForOwner(
+            store,
+            BLOCK_DOCUMENT_PYTHON_COMMAND_OWNER,
+          );
           unregisterCommandsForOwner(store, HTML_APP_REVISION_COMMAND_OWNER);
         },
         ensureDashboardArtifact: (artifactId) => {
@@ -1177,9 +1182,12 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
               ...(experimentalEnabled
                 ? {html_app_agent: htmlAppAgentTool(store)}
                 : {}),
-              [WORKSHEET_AGENT_TOOL_NAME]: worksheetAgentTool(store, {
-                experimentalEnabled,
-              }),
+              [CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME]: blockDocumentAgentTool(
+                store,
+                {
+                  experimentalEnabled,
+                },
+              ),
               ...webContainerToolkit.tools,
               chart: createVegaChartTool(),
               chart_image_for_markdown: createChartImageForMarkdownTool(store),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated CLI AI and command support to operate on block documents (instead of worksheet-specific tooling).
  * Added block-document actions for creating, updating, moving, and organizing blocks, including dashboard, data-table, HTML app, and map blocks.
  * Local file imports now place new data-table blocks into the correct destination block document.
* **Bug Fixes**
  * Command and tool flows now consistently return and track block document IDs.
  * Improved embedded HTML app block handling when enabled, aligning tool behavior with the provided options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->