### PR TITLE
ci(docs): publish API reference from release tags

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -193,6 +193,7 @@ jobs:
         with:
           name: docs-dist
           path: site/docs/.vitepress/dist
+          include-hidden-files: true
 
   deploy-docs:
     needs: build-docs

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           result-encoding: string
           script: |
-            const semverTag = /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?(?:\+[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?$/;
+            const semverTag = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
             const requestedRef = process.env.REQUESTED_API_REF.trim();
 
             if (requestedRef) {

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,35 +1,81 @@
 name: Deploy docs
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'docs/**'
-      - '.github/workflows/deploy-docs.yml'
+  workflow_call:
+    inputs:
+      content_ref:
+        description: 'Git ref containing the non-API documentation'
+        required: false
+        default: main
+        type: string
+      api_ref:
+        description: 'Published release tag used to generate API documentation'
+        required: true
+        type: string
+    secrets:
+      DOCS_DEPLOY_KEY:
+        required: true
   workflow_dispatch:
+    inputs:
+      content_ref:
+        description: 'Git ref containing the non-API documentation'
+        required: false
+        default: main
+        type: string
+      api_ref:
+        description: 'Published release tag for the API docs (blank uses the newest v* tag)'
+        required: false
+        type: string
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment
 concurrency:
   group: pages
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   build-docs:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout documentation content
         uses: actions/checkout@v6
         with:
-          lfs: true # Enable Git LFS for this checkout
+          ref: ${{ inputs.content_ref || 'main' }}
+          fetch-depth: 0
+          lfs: true
+          path: site
+
+      - name: Resolve published API release
+        id: api-release
+        working-directory: site
+        env:
+          REQUESTED_API_REF: ${{ inputs.api_ref }}
+        run: |
+          api_ref="$REQUESTED_API_REF"
+          if [ -z "$api_ref" ]; then
+            api_ref=$(git for-each-ref --count=1 --sort=-creatordate --format='%(refname:short)' 'refs/tags/v*')
+          fi
+
+          if [[ ! "$api_ref" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Could not resolve a valid published release tag: $api_ref" >&2
+            exit 1
+          fi
+
+          echo "api_ref=$api_ref" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout published API source
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.api-release.outputs.api_ref }}
+          fetch-depth: 0
+          lfs: false
+          path: api-source
 
       - name: Verify Git LFS media
+        working-directory: site
         run: |
           git lfs ls-files | wc -l
           du -sh docs/public/media
@@ -46,61 +92,58 @@ jobs:
           echo "After cleanup:"
           df -h
           df -i
-          du -sh /usr/share/dotnet /opt/ghc /usr/local/lib/android 2>/dev/null || true
 
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
+          version: 11.1.2
           run_install: false
 
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: 'pnpm'
+          cache: pnpm
+          cache-dependency-path: |
+            site/pnpm-lock.yaml
+            api-source/pnpm-lock.yaml
 
-      - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+      - name: Install API source dependencies
+        run: pnpm --dir api-source install --frozen-lockfile
 
-      - name: Cache for Turbo
-        uses: actions/cache@v5
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-turbo-
+      - name: Build published packages
+        run: pnpm --dir api-source build
 
-      - name: Print TypeScript, TypeDoc, and plugin versions
-        run: |
-          pnpm list typescript typedoc typedoc-vitepress-theme typedoc-plugin-markdown typedoc-plugin-zod || true
-          npx tsc --version
-          npx typedoc --version
+      - name: Build API docs from published source
+        run: pnpm --dir api-source run docs:clean && pnpm --dir api-source run docs:build:typedoc
 
-      - name: List files in packages/duckdb/src
-        run: ls -l packages/duckdb/src
-      - name: Build packages (required for TypeDoc module resolution)
-        run: pnpm build
+      - name: Assemble versioned documentation
+        run: >-
+          node site/scripts/assemble-versioned-docs.mjs
+          --site site
+          --api-source api-source
+          --api-ref ${{ steps.api-release.outputs.api_ref }}
 
-      - name: Build API docs (TypeDoc)
-        run: pnpm run docs:clean && pnpm run docs:build:typedoc
+      - name: Reclaim API build output
+        run: pnpm --dir api-source run clean
 
-      - name: Reclaim disk before VitePress build
-        run: |
-          pnpm run clean
-          df -h
-          df -i
+      - name: Install documentation dependencies
+        run: pnpm --dir site install --frozen-lockfile
 
-      - name: Build docs site (VitePress)
-        run: pnpm run docs:build:vitepress
+      - name: Build docs site
+        run: pnpm --dir site run docs:build:vitepress
+
+      - name: Verify rendered API release
+        run: node site/scripts/verify-docs-release.mjs --site site
 
       - name: Upload docs artifact
         uses: actions/upload-artifact@v7
         with:
           name: docs-dist
-          path: docs/.vitepress/dist
+          path: site/docs/.vitepress/dist
 
   deploy-docs:
     needs: build-docs
-    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment:
       name: github-pages
@@ -110,22 +153,22 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: docs-dist
-          path: docs/.vitepress/dist
+          path: docs-dist
 
       - name: Create CNAME file
-        run: echo "sqlrooms.org" > docs/.vitepress/dist/CNAME
+        run: echo "sqlrooms.org" > docs-dist/CNAME
 
       - name: Upload artifact to GitHub Pages
         uses: actions/upload-pages-artifact@v5
         with:
-          path: docs/.vitepress/dist
+          path: docs-dist
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
           deploy_key: ${{ secrets.DOCS_DEPLOY_KEY }}
           external_repository: sqlrooms/sqlrooms.github.io
-          publish_dir: docs/.vitepress/dist
+          publish_dir: docs-dist
           publish_branch: main
           force_orphan: true
           user_name: 'github-actions[bot]'

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -29,8 +29,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -39,6 +37,8 @@ concurrency:
 jobs:
   build-docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout documentation content
         uses: actions/checkout@v6
@@ -47,32 +47,84 @@ jobs:
           fetch-depth: 0
           lfs: true
           path: site
+          persist-credentials: false
 
       - name: Resolve published API release
         id: api-release
-        working-directory: site
+        uses: actions/github-script@v8
         env:
           REQUESTED_API_REF: ${{ inputs.api_ref }}
-        run: |
-          api_ref="$REQUESTED_API_REF"
-          if [ -z "$api_ref" ]; then
-            api_ref=$(git for-each-ref --count=1 --sort=-creatordate --format='%(refname:short)' 'refs/tags/v*')
-          fi
+        with:
+          result-encoding: string
+          script: |
+            const semverTag = /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?(?:\+[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?$/;
+            const requestedRef = process.env.REQUESTED_API_REF.trim();
 
-          if [[ ! "$api_ref" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]]; then
-            echo "Could not resolve a valid published release tag: $api_ref" >&2
-            exit 1
-          fi
+            if (requestedRef) {
+              if (!semverTag.test(requestedRef)) {
+                core.setFailed(`Invalid published release tag: ${requestedRef}`);
+                return;
+              }
 
-          echo "api_ref=$api_ref" >> "$GITHUB_OUTPUT"
+              let requestedRelease;
+              try {
+                ({data: requestedRelease} =
+                  await github.rest.repos.getReleaseByTag({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    tag: requestedRef,
+                  }));
+              } catch (error) {
+                if (error.status === 404) {
+                  core.setFailed(`${requestedRef} is not a published release`);
+                  return;
+                }
+                throw error;
+              }
+
+              if (requestedRelease.draft || !requestedRelease.published_at) {
+                core.setFailed(`${requestedRef} is not a published release`);
+                return;
+              }
+
+              return requestedRef;
+            }
+
+            const releases = await github.paginate(
+              github.rest.repos.listReleases,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                per_page: 100,
+              },
+            );
+            const latestRelease = releases
+              .filter(
+                (release) =>
+                  !release.draft &&
+                  release.published_at &&
+                  semverTag.test(release.tag_name),
+              )
+              .sort(
+                (left, right) =>
+                  Date.parse(right.published_at) - Date.parse(left.published_at),
+              )[0];
+
+            if (!latestRelease) {
+              core.setFailed('Could not find a published semver release');
+              return;
+            }
+
+            return latestRelease.tag_name;
 
       - name: Checkout published API source
         uses: actions/checkout@v6
         with:
-          ref: ${{ steps.api-release.outputs.api_ref }}
+          ref: ${{ steps.api-release.outputs.result }}
           fetch-depth: 0
           lfs: false
           path: api-source
+          persist-credentials: false
 
       - name: Verify Git LFS media
         working-directory: site
@@ -122,7 +174,7 @@ jobs:
           node site/scripts/assemble-versioned-docs.mjs
           --site site
           --api-source api-source
-          --api-ref ${{ steps.api-release.outputs.api_ref }}
+          --api-ref ${{ steps.api-release.outputs.result }}
 
       - name: Reclaim API build output
         run: pnpm --dir api-source run clean
@@ -145,9 +197,13 @@ jobs:
   deploy-docs:
     needs: build-docs
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: https://sqlrooms.org
     steps:
       - name: Download docs artifact
         uses: actions/download-artifact@v8

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -34,6 +34,7 @@ on:
 
 permissions:
   contents: write
+  pages: write
   id-token: write
 
 concurrency:
@@ -43,6 +44,8 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.release-metadata.outputs.tag }}
     env:
       HUSKY: 0
     # only run publish if run manually or if commit starts with one of "feat|fix"
@@ -119,6 +122,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
 
+      - name: Read release metadata
+        id: release-metadata
+        run: |
+          version=$(node -p "require('./lerna.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+
       - name: Publish prerelease
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.version == 'prerelease' }}
         run: pnpm publish-prerelease
@@ -126,6 +136,9 @@ jobs:
       - name: Publish
         if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.version == 'prerelease') }}
         run: pnpm publish-release
+
+      - name: Verify packages are available from npm
+        run: pnpm verify-published-packages ${{ steps.release-metadata.outputs.version }}
 
       - name: Push version commit and tags
         if: ${{ success() }}
@@ -142,7 +155,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
-          tag=$(git describe --abbrev=0 --tags)
+          tag=${{ steps.release-metadata.outputs.tag }}
           if gh release view "$tag" >/dev/null 2>&1; then
             echo "Release $tag already exists, skipping"
             exit 0
@@ -152,3 +165,11 @@ jobs:
             prerelease_flag="--prerelease"
           fi
           gh release create "$tag" --title "$tag" --generate-notes ${prerelease_flag}
+
+  deploy-docs:
+    needs: publish
+    uses: ./.github/workflows/deploy-docs.yml
+    with:
+      content_ref: ${{ needs.publish.outputs.release_tag }}
+      api_ref: ${{ needs.publish.outputs.release_tag }}
+    secrets: inherit

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -33,9 +33,7 @@ on:
           - major
 
 permissions:
-  contents: write
-  pages: write
-  id-token: write
+  contents: read
 
 concurrency:
   group: npm-publish-${{ github.ref }}
@@ -44,6 +42,9 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     outputs:
       release_tag: ${{ steps.release-metadata.outputs.tag }}
     env:
@@ -137,9 +138,6 @@ jobs:
         if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.version == 'prerelease') }}
         run: pnpm publish-release
 
-      - name: Verify packages are available from npm
-        run: pnpm verify-published-packages ${{ steps.release-metadata.outputs.version }}
-
       - name: Push version commit and tags
         if: ${{ success() }}
         # CI already validated quality gates earlier; avoid local husky pre-push checks here.
@@ -149,6 +147,9 @@ jobs:
           git config lfs.https://github.com/sqlrooms/sqlrooms.git/info/lfs.locksverify false
           git push origin HEAD:${{ github.ref_name }}
           git push origin --tags
+
+      - name: Verify packages are available from npm
+        run: pnpm verify-published-packages ${{ steps.release-metadata.outputs.version }}
 
       - name: Create GitHub release
         if: ${{ success() }}
@@ -168,6 +169,10 @@ jobs:
 
   deploy-docs:
     needs: publish
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     uses: ./.github/workflows/deploy-docs.yml
     with:
       content_ref: ${{ needs.publish.outputs.release_tag }}

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -4,4 +4,4 @@ dist
 .vitepress/temp
 .vitepress/.temp
 .vitepress/*.timestamp-*.mjs
-
+.vitepress/api-release.generated.json

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,4 +1,6 @@
 import {createRequire} from 'node:module';
+import {existsSync, readFileSync} from 'node:fs';
+import {fileURLToPath} from 'node:url';
 import {defineConfig} from 'vitepress';
 import llmstxt from 'vitepress-plugin-llms';
 import {apiSidebarConfig} from './gen-api-sidebar.ts';
@@ -6,6 +8,26 @@ import {apiSidebarConfig} from './gen-api-sidebar.ts';
 const SITE_URL = 'https://sqlrooms.org';
 const require = createRequire(import.meta.url);
 const mermaidRequire = createRequire(require.resolve('mermaid/package.json'));
+const localVersion = require('../../lerna.json').version;
+
+function loadApiReleaseMetadata() {
+  const metadataPath = fileURLToPath(
+    new URL('./api-release.generated.json', import.meta.url),
+  );
+
+  if (existsSync(metadataPath)) {
+    return JSON.parse(readFileSync(metadataPath, 'utf8'));
+  }
+
+  return {
+    version: localVersion,
+    ref: `v${localVersion}`,
+    prerelease: localVersion.includes('-'),
+  };
+}
+
+const apiRelease = loadApiReleaseMetadata();
+const apiReleaseUrl = `https://github.com/sqlrooms/sqlrooms/releases/tag/${apiRelease.ref}`;
 
 function publicUrl(relativePath?: string) {
   const normalizedRelativePath = (relativePath || '').replace(/^\/+/, '');
@@ -194,6 +216,10 @@ Canonical package combos:
     ],
   ],
   themeConfig: {
+    apiRelease: {
+      ...apiRelease,
+      url: apiReleaseUrl,
+    },
     outline: 'deep',
     logo: '/logo.svg',
     search: {
@@ -207,6 +233,10 @@ Canonical package combos:
       {text: 'Examples', link: '/examples'},
       {text: 'Case Studies', link: '/case-studies'},
       {text: 'Get started', link: '/getting-started'},
+      {
+        text: `API v${apiRelease.version}`,
+        link: apiReleaseUrl,
+      },
       // {
       //   text: 'Join Slack',
       //   link: '/join-slack',

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -1,8 +1,8 @@
 <script setup>
 import DefaultTheme from 'vitepress/theme';
-import {ref, onMounted} from 'vue';
+import {computed, ref, onMounted} from 'vue';
 import {useData} from 'vitepress';
-const {frontmatter} = useData();
+const {frontmatter, page, theme} = useData();
 import CaseStudiesCarousel from './CaseStudiesCarousel.vue';
 
 const SHOW_BANNER = false; // Set to false to hide banner and margin everywhere
@@ -10,6 +10,10 @@ const SHOW_BANNER = false; // Set to false to hide banner and margin everywhere
 const BANNER_ID = 'sqlrooms-launch-2025';
 const open = ref(true);
 const currentYear = new Date().getFullYear();
+const isApiReference = computed(() =>
+  page.value.relativePath.startsWith('api/'),
+);
+const apiRelease = computed(() => theme.value.apiRelease);
 
 onMounted(() => {
   if (localStorage.getItem(`sqlrooms-banner-${BANNER_ID}`) === 'true') {
@@ -49,6 +53,18 @@ function dismiss() {
       <button @click="dismiss" aria-label="Close banner">&times;</button>
     </div>
     <DefaultTheme.Layout>
+      <template #doc-before>
+        <aside v-if="isApiReference" class="api-release-notice">
+          <span>
+            API reference for SQLRooms
+            <a :href="apiRelease.url">v{{ apiRelease.version }}</a>
+          </span>
+          <span v-if="apiRelease.prerelease" class="api-release-badge">
+            prerelease
+          </span>
+        </aside>
+      </template>
+
       <template #home-hero-image>
         <video
           class="video"

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -41,3 +41,32 @@
 .mermaid-diagram-error {
   text-align: left;
 }
+
+.api-release-notice {
+  align-items: center;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  color: var(--vp-c-text-2);
+  display: flex;
+  font-size: 0.875rem;
+  gap: 0.625rem;
+  justify-content: space-between;
+  margin-bottom: 1.5rem;
+  padding: 0.625rem 0.75rem;
+}
+
+.api-release-notice a {
+  color: var(--vp-c-brand-1);
+  font-weight: 600;
+}
+
+.api-release-badge {
+  background: var(--vp-c-warning-soft);
+  border-radius: 999px;
+  color: var(--vp-c-warning-1);
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.125rem 0.5rem;
+  white-space: nowrap;
+}

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "typedoc:watch": "pnpm run check:typedoc-links && turbo typedoc -- -watch",
     "update-deps": "pnpm --filter '*' update --interactive",
     "update-readme": "node scripts/update-readme.mjs",
+    "verify-published-packages": "node scripts/verify-published-packages.mjs",
     "version-auto": "lerna version --conventional-commits --yes --sync-workspace-lock",
     "version-major": "lerna version major --yes --sync-workspace-lock",
     "version-minor": "lerna version minor --yes --sync-workspace-lock",

--- a/scripts/assemble-versioned-docs.mjs
+++ b/scripts/assemble-versioned-docs.mjs
@@ -1,0 +1,110 @@
+import {cp, mkdir, readFile, readdir, rm, writeFile} from 'node:fs/promises';
+import path from 'node:path';
+
+function readArguments(argv) {
+  const argumentsByName = new Map();
+
+  for (let index = 0; index < argv.length; index += 2) {
+    const name = argv[index];
+    const value = argv[index + 1];
+
+    if (!name?.startsWith('--') || !value) {
+      throw new Error(`Invalid argument near ${name || '<end>'}`);
+    }
+
+    argumentsByName.set(name.slice(2), value);
+  }
+
+  return argumentsByName;
+}
+
+async function readJson(filePath) {
+  return JSON.parse(await readFile(filePath, 'utf8'));
+}
+
+async function getPublicPackages(apiSourceDir) {
+  const packagesDir = path.join(apiSourceDir, 'packages');
+  const entries = await readdir(packagesDir, {withFileTypes: true});
+  const packages = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    try {
+      const packageJson = await readJson(
+        path.join(packagesDir, entry.name, 'package.json'),
+      );
+
+      if (packageJson.name?.startsWith('@sqlrooms/') && !packageJson.private) {
+        packages.push(packageJson);
+      }
+    } catch (error) {
+      if (error.code !== 'ENOENT') {
+        throw error;
+      }
+    }
+  }
+
+  return packages;
+}
+
+const args = readArguments(process.argv.slice(2));
+const siteDir = path.resolve(args.get('site') || 'site');
+const apiSourceDir = path.resolve(args.get('api-source') || 'api-source');
+const apiRef = args.get('api-ref');
+
+if (!apiRef) {
+  throw new Error('--api-ref is required');
+}
+
+const lernaConfig = await readJson(path.join(apiSourceDir, 'lerna.json'));
+const version = lernaConfig.version;
+const expectedRef = `v${version}`;
+
+if (apiRef !== expectedRef) {
+  throw new Error(
+    `API ref ${apiRef} does not match the source version ${expectedRef}`,
+  );
+}
+
+const publicPackages = await getPublicPackages(apiSourceDir);
+const mismatchedPackages = publicPackages.filter(
+  (packageJson) => packageJson.version !== version,
+);
+
+if (publicPackages.length === 0) {
+  throw new Error('No public @sqlrooms packages were found in the API source');
+}
+
+if (mismatchedPackages.length > 0) {
+  throw new Error(
+    `Packages do not match ${version}: ${mismatchedPackages
+      .map((packageJson) => `${packageJson.name}@${packageJson.version}`)
+      .join(', ')}`,
+  );
+}
+
+const generatedApiDir = path.join(apiSourceDir, 'docs', 'api');
+const siteApiDir = path.join(siteDir, 'docs', 'api');
+const metadataPath = path.join(
+  siteDir,
+  'docs',
+  '.vitepress',
+  'api-release.generated.json',
+);
+const metadata = {
+  version,
+  ref: apiRef,
+  prerelease: version.includes('-'),
+};
+
+await rm(siteApiDir, {recursive: true, force: true});
+await cp(generatedApiDir, siteApiDir, {recursive: true});
+await mkdir(path.dirname(metadataPath), {recursive: true});
+await writeFile(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`);
+
+console.log(
+  `Assembled API documentation for ${apiRef} (${publicPackages.length} public packages)`,
+);

--- a/scripts/verify-docs-release.mjs
+++ b/scripts/verify-docs-release.mjs
@@ -1,0 +1,74 @@
+import {readFile, readdir} from 'node:fs/promises';
+import path from 'node:path';
+
+function readArguments(argv) {
+  const argumentsByName = new Map();
+
+  for (let index = 0; index < argv.length; index += 2) {
+    const name = argv[index];
+    const value = argv[index + 1];
+
+    if (!name?.startsWith('--') || !value) {
+      throw new Error(`Invalid argument near ${name || '<end>'}`);
+    }
+
+    argumentsByName.set(name.slice(2), value);
+  }
+
+  return argumentsByName;
+}
+
+const args = readArguments(process.argv.slice(2));
+const siteDir = path.resolve(args.get('site') || 'site');
+const metadata = JSON.parse(
+  await readFile(
+    path.join(siteDir, 'docs', '.vitepress', 'api-release.generated.json'),
+    'utf8',
+  ),
+);
+const apiDistDir = path.join(siteDir, 'docs', '.vitepress', 'dist', 'api');
+const apiPackages = (await readdir(apiDistDir, {withFileTypes: true})).filter(
+  (entry) => entry.isDirectory(),
+);
+
+if (apiPackages.length === 0) {
+  throw new Error('The rendered site contains no API package directories');
+}
+
+const representativePackage = apiPackages.find(
+  (entry) => entry.name === 'duckdb',
+)?.name;
+
+if (!representativePackage) {
+  throw new Error('The rendered site is missing the @sqlrooms/duckdb API docs');
+}
+
+const apiPage = await readFile(
+  path.join(apiDistDir, representativePackage, 'index.html'),
+  'utf8',
+);
+const homePage = await readFile(
+  path.join(siteDir, 'docs', '.vitepress', 'dist', 'index.html'),
+  'utf8',
+);
+const apiPageText = apiPage.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ');
+const homePageText = homePage.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ');
+
+if (
+  !apiPageText.includes(`API reference for SQLRooms v${metadata.version}`) ||
+  !apiPage.includes(metadata.ref)
+) {
+  throw new Error(
+    `The rendered API page does not identify release ${metadata.ref}`,
+  );
+}
+
+if (!homePageText.includes(`API v${metadata.version}`)) {
+  throw new Error(
+    `The rendered site navigation does not show API v${metadata.version}`,
+  );
+}
+
+console.log(
+  `Verified ${apiPackages.length} rendered API packages for ${metadata.ref}`,
+);

--- a/scripts/verify-published-packages.mjs
+++ b/scripts/verify-published-packages.mjs
@@ -1,0 +1,112 @@
+import {execFile} from 'node:child_process';
+import {readFile, readdir} from 'node:fs/promises';
+import path from 'node:path';
+import {promisify} from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const requestedVersion = process.argv[2];
+const registry = 'https://registry.npmjs.org/';
+const attempts = 8;
+const batchSize = 8;
+
+async function readJson(filePath) {
+  return JSON.parse(await readFile(filePath, 'utf8'));
+}
+
+async function getPublicPackages() {
+  const packagesDir = path.resolve('packages');
+  const entries = await readdir(packagesDir, {withFileTypes: true});
+  const packageNames = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    try {
+      const packageJson = await readJson(
+        path.join(packagesDir, entry.name, 'package.json'),
+      );
+
+      if (packageJson.name?.startsWith('@sqlrooms/') && !packageJson.private) {
+        packageNames.push(packageJson.name);
+      }
+    } catch (error) {
+      if (error.code !== 'ENOENT') {
+        throw error;
+      }
+    }
+  }
+
+  return packageNames.sort();
+}
+
+function wait(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function verifyPackage(packageName, version) {
+  let lastError;
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const {stdout} = await execFileAsync(
+        'npm',
+        [
+          'view',
+          `${packageName}@${version}`,
+          'version',
+          '--json',
+          `--registry=${registry}`,
+        ],
+        {encoding: 'utf8'},
+      );
+      const publishedVersion = JSON.parse(stdout);
+
+      if (publishedVersion === version) {
+        console.log(`Verified ${packageName}@${version}`);
+        return;
+      }
+
+      lastError = new Error(
+        `npm returned ${JSON.stringify(publishedVersion)} instead of ${version}`,
+      );
+    } catch (error) {
+      lastError = error;
+    }
+
+    if (attempt < attempts) {
+      await wait(attempt * 2_000);
+    }
+  }
+
+  throw new Error(
+    `Could not verify ${packageName}@${version}: ${lastError?.message}`,
+  );
+}
+
+const lernaConfig = await readJson(path.resolve('lerna.json'));
+
+if (!requestedVersion) {
+  throw new Error('Usage: verify-published-packages.mjs <version>');
+}
+
+if (requestedVersion !== lernaConfig.version) {
+  throw new Error(
+    `Requested version ${requestedVersion} does not match lerna.json version ${lernaConfig.version}`,
+  );
+}
+
+const packageNames = await getPublicPackages();
+
+for (let index = 0; index < packageNames.length; index += batchSize) {
+  await Promise.all(
+    packageNames
+      .slice(index, index + batchSize)
+      .map((packageName) => verifyPackage(packageName, requestedVersion)),
+  );
+}
+
+console.log(
+  `Verified ${packageNames.length} public packages at ${requestedVersion}`,
+);


### PR DESCRIPTION
## Summary

- build non-API documentation from a selectable content ref while generating API docs from an immutable published release tag
- make manual docs deployments default to `main` content plus the newest pushed `v*` tag, including prereleases
- trigger the same reusable docs workflow after npm publication and verify every public package is available before deployment
- show the exact API version and prerelease status in the site navigation and on every API page
- verify the assembled source versions and rendered release metadata before deployment

## Why

The previous docs workflow generated TypeDoc directly from `main` and only ran automatically for `docs/**` changes. API docs could therefore lag a release or move ahead of the packages on npm. Package READMEs are pulled into TypeDoc through package source directives, so they now come from the release-tag checkout together with the API source.

## Validation

- `pnpm build`
- generated TypeDoc from an actual `v0.29.0-rc.10` checkout
- assembled that API output into current non-API docs and ran `pnpm run docs:build:vitepress`
- `node scripts/verify-docs-release.mjs --site .`
- `node scripts/verify-published-packages.mjs 0.29.0-rc.10` (47 public packages)
- pre-push hooks: Knip, workspace typecheck, circular-dependency check, and full test suite
- Prettier, package sorting, YAML parsing, and `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added versioned API reference links and release metadata to documentation.
  * API pages now display release notices, version links, and prerelease indicators.

* **Improvements**
  * Documentation deployments support reusable workflows and configurable release inputs.
  * Publishing now automatically deploys matching versioned documentation and API references.
  * Added validation to prevent incomplete or mismatched documentation releases.
  * Added automated checks confirming packages and documentation match the published release version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->