### PR TITLE
fix(room-store): tolerate unavailable persistence storage

### DIFF
--- a/packages/room-store/README.md
+++ b/packages/room-store/README.md
@@ -115,11 +115,12 @@ project-owned store. See the
 full integration model, data flow, and examples.
 
 `persistSliceConfigs()` defaults to browser `localStorage`. If browser storage
-is `null`, cannot be accessed, or fails during an operation, the room state
-continues to work in memory and persistence is skipped. Read failures from an
-explicit custom storage adapter still propagate through Zustand's
-`onRehydrateStorage` callback so hosts can distinguish a failed load from an
-empty store; custom write and removal failures are logged and skipped.
+is `null`, cannot be accessed, or a raw storage operation fails, the room state
+continues to work in memory and persistence is skipped. Malformed persisted JSON
+and read failures from an explicit custom storage adapter still propagate
+through Zustand's `onRehydrateStorage` callback so hosts can distinguish a
+failed load from an empty store; custom write and removal failures are logged
+and skipped.
 
 Use the lower-level `createPersistenceController()` only when you need the same
 persistence policy outside a room store or Zustand persist. The controller is

--- a/packages/room-store/README.md
+++ b/packages/room-store/README.md
@@ -114,6 +114,13 @@ project-owned store. See the
 [Persistence developer guide](https://sqlrooms.org/persistence.html) for the
 full integration model, data flow, and examples.
 
+`persistSliceConfigs()` defaults to browser `localStorage`. If browser storage
+is `null`, cannot be accessed, or fails during an operation, the room state
+continues to work in memory and persistence is skipped. Read failures from an
+explicit custom storage adapter still propagate through Zustand's
+`onRehydrateStorage` callback so hosts can distinguish a failed load from an
+empty store; custom write and removal failures are logged and skipped.
+
 Use the lower-level `createPersistenceController()` only when you need the same
 persistence policy outside a room store or Zustand persist. The controller is
 storage-agnostic: hosts provide `load()` and `save()` adapter functions, while

--- a/packages/room-store/__tests__/createPersistHelpers.test.ts
+++ b/packages/room-store/__tests__/createPersistHelpers.test.ts
@@ -1,7 +1,12 @@
-import {describe, expect, it} from '@jest/globals';
+import {afterEach, describe, expect, it, jest} from '@jest/globals';
 import {AiSettingsSliceConfig} from '@sqlrooms/ai-config';
 import {z} from 'zod';
-import {createPersistHelpers} from '../src/createPersistHelpers';
+import {createStore, StateCreator} from 'zustand/vanilla';
+import {PersistStorage, StateStorage} from 'zustand/middleware';
+import {
+  createPersistHelpers,
+  persistSliceConfigs,
+} from '../src/createPersistHelpers';
 
 const PersistMergeInputSymbol = Symbol.for('sqlrooms.persist.mergeInput');
 
@@ -139,5 +144,136 @@ describe('createPersistHelpers.merge', () => {
       enabled: false,
       limit: 10,
     });
+  });
+});
+
+const CounterConfig = z.object({count: z.number()});
+
+type CounterState = {
+  counter: {
+    config: z.infer<typeof CounterConfig>;
+    increment: () => void;
+  };
+};
+
+const counterStateCreator: StateCreator<CounterState> = (set) => ({
+  counter: {
+    config: {count: 0},
+    increment: () =>
+      set((state) => ({
+        counter: {
+          ...state.counter,
+          config: {count: state.counter.config.count + 1},
+        },
+      })),
+  },
+});
+
+function createCounterStore(
+  storage?: PersistStorage<{counter: z.infer<typeof CounterConfig>}>,
+) {
+  return createStore(
+    persistSliceConfigs(
+      {
+        name: 'counter-test-storage',
+        sliceConfigSchemas: {counter: CounterConfig},
+        ...(storage ? {storage} : {}),
+      },
+      counterStateCreator,
+    ),
+  );
+}
+
+const originalWindowDescriptor = Object.getOwnPropertyDescriptor(
+  globalThis,
+  'window',
+);
+
+function setWindowStorage(storage: StateStorage | null) {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {localStorage: storage},
+  });
+}
+
+describe('persistSliceConfigs storage', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    if (originalWindowDescriptor) {
+      Object.defineProperty(globalThis, 'window', originalWindowDescriptor);
+    } else {
+      delete (globalThis as {window?: unknown}).window;
+    }
+  });
+
+  it('continues updating state when default browser storage is unavailable', () => {
+    setWindowStorage(null);
+
+    const store = createCounterStore();
+
+    expect(() => store.getState().counter.increment()).not.toThrow();
+    expect(store.getState().counter.config.count).toBe(1);
+  });
+
+  it('continues updating state when resolving browser storage throws', () => {
+    const browserWindow = {};
+    Object.defineProperty(browserWindow, 'localStorage', {
+      get: () => {
+        throw new Error('Storage access denied');
+      },
+    });
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: browserWindow,
+    });
+
+    const store = createCounterStore();
+
+    expect(() => store.getState().counter.increment()).not.toThrow();
+    expect(store.getState().counter.config.count).toBe(1);
+  });
+
+  it('uses default browser storage when it is available', () => {
+    const values = new Map<string, string>();
+    const storage: StateStorage = {
+      getItem: jest.fn((key) => values.get(key) ?? null),
+      setItem: jest.fn((key, value) => values.set(key, value)),
+      removeItem: jest.fn((key) => values.delete(key)),
+    };
+    setWindowStorage(storage);
+
+    const store = createCounterStore();
+    store.getState().counter.increment();
+
+    expect(storage.setItem).toHaveBeenCalled();
+    expect(JSON.parse(values.get('counter-test-storage') ?? '')).toEqual({
+      state: {counter: {count: 1}},
+      version: 0,
+    });
+  });
+
+  it('tolerates failures from custom storage methods', () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const storage: PersistStorage<{counter: {count: number}}> = {
+      getItem: () => {
+        throw new Error('getItem failed');
+      },
+      setItem: () => {
+        throw new Error('setItem failed');
+      },
+      removeItem: () => {
+        throw new Error('removeItem failed');
+      },
+    };
+
+    const store = createCounterStore(storage);
+
+    expect(() => store.getState().counter.increment()).not.toThrow();
+    expect(() =>
+      (
+        store as typeof store & {persist: {clearStorage: () => void}}
+      ).persist.clearStorage(),
+    ).not.toThrow();
+    expect(store.getState().counter.config.count).toBe(1);
   });
 });

--- a/packages/room-store/__tests__/createPersistHelpers.test.ts
+++ b/packages/room-store/__tests__/createPersistHelpers.test.ts
@@ -258,6 +258,50 @@ describe('persistSliceConfigs storage', () => {
     });
   });
 
+  it('propagates malformed JSON from default browser storage', () => {
+    const onHydrationFinished = jest.fn();
+    const storage: StateStorage = {
+      getItem: () => '{malformed',
+      setItem: jest.fn(),
+      removeItem: jest.fn(),
+    };
+    setWindowStorage(storage);
+
+    createCounterStore(undefined, () => onHydrationFinished);
+
+    expect(onHydrationFinished).toHaveBeenCalledWith(
+      undefined,
+      expect.any(SyntaxError),
+    );
+    expect(storage.setItem).not.toHaveBeenCalled();
+  });
+
+  it('tolerates failures from default browser storage methods', () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const storage: StateStorage = {
+      getItem: () => {
+        throw new Error('getItem failed');
+      },
+      setItem: () => {
+        throw new Error('setItem failed');
+      },
+      removeItem: () => {
+        throw new Error('removeItem failed');
+      },
+    };
+    setWindowStorage(storage);
+
+    const store = createCounterStore();
+
+    expect(() => store.getState().counter.increment()).not.toThrow();
+    expect(() =>
+      (
+        store as typeof store & {persist: {clearStorage: () => void}}
+      ).persist.clearStorage(),
+    ).not.toThrow();
+    expect(store.getState().counter.config.count).toBe(1);
+  });
+
   it('propagates custom reads while tolerating write and removal failures', () => {
     jest.spyOn(console, 'warn').mockImplementation(() => undefined);
     const getItemError = new Error('getItem failed');

--- a/packages/room-store/__tests__/createPersistHelpers.test.ts
+++ b/packages/room-store/__tests__/createPersistHelpers.test.ts
@@ -2,7 +2,7 @@ import {afterEach, describe, expect, it, jest} from '@jest/globals';
 import {AiSettingsSliceConfig} from '@sqlrooms/ai-config';
 import {z} from 'zod';
 import {createStore, StateCreator} from 'zustand/vanilla';
-import {PersistStorage, StateStorage} from 'zustand/middleware';
+import {PersistOptions, PersistStorage, StateStorage} from 'zustand/middleware';
 import {
   createPersistHelpers,
   persistSliceConfigs,
@@ -148,6 +148,7 @@ describe('createPersistHelpers.merge', () => {
 });
 
 const CounterConfig = z.object({count: z.number()});
+type PersistedCounterState = {counter: z.infer<typeof CounterConfig>};
 
 type CounterState = {
   counter: {
@@ -170,7 +171,11 @@ const counterStateCreator: StateCreator<CounterState> = (set) => ({
 });
 
 function createCounterStore(
-  storage?: PersistStorage<{counter: z.infer<typeof CounterConfig>}>,
+  storage?: PersistStorage<PersistedCounterState>,
+  onRehydrateStorage?: PersistOptions<
+    CounterState,
+    PersistedCounterState
+  >['onRehydrateStorage'],
 ) {
   return createStore(
     persistSliceConfigs(
@@ -178,6 +183,7 @@ function createCounterStore(
         name: 'counter-test-storage',
         sliceConfigSchemas: {counter: CounterConfig},
         ...(storage ? {storage} : {}),
+        ...(onRehydrateStorage ? {onRehydrateStorage} : {}),
       },
       counterStateCreator,
     ),
@@ -252,11 +258,13 @@ describe('persistSliceConfigs storage', () => {
     });
   });
 
-  it('tolerates failures from custom storage methods', () => {
+  it('propagates custom reads while tolerating write and removal failures', () => {
     jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const getItemError = new Error('getItem failed');
+    const onHydrationFinished = jest.fn();
     const storage: PersistStorage<{counter: {count: number}}> = {
       getItem: () => {
-        throw new Error('getItem failed');
+        throw getItemError;
       },
       setItem: () => {
         throw new Error('setItem failed');
@@ -266,8 +274,9 @@ describe('persistSliceConfigs storage', () => {
       },
     };
 
-    const store = createCounterStore(storage);
+    const store = createCounterStore(storage, () => onHydrationFinished);
 
+    expect(onHydrationFinished).toHaveBeenCalledWith(undefined, getItemError);
     expect(() => store.getState().counter.increment()).not.toThrow();
     expect(() =>
       (

--- a/packages/room-store/src/createPersistHelpers.ts
+++ b/packages/room-store/src/createPersistHelpers.ts
@@ -53,12 +53,14 @@ function runSafeStorageOperation<T>(
 }
 
 /**
- * Wraps a Zustand persist storage so unavailable or failing storage does not
- * prevent normal state updates. This also protects serialisation from errors
- * such as `RangeError: Invalid string length` when state grows unexpectedly.
+ * Protects storage writes and removals so failures do not prevent normal state
+ * updates, and optionally handles read failures for default browser storage.
+ * This also protects serialisation from errors such as `RangeError: Invalid
+ * string length` when state grows unexpectedly.
  */
 function createSafeStorage<S, PersistedState>(
   base: PersistOptions<S, PersistedState>['storage'],
+  suppressReadErrors: boolean,
 ): PersistOptions<S, PersistedState>['storage'] {
   if (!base) return base;
   const originalGetItem = base.getItem.bind(base);
@@ -68,7 +70,13 @@ function createSafeStorage<S, PersistedState>(
   return {
     ...base,
     getItem: (...args: Parameters<typeof originalGetItem>) =>
-      runSafeStorageOperation('getItem', () => originalGetItem(...args), null),
+      suppressReadErrors
+        ? runSafeStorageOperation(
+            'getItem',
+            () => originalGetItem(...args),
+            null,
+          )
+        : originalGetItem(...args),
     setItem: (...args: Parameters<typeof originalSetItem>) =>
       runSafeStorageOperation(
         'setItem',
@@ -292,6 +300,7 @@ export function persistSliceConfigs<
 
   const safeStorage = createSafeStorage(
     storage ?? createJSONStorage<PersistedState>(getBrowserStorage),
+    storage === undefined,
   );
 
   return persist<S, [], [], PersistedState>(stateCreator, {

--- a/packages/room-store/src/createPersistHelpers.ts
+++ b/packages/room-store/src/createPersistHelpers.ts
@@ -17,14 +17,6 @@ const unavailableStorage: StateStorage = {
   removeItem: () => undefined,
 };
 
-function getBrowserStorage(): StateStorage {
-  try {
-    return window.localStorage ?? unavailableStorage;
-  } catch {
-    return unavailableStorage;
-  }
-}
-
 function warnStorageFailure(operation: string, error: unknown) {
   console.warn(
     `Persist storage ${operation} failed; persistence was skipped:`,
@@ -52,31 +44,52 @@ function runSafeStorageOperation<T>(
   }
 }
 
-/**
- * Protects storage writes and removals so failures do not prevent normal state
- * updates, and optionally handles read failures for default browser storage.
- * This also protects serialisation from errors such as `RangeError: Invalid
- * string length` when state grows unexpectedly.
- */
-function createSafeStorage<S, PersistedState>(
-  base: PersistOptions<S, PersistedState>['storage'],
-  suppressReadErrors: boolean,
-): PersistOptions<S, PersistedState>['storage'] {
-  if (!base) return base;
+function createSafeBrowserStorage(base: StateStorage): StateStorage {
   const originalGetItem = base.getItem.bind(base);
   const originalSetItem = base.setItem.bind(base);
   const originalRemoveItem = base.removeItem.bind(base);
 
   return {
+    getItem: (...args) =>
+      runSafeStorageOperation('getItem', () => originalGetItem(...args), null),
+    setItem: (...args) =>
+      runSafeStorageOperation(
+        'setItem',
+        () => originalSetItem(...args),
+        undefined,
+      ),
+    removeItem: (...args) =>
+      runSafeStorageOperation(
+        'removeItem',
+        () => originalRemoveItem(...args),
+        undefined,
+      ),
+  };
+}
+
+function getBrowserStorage(): StateStorage {
+  try {
+    const storage = window.localStorage;
+    return storage ? createSafeBrowserStorage(storage) : unavailableStorage;
+  } catch {
+    return unavailableStorage;
+  }
+}
+
+/**
+ * Protects storage writes and removals so failures do not prevent normal state
+ * updates. This also protects serialisation from errors such as `RangeError:
+ * Invalid string length` when state grows unexpectedly.
+ */
+function createSafeStorage<S, PersistedState>(
+  base: PersistOptions<S, PersistedState>['storage'],
+): PersistOptions<S, PersistedState>['storage'] {
+  if (!base) return base;
+  const originalSetItem = base.setItem.bind(base);
+  const originalRemoveItem = base.removeItem.bind(base);
+
+  return {
     ...base,
-    getItem: (...args: Parameters<typeof originalGetItem>) =>
-      suppressReadErrors
-        ? runSafeStorageOperation(
-            'getItem',
-            () => originalGetItem(...args),
-            null,
-          )
-        : originalGetItem(...args),
     setItem: (...args: Parameters<typeof originalSetItem>) =>
       runSafeStorageOperation(
         'setItem',
@@ -300,7 +313,6 @@ export function persistSliceConfigs<
 
   const safeStorage = createSafeStorage(
     storage ?? createJSONStorage<PersistedState>(getBrowserStorage),
-    storage === undefined,
   );
 
   return persist<S, [], [], PersistedState>(stateCreator, {

--- a/packages/room-store/src/createPersistHelpers.ts
+++ b/packages/room-store/src/createPersistHelpers.ts
@@ -1,35 +1,86 @@
 import z from 'zod';
-import {persist, PersistOptions} from 'zustand/middleware';
+import {
+  createJSONStorage,
+  persist,
+  PersistOptions,
+  StateStorage,
+} from 'zustand/middleware';
 import {StateCreator} from './BaseRoomStore';
 
 type PersistedSliceConfigs<T extends Record<string, z.ZodType>> = {
   [K in keyof T]: z.infer<T[K]>;
 };
 
+const unavailableStorage: StateStorage = {
+  getItem: () => null,
+  setItem: () => undefined,
+  removeItem: () => undefined,
+};
+
+function getBrowserStorage(): StateStorage {
+  try {
+    return window.localStorage ?? unavailableStorage;
+  } catch {
+    return unavailableStorage;
+  }
+}
+
+function warnStorageFailure(operation: string, error: unknown) {
+  console.warn(
+    `Persist storage ${operation} failed; persistence was skipped:`,
+    error instanceof Error ? error.message : error,
+  );
+}
+
+function runSafeStorageOperation<T>(
+  operation: string,
+  callback: () => T,
+  fallback: T,
+): T {
+  try {
+    const result = callback();
+    if (result instanceof Promise) {
+      return result.catch((error) => {
+        warnStorageFailure(operation, error);
+        return fallback;
+      }) as T;
+    }
+    return result;
+  } catch (error) {
+    warnStorageFailure(operation, error);
+    return fallback;
+  }
+}
+
 /**
- * Wraps a Zustand persist storage so that `setItem` silently drops writes
- * whose serialised payload exceeds the engine's string-length limit (or any
- * other serialisation error).  This prevents `RangeError: Invalid string
- * length` from crashing the app when the state grows unexpectedly large.
+ * Wraps a Zustand persist storage so unavailable or failing storage does not
+ * prevent normal state updates. This also protects serialisation from errors
+ * such as `RangeError: Invalid string length` when state grows unexpectedly.
  */
 function createSafeStorage<S, PersistedState>(
   base: PersistOptions<S, PersistedState>['storage'],
 ): PersistOptions<S, PersistedState>['storage'] {
   if (!base) return base;
-  const originalSetItem = base.setItem?.bind(base);
-  if (!originalSetItem) return base;
+  const originalGetItem = base.getItem.bind(base);
+  const originalSetItem = base.setItem.bind(base);
+  const originalRemoveItem = base.removeItem.bind(base);
+
   return {
     ...base,
-    setItem: (...args: Parameters<typeof originalSetItem>) => {
-      try {
-        return originalSetItem(...args);
-      } catch (error) {
-        console.warn(
-          'Persist storage setItem failed (payload too large?):',
-          error instanceof Error ? error.message : error,
-        );
-      }
-    },
+    getItem: (...args: Parameters<typeof originalGetItem>) =>
+      runSafeStorageOperation('getItem', () => originalGetItem(...args), null),
+    setItem: (...args: Parameters<typeof originalSetItem>) =>
+      runSafeStorageOperation(
+        'setItem',
+        () => originalSetItem(...args),
+        undefined,
+      ),
+    removeItem: (...args: Parameters<typeof originalRemoveItem>) =>
+      runSafeStorageOperation(
+        'removeItem',
+        () => originalRemoveItem(...args),
+        undefined,
+      ),
   };
 }
 
@@ -168,7 +219,7 @@ export function createPersistHelpers<T extends Record<string, z.ZodType>>(
  * @param options.sliceConfigSchemas - Map of slice names to Zod schemas for their configs
  * @param options.partialize - Optional custom partialize function (overrides auto-generated one)
  * @param options.merge - Optional custom merge function (overrides auto-generated one)
- * @param options.storage - Custom storage implementation (optional, defaults to localStorage)
+ * @param options.storage - Custom storage implementation (optional, defaults to localStorage with a no-op fallback)
  * @param options.version - Schema version for migrations (optional)
  * @param options.migrate - Migration function for version changes (optional)
  * @param options.skipHydration - Skip auto-hydration for SSR (optional)
@@ -239,7 +290,9 @@ export function persistSliceConfigs<
     options;
   const helpers = createPersistHelpers(sliceConfigSchemas);
 
-  const safeStorage = createSafeStorage(storage);
+  const safeStorage = createSafeStorage(
+    storage ?? createJSONStorage<PersistedState>(getBrowserStorage),
+  );
 
   return persist<S, [], [], PersistedState>(stateCreator, {
     ...persistOptions,


### PR DESCRIPTION
## Summary

- resolve the default browser storage through a no-op fallback when `localStorage` is null or throws
- keep raw browser storage failures non-fatal while preserving malformed JSON and explicit custom-storage read errors
- add regression coverage for unavailable, throwing, working, corrupt, and custom failing storage
- document the fallback and hydration-error behavior in the package README

## Root cause

`persistSliceConfigs` only wrapped an explicitly supplied storage adapter, so its default path fell back to Zustand's unguarded `createJSONStorage(() => window.localStorage)` behavior. When a browser or WebView exposed `window.localStorage` as `null`, the next persisted update called `setItem` on that null value and crashed.

The safety boundary now wraps the raw browser `StateStorage` before JSON conversion. Browser API failures are skipped, while malformed JSON and explicit custom-storage read errors remain observable through Zustand's `onRehydrateStorage` callback, preventing a failed load from being mistaken for an empty store.

## Validation

- `pnpm build`
- `pnpm --filter @sqlrooms/room-store test` (57 tests)
- repository pre-push checks: Knip, workspace typecheck, circular-dependency check, and full test suite

Closes #843

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved persistence reliability when browser storage is unavailable, inaccessible, or fails during writes or removals.
  * Prevented storage errors from interrupting in-memory operation.
  * Added clearer handling for malformed persisted data and custom storage read failures.

* **Documentation**
  * Expanded persistence documentation to explain default storage behavior, fallbacks, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->