### PR TITLE
fix(examples): sync DataFusion demo

### DIFF
--- a/docs/public/media/examples/sqlrooms-deckgl-mosaic-datafusion-example.mp4
+++ b/docs/public/media/examples/sqlrooms-deckgl-mosaic-datafusion-example.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b76f0c502593fec0b745e0c1a4a1d5298aab3ac97bcaf3b9b5f242c02098b174
+size 4090150

--- a/examples/deckgl-mosaic-datafusion/README.md
+++ b/examples/deckgl-mosaic-datafusion/README.md
@@ -1,6 +1,9 @@
-### [Mosaic + DataFusion-WASM + Zarr](https://github.com/sqlrooms/sqlrooms/tree/main/examples/deckgl-mosaic-datafusion)
+### [Mosaic + DataFusion-WASM + Zarr](https://sqlrooms-deckgl-mosaic-datafusion.netlify.app/)
 
-[GitHub repo](https://github.com/sqlrooms/sqlrooms/tree/main/examples/deckgl-mosaic-datafusion)
+[Try live](https://sqlrooms-deckgl-mosaic-datafusion.netlify.app/)
+| [GitHub repo](https://github.com/sqlrooms/sqlrooms/tree/main/examples/deckgl-mosaic-datafusion)
+
+<video src="https://sqlrooms.org/media/examples/sqlrooms-deckgl-mosaic-datafusion-example.mp4" alt="SQLRooms Deck.gl, Mosaic, and DataFusion example app" width="450" controls loop muted></video>
 
 This example ports [Gjore Milevski](https://github.com/dzole0311)'s
 [mosaic-datafusion-zarr-deckgl](https://github.com/dzole0311/mosaic-datafusion-zarr-deckgl)

--- a/examples/deckgl-mosaic-datafusion/README.md
+++ b/examples/deckgl-mosaic-datafusion/README.md
@@ -3,7 +3,7 @@
 [Try live](https://sqlrooms-deckgl-mosaic-datafusion.netlify.app/)
 | [GitHub repo](https://github.com/sqlrooms/sqlrooms/tree/main/examples/deckgl-mosaic-datafusion)
 
-<video src="https://sqlrooms.org/media/examples/sqlrooms-deckgl-mosaic-datafusion-example.mp4" alt="SQLRooms Deck.gl, Mosaic, and DataFusion example app" width="450" controls loop muted></video>
+<video src="https://sqlrooms.org/media/examples/sqlrooms-deckgl-mosaic-datafusion-example.mp4" aria-label="SQLRooms Deck.gl, Mosaic, and DataFusion example app preview" width="450" controls loop muted>Preview of the SQLRooms Deck.gl, Mosaic, and DataFusion example app.</video>
 
 This example ports [Gjore Milevski](https://github.com/dzole0311)'s
 [mosaic-datafusion-zarr-deckgl](https://github.com/dzole0311/mosaic-datafusion-zarr-deckgl)

--- a/examples/deckgl-mosaic-datafusion/jest.config.js
+++ b/examples/deckgl-mosaic-datafusion/jest.config.js
@@ -1,8 +1,12 @@
+import {createRequire} from 'node:module';
+
+const requireFromExample = createRequire(import.meta.url);
+
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 export default {
   preset: 'ts-jest',
   extensionsToTreatAsEsm: ['.ts', '.tsx'],
-  testEnvironment: 'node',
+  testEnvironment: requireFromExample.resolve('jest-environment-node'),
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
     '\\.(css|less|sass|scss)$': 'identity-obj-proxy',

--- a/examples/deckgl-mosaic-datafusion/jest.config.js
+++ b/examples/deckgl-mosaic-datafusion/jest.config.js
@@ -1,6 +1,25 @@
-import nodeConfig from '@sqlrooms/preset-jest/node.js';
-
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 export default {
-  ...nodeConfig,
+  preset: 'ts-jest',
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+    '\\.(css|less|sass|scss)$': 'identity-obj-proxy',
+  },
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        useESM: true,
+      },
+    ],
+  },
+  testMatch: ['**/__tests__/**/*.test.{ts,tsx}'],
+  collectCoverageFrom: [
+    'src/**/*.{ts,tsx}',
+    '!src/**/*.d.ts',
+    '!src/**/*.stories.{ts,tsx}',
+    '!src/**/index.{ts,tsx}',
+  ],
 };

--- a/examples/deckgl-mosaic-datafusion/package.json
+++ b/examples/deckgl-mosaic-datafusion/package.json
@@ -38,7 +38,6 @@
   "devDependencies": {
     "@eslint/js": "^9.36.0",
     "@jest/globals": "^30.3.0",
-    "@sqlrooms/preset-jest": "workspace:*",
     "@tailwindcss/vite": "^4.1.18",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
@@ -47,7 +46,9 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.21",
     "globals": "^15.15.0",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^30.1.3",
+    "jest-environment-node": "^30.1.2",
     "tailwindcss": "^4.1.18",
     "ts-jest": "^29.4.4",
     "typescript": "5.9.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1586,9 +1586,6 @@ importers:
       '@jest/globals':
         specifier: ^30.3.0
         version: 30.4.1
-      '@sqlrooms/preset-jest':
-        specifier: workspace:*
-        version: link:../../packages/preset-jest
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.3.0(vite@8.2.0(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
@@ -1613,9 +1610,15 @@ importers:
       globals:
         specifier: ^15.15.0
         version: 15.15.0
+      identity-obj-proxy:
+        specifier: ^3.0.0
+        version: 3.0.0
       jest:
         specifier: ^30.1.3
         version: 30.4.2(@types/node@24.12.4)
+      jest-environment-node:
+        specifier: ^30.1.2
+        version: 30.4.1
       tailwindcss:
         specifier: ^4.1.18
         version: 4.3.0


### PR DESCRIPTION
## Summary

- add the Deck.gl + Mosaic + DataFusion live demo URL to the featured examples page
- add the MP4 preview asset for the example
- make the example's Jest configuration standalone so it can be copied out of the monorepo
- remove the private `@sqlrooms/preset-jest` workspace dependency and add the runtime dependencies directly

## Root cause

The examples sync workflow rewrites `@sqlrooms/*` entries in `dependencies`, but the DataFusion example was the only example with an `@sqlrooms/*` `workspace:*` entry in `devDependencies`. After copying the example out of the pnpm workspace, npm rejected that unresolved protocol. Rewriting it to the release version would not be sufficient because `@sqlrooms/preset-jest` is private and unpublished, so the example now carries an equivalent standalone Jest configuration.

## Validation

- DataFusion example Jest suite: 2 suites, 6 tests passed
- isolated `npm install --package-lock-only --legacy-peer-deps`: passed after applying the sync workflow's version rewrite
- VitePress docs build: passed
- Prettier and `git diff --check`: passed
- staged-file lint/format hooks: passed
- full workspace typecheck was attempted by the pre-push hook, but currently fails in unchanged `packages/documents/src/crdt.ts` because `pinnedArtifactIds` is absent from its inferred config type

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the example README with direct links to the live demo and repository.
  - Added an embedded video preview with accessible labeling and fallback text.

- **Tests**
  - Improved the example’s test setup for more reliable test execution, module handling, and coverage reporting.
  - Enhanced support for browser-style asset imports during testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->