### PR TITLE
fix(deck): remove unused quoteDeckMapSqlIdentifier import

### DIFF
--- a/packages/deck/src/ai.ts
+++ b/packages/deck/src/ai.ts
@@ -25,7 +25,6 @@ import {
   getFirstDatasetSourceTableName,
   hasSqlOnlyDatasetSource,
 } from './datasetSourceUtils';
-import {quoteDeckMapSqlIdentifier} from './mapConfigUtils';
 import {getDeckMapSharedAiContractRules} from './mapAiSharedInstructions';
 import {prepareAiDeckMapConfig} from './aiNormalize';
 import type {PrepareAiDeckMapConfigOptions} from './aiNormalize';


### PR DESCRIPTION
Removes an unused import in `packages/deck/src/ai.ts`.

## Why

`ai.ts` imports `quoteDeckMapSqlIdentifier` from `./mapConfigUtils` but never references it. Consumers that typecheck `@sqlrooms/deck` from source with `noUnusedLocals` enabled fail with:

```
packages/deck/src/ai.ts(28,1): error TS6133: 'quoteDeckMapSqlIdentifier' is declared but its value is never read.
```

## Scope

Import-only. No API or behavior change:

- `quoteDeckMapSqlIdentifier` stays defined in `mapConfigUtils.ts`, where it is still used, and stays exported from the package entry.
- The separate local copy in `aiNormalize.ts` is intentional (it carries a comment explaining it avoids pulling in duckdb/mosaic to keep Jest light) and is left untouched.

## Verification

`@sqlrooms/deck` typecheck passes with 0 errors.

Note: `pnpm typecheck` and `pnpm test` currently fail on `@sqlrooms/documents` on `main` — 2 errors in `src/crdt.ts` referencing `pinnedArtifactIds`, plus a Jest transform failure across 9 suites. Both reproduce identically on the parent commit without this change, so they are pre-existing and unrelated. Happy to open a separate PR for the `crdt.ts` one if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)