### PR TITLE
fix(ui): correct ScrollableRow overflow-state tracking

### DIFF
--- a/packages/ui/__tests__/scrollable-row.test.tsx
+++ b/packages/ui/__tests__/scrollable-row.test.tsx
@@ -18,6 +18,83 @@ Object.assign(globalThis, {
 });
 
 describe('ScrollableRow', () => {
+  it.each([
+    [
+      'direct text',
+      (wide: boolean) => (wide ? 'long text'.repeat(20) : 'short'),
+    ],
+    ['direct number', (wide: boolean) => (wide ? 123456789012345 : 1)],
+    [
+      'nested text in a fixed-size child',
+      (wide: boolean) => (
+        <span style={{width: 100}}>
+          <span>{wide ? 'long text'.repeat(20) : 'short'}</span>
+        </span>
+      ),
+    ],
+    [
+      'nested child additions and removals',
+      (wide: boolean) => (
+        <span style={{width: 100}}>
+          <span>short</span>
+          {wide && <span>{'extra content'.repeat(20)}</span>}
+        </span>
+      ),
+    ],
+    [
+      'direct child additions and removals',
+      (wide: boolean) => [
+        <span key="first">short</span>,
+        ...(wide
+          ? [<span key="extra">{'extra content'.repeat(20)}</span>]
+          : []),
+      ],
+    ],
+  ])('refreshes arrows after %s changes', async (_name, content) => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    const render = async (wide: boolean) => {
+      await act(async () => {
+        root.render(<ScrollableRow>{content(wide)}</ScrollableRow>);
+      });
+    };
+
+    try {
+      await render(false);
+      const wrapper = host.firstElementChild!;
+      const scrollContainer = wrapper.children[1]!;
+      // jsdom has no layout: model content overflow while keeping the viewport
+      // fixed. ResizeObserver is inert, so only real DOM mutations can refresh it.
+      Object.defineProperties(scrollContainer, {
+        clientWidth: {get: () => 100},
+        scrollWidth: {
+          get: () =>
+            Math.max(100, (scrollContainer.textContent?.length ?? 0) * 10),
+        },
+      });
+      const left = wrapper.querySelector<HTMLButtonElement>(
+        '[aria-label="Scroll left"]',
+      )!;
+      const right = wrapper.querySelector<HTMLButtonElement>(
+        '[aria-label="Scroll right"]',
+      )!;
+      expect(right.disabled).toBe(true);
+
+      await render(true);
+      expect(wrapper.children[1]).toBe(scrollContainer);
+      expect(right.disabled).toBe(false);
+      expect(left.disabled).toBe(true);
+
+      await render(false);
+      expect(wrapper.children[1]).toBe(scrollContainer);
+      expect(right.disabled).toBe(true);
+    } finally {
+      await act(async () => root.unmount());
+      host.remove();
+    }
+  });
+
   it('forwards its ref to a real DOM node and passes through a data- prop', async () => {
     const ref: React.RefObject<HTMLDivElement | null> = {current: null};
     const container = document.createElement('div');

--- a/packages/ui/__tests__/scrollable-row.test.tsx
+++ b/packages/ui/__tests__/scrollable-row.test.tsx
@@ -98,6 +98,24 @@ describe('ScrollableRow', () => {
       ),
     ],
     [
+      'nested hidden attribute',
+      (wide: boolean) => (
+        <div style={{width: 100, height: 20, whiteSpace: 'nowrap'}}>
+          <span hidden={!wide}>The text stays unchanged</span>
+        </div>
+      ),
+    ],
+    [
+      'nested data attribute used by a CSS selector',
+      (wide: boolean) => (
+        <div style={{width: 100, height: 20}}>
+          <span data-wrap={wide ? 'nowrap' : 'normal'}>
+            The text stays unchanged
+          </span>
+        </div>
+      ),
+    ],
+    [
       'nested style',
       (wide: boolean) => (
         <div style={{width: 100, height: 20}}>

--- a/packages/ui/__tests__/scrollable-row.test.tsx
+++ b/packages/ui/__tests__/scrollable-row.test.tsx
@@ -7,9 +7,22 @@ import {ScrollableRow} from '../src/components/scrollable-row';
 
 // jsdom does not implement ResizeObserver.
 class ResizeObserverStub {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
+  static instances: ResizeObserverStub[] = [];
+  readonly targets = new Set<Element>();
+
+  constructor(readonly callback: ResizeObserverCallback) {
+    ResizeObserverStub.instances.push(this);
+  }
+
+  observe(target: Element) {
+    this.targets.add(target);
+  }
+  unobserve(target: Element) {
+    this.targets.delete(target);
+  }
+  disconnect() {
+    this.targets.clear();
+  }
 }
 
 Object.assign(globalThis, {
@@ -18,6 +31,10 @@ Object.assign(globalThis, {
 });
 
 describe('ScrollableRow', () => {
+  beforeEach(() => {
+    ResizeObserverStub.instances = [];
+  });
+
   it.each([
     [
       'direct text',
@@ -50,11 +67,53 @@ describe('ScrollableRow', () => {
           : []),
       ],
     ],
+    [
+      'className on a fixed-size child',
+      (wide: boolean) => (
+        <div style={{width: 100, height: 20}} className={wide ? 'nowrap' : ''}>
+          The text stays unchanged
+        </div>
+      ),
+    ],
+    [
+      'style on a fixed-size child',
+      (wide: boolean) => (
+        <div
+          style={{
+            width: 100,
+            height: 20,
+            whiteSpace: wide ? 'nowrap' : 'normal',
+          }}
+        >
+          The text stays unchanged
+        </div>
+      ),
+    ],
+    [
+      'nested className',
+      (wide: boolean) => (
+        <div style={{width: 100, height: 20}}>
+          <span className={wide ? 'nowrap' : ''}>The text stays unchanged</span>
+        </div>
+      ),
+    ],
+    [
+      'nested style',
+      (wide: boolean) => (
+        <div style={{width: 100, height: 20}}>
+          <span style={{whiteSpace: wide ? 'nowrap' : 'normal'}}>
+            The text stays unchanged
+          </span>
+        </div>
+      ),
+    ],
   ])('refreshes arrows after %s changes', async (_name, content) => {
     const host = document.createElement('div');
     document.body.appendChild(host);
     const root = createRoot(host);
+    let scrollWidth = 100;
     const render = async (wide: boolean) => {
+      scrollWidth = wide ? 600 : 100;
       await act(async () => {
         root.render(<ScrollableRow>{content(wide)}</ScrollableRow>);
       });
@@ -65,13 +124,10 @@ describe('ScrollableRow', () => {
       const wrapper = host.firstElementChild!;
       const scrollContainer = wrapper.children[1]!;
       // jsdom has no layout: model content overflow while keeping the viewport
-      // fixed. ResizeObserver is inert, so only real DOM mutations can refresh it.
+      // fixed. No resize callbacks fire, so only DOM mutations can refresh it.
       Object.defineProperties(scrollContainer, {
         clientWidth: {get: () => 100},
-        scrollWidth: {
-          get: () =>
-            Math.max(100, (scrollContainer.textContent?.length ?? 0) * 10),
-        },
+        scrollWidth: {get: () => scrollWidth},
       });
       const left = wrapper.querySelector<HTMLButtonElement>(
         '[aria-label="Scroll left"]',
@@ -93,6 +149,52 @@ describe('ScrollableRow', () => {
       await act(async () => root.unmount());
       host.remove();
     }
+  });
+
+  it('refreshes arrows when a direct child resizes without a DOM mutation', async () => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    try {
+      await act(async () => {
+        root.render(
+          <ScrollableRow>
+            <span>Content with a changing intrinsic size</span>
+          </ScrollableRow>,
+        );
+      });
+      const wrapper = host.firstElementChild!;
+      const scrollContainer = wrapper.children[1]!;
+      const child = scrollContainer.firstElementChild!;
+      let childWidth = 100;
+      Object.defineProperties(scrollContainer, {
+        clientWidth: {get: () => 100},
+        scrollWidth: {get: () => child.clientWidth},
+      });
+      Object.defineProperty(child, 'clientWidth', {get: () => childWidth});
+      const right = wrapper.querySelector<HTMLButtonElement>(
+        '[aria-label="Scroll right"]',
+      )!;
+      const observer = ResizeObserverStub.instances.find((instance) =>
+        instance.targets.has(child),
+      );
+      expect(observer).toBeDefined();
+      expect(right.disabled).toBe(true);
+
+      for (const width of [600, 100]) {
+        await act(async () => {
+          childWidth = width;
+          observer!.callback([], observer!);
+        });
+        expect(right.disabled).toBe(width === 100);
+      }
+    } finally {
+      await act(async () => root.unmount());
+      host.remove();
+    }
+    expect(
+      ResizeObserverStub.instances.every(({targets}) => targets.size === 0),
+    ).toBe(true);
   });
 
   it('forwards its ref to a real DOM node and passes through a data- prop', async () => {

--- a/packages/ui/__tests__/scrollable-row.test.tsx
+++ b/packages/ui/__tests__/scrollable-row.test.tsx
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import {jest} from '@jest/globals';
 import React, {act} from 'react';
 import {createRoot} from 'react-dom/client';
 import {ScrollableRow} from '../src/components/scrollable-row';
@@ -214,6 +215,63 @@ describe('ScrollableRow', () => {
       ResizeObserverStub.instances.every(({targets}) => targets.size === 0),
     ).toBe(true);
   });
+
+  it.each(['loadingdone', 'loadingerror'])(
+    'refreshes direct-text overflow after fonts emit %s and cleans up listeners',
+    async (eventType) => {
+      // jsdom has no FontFaceSet. Use real events with mocked layout metrics.
+      const fonts = new EventTarget();
+      const originalFonts = Object.getOwnPropertyDescriptor(document, 'fonts');
+      Object.defineProperty(document, 'fonts', {
+        configurable: true,
+        value: fonts,
+      });
+      const addListener = jest.spyOn(fonts, 'addEventListener');
+      const removeListener = jest.spyOn(fonts, 'removeEventListener');
+      const host = document.createElement('div');
+      document.body.appendChild(host);
+      const root = createRoot(host);
+      try {
+        await act(async () => {
+          root.render(
+            <ScrollableRow>Direct text in a late-loading font</ScrollableRow>,
+          );
+        });
+        const wrapper = host.firstElementChild!;
+        const scrollContainer = wrapper.children[1]!;
+        let scrollWidth = 100;
+        Object.defineProperties(scrollContainer, {
+          clientWidth: {get: () => 100},
+          scrollWidth: {get: () => scrollWidth},
+        });
+        const right = wrapper.querySelector<HTMLButtonElement>(
+          '[aria-label="Scroll right"]',
+        )!;
+        expect(scrollContainer.children.length).toBe(0);
+        expect(right.disabled).toBe(true);
+
+        for (const width of [600, 100]) {
+          await act(async () => {
+            scrollWidth = width;
+            fonts.dispatchEvent(new Event(eventType));
+          });
+          expect(right.disabled).toBe(width === 100);
+        }
+      } finally {
+        await act(async () => root.unmount());
+        host.remove();
+        if (originalFonts) {
+          Object.defineProperty(document, 'fonts', originalFonts);
+        } else {
+          Reflect.deleteProperty(document, 'fonts');
+        }
+      }
+      expect(addListener).toHaveBeenCalled();
+      for (const [type, listener] of addListener.mock.calls) {
+        expect(removeListener).toHaveBeenCalledWith(type, listener);
+      }
+    },
+  );
 
   it('forwards its ref to a real DOM node and passes through a data- prop', async () => {
     const ref: React.RefObject<HTMLDivElement | null> = {current: null};

--- a/packages/ui/src/components/scrollable-row.tsx
+++ b/packages/ui/src/components/scrollable-row.tsx
@@ -112,17 +112,25 @@ export const ScrollableRow = React.forwardRef<
       subtree: true,
     });
 
+    // Font metrics can change direct-text overflow without a DOM mutation or
+    // an element resize. Refresh after font loading settles, including failures.
+    const fonts = container.ownerDocument.fonts;
+    fonts?.addEventListener('loadingdone', updateScrollState);
+    fonts?.addEventListener('loadingerror', updateScrollState);
+
     return () => {
       container.removeEventListener('scroll', updateScrollState);
       resizeObserver.disconnect();
       contentObserver.disconnect();
       mutationObserver.disconnect();
+      fonts?.removeEventListener('loadingdone', updateScrollState);
+      fonts?.removeEventListener('loadingerror', updateScrollState);
     };
     // `children` is intentionally excluded from the deps: it is typically a
     // fresh array on every parent render, and re-running this effect (which
     // calls setState) on every render would trip React's "Maximum update depth
-    // exceeded" warning. Content changes are handled by the resize and mutation
-    // observers above; the scroll listener covers user/dnd scrolling.
+    // exceeded" warning. DOM observers and font events handle content changes;
+    // the scroll listener covers user/dnd scrolling.
   }, [containerRef]);
 
   const arrowBaseClass = cn(

--- a/packages/ui/src/components/scrollable-row.tsx
+++ b/packages/ui/src/components/scrollable-row.tsx
@@ -92,11 +92,23 @@ export const ScrollableRow = React.forwardRef<
     };
     observeChildren();
 
-    const mutationObserver = new MutationObserver(() => {
-      observeChildren();
+    const mutationObserver = new MutationObserver((mutations) => {
+      // Only direct child additions/removals change the resize-observer targets.
+      if (
+        mutations.some(
+          ({type, target}) => type === 'childList' && target === container,
+        )
+      ) {
+        observeChildren();
+      }
       updateScrollState();
     });
-    mutationObserver.observe(container, {childList: true});
+    // Text and nested content can change overflow without resizing a direct child.
+    mutationObserver.observe(container, {
+      childList: true,
+      characterData: true,
+      subtree: true,
+    });
 
     return () => {
       container.removeEventListener('scroll', updateScrollState);
@@ -107,8 +119,8 @@ export const ScrollableRow = React.forwardRef<
     // `children` is intentionally excluded from the deps: it is typically a
     // fresh array on every parent render, and re-running this effect (which
     // calls setState) on every render would trip React's "Maximum update depth
-    // exceeded" warning. Content changes are handled instead by observing the
-    // child elements above; the scroll listener covers user/dnd scrolling.
+    // exceeded" warning. Content changes are handled by the resize and mutation
+    // observers above; the scroll listener covers user/dnd scrolling.
   }, [containerRef]);
 
   const arrowBaseClass = cn(

--- a/packages/ui/src/components/scrollable-row.tsx
+++ b/packages/ui/src/components/scrollable-row.tsx
@@ -81,7 +81,13 @@ export const ScrollableRow = React.forwardRef<
       container.removeEventListener('scroll', updateScrollState);
       resizeObserver.disconnect();
     };
-  }, [children, containerRef]);
+    // `children` is intentionally excluded: it is typically a fresh array on
+    // every parent render, and depending on it would re-run this effect (and
+    // call setState) on every render, tripping React's "Maximum update depth
+    // exceeded" warning. Content changes are still reflected here because
+    // ResizeObserver re-fires on content-size changes and the scroll listener
+    // covers user/dnd scrolling.
+  }, [containerRef]);
 
   const arrowBaseClass = cn(
     'absolute top-0 z-10 flex h-full w-8 items-center backdrop-blur-md bg-background/50 transition-colors',

--- a/packages/ui/src/components/scrollable-row.tsx
+++ b/packages/ui/src/components/scrollable-row.tsx
@@ -74,19 +74,41 @@ export const ScrollableRow = React.forwardRef<
     updateScrollState();
 
     container.addEventListener('scroll', updateScrollState);
+
     const resizeObserver = new ResizeObserver(updateScrollState);
     resizeObserver.observe(container);
+
+    // The container's own box stays fixed when its content changes size (e.g.
+    // loading placeholders replaced by wider suggestions), so ResizeObserver
+    // on the container alone would leave the arrows stale. Observe each child
+    // element instead, and re-observe as children are added or removed, so
+    // overflow changes track content-size changes too.
+    const contentObserver = new ResizeObserver(updateScrollState);
+    const observeChildren = () => {
+      contentObserver.disconnect();
+      for (const child of Array.from(container.children)) {
+        contentObserver.observe(child);
+      }
+    };
+    observeChildren();
+
+    const mutationObserver = new MutationObserver(() => {
+      observeChildren();
+      updateScrollState();
+    });
+    mutationObserver.observe(container, {childList: true});
 
     return () => {
       container.removeEventListener('scroll', updateScrollState);
       resizeObserver.disconnect();
+      contentObserver.disconnect();
+      mutationObserver.disconnect();
     };
-    // `children` is intentionally excluded: it is typically a fresh array on
-    // every parent render, and depending on it would re-run this effect (and
-    // call setState) on every render, tripping React's "Maximum update depth
-    // exceeded" warning. Content changes are still reflected here because
-    // ResizeObserver re-fires on content-size changes and the scroll listener
-    // covers user/dnd scrolling.
+    // `children` is intentionally excluded from the deps: it is typically a
+    // fresh array on every parent render, and re-running this effect (which
+    // calls setState) on every render would trip React's "Maximum update depth
+    // exceeded" warning. Content changes are handled instead by observing the
+    // child elements above; the scroll listener covers user/dnd scrolling.
   }, [containerRef]);
 
   const arrowBaseClass = cn(

--- a/packages/ui/src/components/scrollable-row.tsx
+++ b/packages/ui/src/components/scrollable-row.tsx
@@ -103,10 +103,12 @@ export const ScrollableRow = React.forwardRef<
       }
       updateScrollState();
     });
-    // Text and nested content can change overflow without resizing a direct child.
+    // Text and styling can change overflow without resizing a direct child.
     mutationObserver.observe(container, {
       childList: true,
       characterData: true,
+      attributes: true,
+      attributeFilter: ['class', 'style'],
       subtree: true,
     });
 

--- a/packages/ui/src/components/scrollable-row.tsx
+++ b/packages/ui/src/components/scrollable-row.tsx
@@ -104,11 +104,11 @@ export const ScrollableRow = React.forwardRef<
       updateScrollState();
     });
     // Text and styling can change overflow without resizing a direct child.
+    // Observe all attributes: hidden and arbitrary CSS selectors affect layout too.
     mutationObserver.observe(container, {
       childList: true,
       characterData: true,
       attributes: true,
-      attributeFilter: ['class', 'style'],
       subtree: true,
     });
 


### PR DESCRIPTION
## What

Fixes `ScrollableRow` (`packages/ui/src/components/scrollable-row.tsx`) in two related ways:

1. **Removes `children` from the scroll-state effect deps** — the original cause of the "Maximum update depth exceeded" warning.
2. **Tracks content-size changes directly** so the arrows stay accurate when content overflows without the container resizing or scrolling.

## The max-depth warning

The effect called `setCanScrollLeft` / `setCanScrollRight` unconditionally and depended on `children`, which callers pass as a fresh array every render (`TabStripTabs` renders `<ScrollableRow>{openTabItems.map(...)}</ScrollableRow>`). Under sustained parent re-renders (e.g. AI streaming) with changing scroll metrics (smooth `scrollIntoView`, dnd auto-scroll), this crossed React 19's nested-passive-update limit (50) and fired:

```
Warning: Maximum update depth exceeded. ...
    at ScrollableRow (scrollable-row.tsx:17:3)
    at SortableContext ...
    at TabStripTabs (tab-strip.tsx:434:24)
```

## The content-change regression

Removing `children` alone left the arrows stale: content can change `scrollWidth` without the container's own box changing, and `ResizeObserver` on the container only fires when the observed element's box changes. `PromptSuggestions.Container` replaces fixed-width loading placeholders with variable-width suggestions — the row box stays fixed, no scroll event occurs, and `canScrollRight` retained its old value, hiding the right arrow even though the new content overflows.

## Fix

- Effect deps → `[containerRef]`.
- Observe each **child element** with a second `ResizeObserver`, and re-observe on `childList` mutations via `MutationObserver`, so overflow changes track content-size changes. State updates run in observer callbacks (not the effect body), so the max-depth fix is preserved.
- `children` stays out of the deps; a comment explains why.

## Verification

A standalone headless-Chromium harness (reusable: `~/Downloads/headless-chromium`) was extended with a `contentchange` driver that swaps children wider with no scroll and no container resize:

- **Before**: right arrow stays disabled with content overflowing (`sw=746 > cw=300`) — the regression.
- **After**: arrow enables, metrics `pass (sl=0 sw=746 cw=300)`.
- The `scrollable` driver (80 parent re-renders + oscillating scroll) still produces **no** "Maximum update depth exceeded" warning, and the `badloop` control still captures it verbatim — both the fix and the harness capture path confirmed live.

`pnpm --filter @sqlrooms/ui build`, `knip`, and `check-circular-deps` pass locally.

> Note: `pnpm typecheck` currently fails on `main` in `@sqlrooms/artifacts` (`packages/artifacts/src/artifactTarget.ts`), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scrollable row navigation arrows now update correctly when content is resized, added, removed, hidden, or changed through styling and attribute updates.
  * Improved handling of direct and nested content changes so scroll controls accurately reflect available content and overflow.

* **Tests**
  * Added coverage for text, numeric, nested, class, style, hidden, and data-attribute changes, as well as child updates and resizing without DOM mutations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->