### PR TITLE
fix(sql-editor): abort query immediately instead of waiting on the query promise

### DIFF
--- a/packages/sql-editor/README.md
+++ b/packages/sql-editor/README.md
@@ -126,8 +126,16 @@ server-side. This is reflected on the `QueryResult`:
   silently (a late result is simply discarded), so no warning is shown.
 
 `QueryResultPanel` renders the `warning` beneath the "Query was aborted"
-message. For connectors that support true server-side cancellation, implement
-`cancelQueryInternal` so the statement is actually stopped.
+message.
+
+For true server-side cancellation, honor the **`AbortSignal`** inside your
+connector's `executeQueryInternal(sql, signal)`: the SQL editor cancels by
+aborting the signal passed to `connector.query(sql, {signal})`, so a connector
+must watch `signal` (e.g. abort the in-flight request and/or interrupt the
+backend statement) to actually stop the work. Note that `cancelQueryInternal`
+is **not** invoked on this path — it only runs via `QueryHandle.cancel()`, which
+the editor does not use — so implementing `cancelQueryInternal` alone will not
+stop editor-initiated queries.
 
 ## Single Query UI
 

--- a/packages/sql-editor/README.md
+++ b/packages/sql-editor/README.md
@@ -107,6 +107,28 @@ ensureQuery('query-1', {name: 'Top Airports', query: 'SELECT * FROM airports'});
 await runQueryById('query-1');
 ```
 
+### Cancelling queries
+
+`abortQueryById(queryId)` (or `abortCurrentQuery()`) cancels a running query.
+The result transitions to `status: 'aborted'` **immediately** — it does not
+wait for the underlying query promise to settle — so the UI never gets stuck
+while a slow/blocked connector unwinds.
+
+Cancellation is **best-effort**: `AbortController.abort()` signals the
+connector, but not every connector can actually stop an in-flight statement
+server-side. This is reflected on the `QueryResult`:
+
+- While running, a `loading` result is stamped with `isWrite` once the
+  statement is parsed (`true` for a non-`SELECT` or multi-statement query).
+- On cancel, an `aborted` result carries a `warning` string **only for writes**
+  (or a statement whose type isn't known yet): the statement may still complete
+  on the backend even though the UI reports it aborted. Reads are aborted
+  silently (a late result is simply discarded), so no warning is shown.
+
+`QueryResultPanel` renders the `warning` beneath the "Query was aborted"
+message. For connectors that support true server-side cancellation, implement
+`cancelQueryInternal` so the statement is actually stopped.
+
 ## Single Query UI
 
 `SqlQuery` is a compound component for rearranging and styling a single query

--- a/packages/sql-editor/src/SqlEditorSlice.tsx
+++ b/packages/sql-editor/src/SqlEditorSlice.tsx
@@ -38,26 +38,40 @@ export type EnsureSqlQueryOptions = {
   select?: boolean;
 };
 
+/**
+ * Lifecycle state and output of a single SQL query execution, keyed by query id
+ * in the editor slice.
+ *
+ * - `loading` results may gain an {@link QueryResult.isWrite | isWrite}
+ *   classification once the statement has been parsed.
+ * - `aborted` results may carry a {@link QueryResult.warning | warning} when
+ *   the connector cannot guarantee the statement was stopped server-side.
+ */
 export type QueryResult =
   | {
       status: 'loading';
       isBeingAborted?: boolean;
       controller: AbortController;
       startedAt?: number;
-      // Whether the running statement is a write (non-SELECT). Stamped once the
-      // statement has been parsed (see runQueryById). Undefined until known.
-      // Used by abortQueryById to decide whether cancelling needs a warning:
-      // aborting a read is harmless, but the underlying cancel is best-effort,
-      // so a write may still complete on the backend after the UI reports it
-      // aborted.
+      /**
+       * Whether the running statement is a write (non-SELECT or multi-statement).
+       * Stamped once the statement has been parsed (see `runQueryById`);
+       * `undefined` until then. `abortQueryById` reads this to decide whether
+       * cancelling needs a warning: aborting a read is harmless, but the
+       * underlying cancel is best-effort, so a write may still complete on the
+       * backend after the UI reports it aborted.
+       */
       isWrite?: boolean;
     }
   | {
       status: 'aborted';
       durationMs?: number;
       completedAt?: number;
-      // Set when a write was aborted but the connector can't guarantee it was
-      // actually stopped server-side — surfaced to the user in the result pane.
+      /**
+       * User-facing warning shown in the result pane when a write (or a
+       * statement of not-yet-known type) was aborted but the connector cannot
+       * guarantee it was actually stopped server-side. Absent for reads.
+       */
       warning?: string;
     }
   | {status: 'error'; error: string; durationMs?: number; completedAt?: number}

--- a/packages/sql-editor/src/SqlEditorSlice.tsx
+++ b/packages/sql-editor/src/SqlEditorSlice.tsx
@@ -44,8 +44,22 @@ export type QueryResult =
       isBeingAborted?: boolean;
       controller: AbortController;
       startedAt?: number;
+      // Whether the running statement is a write (non-SELECT). Stamped once the
+      // statement has been parsed (see runQueryById). Undefined until known.
+      // Used by abortQueryById to decide whether cancelling needs a warning:
+      // aborting a read is harmless, but the underlying cancel is best-effort,
+      // so a write may still complete on the backend after the UI reports it
+      // aborted.
+      isWrite?: boolean;
     }
-  | {status: 'aborted'; durationMs?: number; completedAt?: number}
+  | {
+      status: 'aborted';
+      durationMs?: number;
+      completedAt?: number;
+      // Set when a write was aborted but the connector can't guarantee it was
+      // actually stopped server-side — surfaced to the user in the result pane.
+      warning?: string;
+    }
   | {status: 'error'; error: string; durationMs?: number; completedAt?: number}
   | {
       status: 'success';
@@ -566,6 +580,20 @@ export function createSqlEditorSlice({
           // makes any late settle a no-op — no overwrite, no race.
           const startedAt = currentResult.startedAt;
           const now = Date.now();
+          // Cancellation is best-effort: controller.abort() signals the
+          // connector, but not every connector can actually stop an in-flight
+          // statement server-side. Aborting a read is harmless (a late result
+          // is simply discarded), but a write (INSERT/CREATE/DROP/…) may still
+          // complete on the backend after we report it aborted. Warn only in
+          // that case — reads cancel silently, so we don't nag the user. If the
+          // statement type isn't known yet (parsed asynchronously), isWrite is
+          // undefined and we warn conservatively.
+          const mayStillBeWriting = currentResult.isWrite !== false;
+          const warning = mayStillBeWriting
+            ? 'Cancellation requested. The statement may be a write and could ' +
+              'still complete on the server — this connector cannot guarantee ' +
+              'it was stopped.'
+            : undefined;
           set((state) => ({
             ...state,
             sqlEditor: {
@@ -576,6 +604,7 @@ export function createSqlEditorSlice({
                   status: 'aborted',
                   durationMs: startedAt ? now - startedAt : undefined,
                   completedAt: now,
+                  ...(warning ? {warning} : {}),
                 },
               },
             },
@@ -654,6 +683,24 @@ export function createSqlEditorSlice({
             }
 
             const isValidSelectQuery = !parsedLastStatement.error;
+
+            // Stamp read/write onto the loading result now that we've parsed the
+            // statement. abortQueryById reads this to decide whether cancelling
+            // needs a "may still be running" warning (writes) or is silent
+            // (reads). A multi-statement query is treated as a write. Guard on
+            // the controller so we don't clobber a result the user already
+            // aborted/re-ran in the brief window before parsing finished.
+            {
+              const isWrite = !isValidSelectQuery || hasMultipleStatements;
+              set((state) =>
+                produce(state, (draft) => {
+                  const r = draft.sqlEditor.queryResultsById[queryId];
+                  if (r?.status === 'loading' && r.controller === queryController) {
+                    r.isWrite = isWrite;
+                  }
+                }),
+              );
+            }
 
             if (isValidSelectQuery) {
               // Add limit to the last statement

--- a/packages/sql-editor/src/SqlEditorSlice.tsx
+++ b/packages/sql-editor/src/SqlEditorSlice.tsx
@@ -551,18 +551,35 @@ export function createSqlEditorSlice({
 
         abortQueryById: (queryId) => {
           const currentResult = get().sqlEditor.queryResultsById[queryId];
-          if (currentResult?.status === 'loading' && currentResult.controller) {
-            currentResult.controller.abort();
+          if (currentResult?.status !== 'loading') {
+            return;
           }
+          // Fire the abort signal (best-effort server-side/underlying cancel)…
+          currentResult.controller?.abort();
 
-          set((state) =>
-            produce(state, (draft) => {
-              const result = draft.sqlEditor.queryResultsById[queryId];
-              if (result?.status === 'loading') {
-                result.isBeingAborted = true;
-              }
-            }),
-          );
+          // …then transition to `aborted` IMMEDIATELY rather than waiting for the
+          // query promise to reject. The underlying connector may not reject
+          // promptly (e.g. an abort swallowed during a pre-flight parse query, or
+          // a blocked backend fetch), which would otherwise leave the UI stuck on
+          // "Stopping" indefinitely. The finalize `set()` in runQueryById only
+          // writes its result while status === 'loading', so this state change
+          // makes any late settle a no-op — no overwrite, no race.
+          const startedAt = currentResult.startedAt;
+          const now = Date.now();
+          set((state) => ({
+            ...state,
+            sqlEditor: {
+              ...state.sqlEditor,
+              queryResultsById: {
+                ...state.sqlEditor.queryResultsById,
+                [queryId]: {
+                  status: 'aborted',
+                  durationMs: startedAt ? now - startedAt : undefined,
+                  completedAt: now,
+                },
+              },
+            },
+          }));
         },
 
         clearQueryResult: (queryId) => {

--- a/packages/sql-editor/src/components/QueryResultPanel.tsx
+++ b/packages/sql-editor/src/components/QueryResultPanel.tsx
@@ -171,7 +171,10 @@ const QueryResultPanelRoot: React.FC<QueryResultPanelProps> = ({
 
   if (queryResult?.status === 'aborted') {
     return (
-      <div className="p-5 font-mono text-xs leading-tight text-red-500">
+      <div
+        role="alert"
+        className="p-5 font-mono text-xs leading-tight text-red-500"
+      >
         Query was aborted
         {queryResult.warning && (
           <div className="text-muted-foreground mt-2">

--- a/packages/sql-editor/src/components/QueryResultPanel.tsx
+++ b/packages/sql-editor/src/components/QueryResultPanel.tsx
@@ -173,6 +173,11 @@ const QueryResultPanelRoot: React.FC<QueryResultPanelProps> = ({
     return (
       <div className="p-5 font-mono text-xs leading-tight text-red-500">
         Query was aborted
+        {queryResult.warning && (
+          <div className="text-muted-foreground mt-2">
+            {queryResult.warning}
+          </div>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
## Problem

Cancelling a running SQL query can leave the UI stuck on **"Stopping…"** indefinitely.

`abortQueryById` fires `controller.abort()` and sets `isBeingAborted = true` (which renders "Stopping"), then relies on the query's own promise to reject before the result transitions to `status: 'aborted'`. But that promise isn't guaranteed to reject promptly — a connector can swallow the abort (e.g. an abort landing during a pre-flight parse sub-query wrapped in `try/catch`) or be blocked on a fetch with no server-side cancel. If it never rejects, the result stays `loading` + `isBeingAborted` forever.

## Fix

Transition the result to `status: 'aborted'` **synchronously**, right after firing `controller.abort()`, instead of waiting for the promise to settle.

This is safe against a late settle of the original promise: the finalize `set()` in `runQueryById` already guards on `status === 'loading'` **and** the matching `controller`, so once we've flipped the status to `aborted`, any late resolution/rejection is a no-op — no race, no double-write. `controller.abort()` still fires for best-effort underlying cancellation.

Side benefit: re-running a query immediately after cancel now works — the entry no longer stays `loading`, so `runQueryById`'s `"Query already running"` guard no longer blocks it.

## Cancelling non-SELECT (write) operations

Cancellation is **best-effort**: `controller.abort()` signals the connector, but not every connector can actually stop an in-flight statement server-side (e.g. `NodeDuckDbConnector` only checks `signal.aborted` *before* executing). Aborting a **read** is harmless — a late result is simply discarded by the finalize guard. But aborting a **write** (`INSERT`/`CREATE`/`DROP`/… or a multi-statement query) may still complete on the backend after the UI reports it aborted.

Rather than block the user to "protect" against this (the `status === 'loading'` guard is only a UI double-submit convenience for a single query slot — the multi-tab/window case already bypasses it, so it was never a concurrency control), we **inform** them, and only when it matters:

- Once the statement is parsed, the loading result is stamped with `isWrite` (`true` for a non-SELECT or multi-statement query).
- On cancel, `abortQueryById` still transitions to `aborted` immediately (no "Stopping" hang), and for a **write** (or a not-yet-known type) it attaches a warning; **reads cancel silently** with no nag.
- `QueryResultPanel` surfaces that warning beneath "Query was aborted".

The warning reads:

> Cancellation requested. The statement may be a write and could still complete on the server — this connector cannot guarantee it was stopped.

<!-- SCREENSHOT: aborted write showing the warning message -->

True server-side cancellation (a real `cancelQueryInternal` in the connector) remains the proper fix and is out of scope for this PR.

## Scope / notes

- Files changed: `packages/sql-editor/src/SqlEditorSlice.tsx` (`abortQueryById`, `runQueryById`, `QueryResult` type) and `packages/sql-editor/src/components/QueryResultPanel.tsx` (render the warning).
- Behavior change: the transient `isBeingAborted` / "Stopping" state is effectively skipped for the abort path — cancel goes straight to "aborted". `SqlQueryBlock`'s `isCancelling = isLoading && isBeingAborted` simply won't trigger.
- **Not addressed (follow-up):** this is a client-side abort. Connectors whose `cancelQueryInternal` is a no-op won't actually stop the server-side query; it continues in the background until it finishes or the connection drops. True server-side cancellation is a separate, connector-level change.
- `pnpm --filter @sqlrooms/sql-editor tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query cancellation so results switch to “aborted” immediately.
  * Enhanced classification to detect potentially write-related queries when a cancellation occurs.
  * When an aborted query may still be a write, a contextual warning is now prepared for display.

* **User Interface**
  * Aborted query results now use an alert-style message and show an additional warning block when applicable.

* **Documentation**
  * Added a “Cancelling queries” section explaining cancellation timing, best-effort limits, and how warnings are handled for writes vs reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->