### PR TITLE
refactor(artifacts): separate association and workspace state

### DIFF
--- a/apps/sqlrooms-cli-ui/src/__tests__/artifactChatAssociation.test.ts
+++ b/apps/sqlrooms-cli-ui/src/__tests__/artifactChatAssociation.test.ts
@@ -67,7 +67,6 @@ it('links a newly selected artifact to the invoking chat and keeps it selected',
   expect(addSessionArtifactLink).toHaveBeenCalledWith(
     sourceSessionId,
     targetArtifactId,
-    'created',
   );
   expect(switchSession).toHaveBeenCalledWith(sourceSessionId);
 });

--- a/apps/sqlrooms-cli-ui/src/__tests__/getRunContext.test.ts
+++ b/apps/sqlrooms-cli-ui/src/__tests__/getRunContext.test.ts
@@ -162,14 +162,12 @@ function createMultiArtifactStore(
           {
             sessionId: 'session-1',
             artifactId: 'worksheet-old',
-            createdAt: 1000,
-            linkType: 'created',
+            linkedAt: 1000,
           },
           {
             sessionId: 'session-1',
             artifactId: 'worksheet-new',
-            createdAt: 2000,
-            linkType: 'attached',
+            linkedAt: 2000,
           },
         ],
       },

--- a/apps/sqlrooms-cli-ui/src/artifactChatAssociation.ts
+++ b/apps/sqlrooms-cli-ui/src/artifactChatAssociation.ts
@@ -35,8 +35,7 @@ function isRoomCommandResult(
  *
  * The command must return an `artifactId`, either as raw command data or as
  * normalized `result.data`, and that artifact must be current when the command
- * completes. Newly created artifacts receive a `created` link; existing
- * artifacts receive an `attached` link.
+ * completes.
  */
 export const artifactChatAssociationMiddleware: RoomCommandMiddleware<
   RoomState
@@ -48,10 +47,6 @@ export const artifactChatAssociationMiddleware: RoomCommandMiddleware<
 
   const stateBefore = context.getState();
   const previousArtifactId = stateBefore.artifacts.config.currentArtifactId;
-  const artifactIdsBefore = new Set(
-    Object.keys(stateBefore.artifacts.config.artifactsById),
-  );
-
   const result = await next();
   if (isRoomCommandResult(result) && !result.success) return result;
 
@@ -69,11 +64,7 @@ export const artifactChatAssociationMiddleware: RoomCommandMiddleware<
     return result;
   }
 
-  state.artifactAi.addSessionArtifactLink(
-    sessionId,
-    artifactId,
-    artifactIdsBefore.has(artifactId) ? 'attached' : 'created',
-  );
+  state.artifactAi.addSessionArtifactLink(sessionId, artifactId);
   if (state.ai.config.currentSessionId !== sessionId) {
     state.ai.switchSession(sessionId);
   }

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -10,36 +10,43 @@ When upgrading, please follow the version-specific instructions below that apply
 
 ## 0.29.0 (upcoming)
 
-### `@sqlrooms/artifacts`: artifact AI sessions use many-to-many links (breaking)
+### `@sqlrooms/artifacts`: artifact AI sessions use pure many-to-many associations (breaking)
 
-The prerelease-only one-to-one `artifactAi.aiSessionArtifacts` map and separate
-`artifactCreators` map were removed. `artifactAi.sessionArtifactLinks` is now
-the only persisted and runtime representation of relationships between AI
-sessions and artifacts:
+The prerelease-only one-to-one `artifactAi.aiSessionArtifacts` map,
+`artifactCreators` map, and provenance-bearing link shape were removed.
+`artifactAi.sessionArtifactLinks` is now the only persisted and runtime
+representation of relationships between AI sessions and artifacts:
 
 ```ts
 type ArtifactSessionLink = {
   sessionId: string;
   artifactId: string;
-  createdAt: number;
-  linkType: 'created' | 'attached';
+  linkedAt: number;
 };
 ```
 
 This is a clean prerelease break: `ArtifactAiConfigSchema` does not migrate the
-removed fields. If you need to retain prerelease state, convert each
-`aiSessionArtifacts` entry to an `attached` link and represent creator
-provenance with a `created` link before parsing the config. Helper APIs now
-require `sessionArtifactLinks` and the deprecated one-to-one slice methods were
-removed:
+removed fields or the previous `{createdAt, linkType}` link shape. If you need
+to retain prerelease state, convert each relationship to an association and
+rename its relationship timestamp from `createdAt` to `linkedAt`. Creation
+provenance, when needed, should live in the artifact's domain metadata rather
+than in its chat associations. Helper APIs now require
+`sessionArtifactLinks`, and the deprecated one-to-one and creator-provenance
+slice methods were removed:
 
-- `setSessionArtifact` → `addSessionArtifactLink`
+- `setSessionArtifact` → `addSessionArtifactLink(sessionId, artifactId)`
 - `clearSessionArtifact` → `removeAllLinksForSession`
 - `getSessionArtifactId` → `getLatestArtifactForSession`
-- `setArtifactCreator` → `addSessionArtifactLink` with `linkType: 'created'`
-- `getArtifactCreatorSessionId` → `getCreatorSessionForArtifact`
-- `getCreatedArtifactIds` → filter `sessionArtifactLinks` by
-  `linkType: 'created'`
+- `setArtifactCreator`, `getArtifactCreatorSessionId`, and
+  `getCreatedArtifactIds` have no association-layer replacement
+
+Artifact pinning is workspace state and has moved from the AI companion slice
+to the base artifacts slice:
+
+- `artifactAi.config.pinnedArtifactIds` →
+  `artifacts.config.pinnedArtifactIds`
+- `artifactAi.togglePinArtifact(id)` → `artifacts.togglePinArtifact(id)`
+- `artifactAi.isPinnedArtifact(id)` → `artifacts.isPinnedArtifact(id)`
 
 ### `@sqlrooms/artifacts`: "Sheets" terminology migrated to "Artifacts" (breaking)
 

--- a/packages/artifacts/README.md
+++ b/packages/artifacts/README.md
@@ -93,6 +93,7 @@ Config uses artifact terminology throughout:
 
 - `artifacts.config.artifactsById`
 - `artifacts.config.artifactOrder`
+- `artifacts.config.pinnedArtifactIds`
 - `artifacts.config.currentArtifactId`
 
 - `artifacts.createArtifact({type, title?, id?})`
@@ -102,6 +103,8 @@ Config uses artifact terminology throughout:
 - `artifacts.deleteArtifact(id)`
 - `artifacts.setCurrentArtifact(id?)`
 - `artifacts.setArtifactOrder(order)`
+- `artifacts.togglePinArtifact(id)`
+- `artifacts.isPinnedArtifact(id)`
 - `artifacts.getArtifact(id)`
 
 `closeArtifact` is non-destructive. It runs close lifecycle cleanup, while the
@@ -215,27 +218,28 @@ representation. The prerelease-only `aiSessionArtifacts` and
 `artifactCreators` fields were removed without an automatic migration. Update
 persisted prerelease configs before parsing them with `ArtifactAiConfigSchema`.
 
-The link types are exported from `@sqlrooms/artifacts`:
+The link type is exported from `@sqlrooms/artifacts`:
 
-- `ArtifactSessionLink` — a single link: `{sessionId, artifactId, createdAt, linkType}`.
-  `createdAt` is a Unix timestamp in milliseconds.
-- `ArtifactSessionLinkType` — `'created' | 'attached'`. `'created'` records that
-  the session created the artifact; `'attached'` records that it references/works
-  in the artifact. A session may hold links to multiple artifacts.
+- `ArtifactSessionLink` — a single association:
+  `{sessionId, artifactId, linkedAt}`. `linkedAt` is a Unix timestamp in
+  milliseconds. A session may be associated with multiple artifacts.
 - `ArtifactSessionLinkSchema` — the Zod schema used to validate a link (for
   example when persisting `ArtifactAiConfigSchema`).
 
+Links intentionally describe association only. If an app needs creation
+provenance, store it with the artifact's domain metadata instead of overloading
+the chat association.
+
 All artifact AI session helpers accept `sessionArtifactLinks`; they do not
-accept a parallel one-to-one ownership map.
+accept a parallel one-to-one association map.
 
 Use `artifactAi.createArtifactScopedSession()` when creating chats from an
-artifact-scoped assistant. It creates a fresh session and attaches it to the
-current artifact; use `linkType: 'created'` only when the session itself creates
-the artifact.
+artifact-scoped assistant. It creates a fresh session and associates it with
+the current artifact.
 `artifactAi.selectLatestSessionForArtifact()` and
 `artifactAi.syncCurrentArtifactAiSession()` keep the current AI session aligned
-with `artifacts.config.currentArtifactId`. Sessions without explicit artifact
-ownership are ignored by artifact-scoped history.
+with `artifacts.config.currentArtifactId`. Sessions without an explicit
+artifact association are ignored by artifact-scoped history.
 
 Reusable helpers include:
 

--- a/packages/artifacts/__tests__/ArtifactsSlice.test.ts
+++ b/packages/artifacts/__tests__/ArtifactsSlice.test.ts
@@ -130,6 +130,23 @@ describe('ArtifactsSlice', () => {
     expect(store.getState().artifacts.config.pinnedArtifactIds).toEqual([]);
   });
 
+  it('removes every persisted duplicate when unpinning an artifact', () => {
+    const store = createTestStore();
+    store.getState().artifacts.setConfig(
+      ArtifactsSliceConfig.parse({
+        artifactsById: {
+          a: {id: 'a', type: 'dashboard', title: 'A'},
+        },
+        artifactOrder: ['a'],
+        pinnedArtifactIds: ['a', 'a'],
+      }),
+    );
+
+    store.getState().artifacts.togglePinArtifact('a');
+
+    expect(store.getState().artifacts.config.pinnedArtifactIds).toEqual([]);
+  });
+
   it('parses artifact metadata without visibility state', () => {
     const result = ArtifactsSliceConfig.parse({
       artifactsById: {

--- a/packages/artifacts/__tests__/ArtifactsSlice.test.ts
+++ b/packages/artifacts/__tests__/ArtifactsSlice.test.ts
@@ -106,6 +106,30 @@ describe('ArtifactsSlice', () => {
     expect(store.getState().artifacts.config.currentArtifactId).toBeUndefined();
   });
 
+  it('owns pinned artifact workspace state', () => {
+    const store = createTestStore();
+    store.getState().artifacts.ensureArtifact('a', {
+      type: 'dashboard',
+      title: 'A',
+    });
+
+    expect(store.getState().artifacts.isPinnedArtifact('a')).toBe(false);
+    store.getState().artifacts.togglePinArtifact('a');
+    expect(store.getState().artifacts.isPinnedArtifact('a')).toBe(true);
+    expect(store.getState().artifacts.config.pinnedArtifactIds).toEqual(['a']);
+
+    store.getState().artifacts.deleteArtifact('a');
+    expect(store.getState().artifacts.config.pinnedArtifactIds).toEqual([]);
+  });
+
+  it('does not pin missing artifacts', () => {
+    const store = createTestStore();
+    store.getState().artifacts.togglePinArtifact('missing');
+
+    expect(store.getState().artifacts.isPinnedArtifact('missing')).toBe(false);
+    expect(store.getState().artifacts.config.pinnedArtifactIds).toEqual([]);
+  });
+
   it('parses artifact metadata without visibility state', () => {
     const result = ArtifactsSliceConfig.parse({
       artifactsById: {
@@ -119,6 +143,7 @@ describe('ArtifactsSlice', () => {
       type: 'dashboard',
       title: 'A',
     });
+    expect(result.pinnedArtifactIds).toEqual([]);
   });
 
   it('validates configured artifact types', () => {

--- a/packages/artifacts/__tests__/artifactAiSessions.test.ts
+++ b/packages/artifacts/__tests__/artifactAiSessions.test.ts
@@ -147,20 +147,17 @@ describe('artifact AI session helpers', () => {
     {
       sessionId: 'session-a-old',
       artifactId: 'artifact-a',
-      createdAt: 1000,
-      linkType: 'created' as const,
+      linkedAt: 1000,
     },
     {
       sessionId: 'session-a-new',
       artifactId: 'artifact-a',
-      createdAt: 3000,
-      linkType: 'attached' as const,
+      linkedAt: 3000,
     },
     {
       sessionId: 'session-b',
       artifactId: 'artifact-b',
-      createdAt: 2000,
-      linkType: 'created' as const,
+      linkedAt: 2000,
     },
   ];
 
@@ -234,26 +231,22 @@ describe('artifact AI session helpers', () => {
           {
             sessionId: 'empty-older',
             artifactId: 'artifact-a',
-            createdAt: 1000,
-            linkType: 'created',
+            linkedAt: 1000,
           },
           {
             sessionId: 'non-empty-newer',
             artifactId: 'artifact-a',
-            createdAt: 3000,
-            linkType: 'attached',
+            linkedAt: 3000,
           },
           {
             sessionId: 'empty-newer',
             artifactId: 'artifact-a',
-            createdAt: 2000,
-            linkType: 'attached',
+            linkedAt: 2000,
           },
           {
             sessionId: 'running-empty',
             artifactId: 'artifact-a',
-            createdAt: 4000,
-            linkType: 'attached',
+            linkedAt: 4000,
           },
         ],
         artifactId: 'artifact-a',
@@ -282,20 +275,17 @@ describe('artifact AI session helpers', () => {
           {
             sessionId: 'older-draft-match',
             artifactId: 'artifact-a',
-            createdAt: 1000,
-            linkType: 'created',
+            linkedAt: 1000,
           },
           {
             sessionId: 'newer-draft-match',
             artifactId: 'artifact-a',
-            createdAt: 2000,
-            linkType: 'attached',
+            linkedAt: 2000,
           },
           {
             sessionId: 'other-artifact-match',
             artifactId: 'artifact-b',
-            createdAt: 3000,
-            linkType: 'created',
+            linkedAt: 3000,
           },
         ],
         artifactId: 'artifact-a',
@@ -326,8 +316,7 @@ describe('artifact AI session helpers', () => {
           {
             sessionId: 'run-match',
             artifactId: 'artifact-a',
-            createdAt: 1000,
-            linkType: 'created',
+            linkedAt: 1000,
           },
         ],
         artifactId: 'artifact-a',
@@ -345,8 +334,7 @@ describe('artifact AI session helpers', () => {
       {
         sessionId: 'running-match',
         artifactId: 'artifact-a',
-        createdAt: 3000,
-        linkType: 'created' as const,
+        linkedAt: 3000,
       },
     ];
 
@@ -383,8 +371,7 @@ describe('artifact AI session helpers', () => {
           {
             sessionId: 'no-match',
             artifactId: 'artifact-a',
-            createdAt: 1000,
-            linkType: 'created',
+            linkedAt: 1000,
           },
         ],
         artifactId: 'artifact-a',
@@ -404,14 +391,12 @@ describe('artifact AI session helpers', () => {
           {
             sessionId: 'empty-older',
             artifactId: 'artifact-a',
-            createdAt: 1000,
-            linkType: 'created',
+            linkedAt: 1000,
           },
           {
             sessionId: 'empty-newer',
             artifactId: 'artifact-a',
-            createdAt: 2000,
-            linkType: 'attached',
+            linkedAt: 2000,
           },
         ],
         artifactId: 'artifact-a',
@@ -434,8 +419,7 @@ describe('artifact AI session helpers', () => {
           {
             sessionId: 'summary-only',
             artifactId: 'artifact-a',
-            createdAt: 1000,
-            linkType: 'created',
+            linkedAt: 1000,
           },
         ],
         artifactId: 'artifact-a',
@@ -467,8 +451,7 @@ describe('artifact AI session helpers', () => {
           {
             sessionId: 'deleted-session',
             artifactId: 'artifact-a',
-            createdAt: 5000,
-            linkType: 'attached' as const,
+            linkedAt: 5000,
           },
         ],
       }),
@@ -486,14 +469,12 @@ describe('artifact AI session helpers', () => {
           {
             sessionId: 'deleted-session',
             artifactId: 'artifact-a',
-            createdAt: 5000,
-            linkType: 'attached',
+            linkedAt: 5000,
           },
           {
             sessionId: 'session-a-new',
             artifactId: 'deleted-artifact',
-            createdAt: 6000,
-            linkType: 'attached',
+            linkedAt: 6000,
           },
         ],
         sessions,
@@ -503,20 +484,17 @@ describe('artifact AI session helpers', () => {
       {
         sessionId: 'session-a-old',
         artifactId: 'artifact-a',
-        createdAt: 1000,
-        linkType: 'created',
+        linkedAt: 1000,
       },
       {
         sessionId: 'session-a-new',
         artifactId: 'artifact-a',
-        createdAt: 3000,
-        linkType: 'attached',
+        linkedAt: 3000,
       },
       {
         sessionId: 'session-b',
         artifactId: 'artifact-b',
-        createdAt: 2000,
-        linkType: 'created',
+        linkedAt: 2000,
       },
     ]);
   });
@@ -557,15 +535,14 @@ describe('artifact AI session helpers', () => {
   });
 
   it('prefers the target artifact over the most recently linked one', () => {
-    // session-a-new is linked to artifact-a (createdAt 3000). Add a newer link
+    // session-a-new is linked to artifact-a (linkedAt 3000). Add a newer link
     // to artifact-b so the "latest" artifact is artifact-b.
     const multiLinks = [
       ...sessionArtifactLinks,
       {
         sessionId: 'session-a-new',
         artifactId: 'artifact-b',
-        createdAt: 4000,
-        linkType: 'attached' as const,
+        linkedAt: 4000,
       },
     ];
     const artifactsById = {
@@ -608,8 +585,7 @@ describe('artifact AI session helpers', () => {
       {
         sessionId: 'session-a-new',
         artifactId: 'artifact-b',
-        createdAt: 4000,
-        linkType: 'attached' as const,
+        linkedAt: 4000,
       },
     ];
     const artifactsById = {
@@ -649,10 +625,8 @@ describe('createArtifactAiSlice', () => {
     expect(
       store
         .getState()
-        .artifactAi.config.sessionArtifactLinks.find(
-          (link) => link.sessionId === 'session-1',
-        )?.linkType,
-    ).toBe('attached');
+        .artifactAi.hasSessionArtifactLink('session-1', 'artifact-a'),
+    ).toBe(true);
   });
 
   it('creates a new artifact-scoped session instead of reusing the current empty session', () => {
@@ -666,8 +640,7 @@ describe('createArtifactAiSlice', () => {
           {
             sessionId: 'current-empty',
             artifactId: 'artifact-a',
-            createdAt: 1000,
-            linkType: 'created',
+            linkedAt: 1000,
           },
         ];
       }),
@@ -693,8 +666,7 @@ describe('createArtifactAiSlice', () => {
           {
             sessionId: 'empty-session',
             artifactId: 'artifact-a',
-            createdAt: 1000,
-            linkType: 'created',
+            linkedAt: 1000,
           },
         ];
       }),
@@ -755,8 +727,7 @@ describe('createArtifactAiSlice', () => {
           {
             sessionId: 'session-a',
             artifactId: 'artifact-a',
-            createdAt: 1000,
-            linkType: 'created',
+            linkedAt: 1000,
           },
         ];
       }),
@@ -824,8 +795,7 @@ describe('createArtifactAiSlice', () => {
           {
             sessionId: 'source-session',
             artifactId: 'artifact-a',
-            createdAt: 1000,
-            linkType: 'created',
+            linkedAt: 1000,
           },
         ];
       }),
@@ -858,14 +828,12 @@ describe('createArtifactAiSlice', () => {
           {
             sessionId: 'source-session',
             artifactId: 'artifact-a',
-            createdAt: 1000,
-            linkType: 'created',
+            linkedAt: 1000,
           },
           {
             sessionId: 'source-session',
             artifactId: 'artifact-b',
-            createdAt: 2000,
-            linkType: 'attached',
+            linkedAt: 2000,
           },
         ];
       }),
@@ -886,7 +854,7 @@ describe('createArtifactAiSlice', () => {
         .artifactAi.config.sessionArtifactLinks.filter(
           (link) => link.sessionId === 'target-session',
         )
-        .map((link) => link.createdAt),
+        .map((link) => link.linkedAt),
     ).toEqual([1000, 2000]);
   });
 
@@ -904,20 +872,17 @@ describe('createArtifactAiSlice', () => {
           {
             sessionId: 'current-session',
             artifactId: 'artifact-a',
-            createdAt: 1000,
-            linkType: 'created',
+            linkedAt: 1000,
           },
           {
             sessionId: 'current-session',
             artifactId: 'artifact-b',
-            createdAt: 2000,
-            linkType: 'attached',
+            linkedAt: 2000,
           },
           {
             sessionId: 'other-session',
             artifactId: 'artifact-a',
-            createdAt: 3000,
-            linkType: 'attached',
+            linkedAt: 3000,
           },
         ];
       }),
@@ -951,14 +916,12 @@ describe('createArtifactAiSlice', () => {
           {
             sessionId: 'owned-older',
             artifactId: 'artifact-a',
-            createdAt: 1000,
-            linkType: 'created',
+            linkedAt: 1000,
           },
           {
             sessionId: 'owned-newer',
             artifactId: 'artifact-a',
-            createdAt: 5000,
-            linkType: 'attached',
+            linkedAt: 5000,
           },
         ];
       }),
@@ -982,8 +945,7 @@ describe('createArtifactAiSlice', () => {
           {
             sessionId: 'session-1',
             artifactId: 'artifact-a',
-            createdAt: 1000,
-            linkType: 'created',
+            linkedAt: 1000,
           },
         ];
       }),
@@ -1025,14 +987,12 @@ describe('createArtifactAiSlice', () => {
           {
             sessionId: 'session-current',
             artifactId: 'artifact-a',
-            createdAt: 2000,
-            linkType: 'created',
+            linkedAt: 2000,
           },
           {
             sessionId: 'session-other',
             artifactId: 'artifact-a',
-            createdAt: 1000,
-            linkType: 'attached',
+            linkedAt: 1000,
           },
         ];
       }),
@@ -1081,20 +1041,17 @@ describe('createArtifactAiSlice', () => {
           {
             sessionId: 'session-current',
             artifactId: 'artifact-a',
-            createdAt: 3000,
-            linkType: 'created',
+            linkedAt: 3000,
           },
           {
             sessionId: 'session-b',
             artifactId: 'artifact-b',
-            createdAt: 2000,
-            linkType: 'created',
+            linkedAt: 2000,
           },
           {
             sessionId: 'session-a-other',
             artifactId: 'artifact-a',
-            createdAt: 1000,
-            linkType: 'attached',
+            linkedAt: 1000,
           },
         ];
       }),
@@ -1137,20 +1094,17 @@ describe('createArtifactAiSlice', () => {
           {
             sessionId: 'session-a',
             artifactId: 'artifact-a',
-            createdAt: 1000,
-            linkType: 'created',
+            linkedAt: 1000,
           },
           {
             sessionId: 'deleted-session',
             artifactId: 'artifact-a',
-            createdAt: 2000,
-            linkType: 'attached',
+            linkedAt: 2000,
           },
           {
             sessionId: 'session-b',
             artifactId: 'deleted-artifact',
-            createdAt: 3000,
-            linkType: 'created',
+            linkedAt: 3000,
           },
         ];
       }),
@@ -1162,23 +1116,22 @@ describe('createArtifactAiSlice', () => {
       {
         sessionId: 'session-a',
         artifactId: 'artifact-a',
-        createdAt: 1000,
-        linkType: 'created',
+        linkedAt: 1000,
       },
     ]);
   });
 });
 
-describe('artifactAi link and pin mutations', () => {
+describe('artifactAi link mutations', () => {
   it('adds, queries, and removes session-artifact links', () => {
     const store = createTestStore();
     const {artifactAi} = store.getState();
 
     expect(artifactAi.hasSessionArtifactLink('s1', 'artifact-a')).toBe(false);
 
-    artifactAi.addSessionArtifactLink('s1', 'artifact-a', 'created');
-    artifactAi.addSessionArtifactLink('s1', 'artifact-b', 'attached');
-    artifactAi.addSessionArtifactLink('s2', 'artifact-a', 'attached');
+    artifactAi.addSessionArtifactLink('s1', 'artifact-a');
+    artifactAi.addSessionArtifactLink('s1', 'artifact-b');
+    artifactAi.addSessionArtifactLink('s2', 'artifact-a');
 
     expect(
       store.getState().artifactAi.hasSessionArtifactLink('s1', 'artifact-a'),
@@ -1202,12 +1155,8 @@ describe('artifactAi link and pin mutations', () => {
 
   it('does not duplicate an existing link', () => {
     const store = createTestStore();
-    store
-      .getState()
-      .artifactAi.addSessionArtifactLink('s1', 'artifact-a', 'created');
-    store
-      .getState()
-      .artifactAi.addSessionArtifactLink('s1', 'artifact-a', 'attached');
+    store.getState().artifactAi.addSessionArtifactLink('s1', 'artifact-a');
+    store.getState().artifactAi.addSessionArtifactLink('s1', 'artifact-a');
 
     expect(
       store
@@ -1218,41 +1167,12 @@ describe('artifactAi link and pin mutations', () => {
     ).toHaveLength(1);
   });
 
-  it('promotes attached provenance to created without changing link order', () => {
-    const store = createTestStore();
-    store.setState(
-      produce(store.getState(), (draft: TestRoomState) => {
-        draft.artifactAi.config.sessionArtifactLinks = [
-          {
-            sessionId: 's1',
-            artifactId: 'artifact-a',
-            createdAt: 1000,
-            linkType: 'attached',
-          },
-        ];
-      }),
-    );
-
-    store
-      .getState()
-      .artifactAi.addSessionArtifactLink('s1', 'artifact-a', 'created');
-
-    expect(store.getState().artifactAi.config.sessionArtifactLinks).toEqual([
-      {
-        sessionId: 's1',
-        artifactId: 'artifact-a',
-        createdAt: 1000,
-        linkType: 'created',
-      },
-    ]);
-  });
-
   it('removes all links for a session', () => {
     const store = createTestStore();
     const {artifactAi} = store.getState();
-    artifactAi.addSessionArtifactLink('s1', 'artifact-a', 'created');
-    artifactAi.addSessionArtifactLink('s1', 'artifact-b', 'attached');
-    artifactAi.addSessionArtifactLink('s2', 'artifact-a', 'attached');
+    artifactAi.addSessionArtifactLink('s1', 'artifact-a');
+    artifactAi.addSessionArtifactLink('s1', 'artifact-b');
+    artifactAi.addSessionArtifactLink('s2', 'artifact-a');
 
     store.getState().artifactAi.removeAllLinksForSession('s1');
 
@@ -1267,9 +1187,9 @@ describe('artifactAi link and pin mutations', () => {
   it('removes all links for an artifact', () => {
     const store = createTestStore();
     const {artifactAi} = store.getState();
-    artifactAi.addSessionArtifactLink('s1', 'artifact-a', 'created');
-    artifactAi.addSessionArtifactLink('s2', 'artifact-a', 'attached');
-    artifactAi.addSessionArtifactLink('s1', 'artifact-b', 'attached');
+    artifactAi.addSessionArtifactLink('s1', 'artifact-a');
+    artifactAi.addSessionArtifactLink('s2', 'artifact-a');
+    artifactAi.addSessionArtifactLink('s1', 'artifact-b');
 
     store.getState().artifactAi.removeAllLinksForArtifact('artifact-a');
 
@@ -1279,41 +1199,6 @@ describe('artifactAi link and pin mutations', () => {
     expect(store.getState().artifactAi.getArtifactIdsForSession('s1')).toEqual([
       'artifact-b',
     ]);
-  });
-
-  it('toggles and persists pinned artifacts', () => {
-    const store = createTestStore();
-
-    expect(store.getState().artifactAi.isPinnedArtifact('artifact-a')).toBe(
-      false,
-    );
-
-    store.getState().artifactAi.togglePinArtifact('artifact-a');
-    expect(store.getState().artifactAi.isPinnedArtifact('artifact-a')).toBe(
-      true,
-    );
-    expect(store.getState().artifactAi.config.pinnedArtifactIds).toEqual([
-      'artifact-a',
-    ]);
-
-    store.getState().artifactAi.togglePinArtifact('artifact-a');
-    expect(store.getState().artifactAi.isPinnedArtifact('artifact-a')).toBe(
-      false,
-    );
-    expect(store.getState().artifactAi.config.pinnedArtifactIds).toEqual([]);
-  });
-
-  it('does not pin missing artifacts', () => {
-    const store = createTestStore();
-
-    store.getState().artifactAi.togglePinArtifact('missing-artifact');
-
-    expect(
-      store.getState().artifactAi.isPinnedArtifact('missing-artifact'),
-    ).toBe(false);
-    expect(
-      store.getState().artifactAi.config.pinnedArtifactIds,
-    ).toBeUndefined();
   });
 });
 
@@ -1331,8 +1216,7 @@ describe('ArtifactAiConfigSchema', () => {
           {
             sessionId: 'session-2',
             artifactId: 'artifact-b',
-            createdAt: 2000,
-            linkType: 'created',
+            linkedAt: 2000,
           },
         ],
       }).sessionArtifactLinks,
@@ -1340,13 +1224,12 @@ describe('ArtifactAiConfigSchema', () => {
       {
         sessionId: 'session-2',
         artifactId: 'artifact-b',
-        createdAt: 2000,
-        linkType: 'created',
+        linkedAt: 2000,
       },
     ]);
   });
 
-  it('rejects removed one-to-one artifact AI fields', () => {
+  it('rejects fields no longer owned by the artifact AI slice', () => {
     expect(
       ArtifactAiConfigSchema.safeParse({
         aiSessionArtifacts: {'session-1': 'artifact-a'},
@@ -1357,16 +1240,19 @@ describe('ArtifactAiConfigSchema', () => {
         artifactCreators: {'artifact-a': 'session-1'},
       }).success,
     ).toBe(false);
+    expect(
+      ArtifactAiConfigSchema.safeParse({pinnedArtifactIds: ['artifact-a']})
+        .success,
+    ).toBe(false);
   });
 });
 
 describe('ArtifactSessionLink types', () => {
-  it('should validate a valid created link', () => {
+  it('validates an association', () => {
     const link = {
       sessionId: 'session-1',
       artifactId: 'artifact-1',
-      createdAt: Date.now(),
-      linkType: 'created' as const,
+      linkedAt: Date.now(),
     };
 
     const result = ArtifactSessionLinkSchema.safeParse(link);
@@ -1376,24 +1262,12 @@ describe('ArtifactSessionLink types', () => {
     }
   });
 
-  it('should validate a valid attached link', () => {
-    const link = {
-      sessionId: 'session-2',
-      artifactId: 'artifact-2',
-      createdAt: Date.now(),
-      linkType: 'attached' as const,
-    };
-
-    const result = ArtifactSessionLinkSchema.safeParse(link);
-    expect(result.success).toBe(true);
-  });
-
-  it('should reject invalid linkType', () => {
+  it('rejects legacy provenance metadata', () => {
     const link = {
       sessionId: 'session-1',
       artifactId: 'artifact-1',
-      createdAt: Date.now(),
-      linkType: 'invalid',
+      linkedAt: Date.now(),
+      linkType: 'created',
     };
 
     const result = ArtifactSessionLinkSchema.safeParse(link);
@@ -1404,17 +1278,11 @@ describe('ArtifactSessionLink types', () => {
     const validLink = {
       sessionId: 'session-1',
       artifactId: 'artifact-1',
-      createdAt: 1000,
-      linkType: 'created' as const,
+      linkedAt: 1000,
     };
 
-    for (const field of [
-      'sessionId',
-      'artifactId',
-      'createdAt',
-      'linkType',
-    ] as const) {
-      const {[field]: _omitted, ...link} = validLink;
+    for (const field of ['sessionId', 'artifactId', 'linkedAt'] as const) {
+      const link = {...validLink, [field]: undefined};
       const result = ArtifactSessionLinkSchema.safeParse(link);
       expect(result.success).toBe(false);
     }

--- a/packages/artifacts/__tests__/artifactAiSessions.test.ts
+++ b/packages/artifacts/__tests__/artifactAiSessions.test.ts
@@ -1274,6 +1274,16 @@ describe('ArtifactSessionLink types', () => {
     expect(result.success).toBe(false);
   });
 
+  it.each([-1, 1.5])('rejects invalid linkedAt value %s', (linkedAt) => {
+    const result = ArtifactSessionLinkSchema.safeParse({
+      sessionId: 'session-1',
+      artifactId: 'artifact-1',
+      linkedAt,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
   it('should reject a link missing each required field independently', () => {
     const validLink = {
       sessionId: 'session-1',

--- a/packages/artifacts/src/ArtifactsSlice.ts
+++ b/packages/artifacts/src/ArtifactsSlice.ts
@@ -277,7 +277,8 @@ export function createArtifactsSlice<
             if (index === -1) {
               pinnedArtifactIds.push(id);
             } else {
-              pinnedArtifactIds.splice(index, 1);
+              draft.artifacts.config.pinnedArtifactIds =
+                pinnedArtifactIds.filter((candidate) => candidate !== id);
             }
           }),
         );

--- a/packages/artifacts/src/ArtifactsSlice.ts
+++ b/packages/artifacts/src/ArtifactsSlice.ts
@@ -52,6 +52,10 @@ export type ArtifactsSliceState = {
     deleteArtifact: (id: string) => void;
     setCurrentArtifact: (id?: string) => void;
     setArtifactOrder: (artifactOrder: string[]) => void;
+    /** Pins an artifact when unpinned, or unpins it when already pinned. */
+    togglePinArtifact: (id: string) => void;
+    /** Returns whether an artifact is pinned in the workspace. */
+    isPinnedArtifact: (id: string) => boolean;
     getArtifact: (id: string) => ArtifactMetadataType | undefined;
   };
 };
@@ -222,6 +226,10 @@ export function createArtifactsSlice<
               draft.artifacts.config.artifactOrder.filter(
                 (candidate: string) => candidate !== id,
               );
+            draft.artifacts.config.pinnedArtifactIds =
+              draft.artifacts.config.pinnedArtifactIds.filter(
+                (candidate: string) => candidate !== id,
+              );
             if (draft.artifacts.config.currentArtifactId === id) {
               draft.artifacts.config.currentArtifactId = getFirstArtifactId(
                 draft.artifacts.config,
@@ -258,6 +266,25 @@ export function createArtifactsSlice<
             }
           }),
         );
+      },
+
+      togglePinArtifact(id) {
+        set((state) =>
+          produce(state, (draft) => {
+            if (!draft.artifacts.config.artifactsById[id]) return;
+            const pinnedArtifactIds = draft.artifacts.config.pinnedArtifactIds;
+            const index = pinnedArtifactIds.indexOf(id);
+            if (index === -1) {
+              pinnedArtifactIds.push(id);
+            } else {
+              pinnedArtifactIds.splice(index, 1);
+            }
+          }),
+        );
+      },
+
+      isPinnedArtifact(id) {
+        return get().artifacts.config.pinnedArtifactIds.includes(id);
       },
 
       getArtifact(id) {

--- a/packages/artifacts/src/ArtifactsSliceConfig.ts
+++ b/packages/artifacts/src/ArtifactsSliceConfig.ts
@@ -13,31 +13,8 @@ export type ArtifactMetadata = z.infer<typeof ArtifactMetadata>;
 export const ArtifactsSliceConfig = z.object({
   artifactsById: z.record(z.string(), ArtifactMetadata).default({}),
   artifactOrder: z.array(z.string()).default([]),
+  /** Artifact IDs pinned in workspace navigation. */
+  pinnedArtifactIds: z.array(z.string()).default([]),
   currentArtifactId: z.string().optional(),
 });
 export type ArtifactsSliceConfig = z.infer<typeof ArtifactsSliceConfig>;
-
-/**
- * Type of relationship between an AI session and an artifact.
- */
-export type ArtifactSessionLinkType = 'created' | 'attached';
-
-/**
- * A link between an AI session and an artifact with metadata.
- */
-export type ArtifactSessionLink = {
-  sessionId: string;
-  artifactId: string;
-  createdAt: number; // Unix timestamp in milliseconds
-  linkType: ArtifactSessionLinkType;
-};
-
-/**
- * Zod schema for ArtifactSessionLink validation.
- */
-export const ArtifactSessionLinkSchema = z.object({
-  sessionId: z.string(),
-  artifactId: z.string(),
-  createdAt: z.number(),
-  linkType: z.enum(['created', 'attached']),
-});

--- a/packages/artifacts/src/ai/ArtifactSessionLink.ts
+++ b/packages/artifacts/src/ai/ArtifactSessionLink.ts
@@ -15,6 +15,6 @@ export const ArtifactSessionLinkSchema = z
   .object({
     sessionId: z.string(),
     artifactId: z.string(),
-    linkedAt: z.number(),
+    linkedAt: z.number().int().nonnegative(),
   })
   .strict();

--- a/packages/artifacts/src/ai/ArtifactSessionLink.ts
+++ b/packages/artifacts/src/ai/ArtifactSessionLink.ts
@@ -1,0 +1,20 @@
+import {z} from 'zod';
+
+/**
+ * An association between an AI session and an artifact.
+ */
+export type ArtifactSessionLink = {
+  sessionId: string;
+  artifactId: string;
+  /** Unix timestamp in milliseconds when the association was established. */
+  linkedAt: number;
+};
+
+/** Zod schema for persisted session-to-artifact associations. */
+export const ArtifactSessionLinkSchema = z
+  .object({
+    sessionId: z.string(),
+    artifactId: z.string(),
+    linkedAt: z.number(),
+  })
+  .strict();

--- a/packages/artifacts/src/ai/artifactAiSessionHelpers.ts
+++ b/packages/artifacts/src/ai/artifactAiSessionHelpers.ts
@@ -3,13 +3,11 @@ import {
   ChatSessionSchema,
   getAiRunContextItems,
 } from '@sqlrooms/ai-config';
-import type {
-  ArtifactMetadata,
-  ArtifactSessionLink,
-} from '../ArtifactsSliceConfig';
+import type {ArtifactMetadata} from '../ArtifactsSliceConfig';
+import type {ArtifactSessionLink} from './ArtifactSessionLink';
 
 /**
- * Minimal AI session fields needed by artifact ownership helpers.
+ * Minimal AI session fields needed by artifact association helpers.
  */
 export type ArtifactAiSession = Pick<
   ChatSessionSchema,
@@ -42,7 +40,7 @@ export type ArtifactAiSessionFilterOptions = {
 /**
  * Returns true only when the session is explicitly linked to the artifact.
  *
- * Missing ownership is treated as unowned, not as visible everywhere.
+ * A missing association is treated as unassociated, not as visible everywhere.
  *
  */
 export function isAiSessionVisibleForArtifact({
@@ -132,7 +130,7 @@ export function getLatestAiSessionIdForArtifact({
       .map((link) => link.sessionId),
   );
 
-  // Sort by session.lastOpenedAt (not link.createdAt)
+  // Sort by session.lastOpenedAt (not link.linkedAt)
   return sessions
     .filter((session) => linkedSessionIds.has(session.id))
     .sort((a, b) => (b.lastOpenedAt ?? 0) - (a.lastOpenedAt ?? 0))[0]?.id;
@@ -292,7 +290,7 @@ export function getRunningAiSessionCountsByArtifact({
 }
 
 /**
- * Input for removing stale artifact AI ownership entries.
+ * Input for removing stale artifact AI associations.
  */
 export type CleanupSessionArtifactLinksOptions = {
   sessionArtifactLinks: ArtifactSessionLink[];
@@ -330,7 +328,7 @@ function createArtifactContextItem(
 }
 
 /**
- * Input for deriving run-context items from artifact AI ownership.
+ * Input for deriving run-context items from artifact AI associations.
  */
 export type GetOwningArtifactRunContextItemsOptions = {
   sessionId: string;
@@ -338,7 +336,7 @@ export type GetOwningArtifactRunContextItemsOptions = {
   artifactsById: Record<string, ArtifactMetadata>;
   /** Explicit context items selected by the user or host app. */
   extraItems?: AiRunContextItem[];
-  /** Optional artifact-type allow-list predicate for implicit ownership. */
+  /** Optional artifact-type allow-list predicate for implicit associations. */
   isSupportedArtifactType?: (artifactType: string) => boolean;
   /**
    * Artifact the run is being initiated from (for example the currently
@@ -405,7 +403,7 @@ export function getOwningArtifactRunContextItems({
 
 /**
  * Returns all artifact IDs associated with a given AI session.
- * Preserves order by createdAt (oldest first).
+ * Preserves order by linkedAt (oldest first).
  */
 export function getArtifactIdsForAiSession({
   sessionArtifactLinks,
@@ -416,7 +414,7 @@ export function getArtifactIdsForAiSession({
 }): string[] {
   return sessionArtifactLinks
     .filter((link) => link.sessionId === sessionId)
-    .sort((a, b) => a.createdAt - b.createdAt)
+    .sort((a, b) => a.linkedAt - b.linkedAt)
     .map((link) => link.artifactId);
 }
 
@@ -433,21 +431,5 @@ export function getLatestArtifactIdForAiSession({
 }): string | undefined {
   return sessionArtifactLinks
     .filter((link) => link.sessionId === sessionId)
-    .sort((a, b) => b.createdAt - a.createdAt)[0]?.artifactId;
-}
-
-/**
- * Returns the session that created this artifact (linkType: 'created').
- * Returns undefined if artifact was not created by any session.
- */
-export function getCreatorSessionIdForArtifact({
-  sessionArtifactLinks,
-  artifactId,
-}: {
-  sessionArtifactLinks: ArtifactSessionLink[];
-  artifactId: string;
-}): string | undefined {
-  return sessionArtifactLinks.find(
-    (link) => link.artifactId === artifactId && link.linkType === 'created',
-  )?.sessionId;
+    .sort((a, b) => b.linkedAt - a.linkedAt)[0]?.artifactId;
 }

--- a/packages/artifacts/src/ai/artifactAiSlice.ts
+++ b/packages/artifacts/src/ai/artifactAiSlice.ts
@@ -18,29 +18,23 @@ import {produce} from 'immer';
 import {StoreApi} from 'zustand';
 import {z} from 'zod';
 import type {ArtifactsSliceState} from '../ArtifactsSlice';
-import {
-  ArtifactSessionLinkSchema,
-  type ArtifactSessionLinkType,
-} from '../ArtifactsSliceConfig';
+import {ArtifactSessionLinkSchema} from './ArtifactSessionLink';
 import {
   cleanupSessionArtifactLinks,
   getLatestAiSessionIdForArtifact,
   getArtifactIdsForAiSession,
   getLatestArtifactIdForAiSession,
-  getCreatorSessionIdForArtifact,
 } from './artifactAiSessionHelpers';
 
 /**
  * Persisted configuration for artifact-owned AI sessions.
  *
- * `sessionArtifactLinks` is an array of links between sessions and artifacts,
- * each with metadata (createdAt, linkType).
+ * `sessionArtifactLinks` is an array of associations between sessions and
+ * artifacts.
  */
 export const ArtifactAiConfig = z
   .object({
     sessionArtifactLinks: z.array(ArtifactSessionLinkSchema).default([]),
-    /** IDs of pinned artifacts */
-    pinnedArtifactIds: z.array(z.string()).optional(),
   })
   .strict();
 export type ArtifactAiConfig = z.infer<typeof ArtifactAiConfig>;
@@ -57,11 +51,7 @@ export type ArtifactAiSliceState = {
     config: ArtifactAiConfig;
     setConfig: (config: z.input<typeof ArtifactAiConfig>) => void;
 
-    addSessionArtifactLink: (
-      sessionId: string,
-      artifactId: string,
-      linkType: ArtifactSessionLinkType,
-    ) => void;
+    addSessionArtifactLink: (sessionId: string, artifactId: string) => void;
     removeSessionArtifactLink: (sessionId: string, artifactId: string) => void;
     removeAllLinksForSession: (sessionId: string) => void;
     removeAllLinksForArtifact: (artifactId: string) => void;
@@ -69,10 +59,6 @@ export type ArtifactAiSliceState = {
     getArtifactIdsForSession: (sessionId: string) => string[];
     getSessionIdsForArtifact: (artifactId: string) => string[];
     getLatestArtifactForSession: (sessionId: string) => string | undefined;
-    getCreatorSessionForArtifact: (artifactId: string) => string | undefined;
-    togglePinArtifact: (artifactId: string) => void;
-    isPinnedArtifact: (artifactId: string) => boolean;
-
     createArtifactScopedSession: (
       name?: string,
       modelProvider?: string,
@@ -126,7 +112,7 @@ export type RoomStateWithArtifactAi = BaseRoomStoreState &
  *
  * The slice uses this snapshot to avoid running session/artifact alignment for
  * unrelated room-store updates while still reacting to artifact selection, AI
- * session config, artifact registry, and session ownership changes.
+ * session config, artifact registry, and session association changes.
  */
 type ArtifactAiSyncSnapshot = {
   currentArtifactId?: string;
@@ -153,8 +139,9 @@ export type CreateArtifactAiSliceOptions = {
  *
  * Compose this with `createArtifactsSlice` and `createAiSlice` when a room wants
  * AI chats to be scoped to the currently selected artifact. The slice stores
- * ownership separately from AI sessions, creates artifact-scoped sessions, and
- * keeps the current AI session aligned with `artifacts.config.currentArtifactId`.
+ * associations separately from AI sessions, creates artifact-scoped sessions,
+ * and keeps the current AI session aligned with
+ * `artifacts.config.currentArtifactId`.
  */
 export function createArtifactAiSlice<
   TRoomState extends RoomStateWithArtifactAi = RoomStateWithArtifactAi,
@@ -207,7 +194,7 @@ export function createArtifactAiSlice<
       );
     };
 
-    const syncForkedSessionArtifactOwnership = () => {
+    const syncForkedSessionArtifactAssociations = () => {
       const state = get();
       const sessionIds = new Set(
         state.ai.config.sessions.map((session) => session.id),
@@ -216,7 +203,7 @@ export function createArtifactAiSlice<
         state.ai.config.sessionForks ?? {},
       ).flatMap(([targetSessionId, forkOrigin]) => {
         if (!sessionIds.has(targetSessionId)) return [];
-        // Seed ownership only once: skip if the fork already has any link.
+        // Seed associations only once: skip if the fork already has any link.
         if (
           state.artifactAi.config.sessionArtifactLinks.some(
             (link) => link.sessionId === targetSessionId,
@@ -237,7 +224,7 @@ export function createArtifactAiSlice<
             return {
               targetSessionId,
               artifactId: link.artifactId,
-              createdAt: link.createdAt,
+              linkedAt: link.linkedAt,
             };
           });
       });
@@ -249,15 +236,14 @@ export function createArtifactAiSlice<
           for (const {
             targetSessionId,
             artifactId,
-            createdAt,
+            linkedAt,
           } of inheritedEntries) {
             draft.artifactAi.config.sessionArtifactLinks.push({
               sessionId: targetSessionId,
               artifactId,
               // Preserve source ordering so the fork resolves to the same
               // primary artifact even when several links are inherited.
-              createdAt,
-              linkType: 'attached',
+              linkedAt,
             });
           }
         }),
@@ -271,7 +257,7 @@ export function createArtifactAiSlice<
       if (artifactAiSyncing || artifactAiSyncSuspended) return;
       artifactAiSyncing = true;
       try {
-        syncForkedSessionArtifactOwnership();
+        syncForkedSessionArtifactAssociations();
         cleanupSessionArtifacts();
         const state = get();
         const currentArtifactId = state.artifacts.config.currentArtifactId;
@@ -440,7 +426,7 @@ export function createArtifactAiSlice<
           );
         },
 
-        addSessionArtifactLink: (sessionId, artifactId, linkType) => {
+        addSessionArtifactLink: (sessionId, artifactId) => {
           set((state) =>
             produce(state, (draft: TRoomState) => {
               const links = draft.artifactAi.config.sessionArtifactLinks;
@@ -456,16 +442,8 @@ export function createArtifactAiSlice<
                 links.push({
                   sessionId,
                   artifactId,
-                  createdAt: Date.now(),
-                  linkType,
+                  linkedAt: Date.now(),
                 });
-              } else if (
-                existingLink.linkType === 'attached' &&
-                linkType === 'created'
-              ) {
-                // Creation is durable provenance. Promote an existing link
-                // without changing its ordering timestamp; never downgrade it.
-                existingLink.linkType = 'created';
               }
             }),
           );
@@ -527,7 +505,7 @@ export function createArtifactAiSlice<
             .artifactAi.config.sessionArtifactLinks.filter(
               (link) => link.artifactId === artifactId,
             )
-            .sort((a, b) => a.createdAt - b.createdAt)
+            .sort((a, b) => a.linkedAt - b.linkedAt)
             .map((link) => link.sessionId);
         },
 
@@ -536,38 +514,6 @@ export function createArtifactAiSlice<
             sessionArtifactLinks: get().artifactAi.config.sessionArtifactLinks,
             sessionId,
           });
-        },
-
-        getCreatorSessionForArtifact: (artifactId) => {
-          return getCreatorSessionIdForArtifact({
-            sessionArtifactLinks: get().artifactAi.config.sessionArtifactLinks,
-            artifactId,
-          });
-        },
-
-        togglePinArtifact: (artifactId) => {
-          set((state) =>
-            produce(state, (draft) => {
-              const pinnedArtifactIds =
-                draft.artifactAi.config.pinnedArtifactIds;
-              const index = pinnedArtifactIds?.indexOf(artifactId) ?? -1;
-              if (index === -1) {
-                if (!draft.artifacts.config.artifactsById[artifactId]) return;
-                if (!pinnedArtifactIds) {
-                  draft.artifactAi.config.pinnedArtifactIds = [artifactId];
-                } else {
-                  pinnedArtifactIds.push(artifactId);
-                }
-              } else {
-                pinnedArtifactIds?.splice(index, 1);
-              }
-            }),
-          );
-        },
-
-        isPinnedArtifact: (artifactId) => {
-          const pinnedIds = get().artifactAi.config.pinnedArtifactIds ?? [];
-          return pinnedIds.includes(artifactId);
         },
 
         // === INITIALIZATION ===
@@ -607,7 +553,6 @@ export function createArtifactAiSlice<
             get().artifactAi.addSessionArtifactLink(
               sessionId,
               currentArtifactId,
-              'attached',
             );
             return sessionId;
           } finally {

--- a/packages/artifacts/src/ai/index.ts
+++ b/packages/artifacts/src/ai/index.ts
@@ -44,7 +44,6 @@ export {
   isAiSessionVisibleForArtifact,
   getArtifactIdsForAiSession,
   getLatestArtifactIdForAiSession,
-  getCreatorSessionIdForArtifact,
 } from './artifactAiSessionHelpers';
 export type {
   ArtifactAiSession,
@@ -58,8 +57,5 @@ export type {
   EmptyArtifactAiSessionsForArtifactOptions,
   GetOwningArtifactRunContextItemsOptions,
 } from './artifactAiSessionHelpers';
-export {ArtifactSessionLinkSchema} from '../ArtifactsSliceConfig';
-export type {
-  ArtifactSessionLink,
-  ArtifactSessionLinkType,
-} from '../ArtifactsSliceConfig';
+export {ArtifactSessionLinkSchema} from './ArtifactSessionLink';
+export type {ArtifactSessionLink} from './ArtifactSessionLink';

--- a/packages/artifacts/src/index.ts
+++ b/packages/artifacts/src/index.ts
@@ -7,15 +7,15 @@ export {
   ArtifactMetadata,
   ArtifactsSliceConfig,
   ArtifactType,
-  ArtifactSessionLinkSchema,
 } from './ArtifactsSliceConfig';
 export type {
   ArtifactMetadata as ArtifactMetadataType,
   ArtifactsSliceConfig as ArtifactsSliceConfigType,
   ArtifactType as ArtifactTypeType,
-  ArtifactSessionLink,
-  ArtifactSessionLinkType,
 } from './ArtifactsSliceConfig';
+
+export {ArtifactSessionLinkSchema} from './ai/ArtifactSessionLink';
+export type {ArtifactSessionLink} from './ai/ArtifactSessionLink';
 
 export {
   createArtifactTypeFromStatefulBlock,

--- a/packages/documents/__tests__/documentsCrdt.test.ts
+++ b/packages/documents/__tests__/documentsCrdt.test.ts
@@ -148,6 +148,13 @@ describe('documents CRDT mirrors', () => {
       type: 'dashboard',
       title: 'Dashboard',
     });
+    const removedDocumentId = store.getState().artifacts.createArtifact({
+      id: 'removed-document',
+      type: 'document',
+      title: 'Removed document',
+    });
+    store.getState().artifacts.togglePinArtifact(dashboardId);
+    store.getState().artifacts.togglePinArtifact(removedDocumentId);
     store.setState((state) => ({
       ...state,
       artifacts: {
@@ -179,6 +186,9 @@ describe('documents CRDT mirrors', () => {
       dashboardId,
       'doc-1',
       'doc-2',
+    ]);
+    expect(store.getState().artifacts.config.pinnedArtifactIds).toEqual([
+      dashboardId,
     ]);
   });
 

--- a/packages/documents/__tests__/startBlockScopedChat.test.ts
+++ b/packages/documents/__tests__/startBlockScopedChat.test.ts
@@ -104,8 +104,7 @@ describe('startBlockScopedChat', () => {
         {
           sessionId: 'finished-session',
           artifactId: 'doc-1',
-          createdAt: 1,
-          linkType: 'attached',
+          linkedAt: 1,
         },
       ],
       getSessionDraftContextItemIds: (sessionId) =>
@@ -159,14 +158,12 @@ describe('startBlockScopedChat', () => {
         {
           sessionId: 'multi-session',
           artifactId: 'doc-1',
-          createdAt: 1,
-          linkType: 'created',
+          linkedAt: 1,
         },
         {
           sessionId: 'multi-session',
           artifactId: 'other-doc',
-          createdAt: 2,
-          linkType: 'attached',
+          linkedAt: 2,
         },
       ],
       getSessionDraftContextItemIds: (sessionId) =>
@@ -211,8 +208,7 @@ describe('startBlockScopedChat', () => {
         {
           sessionId: 'running-session',
           artifactId: 'doc-1',
-          createdAt: 1,
-          linkType: 'attached',
+          linkedAt: 1,
         },
       ],
       createArtifactScopedSession: jest.fn(() => 'should-not-create'),

--- a/packages/documents/src/crdt.ts
+++ b/packages/documents/src/crdt.ts
@@ -143,7 +143,8 @@ export type CreateDocumentsCrdtMirrorOptions = {
  * Creates a CRDT mirror for Markdown documents, block documents, and their
  * artifact metadata.
  *
- * The room's current artifact selection is intentionally kept local.
+ * The room's current artifact selection and pinned artifacts are intentionally
+ * kept local.
  *
  * TODO: Once the Tiptap document schema settles, replace the Markdown body
  * snapshot in this mirror with a structured ProseMirror/Loro body synced via
@@ -289,6 +290,9 @@ export function createDocumentsCrdtMirror<
         ...incomingSyncedOrder,
         ...missingSyncedOrder,
       ];
+      const pinnedArtifactIds = currentArtifactsConfig.pinnedArtifactIds.filter(
+        (id) => Boolean(artifactsById[id]),
+      );
       const currentArtifactId = currentArtifactsConfig.currentArtifactId;
 
       set((state: S) => ({
@@ -298,6 +302,7 @@ export function createDocumentsCrdtMirror<
           config: ArtifactsSliceConfig.parse({
             artifactsById,
             artifactOrder,
+            pinnedArtifactIds,
             currentArtifactId:
               currentArtifactId && artifactsById[currentArtifactId]
                 ? currentArtifactId


### PR DESCRIPTION
## Summary

- make `ArtifactSessionLink` a pure session–artifact association with `linkedAt`, removing the overloaded creator-provenance flag and unused creator lookup APIs
- move artifact pinning from the AI companion slice into the base artifacts workspace slice
- clean up pins when artifacts are deleted and simplify command middleware that establishes chat associations
- document the prerelease migration and update affected consumers/tests

## Why

PR #831 mixed two unrelated concerns into artifact AI state: generic workspace pinning and partial creator provenance. Pinning belongs to the artifact workspace regardless of whether AI is enabled, while session links only need to answer which chats and artifacts are associated. Removing the unused provenance distinction avoids creating a second source of truth or implying an audit history the model does not actually maintain.

This is a clean prerelease API/config break. Apps using the previous shape must move `pinnedArtifactIds` to `artifacts.config`, rename link `createdAt` to `linkedAt`, and stop passing `linkType`.

## Validation

- `pnpm --filter @sqlrooms/artifacts test --runInBand` — 53 tests passed
- focused Documents and CLI association/run-context tests passed
- typechecks passed for Artifacts, Documents, and SQLRooms CLI
- Artifacts and SQLRooms CLI lint passed
- push hook completed repository-wide `knip` and Turbo typecheck


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added artifact pinning with support for viewing and toggling pinned artifacts.
  * Deleting an artifact now removes it from the pinned list.

* **Updates**
  * Simplified AI session–artifact relationships to represent associations with timestamps.
  * Removed creation-versus-attachment distinctions and related provenance information.

* **Documentation**
  * Updated artifact API documentation and upgrade guidance to reflect the new pinning and association model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->