### PR TITLE
feat(ai-core): export withRunContextTools for nested agent toolsets

### DIFF
--- a/packages/ai-core/README.md
+++ b/packages/ai-core/README.md
@@ -520,6 +520,43 @@ state.ai.devtools.clearAgentSnapshots();
   - `cleanupPendingAnalysisResults`
   - `fixIncompleteToolCalls`
   - `streamSubAgent`
+  - `withRunContextTools`
+
+### Forwarding execution scope into nested agents
+
+Top-level tools receive the invoking turn's `sessionId` and `AiRunContext`
+because the chat transport wraps `state.ai.tools` with `withRunContextTools`.
+Tools handed to a nested `ToolLoopAgent` are not wrapped by the transport, so
+without the same wrapper they execute with no scope and any target resolution
+that defaults to "the current artifact/map" silently follows mutable UI
+selection instead of the artifact captured when the prompt was submitted.
+
+Wrap nested toolsets with the parent's execution options:
+
+```ts
+import {withRunContextTools} from '@sqlrooms/ai-core';
+
+const nestedTool = tool({
+  inputSchema,
+  execute: async (input, options) => {
+    const agent = new ToolLoopAgent({
+      model,
+      instructions,
+      // `options` carries the parent turn's scope; forward it verbatim.
+      tools: withRunContextTools(
+        nestedTools,
+        options as AiToolExecutionContext,
+      ),
+    });
+    return streamSubAgent(agent, prompt, store, options.toolCallId);
+  },
+});
+```
+
+Pass the parent's `getAiRunContext` (not a copied `aiRunContext`) so an in-turn
+retarget via `set_primary_context_artifact` is visible to subsequent nested tool
+calls. Parent scope wins over inner options, so a nested agent cannot reassign
+the owning session; fields the parent leaves `undefined` are preserved.
 
 `AnalysisSessionSchema`, `isAnalysisSessionEmpty`, `AnalysisResultsContainer`,
 `AnalysisResult`, `AnalysisAnswer`, `processAnalysisAnswerContent`, and

--- a/packages/ai-core/README.md
+++ b/packages/ai-core/README.md
@@ -548,10 +548,24 @@ const nestedTool = tool({
         options as AiToolExecutionContext,
       ),
     });
-    return streamSubAgent(agent, prompt, store, options.toolCallId);
+    return streamSubAgent(
+      agent,
+      prompt,
+      store,
+      options.toolCallId,
+      // The wrapper preserves `abortSignal` for the nested tools, but the
+      // sub-agent loop itself only observes cancellation through this argument.
+      options.abortSignal,
+    );
   },
 });
 ```
+
+Forward `options.abortSignal` to `streamSubAgent`. `withRunContextTools` leaves
+the signal intact for the tools the sub-agent calls, but the agent loop —
+including the model stream and any approval wait — is only cancellable through
+`streamSubAgent`'s fifth argument, so omitting it lets a stopped parent turn
+leave the nested run going.
 
 Pass the parent's `getAiRunContext` (not a copied `aiRunContext`) so an in-turn
 retarget via `set_primary_context_artifact` is visible to subsequent nested tool

--- a/packages/ai-core/__tests__/withRunContextTools.test.ts
+++ b/packages/ai-core/__tests__/withRunContextTools.test.ts
@@ -1,0 +1,177 @@
+import type {AiRunContext} from '@sqlrooms/ai-config';
+import {jest} from '@jest/globals';
+import type {ToolSet} from 'ai';
+import {withRunContextTools} from '../src/chatTransport';
+
+// ---------------------------------------------------------------------------
+// `withRunContextTools` as a reusable nested-agent primitive.
+//
+// The chat transport uses it to give top-level tools their turn's execution
+// scope. Nested `ToolLoopAgent` toolsets are not wrapped by the transport, so
+// hosts wrap them with the parent's options — which means the helper has to work
+// without transport-owned session bookkeeping, and must not clobber scope the
+// inner options already carry.
+// ---------------------------------------------------------------------------
+
+function runContextWithPrimary(id: string): AiRunContext {
+  return {
+    items: [{kind: 'artifact', id, type: 'map', title: id}],
+    primaryItemId: id,
+    primaryItemKind: 'artifact',
+    capturedAt: 1,
+  };
+}
+
+function toolSetCapturing(calls: unknown[][]): ToolSet {
+  return {
+    probe: {
+      execute: async (input: unknown, options: unknown) => {
+        calls.push([input, options]);
+        return {success: true};
+      },
+    },
+  } as unknown as ToolSet;
+}
+
+describe('withRunContextTools', () => {
+  it('forwards parent scope without requiring transport state', async () => {
+    const calls: unknown[][] = [];
+    const tools = withRunContextTools(toolSetCapturing(calls), {
+      sessionId: 'session-1',
+      aiRunContext: runContextWithPrimary('map-a'),
+    });
+
+    await tools.probe?.execute?.({}, {toolCallId: 'inner-1'} as never);
+
+    const options = calls[0]?.[1] as {
+      sessionId?: string;
+      aiRunContext?: AiRunContext;
+    };
+    expect(options.sessionId).toBe('session-1');
+    expect(options.aiRunContext?.primaryItemId).toBe('map-a');
+  });
+
+  it('attributes the tool call to the session when transport state is supplied', async () => {
+    const setToolCallSession = jest.fn();
+    const tools = withRunContextTools(toolSetCapturing([]), {
+      sessionId: 'session-1',
+      state: {ai: {setToolCallSession}} as never,
+    });
+
+    await tools.probe?.execute?.({}, {toolCallId: 'inner-1'} as never);
+
+    expect(setToolCallSession).toHaveBeenCalledWith('inner-1', 'session-1');
+  });
+
+  it("preserves the inner call's toolCallId and abort signal", async () => {
+    const calls: unknown[][] = [];
+    const controller = new AbortController();
+    const tools = withRunContextTools(toolSetCapturing(calls), {
+      sessionId: 'session-1',
+    });
+
+    await tools.probe?.execute?.({}, {
+      toolCallId: 'inner-1',
+      abortSignal: controller.signal,
+    } as never);
+
+    const options = calls[0]?.[1] as {
+      toolCallId?: string;
+      abortSignal?: AbortSignal;
+    };
+    expect(options.toolCallId).toBe('inner-1');
+    expect(options.abortSignal).toBe(controller.signal);
+  });
+
+  it('lets parent scope win so a nested agent cannot reassign the owning session', async () => {
+    const calls: unknown[][] = [];
+    const tools = withRunContextTools(toolSetCapturing(calls), {
+      sessionId: 'owner-session',
+    });
+
+    await tools.probe?.execute?.({}, {
+      toolCallId: 'inner-1',
+      sessionId: 'nested-session',
+    } as never);
+
+    expect((calls[0]?.[1] as {sessionId?: string}).sessionId).toBe(
+      'owner-session',
+    );
+  });
+
+  it('preserves inner scope for fields the parent leaves undefined', async () => {
+    const calls: unknown[][] = [];
+    // Headless parent: a run context but no session id.
+    const tools = withRunContextTools(toolSetCapturing(calls), {
+      aiRunContext: runContextWithPrimary('map-a'),
+    });
+
+    await tools.probe?.execute?.({}, {
+      toolCallId: 'inner-1',
+      sessionId: 'inherited-session',
+    } as never);
+
+    const options = calls[0]?.[1] as {
+      sessionId?: string;
+      aiRunContext?: AiRunContext;
+    };
+    expect(options.sessionId).toBe('inherited-session');
+    expect(options.aiRunContext?.primaryItemId).toBe('map-a');
+  });
+
+  it('reads the run context per call so an in-turn retarget reaches later calls', async () => {
+    const calls: unknown[][] = [];
+    let current = runContextWithPrimary('map-a');
+    const tools = withRunContextTools(toolSetCapturing(calls), {
+      sessionId: 'session-1',
+      getAiRunContext: () => current,
+    });
+
+    await tools.probe?.execute?.({}, {toolCallId: 'inner-1'} as never);
+    current = runContextWithPrimary('map-b');
+    await tools.probe?.execute?.({}, {toolCallId: 'inner-2'} as never);
+
+    expect(
+      (calls[0]?.[1] as {aiRunContext?: AiRunContext}).aiRunContext
+        ?.primaryItemId,
+    ).toBe('map-a');
+    expect(
+      (calls[1]?.[1] as {aiRunContext?: AiRunContext}).aiRunContext
+        ?.primaryItemId,
+    ).toBe('map-b');
+  });
+
+  it('keeps concurrent runs isolated from each other', async () => {
+    const callsA: unknown[][] = [];
+    const callsB: unknown[][] = [];
+    const toolsA = withRunContextTools(toolSetCapturing(callsA), {
+      sessionId: 'session-a',
+      getAiRunContext: () => runContextWithPrimary('map-a'),
+    });
+    const toolsB = withRunContextTools(toolSetCapturing(callsB), {
+      sessionId: 'session-b',
+      getAiRunContext: () => runContextWithPrimary('map-b'),
+    });
+
+    await Promise.all([
+      toolsA.probe?.execute?.({}, {toolCallId: 'a-1'} as never),
+      toolsB.probe?.execute?.({}, {toolCallId: 'b-1'} as never),
+    ]);
+
+    expect((callsA[0]?.[1] as {sessionId?: string}).sessionId).toBe(
+      'session-a',
+    );
+    expect((callsB[0]?.[1] as {sessionId?: string}).sessionId).toBe(
+      'session-b',
+    );
+  });
+
+  it('leaves tools without an execute (UI-approval tools) untouched', () => {
+    const approvalTool = {description: 'needs approval'} as never;
+    const tools = withRunContextTools({approve: approvalTool} as ToolSet, {
+      sessionId: 'session-1',
+    });
+
+    expect(tools.approve).toBe(approvalTool);
+  });
+});

--- a/packages/ai-core/src/chatTransport.ts
+++ b/packages/ai-core/src/chatTransport.ts
@@ -224,12 +224,34 @@ function getSessionById(
     .ai.config.sessions.find((s: ChatSessionSchema) => s.id === sessionId);
 }
 
+/**
+ * Wrap every executable tool in `tools` so it receives the invoking turn's
+ * execution scope (`sessionId` plus the mutable `AiRunContext` accessors) in its
+ * AI SDK execution options.
+ *
+ * Use this wherever a toolset is handed to an agent that does not itself own the
+ * chat request — most importantly for nested `ToolLoopAgent` sub-agents, whose
+ * tools would otherwise execute with no scope at all and fall back to whatever
+ * artifact/map/session is currently visible in the UI.
+ *
+ * Semantics:
+ *
+ * - Parent scope wins over inner options when the parent supplies a value, so a
+ *   nested agent cannot accidentally reassign the owning session. Fields the
+ *   parent leaves `undefined` preserve whatever the inner options already had.
+ * - `getAiRunContext` is read at execution time rather than captured, so an
+ *   in-turn retarget (e.g. `set_primary_context_artifact`) is visible to later
+ *   tool calls, including those inside nested agents.
+ * - The inner tool's own `toolCallId`, `messages`, and `abortSignal` are left
+ *   intact.
+ * - `state` is optional and only used for `setToolCallSession` attribution. Omit
+ *   it when forwarding into nested agents; the chat transport passes it so
+ *   top-level tool calls stay attributed to their session.
+ */
 export function withRunContextTools(
   tools: ToolSet,
   args: AiToolExecutionContext & {
-    state: AiSliceStateForTransport;
-    getAiRunContext?: () => AiRunContext | undefined;
-    setAiRunContext?: (runContext: AiRunContext | undefined) => void;
+    state?: AiSliceStateForTransport;
   },
 ): ToolSet {
   return Object.fromEntries(
@@ -252,19 +274,22 @@ export function withRunContextTools(
                 ? options.toolCallId
                 : undefined;
             if (toolCallId && args.sessionId) {
-              args.state.ai.setToolCallSession(toolCallId, args.sessionId);
+              args.state?.ai.setToolCallSession(toolCallId, args.sessionId);
             }
+            const aiRunContext = args.getAiRunContext
+              ? args.getAiRunContext()
+              : args.aiRunContext;
             return originalExecute(
               input as never,
               {
                 ...options,
-                sessionId: args.sessionId,
-                aiRunContext: args.getAiRunContext
-                  ? args.getAiRunContext()
-                  : args.aiRunContext,
-                getAiRunContext: args.getAiRunContext,
-                setAiRunContext: args.setAiRunContext,
-                setPrimaryRunContextItem: args.setPrimaryRunContextItem,
+                ...definedScopeFields({
+                  sessionId: args.sessionId,
+                  aiRunContext,
+                  getAiRunContext: args.getAiRunContext,
+                  setAiRunContext: args.setAiRunContext,
+                  setPrimaryRunContextItem: args.setPrimaryRunContextItem,
+                }),
               } as never,
             );
           },
@@ -272,6 +297,18 @@ export function withRunContextTools(
       ];
     }),
   ) as ToolSet;
+}
+
+/**
+ * Drop `undefined` scope fields so wrapping a toolset with a partially
+ * populated parent context never erases scope the inner options already carry.
+ */
+function definedScopeFields(
+  fields: AiToolExecutionContext,
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(fields).filter(([, value]) => value !== undefined),
+  );
 }
 
 /**

--- a/packages/ai-core/src/index.ts
+++ b/packages/ai-core/src/index.ts
@@ -194,6 +194,8 @@ export type {
 } from './types';
 export {fixIncompleteToolCalls} from './utils';
 
+export {withRunContextTools} from './chatTransport';
+
 export {
   streamSubAgent,
   updateAgentToolCallData,

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -148,7 +148,11 @@ export type {
 export {AiThinkingDots} from '@sqlrooms/ai-core';
 export {cleanupPendingAnalysisResults, ToolAbortError} from '@sqlrooms/ai-core';
 export {fixIncompleteToolCalls} from '@sqlrooms/ai-core';
-export {streamSubAgent, updateAgentToolCallData} from '@sqlrooms/ai-core';
+export {
+  streamSubAgent,
+  updateAgentToolCallData,
+  withRunContextTools,
+} from '@sqlrooms/ai-core';
 export {
   getEffectiveSessionContextItemIds,
   getRunContextItemIds,

--- a/packages/room-store/__tests__/BaseRoomStore.devtools.test.ts
+++ b/packages/room-store/__tests__/BaseRoomStore.devtools.test.ts
@@ -73,8 +73,14 @@ describe('createRoomStoreCreator DevTools integration', () => {
     const creator =
       createRoomStoreCreator<BaseRoomStoreState>()(createBaseRoomSlice);
 
-    const first = creator.createRoomStore({storeKey: 'project-a'});
-    const reused = creator.createRoomStore({storeKey: 'project-a'});
+    const first = creator.createRoomStore({
+      storeKey: 'project-a',
+      devtools: true,
+    });
+    const reused = creator.createRoomStore({
+      storeKey: 'project-a',
+      devtools: true,
+    });
 
     expect(reused).toBe(first);
     expect(connect).toHaveBeenCalledTimes(1);
@@ -91,8 +97,8 @@ describe('createRoomStoreCreator DevTools integration', () => {
     const creator =
       createRoomStoreCreator<BaseRoomStoreState>()(createBaseRoomSlice);
 
-    creator.createRoomStore({storeKey: 'project-a'});
-    creator.createRoomStore({storeKey: 'project-b'});
+    creator.createRoomStore({storeKey: 'project-a', devtools: true});
+    creator.createRoomStore({storeKey: 'project-b', devtools: true});
 
     expect(connections).toHaveLength(2);
     expect(connections[0]?.unsubscribe).toHaveBeenCalledTimes(1);
@@ -102,6 +108,19 @@ describe('createRoomStoreCreator DevTools integration', () => {
     const {connect} = installDevtoolsExtension();
     const {createBaseRoomSlice, createRoomStoreCreator} =
       await loadBaseRoomStore({isDev: false, devHmr: null});
+    const creator =
+      createRoomStoreCreator<BaseRoomStoreState>()(createBaseRoomSlice);
+
+    creator.createRoomStore({storeKey: 'project-a', devtools: true});
+
+    expect(connect).not.toHaveBeenCalled();
+  });
+
+  it('does not connect DevTools unless the option is opted into', async () => {
+    const devHmr = createDevHmr();
+    const {connect} = installDevtoolsExtension();
+    const {createBaseRoomSlice, createRoomStoreCreator} =
+      await loadBaseRoomStore({isDev: true, devHmr});
     const creator =
       createRoomStoreCreator<BaseRoomStoreState>()(createBaseRoomSlice);
 


### PR DESCRIPTION
Makes the existing sub-agent scope-forwarding helper reusable and exports it.

## Why

The chat transport already wraps `state.ai.tools` with `withRunContextTools` so top-level tools receive the invoking turn's `sessionId` and mutable `AiRunContext` accessors. Tools handed to a nested `ToolLoopAgent` are **not** wrapped by the transport, so they execute with no scope at all — and any target resolution that defaults to "the current artifact/map" then silently follows mutable UI selection instead of what the user had selected when they submitted the prompt.

The helper was module-private and required transport state, so hosts hand-rolled their own copies. This exports it instead.

## Changes

- `state` is now optional — it was only used for `setToolCallSession` attribution, which nested callers don't own.
- `undefined` scope fields are dropped, so wrapping with a partially populated parent context can't erase scope the inner options already carry (matters for headless callers that supply only an `aiRunContext`).
- Exported from `@sqlrooms/ai-core` and `@sqlrooms/ai`, with a README section on nested-agent usage.

Behaviour for the existing transport call site is unchanged.

## Review feedback addressed

- **Forward cancellation in the nested-agent example** ([Codex](https://github.com/sqlrooms/sqlrooms/pull/840#discussion_r2609392061)): the README example now passes `options.abortSignal` as `streamSubAgent`'s fifth argument. `withRunContextTools` preserves the signal for the tools a sub-agent calls, but the agent loop itself — model stream and approval wait — is only cancellable through that argument, so consumers copying the sample would have left nested runs going after a `stop()`.

## CI

`packages/room-store/__tests__/BaseRoomStore.devtools.test.ts` was failing on this branch's base (`feat/worksheets`, commit 7958a476) and is unrelated to the change here: the `devtools` option is opt-in per store, but two cases created stores without it and asserted the extension was connected. Fixed in a separate commit, which also adds an off-by-default case and makes the production case actually exercise the `IS_DEV` gate.

The earlier note in this description claiming the `ai-core` suites could not run was wrong — it was a stale local build. All 26 `ai-core` suites (143 tests) pass, including the new `__tests__/withRunContextTools.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
