### PR TITLE
fix: pre-registration query cancellation in async DuckDB server

### DIFF
--- a/python/sqlrooms-server/sqlrooms/server/db_async.py
+++ b/python/sqlrooms-server/sqlrooms/server/db_async.py
@@ -25,10 +25,11 @@ active_queries: Dict[
 ] = {}
 active_queries_lock = threading.Lock()
 
-# Cancel messages can arrive before the event loop has started the query task that
-# registers the query. Keep those requests briefly so the later task can still
-# produce a terminal cancellation outcome instead of silently running.
+# Cancel messages can arrive after a query is scheduled but before the event loop
+# has started the task that registers it. Track only that scheduling gap so a
+# late cancel cannot poison a future query that reuses the same client query id.
 PENDING_CANCELLATION_TTL_SECONDS = 30.0
+scheduled_queries: Dict[str, float] = {}
 pending_cancellations: Dict[str, float] = {}
 
 # Shutdown state flag
@@ -48,6 +49,19 @@ def generate_query_id() -> str:
     return str(uuid.uuid4())
 
 
+def mark_query_scheduled(query_id: str) -> None:
+    """Mark a query id as accepted for scheduling but not yet registered."""
+    with active_queries_lock:
+        _prune_cancellation_state_locked()
+        scheduled_queries[query_id] = time.monotonic()
+
+
+def unmark_query_scheduled(query_id: str) -> None:
+    """Remove a query id from scheduling-gap tracking."""
+    with active_queries_lock:
+        scheduled_queries.pop(query_id, None)
+
+
 def register_query(
     query_id: str,
     future: concurrent.futures.Future,
@@ -57,7 +71,8 @@ def register_query(
     """Register an in-flight query for cancellation tracking."""
     cancel_event = cancel_event or threading.Event()
     with active_queries_lock:
-        _prune_pending_cancellations_locked()
+        _prune_cancellation_state_locked()
+        scheduled_queries.pop(query_id, None)
         active_queries[query_id] = (future, cursor, cancel_event)
         if pending_cancellations.pop(query_id, None) is not None:
             cancel_event.set()
@@ -69,25 +84,33 @@ def unregister_query(query_id: str) -> None:
         active_queries.pop(query_id, None)
 
 
-def _prune_pending_cancellations_locked() -> None:
-    """Remove stale pre-registration cancellation requests."""
+def _prune_cancellation_state_locked() -> None:
+    """Remove stale scheduling-gap cancellation state."""
     now = time.monotonic()
-    expired = [
+    expired_pending = [
         query_id
         for query_id, requested_at in pending_cancellations.items()
         if now - requested_at > PENDING_CANCELLATION_TTL_SECONDS
     ]
-    for query_id in expired:
+    for query_id in expired_pending:
         pending_cancellations.pop(query_id, None)
+    expired_scheduled = [
+        query_id
+        for query_id, scheduled_at in scheduled_queries.items()
+        if now - scheduled_at > PENDING_CANCELLATION_TTL_SECONDS
+    ]
+    for query_id in expired_scheduled:
+        scheduled_queries.pop(query_id, None)
 
 
 def cancel_query(query_id: str) -> bool:
     """Interrupt a running DuckDB query by id. Returns True if found and signaled."""
     with active_queries_lock:
-        _prune_pending_cancellations_locked()
+        _prune_cancellation_state_locked()
         entry = active_queries.get(query_id)
         if not entry:
-            pending_cancellations[query_id] = time.monotonic()
+            if query_id in scheduled_queries:
+                pending_cancellations[query_id] = time.monotonic()
             return False
         _future, con, cancel_event = entry
         cancel_event.set()
@@ -114,6 +137,7 @@ def cancel_all_queries() -> None:
                 future.cancel()
                 logger.info(f"Cancelled query {query_id}")
         active_queries.clear()
+        scheduled_queries.clear()
         pending_cancellations.clear()
 
 
@@ -238,8 +262,14 @@ async def run_db_task(
         except Exception:
             pass
         raise RuntimeError("Executor is shut down") from e
-    register_query(qid, future, cursor, cancel_event)
-    start_event.set()
+    try:
+        try:
+            register_query(qid, future, cursor, cancel_event)
+        except Exception:
+            cancel_event.set()
+            raise
+    finally:
+        start_event.set()
     try:
         return await asyncio.wrap_future(future)
     except asyncio.CancelledError as exc:

--- a/python/sqlrooms-server/sqlrooms/server/db_async.py
+++ b/python/sqlrooms-server/sqlrooms/server/db_async.py
@@ -3,6 +3,7 @@ import concurrent.futures
 import logging
 import os
 import threading
+import time
 import uuid
 from typing import Callable, Optional, Any, Dict, Tuple, List
 
@@ -18,11 +19,17 @@ EXECUTOR = concurrent.futures.ThreadPoolExecutor(max_workers=os.cpu_count() or 4
 GLOBAL_CON: Optional[duckdb.DuckDBPyConnection] = None
 DATABASE_PATH: Optional[str] = None
 
-# Track active queries for cancellation: query_id -> (Future, cursor)
+# Track active queries for cancellation: query_id -> (Future, cursor, cancellation event)
 active_queries: Dict[
-    str, Tuple[concurrent.futures.Future, duckdb.DuckDBPyConnection]
+    str, Tuple[concurrent.futures.Future, duckdb.DuckDBPyConnection, threading.Event]
 ] = {}
 active_queries_lock = threading.Lock()
+
+# Cancel messages can arrive before the event loop has started the query task that
+# registers the query. Keep those requests briefly so the later task can still
+# produce a terminal cancellation outcome instead of silently running.
+PENDING_CANCELLATION_TTL_SECONDS = 30.0
+pending_cancellations: Dict[str, float] = {}
 
 # Shutdown state flag
 SHUTTING_DOWN: bool = False
@@ -42,11 +49,18 @@ def generate_query_id() -> str:
 
 
 def register_query(
-    query_id: str, future: concurrent.futures.Future, cursor: duckdb.DuckDBPyConnection
+    query_id: str,
+    future: concurrent.futures.Future,
+    cursor: duckdb.DuckDBPyConnection,
+    cancel_event: Optional[threading.Event] = None,
 ) -> None:
     """Register an in-flight query for cancellation tracking."""
+    cancel_event = cancel_event or threading.Event()
     with active_queries_lock:
-        active_queries[query_id] = (future, cursor)
+        _prune_pending_cancellations_locked()
+        active_queries[query_id] = (future, cursor, cancel_event)
+        if pending_cancellations.pop(query_id, None) is not None:
+            cancel_event.set()
 
 
 def unregister_query(query_id: str) -> None:
@@ -55,27 +69,43 @@ def unregister_query(query_id: str) -> None:
         active_queries.pop(query_id, None)
 
 
+def _prune_pending_cancellations_locked() -> None:
+    """Remove stale pre-registration cancellation requests."""
+    now = time.monotonic()
+    expired = [
+        query_id
+        for query_id, requested_at in pending_cancellations.items()
+        if now - requested_at > PENDING_CANCELLATION_TTL_SECONDS
+    ]
+    for query_id in expired:
+        pending_cancellations.pop(query_id, None)
+
+
 def cancel_query(query_id: str) -> bool:
     """Interrupt a running DuckDB query by id. Returns True if found and signaled."""
     with active_queries_lock:
+        _prune_pending_cancellations_locked()
         entry = active_queries.get(query_id)
-        if entry:
-            future, con = entry
-            try:
-                if hasattr(con, "interrupt"):
-                    con.interrupt()
-                else:
-                    duckdb.interrupt(con)
-            except Exception as e:
-                logger.error(f"Error interrupting query {query_id}: {e}")
-            return True
-        return False
+        if not entry:
+            pending_cancellations[query_id] = time.monotonic()
+            return False
+        _future, con, cancel_event = entry
+        cancel_event.set()
+    try:
+        if hasattr(con, "interrupt"):
+            con.interrupt()
+        else:
+            duckdb.interrupt(con)
+    except Exception as e:
+        logger.error(f"Error interrupting query {query_id}: {e}")
+    return True
 
 
 def cancel_all_queries() -> None:
     """Cancel and close all active queries. Used on shutdown or reconnection."""
     with active_queries_lock:
-        for query_id, (future, cursor) in list(active_queries.items()):
+        for query_id, (future, cursor, cancel_event) in list(active_queries.items()):
+            cancel_event.set()
             try:
                 cursor.close()
             except Exception as e:
@@ -84,6 +114,7 @@ def cancel_all_queries() -> None:
                 future.cancel()
                 logger.info(f"Cancelled query {query_id}")
         active_queries.clear()
+        pending_cancellations.clear()
 
 
 def init_global_connection(
@@ -180,9 +211,14 @@ async def run_db_task(
     if GLOBAL_CON is None:
         raise RuntimeError("Global DuckDB connection not initialized")
     cursor: duckdb.DuckDBPyConnection = GLOBAL_CON.cursor()
+    start_event = threading.Event()
+    cancel_event = threading.Event()
 
     def _runner(cur: duckdb.DuckDBPyConnection):
         try:
+            start_event.wait()
+            if cancel_event.is_set():
+                raise concurrent.futures.CancelledError()
             return execute_with_cursor(cur)
         except duckdb.InterruptException as ie:
             raise concurrent.futures.CancelledError() from ie
@@ -202,10 +238,13 @@ async def run_db_task(
         except Exception:
             pass
         raise RuntimeError("Executor is shut down") from e
-    register_query(qid, future, cursor)
+    register_query(qid, future, cursor, cancel_event)
+    start_event.set()
     try:
         return await asyncio.wrap_future(future)
-    except asyncio.CancelledError:
+    except asyncio.CancelledError as exc:
+        if cancel_event.is_set():
+            raise concurrent.futures.CancelledError() from exc
         cancel_query(qid)
         raise
     finally:

--- a/python/sqlrooms-server/sqlrooms/server/server.py
+++ b/python/sqlrooms-server/sqlrooms/server/server.py
@@ -152,8 +152,10 @@ async def handle_query_ws(send, cache, query):
     except Exception as e:
         logger.exception("Error executing query")
         send({"type": "error", "queryId": query_id, "error": str(e)}, OpCode.TEXT)
-    total = round((time.time() - start) * 1_000)
-    logger.debug(f"DONE. Query took {total} ms.")
+    finally:
+        db_async.unmark_query_scheduled(query_id)
+        total = round((time.time() - start) * 1_000)
+        logger.debug(f"DONE. Query took {total} ms.")
 
 
 async def handle_upload_arrow_ws(ws, header: dict, payload: bytes):
@@ -404,7 +406,15 @@ def server(
                     app.publish(channel, payload, opcode)
                     return True
 
-                asyncio.create_task(handle_query_ws(_send_to_conn, cache, query))
+                query = dict(query)
+                query_id = query.get("queryId") or db_async.generate_query_id()
+                query["queryId"] = query_id
+                db_async.mark_query_scheduled(query_id)
+                try:
+                    asyncio.create_task(handle_query_ws(_send_to_conn, cache, query))
+                except Exception:
+                    db_async.unmark_query_scheduled(query_id)
+                    raise
             except Exception as e:
                 logger.exception("Failed to schedule query task")
                 ws.send({"type": "error", "error": str(e)}, OpCode.TEXT)

--- a/python/sqlrooms-server/sqlrooms/server/tests/test_db_async.py
+++ b/python/sqlrooms-server/sqlrooms/server/tests/test_db_async.py
@@ -1,0 +1,28 @@
+import asyncio
+import concurrent.futures
+
+import pytest
+
+from .. import db_async
+
+
+def test_run_db_task_honors_cancel_requested_before_registration(tmp_path):
+    db_path = tmp_path / "pending-cancel.duckdb"
+    query_id = "pending-cancel-query"
+    executed = False
+
+    db_async.init_global_connection(str(db_path), extensions=[])
+    try:
+        assert db_async.cancel_query(query_id) is False
+
+        def _run(_cur):
+            nonlocal executed
+            executed = True
+
+        with pytest.raises(concurrent.futures.CancelledError):
+            asyncio.run(db_async.run_db_task(_run, query_id=query_id))
+
+        assert executed is False
+    finally:
+        db_async.cancel_all_queries()
+        db_async.force_checkpoint_and_close()

--- a/python/sqlrooms-server/sqlrooms/server/tests/test_db_async.py
+++ b/python/sqlrooms-server/sqlrooms/server/tests/test_db_async.py
@@ -13,6 +13,7 @@ def test_run_db_task_honors_cancel_requested_before_registration(tmp_path):
 
     db_async.init_global_connection(str(db_path), extensions=[])
     try:
+        db_async.mark_query_scheduled(query_id)
         assert db_async.cancel_query(query_id) is False
 
         def _run(_cur):
@@ -23,6 +24,29 @@ def test_run_db_task_honors_cancel_requested_before_registration(tmp_path):
             asyncio.run(db_async.run_db_task(_run, query_id=query_id))
 
         assert executed is False
+    finally:
+        db_async.cancel_all_queries()
+        db_async.force_checkpoint_and_close()
+
+
+def test_cancel_miss_does_not_cancel_later_reused_query_id(tmp_path):
+    db_path = tmp_path / "reused-query-id.duckdb"
+    query_id = "reused-query-id"
+    executed = False
+
+    db_async.init_global_connection(str(db_path), extensions=[])
+    try:
+        assert db_async.cancel_query(query_id) is False
+
+        def _run(_cur):
+            nonlocal executed
+            executed = True
+            return "ok"
+
+        result = asyncio.run(db_async.run_db_task(_run, query_id=query_id))
+
+        assert result == "ok"
+        assert executed is True
     finally:
         db_async.cancel_all_queries()
         db_async.force_checkpoint_and_close()


### PR DESCRIPTION
## Summary
- Preserve cancel requests that arrive before a query is registered.
- Propagate cancellation through the async DuckDB task runner without letting the query execute.
- Add coverage for the pending-cancel race in the server test suite.

## Testing
- Added a unit test that requests cancellation before query registration and verifies the task is canceled without executing the query.
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of async database query cancellation, including cases where cancellation arrives before a query is fully registered.
  * Ensured cancelled work won’t begin unexpectedly, with clearer handling for pending vs. scheduled queries.
  * Updated WebSocket query completion flow so scheduling state is reliably cleaned up after execution (success, error, or cancellation).
  * Added tests covering early-cancellation and “cancel miss” scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->