### PR TITLE
fix: Use qualified table names in the SQL editor example

### DIFF
--- a/examples/code-editor/src/SqlEditor.tsx
+++ b/examples/code-editor/src/SqlEditor.tsx
@@ -1,5 +1,5 @@
 import {useState, type FC} from 'react';
-import {type DataTable} from '@sqlrooms/duckdb';
+import {makeQualifiedTableName, type DataTable} from '@sqlrooms/duckdb';
 import {SqlCodeMirrorEditor, SqlMonacoEditor} from '@sqlrooms/sql-editor';
 import {type EditorType} from './EditorTypeSwitch';
 
@@ -19,11 +19,7 @@ LIMIT 10;`;
 // Example table schemas for SQL autocomplete
 const tableSchemas: DataTable[] = [
   {
-    table: {
-      table: 'users',
-      toFullString: () => 'users',
-      toString: () => 'users',
-    },
+    table: makeQualifiedTableName({table: 'users'}),
     isView: false,
     schema: 'main',
     tableName: 'users',
@@ -37,11 +33,7 @@ const tableSchemas: DataTable[] = [
     ],
   },
   {
-    table: {
-      table: 'orders',
-      toFullString: () => 'orders',
-      toString: () => 'orders',
-    },
+    table: makeQualifiedTableName({table: 'orders'}),
     isView: false,
     schema: 'main',
     tableName: 'orders',


### PR DESCRIPTION
## Summary

- Replace hand-rolled table name objects with `makeQualifiedTableName` in the SQL editor example
- Keep autocomplete table schemas aligned with the shared DuckDB API

## Testing

Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL editor table-name handling to ensure generated table references are correctly qualified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->