### PR TITLE
ci: remove shamefully hoisted installs

### DIFF
--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -30,8 +30,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        # See https://github.com/pnpm/pnpm/issues/8840
-        run: pnpm install --shamefully-hoist
+        run: pnpm install
 
       - name: Cache for Turbo
         uses: actions/cache@v5

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -60,8 +60,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        # See https://github.com/pnpm/pnpm/issues/8840
-        run: pnpm install --shamefully-hoist --no-frozen-lockfile
+        run: pnpm install --no-frozen-lockfile
 
       - name: Cache for Turbo
         uses: actions/cache@v5

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -72,8 +72,7 @@ jobs:
           scope: '@sqlrooms'
 
       - name: Install dependencies
-        # See https://github.com/pnpm/pnpm/issues/8840
-        run: pnpm install --shamefully-hoist
+        run: pnpm install
 
       - name: Cache for Turbo
         uses: actions/cache@v5

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -34,8 +34,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        # See https://github.com/pnpm/pnpm/issues/8840
-        run: pnpm install --shamefully-hoist
+        run: pnpm install
 
       - name: Cache for Turbo
         uses: actions/cache@v5


### PR DESCRIPTION
## Summary

- remove `--shamefully-hoist` from dependency installation in PR checks, example builds, docs deployment, and npm publishing
- remove the obsolete pnpm issue workaround comments
- retain `--no-frozen-lockfile` for the docs workflow

## Why

The workaround dates from the pnpm 10.5 migration, but the workspace now installs and builds successfully with pnpm's default isolated layout. Keeping shameful hoisting exposes undeclared transitive dependencies at the workspace root and can hide incorrect dependency declarations.

## Validation

- `pnpm install --frozen-lockfile`
- uncached build of all library packages
- uncached CLI app build
- `pnpm docs:build`
- Prettier check for all changed workflows
- pre-push hooks: Knip, workspace typecheck, circular dependency check, and full test suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Simplified dependency installation across automated build, documentation, publishing, and validation processes.
  - Improved consistency and maintainability of project workflows by removing legacy installation workarounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->