### PR TITLE
fix: rollback chat context badge selector

### DIFF
--- a/packages/ai-core/src/components/context/ContextSelectorBadge.tsx
+++ b/packages/ai-core/src/components/context/ContextSelectorBadge.tsx
@@ -37,7 +37,6 @@ export const ContextSelectorBadge: FC<ContextSelectorBadgeProps> = ({
     runningItems,
     renderBadgeLabel,
     removeItem,
-    makeMain,
     reorderItems,
   } = useContextSelectorContext();
 
@@ -111,7 +110,6 @@ export const ContextSelectorBadge: FC<ContextSelectorBadgeProps> = ({
                 key={item.id}
                 item={item}
                 main={index === 0}
-                onMakeMain={makeMain}
                 onRemove={removeItem}
               />
             ))}

--- a/packages/ai-core/src/components/context/ContextSelectorBadge.tsx
+++ b/packages/ai-core/src/components/context/ContextSelectorBadge.tsx
@@ -37,6 +37,7 @@ export const ContextSelectorBadge: FC<ContextSelectorBadgeProps> = ({
     runningItems,
     renderBadgeLabel,
     removeItem,
+    makeMain,
     reorderItems,
   } = useContextSelectorContext();
 
@@ -105,10 +106,12 @@ export const ContextSelectorBadge: FC<ContextSelectorBadgeProps> = ({
             items={selectedItems.map((item) => item.id)}
             strategy={horizontalListSortingStrategy}
           >
-            {selectedItems.map((item) => (
+            {selectedItems.map((item, index) => (
               <ContextSelectorSortableChip
                 key={item.id}
                 item={item}
+                main={index === 0}
+                onMakeMain={makeMain}
                 onRemove={removeItem}
               />
             ))}

--- a/packages/ai-core/src/components/context/ContextSelectorItem.tsx
+++ b/packages/ai-core/src/components/context/ContextSelectorItem.tsx
@@ -59,12 +59,7 @@ export const ContextSelectorItemComponent: FC<ContextSelectorItemProps> = ({
           <span className="text-muted-foreground text-xs capitalize">
             {defaultTypeLabel(item)}
           </span>
-          {running && (
-            <UiBadge variant="secondary" className="h-5 px-1.5 text-[10px]">
-              Running
-            </UiBadge>
-          )}
-          {selected && !running && (
+          {selected && (
             <UiBadge variant="secondary" className="h-5 px-1.5 text-[10px]">
               Selected
             </UiBadge>

--- a/packages/ai-core/src/components/context/ContextSelectorSortableChip.tsx
+++ b/packages/ai-core/src/components/context/ContextSelectorSortableChip.tsx
@@ -45,7 +45,8 @@ export const ContextSelectorSortableChip: FC<
         {main ? (
           <Tooltip>
             <TooltipTrigger asChild>
-              <span
+              <button
+                type="button"
                 className="flex min-w-0 items-center gap-1"
                 aria-label={`${item.title} is the primary context item`}
               >
@@ -53,7 +54,7 @@ export const ContextSelectorSortableChip: FC<
                   <ContextSelectorItemIcon item={item} className="h-3 w-3" />
                 </span>
                 <span className="truncate">{item.title}</span>
-              </span>
+              </button>
             </TooltipTrigger>
             <TooltipContent side="top" className="text-xs">
               Primary context

--- a/packages/ai-core/src/components/context/ContextSelectorSortableChip.tsx
+++ b/packages/ai-core/src/components/context/ContextSelectorSortableChip.tsx
@@ -42,28 +42,49 @@ export const ContextSelectorSortableChip: FC<
         variant={main ? 'default' : 'secondary'}
         className="h-6 max-w-36 min-w-0 gap-1 px-1.5 text-[11px]"
       >
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              className="text-muted-foreground/80 hover:text-foreground shrink-0 cursor-grab active:cursor-grabbing"
-              aria-label={`Drag ${item.title} to reorder context`}
-              {...attributes}
-              {...listeners}
-            >
-              <GripVerticalIcon className="h-2.5 w-2.5" />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="top" className="text-xs">
-            Drag to the front to make primary
-          </TooltipContent>
-        </Tooltip>
-        <span className="flex min-w-0 items-center gap-1">
-          <span className="shrink-0">
-            <ContextSelectorItemIcon item={item} className="h-3 w-3" />
-          </span>
-          <span className="truncate">{item.title}</span>
-        </span>
+        {main ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                className="flex min-w-0 items-center gap-1"
+                aria-label={`${item.title} is the primary context item`}
+              >
+                <span className="shrink-0">
+                  <ContextSelectorItemIcon item={item} className="h-3 w-3" />
+                </span>
+                <span className="truncate">{item.title}</span>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="top" className="text-xs">
+              Primary context
+            </TooltipContent>
+          </Tooltip>
+        ) : (
+          <>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  className="text-muted-foreground/80 hover:text-foreground shrink-0 cursor-grab active:cursor-grabbing"
+                  aria-label={`Drag ${item.title} to reorder context`}
+                  {...attributes}
+                  {...listeners}
+                >
+                  <GripVerticalIcon className="h-2.5 w-2.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="top" className="text-xs">
+                Drag to the front to make primary
+              </TooltipContent>
+            </Tooltip>
+            <span className="flex min-w-0 items-center gap-1">
+              <span className="shrink-0">
+                <ContextSelectorItemIcon item={item} className="h-3 w-3" />
+              </span>
+              <span className="truncate">{item.title}</span>
+            </span>
+          </>
+        )}
         <button
           type="button"
           className="ml-0.5 shrink-0 opacity-70 hover:opacity-100"

--- a/packages/ai-core/src/components/context/ContextSelectorSortableChip.tsx
+++ b/packages/ai-core/src/components/context/ContextSelectorSortableChip.tsx
@@ -42,50 +42,33 @@ export const ContextSelectorSortableChip: FC<
         variant={main ? 'default' : 'secondary'}
         className="h-6 max-w-36 min-w-0 gap-1 px-1.5 text-[11px]"
       >
-        {main ? (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                className="flex min-w-0 items-center gap-1"
-                aria-label={`${item.title} is the primary context item`}
-              >
-                <span className="shrink-0">
-                  <ContextSelectorItemIcon item={item} className="h-3 w-3" />
-                </span>
-                <span className="truncate">{item.title}</span>
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="top" className="text-xs">
-              Primary context
-            </TooltipContent>
-          </Tooltip>
-        ) : (
-          <>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  className="text-muted-foreground/80 hover:text-foreground shrink-0 cursor-grab active:cursor-grabbing"
-                  aria-label={`Drag ${item.title} to reorder context`}
-                  {...attributes}
-                  {...listeners}
-                >
-                  <GripVerticalIcon className="h-2.5 w-2.5" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="top" className="text-xs">
-                Drag to the front to make primary
-              </TooltipContent>
-            </Tooltip>
-            <span className="flex min-w-0 items-center gap-1">
-              <span className="shrink-0">
-                <ContextSelectorItemIcon item={item} className="h-3 w-3" />
-              </span>
-              <span className="truncate">{item.title}</span>
-            </span>
-          </>
-        )}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              className={cn(
+                'shrink-0 cursor-grab active:cursor-grabbing',
+                main
+                  ? 'text-primary-foreground/70 hover:text-primary-foreground'
+                  : 'text-muted-foreground/80 hover:text-foreground',
+              )}
+              aria-label={`Drag ${item.title} to reorder context`}
+              {...attributes}
+              {...listeners}
+            >
+              <GripVerticalIcon className="h-2.5 w-2.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="top" className="text-xs">
+            {main ? 'Primary context' : 'Drag to the front to make primary'}
+          </TooltipContent>
+        </Tooltip>
+        <span className="flex min-w-0 items-center gap-1">
+          <span className="shrink-0">
+            <ContextSelectorItemIcon item={item} className="h-3 w-3" />
+          </span>
+          <span className="truncate">{item.title}</span>
+        </span>
         <button
           type="button"
           className="ml-0.5 shrink-0 opacity-70 hover:opacity-100"

--- a/packages/ai-core/src/components/context/ContextSelectorSortableChip.tsx
+++ b/packages/ai-core/src/components/context/ContextSelectorSortableChip.tsx
@@ -7,12 +7,14 @@ import type {ContextSelectorItem} from './types';
 
 type ContextSelectorSortableChipProps = {
   item: ContextSelectorItem;
+  main: boolean;
+  onMakeMain: (itemId: string) => void;
   onRemove: (itemId: string) => void;
 };
 
 export const ContextSelectorSortableChip: FC<
   ContextSelectorSortableChipProps
-> = ({item, onRemove}) => {
+> = ({item, main, onMakeMain, onRemove}) => {
   const {attributes, listeners, setNodeRef, transform, transition, isDragging} =
     useSortable({id: item.id});
 
@@ -32,7 +34,7 @@ export const ContextSelectorSortableChip: FC<
       }}
     >
       <UiBadge
-        variant="secondary"
+        variant={main ? 'default' : 'secondary'}
         className="h-6 max-w-36 min-w-0 gap-1 px-1.5 text-[11px]"
       >
         <button
@@ -44,12 +46,17 @@ export const ContextSelectorSortableChip: FC<
         >
           <GripVerticalIcon className="h-2.5 w-2.5" />
         </button>
-        <span className="flex min-w-0 items-center gap-1">
+        <button
+          type="button"
+          className="flex min-w-0 items-center gap-1"
+          onClick={() => onMakeMain(item.id)}
+          aria-label={`Make ${item.title} the main context item`}
+        >
           <span className="shrink-0">
             <ContextSelectorItemIcon item={item} className="h-3 w-3" />
           </span>
           <span className="truncate">{item.title}</span>
-        </span>
+        </button>
         <button
           type="button"
           className="ml-0.5 shrink-0 opacity-70 hover:opacity-100"

--- a/packages/ai-core/src/components/context/ContextSelectorSortableChip.tsx
+++ b/packages/ai-core/src/components/context/ContextSelectorSortableChip.tsx
@@ -1,5 +1,11 @@
 import {useSortable} from '@dnd-kit/sortable';
-import {Badge as UiBadge, cn} from '@sqlrooms/ui';
+import {
+  Badge as UiBadge,
+  cn,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@sqlrooms/ui';
 import {GripVerticalIcon, XIcon} from 'lucide-react';
 import type {FC} from 'react';
 import {ContextSelectorItemIcon} from './ContextSelectorItemIcon';
@@ -8,13 +14,12 @@ import type {ContextSelectorItem} from './types';
 type ContextSelectorSortableChipProps = {
   item: ContextSelectorItem;
   main: boolean;
-  onMakeMain: (itemId: string) => void;
   onRemove: (itemId: string) => void;
 };
 
 export const ContextSelectorSortableChip: FC<
   ContextSelectorSortableChipProps
-> = ({item, main, onMakeMain, onRemove}) => {
+> = ({item, main, onRemove}) => {
   const {attributes, listeners, setNodeRef, transform, transition, isDragging} =
     useSortable({id: item.id});
 
@@ -37,26 +42,28 @@ export const ContextSelectorSortableChip: FC<
         variant={main ? 'default' : 'secondary'}
         className="h-6 max-w-36 min-w-0 gap-1 px-1.5 text-[11px]"
       >
-        <button
-          type="button"
-          className="text-muted-foreground/80 hover:text-foreground shrink-0 cursor-grab active:cursor-grabbing"
-          aria-label={`Drag ${item.title} to reorder context`}
-          {...attributes}
-          {...listeners}
-        >
-          <GripVerticalIcon className="h-2.5 w-2.5" />
-        </button>
-        <button
-          type="button"
-          className="flex min-w-0 items-center gap-1"
-          onClick={() => onMakeMain(item.id)}
-          aria-label={`Make ${item.title} the main context item`}
-        >
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              className="text-muted-foreground/80 hover:text-foreground shrink-0 cursor-grab active:cursor-grabbing"
+              aria-label={`Drag ${item.title} to reorder context`}
+              {...attributes}
+              {...listeners}
+            >
+              <GripVerticalIcon className="h-2.5 w-2.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="top" className="text-xs">
+            Drag to the front to make primary
+          </TooltipContent>
+        </Tooltip>
+        <span className="flex min-w-0 items-center gap-1">
           <span className="shrink-0">
             <ContextSelectorItemIcon item={item} className="h-3 w-3" />
           </span>
           <span className="truncate">{item.title}</span>
-        </button>
+        </span>
         <button
           type="button"
           className="ml-0.5 shrink-0 opacity-70 hover:opacity-100"


### PR DESCRIPTION
<img width="272" height="151" alt="Screenshot 2026-07-16 at 09 54 39" src="https://github.com/user-attachments/assets/53112a89-c339-4e67-9c5c-8337c6a9a970" />

Rollback chat badge selection so it shows which Map is active
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added index-aware “main” context chip behavior: the first selected item is treated as the main chip and is visually highlighted.
  * Main chips display the icon and truncated title with a “Primary context” tooltip, while non-main chips remain draggable and show the same icon/title alongside removal.
* **Bug Fixes / UI Updates**
  * Updated context badge logic so the “Selected” badge is shown based only on selection state.
  * The “Running” badge is no longer rendered by the context item component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->