### PR TITLE
fix: remove left padding from chat messages

### DIFF
--- a/packages/ai-core/src/components/ActivityBox.tsx
+++ b/packages/ai-core/src/components/ActivityBox.tsx
@@ -112,7 +112,7 @@ export const ActivityBox: React.FC<ActivityBoxProps> = ({
       <button
         onClick={() => setExpandedForLabel(summaryLabel ?? null)}
         className={cn(
-          'text-muted-foreground hover:text-foreground ml-4 flex w-full cursor-pointer items-center gap-1 py-0.5 text-xs transition-colors',
+          'text-muted-foreground hover:text-foreground flex w-full cursor-pointer items-center gap-1 py-0.5 text-xs transition-colors',
           className,
         )}
       >

--- a/packages/ai-core/src/components/MessageContainer.tsx
+++ b/packages/ai-core/src/components/MessageContainer.tsx
@@ -1,5 +1,5 @@
-import {Badge, cn} from '@sqlrooms/ui';
-import {XCircleIcon} from 'lucide-react';
+import { Badge, cn } from '@sqlrooms/ui';
+import { XCircleIcon } from 'lucide-react';
 
 type MessageContainerProps = {
   className?: string;
@@ -30,7 +30,7 @@ export const MessageContainer: React.FC<MessageContainerProps> = ({
       className={cn(
         'group relative w-full min-w-0 py-2 text-xs',
         className,
-        type === 'error' && 'border-destructive rounded-md border py-4',
+        type === 'error' && 'border-destructive rounded-md border py-4 px-4',
         // borderColor,
         // isSuccess ? borderColor : 'border-red-500',
       )}

--- a/packages/ai-core/src/components/MessageContainer.tsx
+++ b/packages/ai-core/src/components/MessageContainer.tsx
@@ -28,7 +28,7 @@ export const MessageContainer: React.FC<MessageContainerProps> = ({
   return (
     <div
       className={cn(
-        'group relative w-full min-w-0 px-5 py-2 text-xs',
+        'group relative w-full min-w-0 py-2 text-xs',
         className,
         type === 'error' && 'border-destructive rounded-md border py-4',
         // borderColor,

--- a/packages/vega/src/VegaChartToolResult.tsx
+++ b/packages/vega/src/VegaChartToolResult.tsx
@@ -47,7 +47,7 @@ export function VegaChartToolResult({
   return (
     <div className={cn('flex max-w-full flex-col gap-2', className)}>
       {input?.reasoning && (
-        <p className="text-tiny text-muted-foreground ml-4">
+        <p className="text-tiny text-muted-foreground">
           {input.reasoning}
         </p>
       )}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated spacing/alignment for collapsed activity summary toggle to remove the left margin.
  * Refined message container horizontal padding, with error messages now using distinct horizontal spacing compared to non-error types.
  * Adjusted chart reasoning text styling to remove the left margin for consistent alignment.
  * Preserved existing content, layout behavior, and functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<img width="1079" height="743" alt="Screenshot 2026-07-13 at 21 48 33" src="https://github.com/user-attachments/assets/b724759c-9471-4325-af46-c93cfa7d20b5" />
