### PR TITLE
feat(mosaic): per-column summary kind overrides for DataTableExplorer

### DIFF
--- a/examples/deckgl-mosaic/src/components/filters/EarthquakeProfiler.tsx
+++ b/examples/deckgl-mosaic/src/components/filters/EarthquakeProfiler.tsx
@@ -1,8 +1,28 @@
 import {useDataTable} from '@sqlrooms/duckdb';
-import {DataTableExplorer} from '@sqlrooms/mosaic';
+import {
+  DataTableExplorer,
+  type DataTableExplorerColumnKindOverride,
+} from '@sqlrooms/mosaic';
 import {cn} from '@sqlrooms/ui';
+import type {Field} from 'apache-arrow';
 import {FC, useMemo} from 'react';
 import {useRoomStore} from '../../store';
+
+// Demonstrates per-column summary-kind overrides: coordinate columns are
+// shown without summaries (they stay sortable but don't cross-filter), and
+// MagType keeps its type-driven category buckets. Columns not listed here
+// keep the default Arrow-type-driven behavior via 'auto'.
+const COLUMN_KIND_OVERRIDES: Record<
+  string,
+  DataTableExplorerColumnKindOverride
+> = {
+  Latitude: 'none',
+  Longitude: 'none',
+};
+
+function getColumnKind(field: Field): DataTableExplorerColumnKindOverride {
+  return COLUMN_KIND_OVERRIDES[field.name] ?? 'auto';
+}
 
 type EarthquakeProfilerProps = {className?: string};
 
@@ -35,6 +55,7 @@ export const EarthquakeProfiler: FC<EarthquakeProfilerProps> = ({
         pageSize={25}
         selection={brush}
         tableName={dataTable.table}
+        getColumnKind={getColumnKind}
       >
         <div className="flex items-center justify-between gap-4 px-3 py-2">
           <div>

--- a/examples/deckgl-mosaic/src/components/filters/EarthquakeProfiler.tsx
+++ b/examples/deckgl-mosaic/src/components/filters/EarthquakeProfiler.tsx
@@ -2,9 +2,9 @@ import {useDataTable} from '@sqlrooms/duckdb';
 import {
   DataTableExplorer,
   type DataTableExplorerColumnKindOverride,
+  type DataTableExplorerOptions,
 } from '@sqlrooms/mosaic';
 import {cn} from '@sqlrooms/ui';
-import type {Field} from 'apache-arrow';
 import {FC, useMemo} from 'react';
 import {useRoomStore} from '../../store';
 
@@ -20,9 +20,9 @@ const COLUMN_KIND_OVERRIDES: Record<
   Longitude: 'none',
 };
 
-function getColumnKind(field: Field): DataTableExplorerColumnKindOverride {
-  return COLUMN_KIND_OVERRIDES[field.name] ?? 'auto';
-}
+const getColumnKind: NonNullable<DataTableExplorerOptions['getColumnKind']> = (
+  field,
+) => COLUMN_KIND_OVERRIDES[field.name] ?? 'auto';
 
 type EarthquakeProfilerProps = {className?: string};
 

--- a/packages/mosaic/README.md
+++ b/packages/mosaic/README.md
@@ -191,6 +191,45 @@ function EarthquakeExplorer() {
 }
 ```
 
+#### Per-column summary kinds
+
+By default each column's summary is derived from its Arrow type: numeric and
+datetime columns get a brushable histogram, other supported types get category
+buckets. Pass `getColumnKind` to override this per column:
+
+```tsx
+<DataTableExplorer
+  tableName={dataTable.table}
+  selection={brush}
+  getColumnKind={(field) => {
+    // Visible and sortable, but no summary and no cross-filtering.
+    if (field.name === 'Latitude' || field.name === 'Longitude') return 'none';
+    // Force category buckets for a low-cardinality numeric code column.
+    if (field.name === 'StatusCode') return 'category';
+    return 'auto';
+  }}
+>
+```
+
+The resolver returns `'auto' | 'category' | 'histogram' | 'none'`:
+
+- `'auto'` keeps the type-driven default.
+- `'none'` shows the column without a summary. Its summary Mosaic clients are
+  never created, so no summary queries run and the column does not
+  participate in cross-filtering. The column stays sortable.
+- `'category'` / `'histogram'` force a specific summary. Requests the column
+  type cannot support (e.g. a histogram on a string column) fall back to the
+  type-driven default rather than producing broken queries.
+
+Resolved kinds are value-memoized internally, so an inline resolver function
+is safe as long as it is pure.
+
+For fully custom headers built on `useDataTableExplorer`, the default summary
+cells are exported as `DataTableExplorerSummaryCell`,
+`DataTableExplorerHistogramSummaryCell`, and
+`DataTableExplorerCategorySummaryCell`, and the kind resolution logic as
+`resolveDataTableExplorerColumnKind`.
+
 ### Code View Primitives
 
 Use `MosaicCodeViewerPanel` with `CodeViewToggleButton` for settings panels

--- a/packages/mosaic/__tests__/data-table-explorer.utils.test.ts
+++ b/packages/mosaic/__tests__/data-table-explorer.utils.test.ts
@@ -7,11 +7,13 @@ import {
   buildDistinctCountQuery,
   buildDataTableExplorerBaseQuery,
   buildDataTableExplorerPageQuery,
+  createEmptySummaryState,
   fieldInfoToDataTableExplorerField,
   getDataTableExplorerValueType,
   isDataTableExplorerHistogramType,
   isDataTableExplorerUnsupportedSummaryType,
   normalizeDataTableExplorerPagination,
+  resolveDataTableExplorerColumnKind,
   serializeCategoryBucketKey,
   rowsFromQueryResult,
   splitHistogramBins,
@@ -233,5 +235,55 @@ describe('dataTableExplorer utils', () => {
         toArray: () => [{value: 1}, {value: 2}],
       }),
     ).toEqual([{value: 1}, {value: 2}]);
+  });
+});
+
+describe('resolveDataTableExplorerColumnKind', () => {
+  const numberField = new arrow.Field('depth', new arrow.Float64(), true);
+  const stringField = new arrow.Field('name', new arrow.Utf8(), true);
+  const binaryField = new arrow.Field('blob', new arrow.Binary(), true);
+
+  it('derives the kind from the Arrow type when no resolver is given', () => {
+    expect(resolveDataTableExplorerColumnKind(numberField)).toBe('histogram');
+    expect(resolveDataTableExplorerColumnKind(stringField)).toBe('category');
+    expect(resolveDataTableExplorerColumnKind(binaryField)).toBe('unsupported');
+  });
+
+  it("keeps the type-driven kind when the resolver returns 'auto'", () => {
+    expect(resolveDataTableExplorerColumnKind(numberField, () => 'auto')).toBe(
+      'histogram',
+    );
+  });
+
+  it("always honors 'none'", () => {
+    for (const field of [numberField, stringField, binaryField]) {
+      expect(resolveDataTableExplorerColumnKind(field, () => 'none')).toBe(
+        'none',
+      );
+    }
+  });
+
+  it('honors compatible overrides and rejects incompatible ones', () => {
+    // Numeric column forced to category buckets: allowed.
+    expect(
+      resolveDataTableExplorerColumnKind(numberField, () => 'category'),
+    ).toBe('category');
+    // Histogram on a string column would produce broken bin queries.
+    expect(
+      resolveDataTableExplorerColumnKind(stringField, () => 'histogram'),
+    ).toBe('category');
+    // Unsupported types cannot be summarized at all.
+    expect(
+      resolveDataTableExplorerColumnKind(binaryField, () => 'category'),
+    ).toBe('unsupported');
+  });
+
+  it("creates a summary-less empty state for 'none' columns", () => {
+    expect(createEmptySummaryState(numberField, 'none')).toEqual({
+      isLoading: false,
+      kind: 'none',
+    });
+    // Without an explicit kind the type-driven default still applies.
+    expect(createEmptySummaryState(numberField).kind).toBe('histogram');
   });
 });

--- a/packages/mosaic/src/data-table-explorer/DataTableExplorerHeader.tsx
+++ b/packages/mosaic/src/data-table-explorer/DataTableExplorerHeader.tsx
@@ -61,7 +61,12 @@ function formatPercentOfTotal(value: number) {
   }).format(value);
 }
 
-function CategorySummaryCell({
+/**
+ * Renders the category-bucket summary bar for one dataTableExplorer column.
+ * Exported so custom headers built on `useDataTableExplorer` can recompose
+ * summary cells per column.
+ */
+export function DataTableExplorerCategorySummaryCell({
   summary,
 }: {
   summary: DataTableExplorerCategorySummary;
@@ -186,7 +191,12 @@ function formatDomainValue(value: number | Date, valueType: 'date' | 'number') {
   }).format(typeof value === 'number' ? value : value.getTime());
 }
 
-function HistogramSummaryCell({
+/**
+ * Renders the histogram summary (with brush interactor) for one
+ * dataTableExplorer column. Exported so custom headers built on
+ * `useDataTableExplorer` can recompose summary cells per column.
+ */
+export function DataTableExplorerHistogramSummaryCell({
   summary,
 }: {
   summary: DataTableExplorerHistogramSummary;
@@ -393,12 +403,24 @@ function HistogramSummaryCell({
   );
 }
 
-function SummaryCell({column}: {column: DataTableExplorerColumnState}) {
+/**
+ * Renders the summary cell matching a column's summary kind. Columns with a
+ * `'none'` summary render no summary UI. Exported so custom headers built on
+ * `useDataTableExplorer` can reuse the default per-column summary rendering.
+ */
+export function DataTableExplorerSummaryCell({
+  column,
+}: {
+  column: DataTableExplorerColumnState;
+}) {
   if (column.summary.kind === 'histogram') {
-    return <HistogramSummaryCell summary={column.summary} />;
+    return <DataTableExplorerHistogramSummaryCell summary={column.summary} />;
   }
   if (column.summary.kind === 'category') {
-    return <CategorySummaryCell summary={column.summary} />;
+    return <DataTableExplorerCategorySummaryCell summary={column.summary} />;
+  }
+  if (column.summary.kind === 'none') {
+    return null;
   }
   return (
     <div className="text-muted-foreground pt-1.5 text-[10px] font-normal">
@@ -478,7 +500,7 @@ export function DataTableExplorerHeader({
                       )}
                     </span>
                   </button>
-                  <SummaryCell column={column} />
+                  <DataTableExplorerSummaryCell column={column} />
                 </div>
               </TableHead>
             );

--- a/packages/mosaic/src/data-table-explorer/createDataTableExplorerStore.ts
+++ b/packages/mosaic/src/data-table-explorer/createDataTableExplorerStore.ts
@@ -5,6 +5,7 @@ import {createStore} from 'zustand/vanilla';
 import type {DataTableExplorerCountState} from './DataTableExplorerCountClient';
 import type {DataTableExplorerPageState} from './DataTableExplorerPageClient';
 import type {
+  DataTableExplorerColumnKind,
   DataTableExplorerPaginationState,
   DataTableExplorerSorting,
   DataTableExplorerSummaryState,
@@ -57,7 +58,10 @@ export type DataTableExplorerStoreState = {
   syncPageSize: (pageSize: number) => void;
   totalCount: DataTableExplorerCountState;
   clearSummaries: () => void;
-  initializeSummaries: (fields: arrow.Field[]) => void;
+  initializeSummaries: (
+    fields: arrow.Field[],
+    columnKinds?: Record<string, DataTableExplorerColumnKind>,
+  ) => void;
   resetPageIndex: () => void;
 };
 
@@ -203,11 +207,14 @@ export function createDataTableExplorerStore(options: {
         }),
       );
     },
-    initializeSummaries: (fields) => {
+    initializeSummaries: (fields, columnKinds) => {
       set((state) =>
         produce(state, (draft) => {
           draft.summaries = Object.fromEntries(
-            fields.map((field) => [field.name, createEmptySummaryState(field)]),
+            fields.map((field) => [
+              field.name,
+              createEmptySummaryState(field, columnKinds?.[field.name]),
+            ]),
           );
         }),
       );

--- a/packages/mosaic/src/data-table-explorer/dataTableExplorerController.ts
+++ b/packages/mosaic/src/data-table-explorer/dataTableExplorerController.ts
@@ -13,6 +13,7 @@ import {
 import {DataTableExplorerPageClient} from './DataTableExplorerPageClient';
 import {DataTableExplorerUnsupportedSummaryClient} from './DataTableExplorerUnsupportedSummaryClient';
 import type {
+  DataTableExplorerColumnKind,
   DataTableExplorerSummaryState,
   DataTableExplorerSqlTableReference,
   DataTableExplorerSorting,
@@ -21,8 +22,7 @@ import type {DataTableExplorerStore} from './createDataTableExplorerStore';
 import {
   fieldInfoToDataTableExplorerField,
   getDataTableExplorerValueType,
-  isDataTableExplorerHistogramType,
-  isDataTableExplorerUnsupportedSummaryType,
+  resolveDataTableExplorerColumnKind,
 } from './utils';
 
 function toError(error: unknown): Error {
@@ -184,6 +184,10 @@ export function connectDataTableExplorerCountClient(options: {
  *
  * @param options.categoryLimit Maximum number of category buckets to expose before
  * grouping the remainder into an overflow bucket.
+ * @param options.columnKinds Resolved summary kind per field name. Fields
+ * missing from the map fall back to the Arrow-type-driven default. Columns
+ * resolved to `'none'` get no summary clients, so no summary queries run for
+ * them.
  * @param options.connection Ready Mosaic connection that owns summary client
  * registration.
  * @param options.fields Active Arrow fields to summarize.
@@ -197,6 +201,7 @@ export function connectDataTableExplorerCountClient(options: {
  */
 export function connectDataTableExplorerSummaryClients(options: {
   categoryLimit: number;
+  columnKinds?: Record<string, DataTableExplorerColumnKind>;
   connection: ReadyConnection;
   fields: arrow.Field[];
   selection: Selection;
@@ -207,6 +212,7 @@ export function connectDataTableExplorerSummaryClients(options: {
 }) {
   const {
     categoryLimit,
+    columnKinds,
     connection,
     fields,
     selection,
@@ -216,14 +222,20 @@ export function connectDataTableExplorerSummaryClients(options: {
     tableReference,
   } = options;
 
-  store.getState().initializeSummaries(fields);
+  store.getState().initializeSummaries(fields, columnKinds);
 
   const clients: MosaicClient[] = fields.flatMap((field): MosaicClient[] => {
+    const kind =
+      columnKinds?.[field.name] ?? resolveDataTableExplorerColumnKind(field);
     const update = (summary: DataTableExplorerSummaryState) => {
       store.getState().setSummary(field.name, summary);
     };
 
-    if (isDataTableExplorerUnsupportedSummaryType(field.type)) {
+    if (kind === 'none') {
+      return [];
+    }
+
+    if (kind === 'unsupported') {
       return [
         new DataTableExplorerUnsupportedSummaryClient({
           field,
@@ -235,7 +247,7 @@ export function connectDataTableExplorerSummaryClients(options: {
       ];
     }
 
-    if (isDataTableExplorerHistogramType(field.type)) {
+    if (kind === 'histogram') {
       const summaryClient = new DataTableExplorerHistogramClient({
         field,
         onStateChange: update,

--- a/packages/mosaic/src/data-table-explorer/hooks/useDataTableExplorerColumns.ts
+++ b/packages/mosaic/src/data-table-explorer/hooks/useDataTableExplorerColumns.ts
@@ -1,13 +1,20 @@
 import {useMemo} from 'react';
 import type {DataTableExplorerStoreState} from '../createDataTableExplorerStore';
-import type {DataTableExplorerColumnState} from '../types';
+import type {
+  DataTableExplorerColumnKind,
+  DataTableExplorerColumnState,
+} from '../types';
 import {
   createEmptySummaryState,
-  isDataTableExplorerHistogramType,
-  isDataTableExplorerUnsupportedSummaryType,
+  resolveDataTableExplorerColumnKind,
 } from '../utils';
 
 export type UseDataTableExplorerColumnsOptions = {
+  /**
+   * Resolved summary kind per field name. Fields missing from the map fall
+   * back to the Arrow-type-driven default.
+   */
+  columnKinds?: Record<string, DataTableExplorerColumnKind>;
   fields: DataTableExplorerStoreState['schema']['fields'];
   summaries: DataTableExplorerStoreState['summaries'];
 };
@@ -17,21 +24,24 @@ export type UseDataTableExplorerColumnsOptions = {
  * the dataTableExplorer header and summary cells.
  */
 export function useDataTableExplorerColumns({
+  columnKinds,
   fields,
   summaries,
 }: UseDataTableExplorerColumnsOptions): DataTableExplorerColumnState[] {
   return useMemo<DataTableExplorerColumnState[]>(
     () =>
-      fields.map((field) => ({
-        field,
-        kind: isDataTableExplorerUnsupportedSummaryType(field.type)
-          ? 'unsupported'
-          : isDataTableExplorerHistogramType(field.type)
-            ? 'histogram'
-            : 'category',
-        name: field.name,
-        summary: summaries[field.name] ?? createEmptySummaryState(field),
-      })),
-    [fields, summaries],
+      fields.map((field) => {
+        const kind =
+          columnKinds?.[field.name] ??
+          resolveDataTableExplorerColumnKind(field);
+        return {
+          field,
+          kind,
+          name: field.name,
+          summary:
+            summaries[field.name] ?? createEmptySummaryState(field, kind),
+        };
+      }),
+    [columnKinds, fields, summaries],
   );
 }

--- a/packages/mosaic/src/data-table-explorer/hooks/useDataTableExplorerLifecycles.ts
+++ b/packages/mosaic/src/data-table-explorer/hooks/useDataTableExplorerLifecycles.ts
@@ -3,6 +3,7 @@ import type {MosaicClient, Selection} from '@uwdata/mosaic-core';
 import type {MosaicSliceState} from '../../MosaicSlice';
 import type {DataTableExplorerStore} from '../createDataTableExplorerStore';
 import type {
+  DataTableExplorerColumnKind,
   DataTableExplorerPaginationState,
   DataTableExplorerSqlTableReference,
   DataTableExplorerSorting,
@@ -21,6 +22,11 @@ import {
  */
 export type UseDataTableExplorerLifecyclesOptions = {
   categoryLimit: number;
+  /**
+   * Resolved summary kind per field name. Columns resolved to `'none'` get no
+   * summary clients.
+   */
+  columnKinds?: Record<string, DataTableExplorerColumnKind>;
   columns?: string[];
   connection: MosaicSliceState['mosaic']['connection'];
   fieldNames: string[];
@@ -67,6 +73,7 @@ export function useDataTableExplorerLifecycles(
 ): UseDataTableExplorerLifecyclesReturn {
   const {
     categoryLimit,
+    columnKinds,
     columns,
     connection,
     fieldNames,
@@ -215,6 +222,7 @@ export function useDataTableExplorerLifecycles(
 
     return connectDataTableExplorerSummaryClients({
       categoryLimit,
+      columnKinds,
       connection,
       fields,
       selection,
@@ -225,6 +233,7 @@ export function useDataTableExplorerLifecycles(
     });
   }, [
     categoryLimit,
+    columnKinds,
     connection,
     fields,
     dataTableExplorerStore,

--- a/packages/mosaic/src/data-table-explorer/types.ts
+++ b/packages/mosaic/src/data-table-explorer/types.ts
@@ -61,15 +61,41 @@ export type DataTableExplorerUnsupportedSummary =
     label: string;
   };
 
+/**
+ * Summary state for columns whose summary was disabled via
+ * {@link DataTableExplorerOptions.getColumnKind}. No summary clients are
+ * connected for these columns.
+ */
+export type DataTableExplorerNoneSummary = DataTableExplorerSummaryStatus & {
+  kind: 'none';
+};
+
 export type DataTableExplorerSummaryState =
   | DataTableExplorerCategorySummary
   | DataTableExplorerHistogramSummary
+  | DataTableExplorerNoneSummary
   | DataTableExplorerUnsupportedSummary;
 
 export type DataTableExplorerColumnKind =
   | 'category'
   | 'histogram'
+  | 'none'
   | 'unsupported';
+
+/**
+ * Per-column summary-kind override returned by
+ * {@link DataTableExplorerOptions.getColumnKind}.
+ *
+ * - `'auto'` keeps the default Arrow-type-driven behavior.
+ * - `'none'` shows the column without a summary or filter interactions.
+ * - `'category'` / `'histogram'` force a specific summary; incompatible
+ *   requests (e.g. a histogram on a string column) fall back to `'auto'`.
+ */
+export type DataTableExplorerColumnKindOverride =
+  | 'auto'
+  | 'category'
+  | 'histogram'
+  | 'none';
 
 export type DataTableExplorerColumnState = {
   field: Field;
@@ -91,6 +117,17 @@ export type DataTableExplorerSqlTableReference = MosaicSqlTableReference;
 export type DataTableExplorerOptions = {
   categoryLimit?: number;
   columns?: string[];
+  /**
+   * Resolves the summary kind for each column. Return `'auto'` (or omit the
+   * option) to keep the default Arrow-type-driven behavior. Return `'none'`
+   * to show a column without a summary — its summary clients are not created,
+   * so no summary queries run and the column does not participate in
+   * cross-filtering.
+   *
+   * Pass a stable function (e.g. via `useCallback`); the resolved kinds are
+   * value-memoized, so an inline lambda works but must stay pure.
+   */
+  getColumnKind?: (field: Field) => DataTableExplorerColumnKindOverride;
   initialSorting?: DataTableExplorerSorting;
   pageSize?: number;
   selection?: Selection;

--- a/packages/mosaic/src/data-table-explorer/useDataTableExplorer.ts
+++ b/packages/mosaic/src/data-table-explorer/useDataTableExplorer.ts
@@ -17,6 +17,7 @@ import {
   getMosaicRawSqlTableReference,
   getMosaicSqlTableReference,
 } from '../mosaicTableReference';
+import {resolveDataTableExplorerColumnKind} from './utils';
 
 /**
  * Aggregates Mosaic-backed schema, rows, counts, and summaries into the stable
@@ -28,6 +29,7 @@ export function useDataTableExplorer(
   const {
     categoryLimit = 20,
     columns,
+    getColumnKind,
     initialSorting = [],
     pageSize = 100,
     selection: providedSelection,
@@ -91,8 +93,28 @@ export function useDataTableExplorer(
     tableIdentity,
     tableReference,
   });
+  // Value-keyed memo: resolved kinds stay referentially stable across renders
+  // even when getColumnKind is an inline lambda, so the summary-client
+  // lifecycle only re-runs when a column's resolved kind actually changes.
+  const columnKindEntries = fields.map(
+    (field) =>
+      [
+        field.name,
+        resolveDataTableExplorerColumnKind(field, getColumnKind),
+      ] as const,
+  );
+  const columnKindsKey = columnKindEntries
+    .map(([name, kind]) => `${name}:${kind}`)
+    .join('|');
+  const columnKinds = useMemo(
+    () => Object.fromEntries(columnKindEntries),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [columnKindsKey],
+  );
+
   useDataTableExplorerLifecycles({
     categoryLimit,
+    columnKinds,
     columns,
     connection,
     fieldNames,
@@ -110,6 +132,7 @@ export function useDataTableExplorer(
     tableReference,
   });
   const dataTableExplorerColumns = useDataTableExplorerColumns({
+    columnKinds,
     fields,
     summaries,
   });

--- a/packages/mosaic/src/data-table-explorer/utils.ts
+++ b/packages/mosaic/src/data-table-explorer/utils.ts
@@ -8,6 +8,8 @@ import * as arrow from 'apache-arrow';
 import type {
   DataTableExplorerBin,
   DataTableExplorerCategoryBucket,
+  DataTableExplorerColumnKind,
+  DataTableExplorerColumnKindOverride,
   DataTableExplorerPaginationState,
   DataTableExplorerSqlTableReference,
   DataTableExplorerSorting,
@@ -34,6 +36,42 @@ export function isDataTableExplorerUnsupportedSummaryType(
 ): boolean {
   const category = getArrowColumnTypeCategory(type);
   return category === 'binary' || category === 'geometry';
+}
+
+/**
+ * Resolves the effective summary kind for a column, combining the default
+ * Arrow-type-driven behavior with an optional user override.
+ *
+ * `'none'` is always honored. `'category'` and `'histogram'` are honored only
+ * when the column type supports them; incompatible requests fall back to the
+ * type-driven default so a bad override can not produce broken summary
+ * queries.
+ */
+export function resolveDataTableExplorerColumnKind(
+  field: arrow.Field,
+  getColumnKind?: (field: arrow.Field) => DataTableExplorerColumnKindOverride,
+): DataTableExplorerColumnKind {
+  const autoKind: DataTableExplorerColumnKind =
+    isDataTableExplorerUnsupportedSummaryType(field.type)
+      ? 'unsupported'
+      : isDataTableExplorerHistogramType(field.type)
+        ? 'histogram'
+        : 'category';
+
+  const override = getColumnKind?.(field) ?? 'auto';
+  if (override === 'auto') {
+    return autoKind;
+  }
+  if (override === 'none') {
+    return 'none';
+  }
+  if (autoKind === 'unsupported') {
+    return autoKind;
+  }
+  if (override === 'histogram' && autoKind !== 'histogram') {
+    return autoKind;
+  }
+  return override;
 }
 
 export function getDataTableExplorerValueType(
@@ -524,8 +562,16 @@ export function parseCategoryBucketKey(key: string):
 
 export function createEmptySummaryState(
   field: arrow.Field,
+  kind: DataTableExplorerColumnKind = resolveDataTableExplorerColumnKind(field),
 ): DataTableExplorerSummaryState {
-  if (isDataTableExplorerUnsupportedSummaryType(field.type)) {
+  if (kind === 'none') {
+    return {
+      isLoading: false,
+      kind: 'none',
+    };
+  }
+
+  if (kind === 'unsupported') {
     return {
       isLoading: false,
       kind: 'unsupported',
@@ -533,7 +579,7 @@ export function createEmptySummaryState(
     };
   }
 
-  return isDataTableExplorerHistogramType(field.type)
+  return kind === 'histogram'
     ? {
         filteredBins: [],
         filteredNullCount: 0,

--- a/packages/mosaic/src/index.ts
+++ b/packages/mosaic/src/index.ts
@@ -239,7 +239,10 @@ export {DataTableBlockRenderer} from './data-table-explorer/block-document/DataT
 export {DataTableBlockSettings} from './data-table-explorer/block-document/DataTableBlockSettings';
 export {MosaicDashboardDataTableExplorerSettings} from './data-table-explorer/dashboard/MosaicDashboardDataTableExplorerSettings';
 export {
+  DataTableExplorerCategorySummaryCell,
   DataTableExplorerHeader,
+  DataTableExplorerHistogramSummaryCell,
+  DataTableExplorerSummaryCell,
   type DataTableExplorerHeaderProps,
 } from './data-table-explorer/DataTableExplorerHeader';
 export {
@@ -261,8 +264,10 @@ export type {
   DataTableExplorerCategoryBucket,
   DataTableExplorerCategorySummary,
   DataTableExplorerColumnKind,
+  DataTableExplorerColumnKindOverride,
   DataTableExplorerColumnState,
   DataTableExplorerHistogramSummary,
+  DataTableExplorerNoneSummary,
   DataTableExplorerOptions,
   DataTableExplorerPaginationState,
   DataTableExplorerSorting,
@@ -270,6 +275,7 @@ export type {
   DataTableExplorerTableReference,
   UseDataTableExplorerReturn,
 } from './data-table-explorer/types';
+export {resolveDataTableExplorerColumnKind} from './data-table-explorer/utils';
 
 // ============================================================================
 // Chart Builder UI Components


### PR DESCRIPTION
## Problem

`DataTableExplorer`'s `columns` option is all-or-nothing: a column is either loaded — with its histogram/category summary and cross-filter UI — or excluded from the table entirely. There is no way to:

- show a column's values while disabling its summary and filtering (e.g. `Latitude`/`Longitude`, where a histogram and brush add noise and query load but no insight), or
- override the Arrow-type-driven summary kind (e.g. a numeric code column that reads better as category buckets than a histogram).

The summary kind decision (`histogram` / `category` / `unsupported`) was hard-coded from the Arrow type in three separate places (`useDataTableExplorerColumns`, `connectDataTableExplorerSummaryClients`, `createEmptySummaryState`), so there was no seam to hook into. Hiding the summary UI from outside wouldn't help either: the summary Mosaic clients would still be created and still run their queries.

## Solution

Add one deep option instead of a per-column config object:

```tsx
<DataTableExplorer
  tableName={dataTable.table}
  selection={brush}
  getColumnKind={(field) => {
    if (field.name === 'Latitude' || field.name === 'Longitude') return 'none';
    return 'auto';
  }}
>
```

- `resolveDataTableExplorerColumnKind(field, getColumnKind?)` is now the single decision point for a column's kind; the three call sites consult it instead of re-deriving from the Arrow type.
- `'none'` renders the column with no summary cell and **creates no summary clients**, so no summary queries run and the column doesn't participate in cross-filtering. Sorting and row rendering are unchanged.
- `'category'` / `'histogram'` force a specific summary. Incompatible requests (histogram on a string column, any summary on binary/geometry) fall back to the type-driven default rather than producing broken queries.
- Resolved kinds are **value-memoized** in `useDataTableExplorer`, so an inline resolver lambda can't tear down and reconnect every summary client on each render — the client lifecycle only restarts when a column's resolved kind actually changes.
- For custom headers built on `useDataTableExplorer`, the default summary cells are now exported: `DataTableExplorerSummaryCell`, `DataTableExplorerHistogramSummaryCell`, `DataTableExplorerCategorySummaryCell`, plus the resolver itself.

Design notes: `columns` stays a pure projection; render concerns (widths, labels, custom cells) stay in the compound-component layer. The resolver is a function, so persisted surfaces (dashboard panels / block documents) that want this can layer a serializable `Record<string, kind>` on top later — deliberately not included here. A read-only summary mode ("show histogram, disable brushing") is a distinct axis and also deliberately out of scope.

## How to test

1. `pnpm install && pnpm build`
2. Unit tests for the resolver (default kinds, `'auto'`, `'none'` always honored, incompatible overrides rejected):
   ```sh
   cd packages/mosaic && pnpm test
   ```
   24 suites / 136 tests pass, including the new `resolveDataTableExplorerColumnKind` block in `__tests__/data-table-explorer.utils.test.ts`.
3. See it live in the deckgl-mosaic example, which now sets `Latitude`/`Longitude` to `'none'`:
   ```sh
   pnpm dev deckgl-mosaic-example
   ```
   In the **Earthquake Profiler** table at the bottom:
   - `Latitude` / `Longitude` show name + type badge only — no histogram, no brush. Clicking the header still sorts.
   - Every other column is unchanged (`DateTime`/`Magnitude` histograms, `MagType`/`Source` category buckets).
   - Click the `Md` bucket under `MagType`: rows filter (≈45,330 of 54,936), all summaries update, and the `'none'` columns stay summary-less.
   - Optional: temporarily return `'category'` for `Depth` in `EarthquakeProfiler.tsx`'s `getColumnKind` to see a numeric column forced to category buckets, with bucket-click filtering working.

All three steps verified locally (macOS, headless Chromium screenshots for step 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
