### PR TITLE
feat(ai-core): expose active status rendering

### DIFF
--- a/packages/ai-core/README.md
+++ b/packages/ai-core/README.md
@@ -117,6 +117,7 @@ order, what is hoistable / running / completed), then asks the nearest
 
 | Slot            | Role                                                          |
 | --------------- | ------------------------------------------------------------- |
+| `ActiveStatus`  | Current in-flight run status and elapsed-time presentation    |
 | `Turn`          | Full turn layout recipe — composes pre-wired semantic regions |
 | `Prompt`        | User prompt chrome for the turn                               |
 | `Activity`      | Collapsible / status chrome around in-progress work           |
@@ -228,6 +229,27 @@ function AppReasoning({text, isRunning}: ChatReasoningProps) {
 
 You can combine any of these in one `components` map by providing both the
 `Prompt` and `Reasoning` entries.
+
+**Active run status** — change or suppress the progress indicator without
+reimplementing chat-run state derivation. The exported `getChatActiveStatus`
+helper is also available when the indicator needs to be placed outside
+`Chat.Messages`:
+
+```tsx
+import {Chat, type ChatActiveStatusProps} from '@sqlrooms/ai-core';
+
+function AppActiveStatus({status}: ChatActiveStatusProps) {
+  return <MyProgressIndicator label={status.label} />;
+}
+
+<Chat.Rendering components={{ActiveStatus: AppActiveStatus}}>
+  <Chat.Messages />
+</Chat.Rendering>;
+```
+
+Set `ActiveStatus` to a component that returns `null` when the host owns the
+indicator's placement entirely. For that case, call `getChatActiveStatus` with
+the current messages and `ToolRenderBehavior` to reuse the same status model.
 
 `TextOutput` receives `isAnswer=true` only for text that is the final message
 part. Planning text followed by tool activity remains regular response text.

--- a/packages/ai-core/__tests__/ChatRenderingContext.test.tsx
+++ b/packages/ai-core/__tests__/ChatRenderingContext.test.tsx
@@ -4,13 +4,24 @@
 import {act} from 'react';
 import {createRoot} from 'react-dom/client';
 import {TransformStream} from 'node:stream/web';
+import type {ChatActiveStatusProps} from '../src/components/ChatRenderingContext';
 
 Object.assign(globalThis, {
   TransformStream,
   IS_REACT_ACT_ENVIRONMENT: true,
 });
 
-const {ChatRendering} = await import('../src/components/ChatRenderingContext');
+const {ChatRendering, useChatRenderingComponents} =
+  await import('../src/components/ChatRenderingContext');
+
+const ActiveStatusConsumer = () => {
+  const ActiveStatus = useChatRenderingComponents().ActiveStatus;
+  return (
+    <ActiveStatus
+      status={{key: 'tool:query-1', label: 'Running query…', kind: 'tool'}}
+    />
+  );
+};
 
 describe('ChatRendering', () => {
   it('resolves defaults without importing Chat or ChatTurnView first', () => {
@@ -26,6 +37,29 @@ describe('ChatRendering', () => {
     });
 
     expect(container.textContent).toBe('ready');
+
+    act(() => root.unmount());
+  });
+
+  it('allows the active run status presentation to be replaced', () => {
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    const CustomActiveStatus = ({status}: ChatActiveStatusProps) => (
+      <span data-testid="custom-active-status">Custom: {status.label}</span>
+    );
+
+    act(() => {
+      root.render(
+        <ChatRendering components={{ActiveStatus: CustomActiveStatus}}>
+          <ActiveStatusConsumer />
+        </ChatRendering>,
+      );
+    });
+
+    expect(
+      container.querySelector('[data-testid="custom-active-status"]')
+        ?.textContent,
+    ).toBe('Custom: Running query…');
 
     act(() => root.unmount());
   });

--- a/packages/ai-core/src/components/ChatActiveStatus.tsx
+++ b/packages/ai-core/src/components/ChatActiveStatus.tsx
@@ -5,18 +5,14 @@ import React, {type FC} from 'react';
 import type {AgentToolCall} from '../types';
 import {useElapsedTime} from '../hooks/useElapsedTime';
 import type {ToolRenderBehavior} from './FlatAgentRenderer';
-import {useToolRenderBehavior} from './FlatAgentRenderer';
+import type {
+  ChatActiveStatusInfo,
+  ChatActiveStatusProps,
+} from './ChatRenderingTypes';
 
 export {hasPendingToolApproval} from '../timeouts';
 
 type AnyUIMessagePart = UIMessagePart<any, any>;
-
-/** User-facing description of the chat run's current active step. */
-export type ChatActiveStatusInfo = {
-  key: string;
-  label: string;
-  kind: 'tool' | 'approval' | 'model';
-};
 
 /**
  * Derives the current user-facing activity from the latest chat turn.
@@ -66,21 +62,16 @@ export function getChatActiveStatus(
 }
 
 /** Displays the current chat activity and elapsed time for that step. */
-export const ChatActiveStatus: FC<{
-  messages: UIMessage[] | undefined;
-  className?: string;
-}> = ({messages, className}) => {
-  const behavior = useToolRenderBehavior();
-  const status = getChatActiveStatus(messages, behavior);
-
-  return (
-    <ChatActiveStatusLine
-      key={status.key}
-      status={status}
-      className={className}
-    />
-  );
-};
+export const ChatActiveStatus: FC<ChatActiveStatusProps> = ({
+  status,
+  className,
+}) => (
+  <ChatActiveStatusLine
+    key={status.key}
+    status={status}
+    className={className}
+  />
+);
 
 const ChatActiveStatusLine: FC<{
   status: ChatActiveStatusInfo;

--- a/packages/ai-core/src/components/ChatMessagesContainer.tsx
+++ b/packages/ai-core/src/components/ChatMessagesContainer.tsx
@@ -6,8 +6,10 @@ import {Components} from 'react-markdown';
 import {useStoreWithAi} from '../AiSlice';
 import {useScrollToBottom} from '../hooks/useScrollToBottom';
 import {ChatTurnView} from './ChatTurnView';
-import {ChatActiveStatus} from './ChatActiveStatus';
+import {getChatActiveStatus} from './ChatActiveStatus';
+import {useChatRenderingComponents} from './ChatRenderingContext';
 import type {ErrorMessageComponentProps} from './ErrorMessage';
+import {useToolRenderBehavior} from './FlatAgentRenderer';
 import {getChatTurnsFromUiMessages} from '../chatTurns';
 import type {AiSessionForkOrigin, ChatSessionSchema} from '@sqlrooms/ai-config';
 
@@ -68,6 +70,12 @@ export const ChatMessagesContainer: React.FC<{
   const uiMessages = useStoreWithAi(
     (s) => s.ai.getCurrentSession()?.uiMessages,
   );
+  const toolRenderBehavior = useToolRenderBehavior();
+  const activeStatus = getChatActiveStatus(
+    uiMessages as UIMessage[] | undefined,
+    toolRenderBehavior,
+  );
+  const ActiveStatus = useChatRenderingComponents().ActiveStatus;
   const chatTurns = React.useMemo(
     () =>
       getChatTurnsFromUiMessages(uiMessages as UIMessage[] | undefined, {
@@ -140,12 +148,7 @@ export const ChatMessagesContainer: React.FC<{
               )}
             </React.Fragment>
           ))}
-          {isRunning && (
-            <ChatActiveStatus
-              messages={uiMessages as UIMessage[] | undefined}
-              className="pb-4"
-            />
-          )}
+          {isRunning && <ActiveStatus status={activeStatus} className="pb-4" />}
           <div className="h-10 w-full shrink-0" />
         </div>
         <ScrollBar orientation="vertical" />

--- a/packages/ai-core/src/components/ChatRenderingContext.tsx
+++ b/packages/ai-core/src/components/ChatRenderingContext.tsx
@@ -22,6 +22,7 @@ export function mergeChatRenderingComponents(
 ): ChatRenderingComponents {
   if (!overrides) return base;
   return {
+    ActiveStatus: overrides.ActiveStatus ?? base.ActiveStatus,
     Turn: overrides.Turn ?? base.Turn,
     Prompt: overrides.Prompt ?? base.Prompt,
     Activity: overrides.Activity ?? base.Activity,
@@ -105,6 +106,8 @@ export function useChatNestedActivityMode(): ChatNestedActivityMode {
 }
 
 export type {
+  ChatActiveStatusInfo,
+  ChatActiveStatusProps,
   ChatComponentType,
   ChatActionsProps,
   ChatActionsRegion,

--- a/packages/ai-core/src/components/ChatRenderingTypes.ts
+++ b/packages/ai-core/src/components/ChatRenderingTypes.ts
@@ -17,6 +17,19 @@ export type ChatComponentType<TProps = object> =
 /** How nested agent activity is composed into turn-level activity. */
 export type ChatNestedActivityMode = 'own-boxes' | 'embed';
 
+/** User-facing description of the chat run's current active step. */
+export type ChatActiveStatusInfo = {
+  key: string;
+  label: string;
+  kind: 'tool' | 'approval' | 'model';
+};
+
+/** Props for the active chat-run status presentation slot. */
+export type ChatActiveStatusProps = {
+  status: ChatActiveStatusInfo;
+  className?: string;
+};
+
 /** Props for the user-prompt presentation slot. */
 export type ChatPromptProps = {
   prompt: string;
@@ -202,6 +215,7 @@ export type ChatTurnSlotProps = {
 
 /** Component slots that define a chat presentation recipe. */
 export type ChatRenderingComponents = {
+  ActiveStatus: ChatComponentType<ChatActiveStatusProps>;
   Turn: ChatComponentType<ChatTurnSlotProps>;
   Prompt: ChatComponentType<ChatPromptProps>;
   Activity: ChatComponentType<ChatActivityProps>;

--- a/packages/ai-core/src/components/LocalAgentChatMessages.tsx
+++ b/packages/ai-core/src/components/LocalAgentChatMessages.tsx
@@ -7,7 +7,8 @@ import remarkGfm from 'remark-gfm';
 import {useScrollToBottom} from '../hooks/useScrollToBottom';
 import type {AgentToolCall} from '../types';
 import {isDynamicToolPart, isToolPart} from '../utils';
-import {ChatActiveStatus} from './ChatActiveStatus';
+import {getChatActiveStatus} from './ChatActiveStatus';
+import {useChatRenderingComponents} from './ChatRenderingContext';
 import {useToolRenderBehavior} from './FlatAgentRenderer';
 import {useChatRuntime} from './ChatRuntimeContext';
 
@@ -19,6 +20,12 @@ export const LocalAgentChatMessages: FC<LocalAgentChatMessagesProps> = ({
   className,
 }) => {
   const runtime = useChatRuntime();
+  const toolRenderBehavior = useToolRenderBehavior();
+  const activeStatus =
+    runtime.mode === 'local-agent'
+      ? getChatActiveStatus(runtime.messages, toolRenderBehavior)
+      : undefined;
+  const ActiveStatus = useChatRenderingComponents().ActiveStatus;
   const containerRef = useRef<HTMLDivElement>(null);
   const {showScrollButton, scrollToBottom} = useScrollToBottom({
     containerRef,
@@ -35,8 +42,8 @@ export const LocalAgentChatMessages: FC<LocalAgentChatMessagesProps> = ({
           {runtime.messages.map((message) => (
             <LocalAgentMessageView key={message.id} message={message} />
           ))}
-          {runtime.isStreaming && (
-            <ChatActiveStatus messages={runtime.messages} className="px-1" />
+          {runtime.isStreaming && activeStatus && (
+            <ActiveStatus status={activeStatus} className="px-1" />
           )}
           <div className="h-4 w-full shrink-0" />
         </div>

--- a/packages/ai-core/src/components/defaultChatRendering.tsx
+++ b/packages/ai-core/src/components/defaultChatRendering.tsx
@@ -29,6 +29,7 @@ import type {
   ChatTurnPresentation,
   ChatTurnSlotProps,
 } from './ChatRenderingTypes';
+import {ChatActiveStatus} from './ChatActiveStatus';
 import {ErrorMessage, type ErrorMessageComponentProps} from './ErrorMessage';
 import {ExpandableContent} from './ExpandableContent';
 import {
@@ -649,6 +650,7 @@ export const DefaultChatTurn: React.FC<ChatTurnSlotProps> = ({turn}) => {
 /** Built-in SQLRooms rendering recipe. */
 export const defaultChatRenderingComponents: Readonly<ChatRenderingComponents> =
   Object.freeze({
+    ActiveStatus: ChatActiveStatus,
     Turn: DefaultChatTurn,
     Prompt: DefaultChatPrompt,
     Activity: DefaultChatActivity,

--- a/packages/ai-core/src/index.ts
+++ b/packages/ai-core/src/index.ts
@@ -17,6 +17,10 @@ export {
 } from './devtools/providerContextDiagnostics';
 export type {MeasureProviderContextArgs} from './devtools/providerContextDiagnostics';
 export type {ProviderContextDiagnostic} from './types';
+export {
+  ChatActiveStatus,
+  getChatActiveStatus,
+} from './components/ChatActiveStatus';
 export {ChatMessagesContainer} from './components/ChatMessagesContainer';
 /** @deprecated Use `Chat.Messages` instead. */
 export {ChatMessagesContainer as AnalysisResultsContainer} from './components/ChatMessagesContainer';
@@ -60,6 +64,8 @@ export {
   mergeChatRenderingComponents,
 } from './components/ChatRenderingContext';
 export type {
+  ChatActiveStatusInfo,
+  ChatActiveStatusProps,
   ChatComponentType,
   ChatRenderingProps,
   ChatRenderingComponents,


### PR DESCRIPTION
## Summary

- export `getChatActiveStatus`, `ChatActiveStatus`, `ChatActiveStatusInfo`, and the slot props from `@sqlrooms/ai-core`
- add an `ActiveStatus` slot to `Chat.Rendering`, with the existing SQLRooms indicator as the default
- pass presentation-ready status semantics to the slot in both session and local-agent chat runtimes
- document custom and suppressed active-status presentations

## Why

Hosts can already customize every other chat presentation region, but the in-flight progress indicator was rendered internally. This forced applications with their own visual language to duplicate active-status derivation or show two indicators.

The new slot keeps status derivation in SQLRooms while allowing hosts to replace, suppress, or relocate its presentation.

Closes #854

## Validation

- `pnpm build`
- `pnpm --filter @sqlrooms/ai-core build`
- `pnpm --filter @sqlrooms/ai-core typecheck`
- `pnpm --filter @sqlrooms/ai-core lint` (passes with two pre-existing warnings)
- `volta run --node 24 pnpm --filter @sqlrooms/ai-core test` (31 suites, 178 tests)
- `pnpm check-circular-deps`
- full pre-push typecheck and test hooks under Node 24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added customizable active-status indicators for current chat runs, including elapsed-time presentation.
  - Added support for replacing or suppressing the active-status display through chat rendering customization.
  - Exposed helpers and types for rendering active status consistently in custom interfaces.

- **Documentation**
  - Expanded chat rendering documentation with active-status customization examples and guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->