### PR TITLE
fix: preserve provider error messages through the agent UI stream

### DIFF
--- a/packages/ai-core/__tests__/chatTransport.test.ts
+++ b/packages/ai-core/__tests__/chatTransport.test.ts
@@ -1,0 +1,34 @@
+import {getChatErrorMessageForDisplay} from '../src/chatTransport';
+
+describe('getChatErrorMessageForDisplay', () => {
+  it('preserves top-level budget retry errors from the pre-skills path', () => {
+    const message =
+      'Failed after 3 attempts. Last error: Budget has been exceeded! Current cost: 1.0374696, Max budget: 1.0';
+
+    expect(getChatErrorMessageForDisplay(new Error(message))).toBe(message);
+  });
+
+  it('extracts LiteLLM error messages from provider response bodies', () => {
+    const error = Object.assign(new Error('An error occurred.'), {
+      responseBody: JSON.stringify({
+        error: {
+          message:
+            'Budget has been exceeded! Current cost: 186.0979088000002, Max budget: 100.0',
+          type: 'budget_exceeded',
+          param: null,
+          code: '429',
+        },
+      }),
+    });
+
+    expect(getChatErrorMessageForDisplay(error)).toBe(
+      'Budget has been exceeded! Current cost: 186.0979088000002, Max budget: 100.0',
+    );
+  });
+
+  it('falls back to the regular error message', () => {
+    expect(getChatErrorMessageForDisplay(new Error('Network error'))).toBe(
+      'Network error',
+    );
+  });
+});

--- a/packages/ai-core/src/chatTransport.ts
+++ b/packages/ai-core/src/chatTransport.ts
@@ -332,6 +332,57 @@ function toMessageTokenUsage(
   };
 }
 
+function extractProviderErrorMessage(
+  error: unknown,
+  seen = new Set<unknown>(),
+): string | undefined {
+  if (typeof error === 'string') {
+    const trimmed = error.trim();
+    if (!trimmed.startsWith('{')) return undefined;
+    try {
+      return extractProviderErrorMessage(JSON.parse(trimmed), seen);
+    } catch {
+      return undefined;
+    }
+  }
+
+  if (!error || typeof error !== 'object' || seen.has(error)) {
+    return undefined;
+  }
+  seen.add(error);
+
+  const record = error as Record<string, unknown>;
+  const providerError = record.error;
+  if (providerError && typeof providerError === 'object') {
+    const providerRecord = providerError as Record<string, unknown>;
+    if (typeof providerRecord.message === 'string') {
+      return providerRecord.message;
+    }
+  }
+
+  const commonFields = [
+    record.data,
+    record.responseBody,
+    record.body,
+    record.response,
+    record.cause,
+  ];
+  for (const field of commonFields) {
+    const message = extractProviderErrorMessage(field, seen);
+    if (message) return message;
+  }
+
+  return undefined;
+}
+
+export function getChatErrorMessageForDisplay(error: unknown): string {
+  const providerMessage = extractProviderErrorMessage(error);
+  if (providerMessage) return providerMessage;
+
+  const message = getErrorMessageForDisplay(error);
+  return message && message.trim().length > 0 ? message : 'Unknown error';
+}
+
 export function createLocalChatTransportFactory({
   sessionId,
   store,
@@ -447,6 +498,7 @@ export function createLocalChatTransportFactory({
           Object.keys(tools),
         ),
         abortSignal,
+        onError: getChatErrorMessageForDisplay,
         messageMetadata: ({part}: {part: TextStreamPart<ToolSet>}) => {
           if (part.type === 'finish-step') {
             const u = part.usage;
@@ -718,10 +770,7 @@ export function createChatHandlers({
     ) => {
       try {
         consumeSessionTokenUsage(sessionId);
-        let errMsg = getErrorMessageForDisplay(error);
-        if (!errMsg || errMsg.trim().length === 0) {
-          errMsg = 'Unknown error';
-        }
+        const errMsg = getChatErrorMessageForDisplay(error);
 
         // Detect API key errors (401/403 or common error messages)
         const isApiKeyError = isAuthenticationError(error, errMsg);


### PR DESCRIPTION
Current ai-core only handles errors escaped as a top-level request error, so onChatError received the real provider message:

> Failed after 3 attempts. Last error: Budget has been exceeded! ...

With SKILL support, the error could be wrapped as an object from the agent stream/tool loop instead:

```js
{
        error: {
          message:
            'Budget has been exceeded! Current cost: 186.0979088000002, Max budget: 100.0',
          type: 'budget_exceeded',
          param: null,
          code: '429',
        },
      }
```

This PR adds stream-level formatter for `onError: getChatErrorMessageForDisplay` to handle both chat errors.

