### PR TITLE
feat(evals): add behavioral evaluation core

### DIFF
--- a/packages/evals/README.md
+++ b/packages/evals/README.md
@@ -11,9 +11,10 @@ application, React, browser, Promptfoo, or SQLite dependency.
 - Scenarios describe user turns, compatible production profiles, fixtures, and
   target-neutral outcome expectations.
 - Oracles inspect the final answer, database snapshot, workspace state, errors,
-  and mutations. They do not require one exact tool trajectory.
-- Run evidence records ordered events and durable outcomes in a versioned JSON
-  envelope.
+  and mutations. Oracle IDs must be unique and cover every scenario
+  expectation; they do not require one exact tool trajectory.
+- Run evidence records strictly ordered events and durable outcomes in a
+  versioned JSON envelope. Preserved extension fields must contain JSON values.
 - `@sqlrooms/evals/promptfoo` contains only structural conversion helpers for
   provider metadata and assertion results. Promptfoo remains a runner, not the
   core package interface.

--- a/packages/evals/README.md
+++ b/packages/evals/README.md
@@ -1,0 +1,68 @@
+# @sqlrooms/evals
+
+Private, evaluator-neutral behavioral evaluation primitives for SQLRooms.
+
+The package defines versioned scenarios, composable oracle results, a durable
+run-evidence envelope, and a deterministic AI SDK language model. It has no CLI
+application, React, browser, Promptfoo, or SQLite dependency.
+
+## Boundaries
+
+- Scenarios describe user turns, compatible production profiles, fixtures, and
+  target-neutral outcome expectations.
+- Oracles inspect the final answer, database snapshot, workspace state, errors,
+  and mutations. They do not require one exact tool trajectory.
+- Run evidence records ordered events and durable outcomes in a versioned JSON
+  envelope.
+- `@sqlrooms/evals/promptfoo` contains only structural conversion helpers for
+  provider metadata and assertion results. Promptfoo remains a runner, not the
+  core package interface.
+- The scripted model implements the AI SDK v3 language-model contract and can
+  assert prompt/tool wiring without credentials or network access.
+
+No generic execution adapter is defined. The in-process CLI target will be the
+first concrete runner; an adapter seam should be introduced only after a second
+working target such as MCP exists.
+
+## Example
+
+```ts
+import {
+  createWorkspaceStateOracle,
+  defineScenario,
+  evaluateOracles,
+} from '@sqlrooms/evals';
+
+const scenario = defineScenario({
+  id: 'worksheet.create-chart-map',
+  version: 1,
+  title: 'Create a chart and map',
+  compatibleProfiles: ['worksheet-charts-maps'],
+  turns: [{id: 'create', input: 'Create a worksheet with a chart and map.'}],
+  expectations: [
+    {
+      oracleId: 'worksheet-has-chart-map',
+      description: 'The worksheet contains valid chart and map blocks.',
+    },
+  ],
+});
+
+const oracle = createWorkspaceStateOracle({
+  id: 'worksheet-has-chart-map',
+  evaluate: (workspace) => ({
+    pass: workspace !== undefined,
+    reason: workspace
+      ? 'Workspace state captured.'
+      : 'Workspace state missing.',
+  }),
+});
+
+const results = await evaluateOracles([oracle], {
+  scenario,
+  workspace: {artifacts: []},
+  finalAnswer: '',
+  errors: [],
+  mutations: [],
+  metadata: {},
+});
+```

--- a/packages/evals/eslint.config.js
+++ b/packages/evals/eslint.config.js
@@ -1,0 +1,13 @@
+import {config} from '@sqlrooms/preset-eslint/base';
+
+/** @type {import("eslint").Linter.Config[]} */
+export default [
+  ...config,
+  {
+    languageOptions: {
+      parserOptions: {
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+];

--- a/packages/evals/jest.config.js
+++ b/packages/evals/jest.config.js
@@ -1,0 +1,6 @@
+import nodeConfig from '@sqlrooms/preset-jest/node.js';
+
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+export default {
+  ...nodeConfig,
+};

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@sqlrooms/evals",
+  "version": "0.29.0-rc.11",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sqlrooms/sqlrooms.git"
+  },
+  "license": "MIT",
+  "author": "SQLRooms Contributors",
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./promptfoo": {
+      "types": "./dist/promptfoo/index.d.ts",
+      "import": "./dist/promptfoo/index.js",
+      "default": "./dist/promptfoo/index.js"
+    }
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc -w",
+    "lint": "eslint .",
+    "test": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest",
+    "test:watch": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest --watch",
+    "typecheck": "tsc --noEmit",
+    "typedoc": "typedoc"
+  },
+  "dependencies": {
+    "@ai-sdk/provider": "^3.0.10",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@jest/globals": "^30.3.0",
+    "@sqlrooms/preset-jest": "workspace:*",
+    "ai": "^6.0.177",
+    "jest": "^30.1.3",
+    "ts-jest": "^29.4.4"
+  }
+}

--- a/packages/evals/src/__tests__/evidence.test.ts
+++ b/packages/evals/src/__tests__/evidence.test.ts
@@ -1,0 +1,75 @@
+import {describe, expect, it} from '@jest/globals';
+import {
+  parseRunEvidence,
+  RUN_EVIDENCE_SCHEMA_VERSION,
+  serializeRunEvidence,
+} from '../evidence';
+
+describe('run evidence', () => {
+  it('round-trips versioned evidence with unknown metadata preserved', () => {
+    const input = {
+      schemaVersion: RUN_EVIDENCE_SCHEMA_VERSION,
+      runId: 'run-1',
+      scenario: {
+        id: 'worksheet.create-chart-map',
+        version: 1,
+        repetition: 0,
+      },
+      target: {
+        type: 'cli-in-process',
+        profileName: 'worksheet-charts-maps',
+        profileVersion: 1,
+      },
+      repository: {commitSha: 'abc123', dirty: false},
+      model: {
+        provider: 'openrouter',
+        modelId: 'deepseek/deepseek-v4-flash-0731',
+        settings: {temperature: 0},
+      },
+      timing: {
+        startedAt: '2026-08-19T12:00:00.000Z',
+        endedAt: '2026-08-19T12:00:01.000Z',
+        latencyMs: 1000,
+      },
+      status: 'passed' as const,
+      promptTurns: [{id: 'create', input: 'Create a worksheet.'}],
+      finalAnswer: 'Created the worksheet.',
+      events: [
+        {
+          sequence: 0,
+          timestamp: '2026-08-19T12:00:00.500Z',
+          type: 'mutation' as const,
+          data: {artifactId: 'worksheet-1'},
+          futureEventField: 'preserved',
+        },
+      ],
+      finalState: {worksheetCount: 1},
+      oracleResults: [
+        {
+          oracleId: 'workspace',
+          kind: 'workspace-state' as const,
+          pass: true,
+          score: 1,
+          reason: 'Worksheet exists.',
+          evidence: {},
+          metadata: {futureOracleMetadata: {value: 42}},
+        },
+      ],
+      metadata: {futureRunnerMetadata: {traceId: 'trace-1'}},
+      futureEnvelopeField: {retained: true},
+    };
+
+    const parsed = parseRunEvidence(serializeRunEvidence(input));
+
+    expect(parsed.metadata).toEqual(input.metadata);
+    expect(parsed.oracleResults[0]?.metadata).toEqual(
+      input.oracleResults[0]?.metadata,
+    );
+    expect(parsed.events[0]).toHaveProperty('futureEventField', 'preserved');
+    expect(parsed).toHaveProperty('futureEnvelopeField', {retained: true});
+  });
+
+  it('rejects unsupported evidence versions', () => {
+    expect(() => parseRunEvidence({schemaVersion: 2})).toThrow();
+  });
+});

--- a/packages/evals/src/__tests__/evidence.test.ts
+++ b/packages/evals/src/__tests__/evidence.test.ts
@@ -103,4 +103,62 @@ describe('run evidence', () => {
   it('rejects unsupported evidence versions', () => {
     expect(() => parseRunEvidence({schemaVersion: 2})).toThrow();
   });
+
+  it('allocates fresh object defaults for every evidence record', () => {
+    const input = {
+      schemaVersion: RUN_EVIDENCE_SCHEMA_VERSION,
+      runId: 'run-defaults',
+      scenario: {
+        id: 'worksheet.defaults',
+        version: 1,
+        repetition: 0,
+      },
+      target: {
+        type: 'cli-in-process',
+        profileName: 'worksheet-charts-maps',
+        profileVersion: 1,
+      },
+      model: {
+        provider: 'scripted',
+        modelId: 'scripted-v1',
+      },
+      timing: {
+        startedAt: '2026-08-19T12:00:00.000Z',
+        endedAt: '2026-08-19T12:00:00.010Z',
+        latencyMs: 10,
+      },
+      status: 'passed',
+      promptTurns: [],
+      finalAnswer: 'Done.',
+      events: [
+        {
+          sequence: 0,
+          timestamp: '2026-08-19T12:00:00.005Z',
+          type: 'tool',
+        },
+      ],
+      oracleResults: [
+        {
+          oracleId: 'workspace',
+          kind: 'workspace-state',
+          pass: true,
+          score: 1,
+          reason: 'Workspace is valid.',
+        },
+      ],
+    };
+
+    const first = parseRunEvidence(input);
+    const second = parseRunEvidence(input);
+
+    expect(first.metadata).not.toBe(second.metadata);
+    expect(first.model.settings).not.toBe(second.model.settings);
+    expect(first.events[0]?.data).not.toBe(second.events[0]?.data);
+    expect(first.oracleResults[0]?.evidence).not.toBe(
+      second.oracleResults[0]?.evidence,
+    );
+    expect(first.oracleResults[0]?.metadata).not.toBe(
+      second.oracleResults[0]?.metadata,
+    );
+  });
 });

--- a/packages/evals/src/__tests__/evidence.test.ts
+++ b/packages/evals/src/__tests__/evidence.test.ts
@@ -14,25 +14,39 @@ describe('run evidence', () => {
         id: 'worksheet.create-chart-map',
         version: 1,
         repetition: 0,
+        futureScenarioField: 'preserved',
       },
       target: {
         type: 'cli-in-process',
         profileName: 'worksheet-charts-maps',
         profileVersion: 1,
+        futureTargetField: 'preserved',
       },
-      repository: {commitSha: 'abc123', dirty: false},
+      repository: {
+        commitSha: 'abc123',
+        dirty: false,
+        futureRepositoryField: 'preserved',
+      },
       model: {
         provider: 'openrouter',
         modelId: 'deepseek/deepseek-v4-flash-0731',
         settings: {temperature: 0},
+        futureModelField: 'preserved',
       },
       timing: {
         startedAt: '2026-08-19T12:00:00.000Z',
         endedAt: '2026-08-19T12:00:01.000Z',
         latencyMs: 1000,
+        futureTimingField: 'preserved',
       },
       status: 'passed' as const,
-      promptTurns: [{id: 'create', input: 'Create a worksheet.'}],
+      promptTurns: [
+        {
+          id: 'create',
+          input: 'Create a worksheet.',
+          futurePromptField: 'preserved',
+        },
+      ],
       finalAnswer: 'Created the worksheet.',
       events: [
         {
@@ -43,6 +57,10 @@ describe('run evidence', () => {
           futureEventField: 'preserved',
         },
       ],
+      usage: {
+        totalTokens: 10,
+        futureUsageField: 'preserved',
+      },
       finalState: {worksheetCount: 1},
       oracleResults: [
         {
@@ -66,6 +84,19 @@ describe('run evidence', () => {
       input.oracleResults[0]?.metadata,
     );
     expect(parsed.events[0]).toHaveProperty('futureEventField', 'preserved');
+    expect(parsed.scenario).toHaveProperty('futureScenarioField', 'preserved');
+    expect(parsed.target).toHaveProperty('futureTargetField', 'preserved');
+    expect(parsed.repository).toHaveProperty(
+      'futureRepositoryField',
+      'preserved',
+    );
+    expect(parsed.model).toHaveProperty('futureModelField', 'preserved');
+    expect(parsed.timing).toHaveProperty('futureTimingField', 'preserved');
+    expect(parsed.promptTurns[0]).toHaveProperty(
+      'futurePromptField',
+      'preserved',
+    );
+    expect(parsed.usage).toHaveProperty('futureUsageField', 'preserved');
     expect(parsed).toHaveProperty('futureEnvelopeField', {retained: true});
   });
 

--- a/packages/evals/src/__tests__/evidence.test.ts
+++ b/packages/evals/src/__tests__/evidence.test.ts
@@ -104,6 +104,71 @@ describe('run evidence', () => {
     expect(() => parseRunEvidence({schemaVersion: 2})).toThrow();
   });
 
+  it.each([
+    ['duplicate', [0, 0]],
+    ['descending', [1, 0]],
+  ])('rejects %s event sequence values', (_name, sequences) => {
+    expect(() =>
+      parseRunEvidence({
+        schemaVersion: RUN_EVIDENCE_SCHEMA_VERSION,
+        runId: 'run-ordering',
+        scenario: {id: 'worksheet.ordering', version: 1, repetition: 0},
+        target: {
+          type: 'cli-in-process',
+          profileName: 'worksheet-charts-maps',
+          profileVersion: 1,
+        },
+        model: {provider: 'scripted', modelId: 'scripted-v1'},
+        timing: {
+          startedAt: '2026-08-19T12:00:00.000Z',
+          endedAt: '2026-08-19T12:00:00.010Z',
+          latencyMs: 10,
+        },
+        status: 'passed',
+        promptTurns: [],
+        finalAnswer: 'Done.',
+        events: sequences.map((sequence) => ({
+          sequence,
+          timestamp: '2026-08-19T12:00:00.005Z',
+          type: 'tool',
+        })),
+        oracleResults: [],
+      }),
+    ).toThrow('Event sequence values must be strictly increasing.');
+  });
+
+  it.each([
+    ['bigint', BigInt(1)],
+    ['undefined', undefined],
+    ['function', () => 1],
+    ['symbol', Symbol('future')],
+  ])('rejects a non-JSON %s extension value', (_name, value) => {
+    expect(() =>
+      parseRunEvidence({
+        schemaVersion: RUN_EVIDENCE_SCHEMA_VERSION,
+        runId: 'run-json-extension',
+        scenario: {id: 'worksheet.json-extension', version: 1, repetition: 0},
+        target: {
+          type: 'cli-in-process',
+          profileName: 'worksheet-charts-maps',
+          profileVersion: 1,
+        },
+        model: {provider: 'scripted', modelId: 'scripted-v1'},
+        timing: {
+          startedAt: '2026-08-19T12:00:00.000Z',
+          endedAt: '2026-08-19T12:00:00.010Z',
+          latencyMs: 10,
+        },
+        status: 'passed',
+        promptTurns: [],
+        finalAnswer: 'Done.',
+        events: [],
+        oracleResults: [],
+        futureEnvelopeField: value,
+      }),
+    ).toThrow();
+  });
+
   it('allocates fresh object defaults for every evidence record', () => {
     const input = {
       schemaVersion: RUN_EVIDENCE_SCHEMA_VERSION,

--- a/packages/evals/src/__tests__/oracle.test.ts
+++ b/packages/evals/src/__tests__/oracle.test.ts
@@ -1,0 +1,109 @@
+import {describe, expect, it} from '@jest/globals';
+import {
+  createAnswerGroundingOracle,
+  createDatabaseOracle,
+  createErrorOracle,
+  createPolicyOracle,
+  createWorkspaceStateOracle,
+  evaluateOracles,
+  summarizeOracleResults,
+  type OracleContext,
+} from '../oracle';
+import {defineScenario} from '../scenario';
+
+const scenario = defineScenario({
+  id: 'worksheet.verify-outcomes',
+  version: 1,
+  title: 'Verify outcomes',
+  compatibleProfiles: ['worksheet-charts-maps'],
+  turns: [{id: 'verify', input: 'Verify the result.'}],
+  expectations: [{oracleId: 'database', description: 'Database is grounded.'}],
+});
+
+const context: OracleContext = {
+  scenario,
+  database: {canonicalTable: 'analytics.events'},
+  workspace: {worksheetCount: 1},
+  finalAnswer: 'Created one worksheet from analytics.events.',
+  errors: [],
+  mutations: [{kind: 'worksheet.create', targetId: 'worksheet-1'}],
+  metadata: {},
+};
+
+describe('behavioral oracles', () => {
+  it('composes database, workspace, answer, error, and policy checks', async () => {
+    const results = await evaluateOracles(
+      [
+        createDatabaseOracle({
+          id: 'database',
+          evaluate: (database) => ({
+            pass:
+              typeof database === 'object' &&
+              database !== null &&
+              !Array.isArray(database) &&
+              database.canonicalTable === 'analytics.events',
+            reason: 'Canonical table matched.',
+          }),
+        }),
+        createWorkspaceStateOracle({
+          id: 'workspace',
+          evaluate: (workspace) => ({
+            pass: workspace !== undefined,
+            reason: 'Workspace snapshot exists.',
+          }),
+        }),
+        createAnswerGroundingOracle({
+          id: 'answer',
+          evaluate: (answer) => ({
+            pass: answer.includes('analytics.events'),
+            score: 0.8,
+            reason: 'Answer names the selected table.',
+          }),
+        }),
+        createErrorOracle({
+          id: 'errors',
+          evaluate: (errors) => ({
+            pass: errors.length === 0,
+            reason: 'No errors observed.',
+          }),
+        }),
+        createPolicyOracle({
+          id: 'policy',
+          evaluate: (mutations) => ({
+            pass: mutations.length === 1,
+            reason: 'Only the intended mutation occurred.',
+            evidence: {mutationCount: mutations.length},
+          }),
+        }),
+      ],
+      context,
+    );
+
+    expect(results).toHaveLength(5);
+    expect(results.every((result) => result.pass)).toBe(true);
+    expect(summarizeOracleResults(results)).toEqual({pass: true, score: 0.96});
+  });
+
+  it('keeps failure reasons and structured evidence', async () => {
+    const [result] = await evaluateOracles(
+      [
+        createPolicyOracle({
+          id: 'read-only',
+          evaluate: (mutations) => ({
+            pass: mutations.length === 0,
+            reason: 'Read-only scenario mutated workspace state.',
+            evidence: {mutations: mutations.length},
+          }),
+        }),
+      ],
+      context,
+    );
+
+    expect(result).toMatchObject({
+      pass: false,
+      score: 0,
+      reason: 'Read-only scenario mutated workspace state.',
+      evidence: {mutations: 1},
+    });
+  });
+});

--- a/packages/evals/src/__tests__/oracle.test.ts
+++ b/packages/evals/src/__tests__/oracle.test.ts
@@ -146,4 +146,15 @@ describe('behavioral oracles', () => {
       ),
     ).rejects.toThrow('Missing required oracle implementations: workspace.');
   });
+
+  it('rejects duplicate oracle implementations', async () => {
+    const duplicateOracle = createDatabaseOracle({
+      id: 'database',
+      evaluate: () => ({pass: true, reason: 'Database is valid.'}),
+    });
+
+    await expect(
+      evaluateOracles([duplicateOracle, duplicateOracle], context),
+    ).rejects.toThrow('Duplicate oracle implementations: database.');
+  });
 });

--- a/packages/evals/src/__tests__/oracle.test.ts
+++ b/packages/evals/src/__tests__/oracle.test.ts
@@ -106,4 +106,8 @@ describe('behavioral oracles', () => {
       evidence: {mutations: 1},
     });
   });
+
+  it('does not pass when no oracle results were produced', () => {
+    expect(summarizeOracleResults([])).toEqual({pass: false, score: 0});
+  });
 });

--- a/packages/evals/src/__tests__/oracle.test.ts
+++ b/packages/evals/src/__tests__/oracle.test.ts
@@ -96,7 +96,18 @@ describe('behavioral oracles', () => {
           }),
         }),
       ],
-      context,
+      {
+        ...context,
+        scenario: defineScenario({
+          ...scenario,
+          expectations: [
+            {
+              oracleId: 'read-only',
+              description: 'Workspace remains read-only.',
+            },
+          ],
+        }),
+      },
     );
 
     expect(result).toMatchObject({
@@ -109,5 +120,30 @@ describe('behavioral oracles', () => {
 
   it('does not pass when no oracle results were produced', () => {
     expect(summarizeOracleResults([])).toEqual({pass: false, score: 0});
+  });
+
+  it('rejects a passing subset when required oracles are missing', async () => {
+    const scenarioWithMultipleExpectations = defineScenario({
+      ...scenario,
+      expectations: [
+        ...scenario.expectations,
+        {
+          oracleId: 'workspace',
+          description: 'Workspace state is valid.',
+        },
+      ],
+    });
+
+    await expect(
+      evaluateOracles(
+        [
+          createDatabaseOracle({
+            id: 'database',
+            evaluate: () => ({pass: true, reason: 'Database is valid.'}),
+          }),
+        ],
+        {...context, scenario: scenarioWithMultipleExpectations},
+      ),
+    ).rejects.toThrow('Missing required oracle implementations: workspace.');
   });
 });

--- a/packages/evals/src/__tests__/promptfoo.test.ts
+++ b/packages/evals/src/__tests__/promptfoo.test.ts
@@ -1,0 +1,68 @@
+import {describe, expect, it} from '@jest/globals';
+import type {RunEvidence} from '../evidence';
+import {
+  toPromptfooAssertionResult,
+  toPromptfooProviderResponse,
+} from '../promptfoo';
+
+const evidence: RunEvidence = {
+  schemaVersion: 1,
+  runId: 'run-1',
+  scenario: {id: 'worksheet.verify', version: 1, repetition: 0},
+  target: {
+    type: 'cli-in-process',
+    profileName: 'worksheet-charts-maps',
+    profileVersion: 1,
+  },
+  model: {provider: 'scripted', modelId: 'scripted-v1', settings: {}},
+  timing: {
+    startedAt: '2026-08-19T12:00:00.000Z',
+    endedAt: '2026-08-19T12:00:00.010Z',
+    latencyMs: 10,
+  },
+  status: 'passed',
+  promptTurns: [],
+  finalAnswer: 'Done.',
+  events: [],
+  oracleResults: [],
+  metadata: {},
+};
+
+describe('Promptfoo boundary helpers', () => {
+  it('puts validated evidence in provider metadata', () => {
+    expect(toPromptfooProviderResponse(evidence)).toEqual({
+      output: 'Done.',
+      metadata: {sqlroomsEvidence: evidence},
+    });
+  });
+
+  it('converts oracle results to one assertion result', () => {
+    expect(
+      toPromptfooAssertionResult([
+        {
+          oracleId: 'workspace',
+          kind: 'workspace-state',
+          pass: true,
+          score: 1,
+          reason: 'Valid.',
+          evidence: {},
+          metadata: {},
+        },
+        {
+          oracleId: 'answer',
+          kind: 'answer-grounding',
+          pass: false,
+          score: 0.25,
+          reason: 'Missing source.',
+          evidence: {},
+          metadata: {},
+        },
+      ]),
+    ).toEqual({
+      pass: false,
+      score: 0.625,
+      reason: 'answer: Missing source.',
+      namedScores: {workspace: 1, answer: 0.25},
+    });
+  });
+});

--- a/packages/evals/src/__tests__/promptfoo.test.ts
+++ b/packages/evals/src/__tests__/promptfoo.test.ts
@@ -65,4 +65,29 @@ describe('Promptfoo boundary helpers', () => {
       namedScores: {workspace: 1, answer: 0.25},
     });
   });
+
+  it('reports an empty result set as a failure', () => {
+    expect(toPromptfooAssertionResult([])).toEqual({
+      pass: false,
+      score: 0,
+      reason: 'No SQLRooms oracle results were produced.',
+      namedScores: {},
+    });
+  });
+
+  it('rejects duplicate oracle result IDs', () => {
+    const result = {
+      oracleId: 'workspace',
+      kind: 'workspace-state' as const,
+      pass: true,
+      score: 1,
+      reason: 'Valid.',
+      evidence: {},
+      metadata: {},
+    };
+
+    expect(() => toPromptfooAssertionResult([result, result])).toThrow(
+      'Duplicate oracle result IDs: workspace.',
+    );
+  });
 });

--- a/packages/evals/src/__tests__/scenario.test.ts
+++ b/packages/evals/src/__tests__/scenario.test.ts
@@ -1,0 +1,42 @@
+import {describe, expect, it} from '@jest/globals';
+import {defineScenario} from '../scenario';
+
+describe('behavioral scenarios', () => {
+  it('expresses compatible profiles and target-neutral outcomes', () => {
+    const scenario = defineScenario({
+      id: 'worksheet.create-chart-map',
+      version: 1,
+      title: 'Create chart and map',
+      compatibleProfiles: ['worksheet-charts-maps'],
+      fixture: {database: 'ambiguous-geospatial'},
+      turns: [{id: 'create', input: 'Create a worksheet.'}],
+      expectations: [
+        {
+          oracleId: 'workspace-chart-map',
+          description: 'Chart and map blocks exist in one worksheet.',
+        },
+      ],
+      metadata: {owner: 'sqlrooms'},
+    });
+
+    expect(scenario.compatibleProfiles).toEqual(['worksheet-charts-maps']);
+    expect(scenario.expectations[0]).toEqual({
+      oracleId: 'workspace-chart-map',
+      description: 'Chart and map blocks exist in one worksheet.',
+      config: {},
+    });
+  });
+
+  it('rejects unstable scenario identifiers and empty turns', () => {
+    expect(() =>
+      defineScenario({
+        id: 'Worksheet Create',
+        version: 1,
+        title: 'Invalid',
+        compatibleProfiles: ['default'],
+        turns: [],
+        expectations: [],
+      }),
+    ).toThrow('Scenario IDs');
+  });
+});

--- a/packages/evals/src/__tests__/scenario.test.ts
+++ b/packages/evals/src/__tests__/scenario.test.ts
@@ -39,4 +39,26 @@ describe('behavioral scenarios', () => {
       }),
     ).toThrow('Scenario IDs');
   });
+
+  it('allocates fresh object defaults for every parsed scenario', () => {
+    const input = {
+      id: 'worksheet.defaults',
+      version: 1,
+      title: 'Fresh defaults',
+      compatibleProfiles: ['default'],
+      turns: [{id: 'verify', input: 'Verify defaults.'}],
+      expectations: [
+        {oracleId: 'workspace', description: 'Workspace is valid.'},
+      ],
+    };
+
+    const first = defineScenario(input);
+    const second = defineScenario(input);
+
+    expect(first.fixture).not.toBe(second.fixture);
+    expect(first.metadata).not.toBe(second.metadata);
+    expect(first.expectations[0]?.config).not.toBe(
+      second.expectations[0]?.config,
+    );
+  });
 });

--- a/packages/evals/src/__tests__/scriptedModel.test.ts
+++ b/packages/evals/src/__tests__/scriptedModel.test.ts
@@ -1,0 +1,88 @@
+import {describe, expect, it} from '@jest/globals';
+import {generateText, stepCountIs, tool} from 'ai';
+import {z} from 'zod';
+import {createScriptedLanguageModel} from '../scriptedModel';
+
+describe('scripted AI SDK model', () => {
+  it('drives a deterministic tool loop and records calls', async () => {
+    const scripted = createScriptedLanguageModel({
+      steps: [
+        {
+          expectation: {
+            promptIncludes: ['Inspect the worksheet'],
+            availableToolNames: ['inspect_workspace'],
+          },
+          content: [
+            {
+              type: 'tool-call',
+              toolName: 'inspect_workspace',
+              input: {worksheetId: 'worksheet-1'},
+            },
+          ],
+        },
+        {
+          content: [{type: 'text', text: 'The worksheet is valid.'}],
+          usage: {inputTokens: 10, outputTokens: 5},
+        },
+      ],
+    });
+
+    const result = await generateText({
+      model: scripted.model,
+      prompt: 'Inspect the worksheet.',
+      tools: {
+        inspect_workspace: tool({
+          description: 'Inspect durable workspace state.',
+          inputSchema: z.object({worksheetId: z.string()}),
+          execute: async ({worksheetId}) => ({worksheetId, valid: true}),
+        }),
+      },
+      stopWhen: stepCountIs(2),
+    });
+
+    expect(result.text).toBe('The worksheet is valid.');
+    expect(scripted.calls).toHaveLength(2);
+    expect(scripted.remainingSteps()).toBe(0);
+    expect(() => scripted.assertComplete()).not.toThrow();
+  });
+
+  it('fails clearly when script expectations or call counts diverge', async () => {
+    const scripted = createScriptedLanguageModel({
+      steps: [
+        {
+          expectation: {promptIncludes: ['expected prompt']},
+          content: [{type: 'text', text: 'unused'}],
+        },
+      ],
+    });
+
+    await expect(
+      scripted.model.doGenerate({prompt: [{role: 'user', content: []}]}),
+    ).rejects.toThrow('expected prompt');
+    expect(() => scripted.assertComplete()).not.toThrow();
+    await expect(
+      scripted.model.doGenerate({prompt: [{role: 'user', content: []}]}),
+    ).rejects.toThrow('more calls than configured');
+  });
+
+  it('supports the AI SDK streaming model path', async () => {
+    const scripted = createScriptedLanguageModel({
+      steps: [{content: [{type: 'text', text: 'streamed result'}]}],
+    });
+    const result = await scripted.model.doStream({
+      prompt: [{role: 'user', content: [{type: 'text', text: 'stream'}]}],
+    });
+    const parts = [];
+    for await (const part of result.stream) parts.push(part);
+
+    expect(parts).toContainEqual({
+      type: 'text-delta',
+      id: 'text-0',
+      delta: 'streamed result',
+    });
+    expect(parts.at(-1)).toMatchObject({
+      type: 'finish',
+      finishReason: {unified: 'stop'},
+    });
+  });
+});

--- a/packages/evals/src/evidence.ts
+++ b/packages/evals/src/evidence.ts
@@ -7,76 +7,102 @@ import {ScenarioIdSchema} from './scenario';
 export const RUN_EVIDENCE_SCHEMA_VERSION = 1 as const;
 
 /** Ordered event captured while a behavioral scenario runs. */
-export const RunEvidenceEventSchema = z.looseObject({
-  sequence: z.number().int().nonnegative(),
-  timestamp: z.string().datetime(),
-  type: z.enum([
-    'model',
-    'tool',
-    'nested-agent',
-    'approval',
-    'error',
-    'mutation',
-  ]),
-  name: z.string().min(1).optional(),
-  data: JsonObjectSchema.default(() => ({})),
-});
+export const RunEvidenceEventSchema = z
+  .looseObject({
+    sequence: z.number().int().nonnegative(),
+    timestamp: z.string().datetime(),
+    type: z.enum([
+      'model',
+      'tool',
+      'nested-agent',
+      'approval',
+      'error',
+      'mutation',
+    ]),
+    name: z.string().min(1).optional(),
+    data: JsonObjectSchema.default(() => ({})),
+  })
+  .catchall(JsonValueSchema);
 
 /** Versioned evidence persisted for one behavioral scenario run. */
-export const RunEvidenceSchema = z.looseObject({
-  schemaVersion: z.literal(RUN_EVIDENCE_SCHEMA_VERSION),
-  runId: z.string().min(1),
-  scenario: z.looseObject({
-    id: ScenarioIdSchema,
-    version: z.number().int().positive(),
-    repetition: z.number().int().nonnegative(),
-  }),
-  target: z.looseObject({
-    type: z.string().min(1),
-    profileName: z.string().min(1),
-    profileVersion: z.number().int().positive(),
-  }),
-  repository: z
-    .looseObject({
-      commitSha: z.string().min(1),
-      dirty: z.boolean(),
-      workflowUrl: z.string().url().optional(),
-    })
-    .optional(),
-  model: z.looseObject({
-    provider: z.string().min(1),
-    modelId: z.string().min(1),
-    configuredRevision: z.string().min(1).optional(),
-    upstreamProvider: z.string().min(1).optional(),
-    settings: JsonObjectSchema.default(() => ({})),
-  }),
-  timing: z.looseObject({
-    startedAt: z.string().datetime(),
-    endedAt: z.string().datetime(),
-    latencyMs: z.number().nonnegative(),
-  }),
-  status: z.enum(['passed', 'failed', 'error', 'cancelled']),
-  promptTurns: z.array(
-    z.looseObject({
-      id: z.string().min(1),
-      input: z.string(),
+export const RunEvidenceSchema = z
+  .looseObject({
+    schemaVersion: z.literal(RUN_EVIDENCE_SCHEMA_VERSION),
+    runId: z.string().min(1),
+    scenario: z
+      .looseObject({
+        id: ScenarioIdSchema,
+        version: z.number().int().positive(),
+        repetition: z.number().int().nonnegative(),
+      })
+      .catchall(JsonValueSchema),
+    target: z
+      .looseObject({
+        type: z.string().min(1),
+        profileName: z.string().min(1),
+        profileVersion: z.number().int().positive(),
+      })
+      .catchall(JsonValueSchema),
+    repository: z
+      .looseObject({
+        commitSha: z.string().min(1),
+        dirty: z.boolean(),
+        workflowUrl: z.string().url().optional(),
+      })
+      .catchall(JsonValueSchema)
+      .optional(),
+    model: z
+      .looseObject({
+        provider: z.string().min(1),
+        modelId: z.string().min(1),
+        configuredRevision: z.string().min(1).optional(),
+        upstreamProvider: z.string().min(1).optional(),
+        settings: JsonObjectSchema.default(() => ({})),
+      })
+      .catchall(JsonValueSchema),
+    timing: z
+      .looseObject({
+        startedAt: z.string().datetime(),
+        endedAt: z.string().datetime(),
+        latencyMs: z.number().nonnegative(),
+      })
+      .catchall(JsonValueSchema),
+    status: z.enum(['passed', 'failed', 'error', 'cancelled']),
+    promptTurns: z.array(
+      z
+        .looseObject({
+          id: z.string().min(1),
+          input: z.string(),
+        })
+        .catchall(JsonValueSchema),
+    ),
+    finalAnswer: z.string(),
+    events: z.array(RunEvidenceEventSchema).superRefine((events, context) => {
+      for (let index = 1; index < events.length; index += 1) {
+        if (events[index]!.sequence <= events[index - 1]!.sequence) {
+          context.addIssue({
+            code: 'custom',
+            message: 'Event sequence values must be strictly increasing.',
+            path: [index, 'sequence'],
+          });
+        }
+      }
     }),
-  ),
-  finalAnswer: z.string(),
-  events: z.array(RunEvidenceEventSchema),
-  usage: z
-    .looseObject({
-      inputTokens: z.number().nonnegative().optional(),
-      outputTokens: z.number().nonnegative().optional(),
-      totalTokens: z.number().nonnegative().optional(),
-      costUsd: z.number().nonnegative().optional(),
-      grader: JsonObjectSchema.optional(),
-    })
-    .optional(),
-  finalState: JsonValueSchema.optional(),
-  oracleResults: z.array(OracleResultSchema),
-  metadata: JsonObjectSchema.default(() => ({})),
-});
+    usage: z
+      .looseObject({
+        inputTokens: z.number().nonnegative().optional(),
+        outputTokens: z.number().nonnegative().optional(),
+        totalTokens: z.number().nonnegative().optional(),
+        costUsd: z.number().nonnegative().optional(),
+        grader: JsonObjectSchema.optional(),
+      })
+      .catchall(JsonValueSchema)
+      .optional(),
+    finalState: JsonValueSchema.optional(),
+    oracleResults: z.array(OracleResultSchema),
+    metadata: JsonObjectSchema.default(() => ({})),
+  })
+  .catchall(JsonValueSchema);
 
 /** Parsed run-evidence envelope. */
 export type RunEvidence = z.infer<typeof RunEvidenceSchema>;

--- a/packages/evals/src/evidence.ts
+++ b/packages/evals/src/evidence.ts
@@ -1,0 +1,94 @@
+import {z} from 'zod';
+import {JsonObjectSchema, JsonValueSchema} from './json';
+import {OracleResultSchema} from './oracle';
+import {ScenarioIdSchema} from './scenario';
+
+/** Current version of the durable run-evidence envelope. */
+export const RUN_EVIDENCE_SCHEMA_VERSION = 1 as const;
+
+/** Ordered event captured while a behavioral scenario runs. */
+export const RunEvidenceEventSchema = z.looseObject({
+  sequence: z.number().int().nonnegative(),
+  timestamp: z.string().datetime(),
+  type: z.enum([
+    'model',
+    'tool',
+    'nested-agent',
+    'approval',
+    'error',
+    'mutation',
+  ]),
+  name: z.string().min(1).optional(),
+  data: JsonObjectSchema.default({}),
+});
+
+/** Versioned evidence persisted for one behavioral scenario run. */
+export const RunEvidenceSchema = z.looseObject({
+  schemaVersion: z.literal(RUN_EVIDENCE_SCHEMA_VERSION),
+  runId: z.string().min(1),
+  scenario: z.object({
+    id: ScenarioIdSchema,
+    version: z.number().int().positive(),
+    repetition: z.number().int().nonnegative(),
+  }),
+  target: z.object({
+    type: z.string().min(1),
+    profileName: z.string().min(1),
+    profileVersion: z.number().int().positive(),
+  }),
+  repository: z
+    .object({
+      commitSha: z.string().min(1),
+      dirty: z.boolean(),
+      workflowUrl: z.string().url().optional(),
+    })
+    .optional(),
+  model: z.object({
+    provider: z.string().min(1),
+    modelId: z.string().min(1),
+    configuredRevision: z.string().min(1).optional(),
+    upstreamProvider: z.string().min(1).optional(),
+    settings: JsonObjectSchema.default({}),
+  }),
+  timing: z.object({
+    startedAt: z.string().datetime(),
+    endedAt: z.string().datetime(),
+    latencyMs: z.number().nonnegative(),
+  }),
+  status: z.enum(['passed', 'failed', 'error', 'cancelled']),
+  promptTurns: z.array(
+    z.object({
+      id: z.string().min(1),
+      input: z.string(),
+    }),
+  ),
+  finalAnswer: z.string(),
+  events: z.array(RunEvidenceEventSchema),
+  usage: z
+    .object({
+      inputTokens: z.number().nonnegative().optional(),
+      outputTokens: z.number().nonnegative().optional(),
+      totalTokens: z.number().nonnegative().optional(),
+      costUsd: z.number().nonnegative().optional(),
+      grader: JsonObjectSchema.optional(),
+    })
+    .optional(),
+  finalState: JsonValueSchema.optional(),
+  oracleResults: z.array(OracleResultSchema),
+  metadata: JsonObjectSchema.default({}),
+});
+
+/** Parsed run-evidence envelope. */
+export type RunEvidence = z.infer<typeof RunEvidenceSchema>;
+
+/** Parses an object or serialized JSON run-evidence envelope. */
+export function parseRunEvidence(input: unknown): RunEvidence {
+  return RunEvidenceSchema.parse(
+    typeof input === 'string' ? JSON.parse(input) : input,
+  );
+}
+
+/** Serializes validated run evidence for storage in runner metadata. */
+export function serializeRunEvidence(evidence: RunEvidence): string {
+  return JSON.stringify(RunEvidenceSchema.parse(evidence));
+}

--- a/packages/evals/src/evidence.ts
+++ b/packages/evals/src/evidence.ts
@@ -19,7 +19,7 @@ export const RunEvidenceEventSchema = z.looseObject({
     'mutation',
   ]),
   name: z.string().min(1).optional(),
-  data: JsonObjectSchema.default({}),
+  data: JsonObjectSchema.default(() => ({})),
 });
 
 /** Versioned evidence persisted for one behavioral scenario run. */
@@ -48,7 +48,7 @@ export const RunEvidenceSchema = z.looseObject({
     modelId: z.string().min(1),
     configuredRevision: z.string().min(1).optional(),
     upstreamProvider: z.string().min(1).optional(),
-    settings: JsonObjectSchema.default({}),
+    settings: JsonObjectSchema.default(() => ({})),
   }),
   timing: z.looseObject({
     startedAt: z.string().datetime(),
@@ -75,7 +75,7 @@ export const RunEvidenceSchema = z.looseObject({
     .optional(),
   finalState: JsonValueSchema.optional(),
   oracleResults: z.array(OracleResultSchema),
-  metadata: JsonObjectSchema.default({}),
+  metadata: JsonObjectSchema.default(() => ({})),
 });
 
 /** Parsed run-evidence envelope. */

--- a/packages/evals/src/evidence.ts
+++ b/packages/evals/src/evidence.ts
@@ -26,38 +26,38 @@ export const RunEvidenceEventSchema = z.looseObject({
 export const RunEvidenceSchema = z.looseObject({
   schemaVersion: z.literal(RUN_EVIDENCE_SCHEMA_VERSION),
   runId: z.string().min(1),
-  scenario: z.object({
+  scenario: z.looseObject({
     id: ScenarioIdSchema,
     version: z.number().int().positive(),
     repetition: z.number().int().nonnegative(),
   }),
-  target: z.object({
+  target: z.looseObject({
     type: z.string().min(1),
     profileName: z.string().min(1),
     profileVersion: z.number().int().positive(),
   }),
   repository: z
-    .object({
+    .looseObject({
       commitSha: z.string().min(1),
       dirty: z.boolean(),
       workflowUrl: z.string().url().optional(),
     })
     .optional(),
-  model: z.object({
+  model: z.looseObject({
     provider: z.string().min(1),
     modelId: z.string().min(1),
     configuredRevision: z.string().min(1).optional(),
     upstreamProvider: z.string().min(1).optional(),
     settings: JsonObjectSchema.default({}),
   }),
-  timing: z.object({
+  timing: z.looseObject({
     startedAt: z.string().datetime(),
     endedAt: z.string().datetime(),
     latencyMs: z.number().nonnegative(),
   }),
   status: z.enum(['passed', 'failed', 'error', 'cancelled']),
   promptTurns: z.array(
-    z.object({
+    z.looseObject({
       id: z.string().min(1),
       input: z.string(),
     }),
@@ -65,7 +65,7 @@ export const RunEvidenceSchema = z.looseObject({
   finalAnswer: z.string(),
   events: z.array(RunEvidenceEventSchema),
   usage: z
-    .object({
+    .looseObject({
       inputTokens: z.number().nonnegative().optional(),
       outputTokens: z.number().nonnegative().optional(),
       totalTokens: z.number().nonnegative().optional(),

--- a/packages/evals/src/index.ts
+++ b/packages/evals/src/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Evaluator-neutral behavioral scenario, oracle, evidence, and scripted-model
+ * primitives for SQLRooms.
+ *
+ * @packageDocumentation
+ */
+
+export * from './evidence';
+export * from './json';
+export * from './oracle';
+export * from './scenario';
+export * from './scriptedModel';

--- a/packages/evals/src/json.ts
+++ b/packages/evals/src/json.ts
@@ -1,0 +1,28 @@
+import {z} from 'zod';
+
+/** A JSON primitive value. */
+export type JsonPrimitive = string | number | boolean | null;
+
+/** A JSON object with recursively serializable values. */
+export type JsonObject = {[key: string]: JsonValue};
+
+/** A value that can be serialized losslessly as JSON. */
+export type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
+
+/** Runtime schema for recursively serializable JSON values. */
+export const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.array(JsonValueSchema),
+    z.record(z.string(), JsonValueSchema),
+  ]),
+);
+
+/** Runtime schema for JSON objects. */
+export const JsonObjectSchema: z.ZodType<JsonObject> = z.record(
+  z.string(),
+  JsonValueSchema,
+);

--- a/packages/evals/src/oracle.ts
+++ b/packages/evals/src/oracle.ts
@@ -142,11 +142,29 @@ export function createPolicyOracle(
   );
 }
 
-/** Evaluates oracles in declaration order and normalizes their results. */
+/**
+ * Evaluates oracles in declaration order and normalizes their results.
+ *
+ * @throws When a scenario expectation has no matching oracle implementation.
+ */
 export async function evaluateOracles(
   oracles: readonly BehavioralOracle[],
   context: OracleContext,
 ): Promise<OracleResult[]> {
+  const availableOracleIds = new Set(oracles.map((oracle) => oracle.id));
+  const missingOracleIds = Array.from(
+    new Set(
+      context.scenario.expectations
+        .map((expectation) => expectation.oracleId)
+        .filter((oracleId) => !availableOracleIds.has(oracleId)),
+    ),
+  );
+  if (missingOracleIds.length > 0) {
+    throw new Error(
+      `Missing required oracle implementations: ${missingOracleIds.join(', ')}.`,
+    );
+  }
+
   const results: OracleResult[] = [];
   for (const oracle of oracles) {
     const evaluation = await oracle.evaluate(context);

--- a/packages/evals/src/oracle.ts
+++ b/packages/evals/src/oracle.ts
@@ -171,7 +171,7 @@ export function summarizeOracleResults(results: readonly OracleResult[]): {
   score: number;
 } {
   return {
-    pass: results.every((result) => result.pass),
+    pass: results.length > 0 && results.every((result) => result.pass),
     score:
       results.length === 0
         ? 0

--- a/packages/evals/src/oracle.ts
+++ b/packages/evals/src/oracle.ts
@@ -19,8 +19,8 @@ export const OracleResultSchema = z.looseObject({
   pass: z.boolean(),
   score: z.number().min(0).max(1),
   reason: z.string().min(1),
-  evidence: JsonObjectSchema.default({}),
-  metadata: JsonObjectSchema.default({}),
+  evidence: JsonObjectSchema.default(() => ({})),
+  metadata: JsonObjectSchema.default(() => ({})),
 });
 
 /** Structured result produced by one behavioral oracle. */

--- a/packages/evals/src/oracle.ts
+++ b/packages/evals/src/oracle.ts
@@ -1,0 +1,181 @@
+import {z} from 'zod';
+import type {JsonObject, JsonValue} from './json';
+import {JsonObjectSchema} from './json';
+import type {ScenarioDefinition} from './scenario';
+
+/** Supported evaluator-neutral oracle categories. */
+export const OracleKindSchema = z.enum([
+  'database',
+  'workspace-state',
+  'answer-grounding',
+  'error',
+  'policy',
+]);
+
+/** Structured result produced by one behavioral oracle. */
+export const OracleResultSchema = z.looseObject({
+  oracleId: z.string().min(1),
+  kind: OracleKindSchema,
+  pass: z.boolean(),
+  score: z.number().min(0).max(1),
+  reason: z.string().min(1),
+  evidence: JsonObjectSchema.default({}),
+  metadata: JsonObjectSchema.default({}),
+});
+
+/** Structured result produced by one behavioral oracle. */
+export type OracleResult = z.infer<typeof OracleResultSchema>;
+
+/** Error observed during a behavioral run. */
+export type ObservedError = {
+  name?: string;
+  message: string;
+  code?: string;
+  metadata?: JsonObject;
+};
+
+/** Durable mutation observed during a behavioral run. */
+export type ObservedMutation = {
+  kind: string;
+  targetId?: string;
+  data?: JsonObject;
+};
+
+/** Target-neutral material available to behavioral oracles. */
+export type OracleContext = {
+  scenario: ScenarioDefinition;
+  database?: JsonValue;
+  workspace?: JsonValue;
+  finalAnswer: string;
+  errors: readonly ObservedError[];
+  mutations: readonly ObservedMutation[];
+  metadata: JsonObject;
+};
+
+/** Unnormalized outcome returned by an oracle implementation. */
+export type OracleEvaluation = {
+  pass: boolean;
+  score?: number;
+  reason: string;
+  evidence?: JsonObject;
+  metadata?: JsonObject;
+};
+
+/** An evaluator-neutral oracle. */
+export type BehavioralOracle = {
+  readonly id: string;
+  readonly kind: z.infer<typeof OracleKindSchema>;
+  evaluate(
+    context: OracleContext,
+  ): OracleEvaluation | Promise<OracleEvaluation>;
+};
+
+/** Definition for an oracle over one selected part of the run context. */
+export type OracleOptions<TValue> = {
+  id: string;
+  evaluate(
+    value: TValue,
+    context: OracleContext,
+  ): OracleEvaluation | Promise<OracleEvaluation>;
+};
+
+function createSpecializedOracle<TValue>(
+  kind: BehavioralOracle['kind'],
+  options: OracleOptions<TValue>,
+  select: (context: OracleContext) => TValue,
+): BehavioralOracle {
+  return {
+    id: options.id,
+    kind,
+    evaluate: (context) => options.evaluate(select(context), context),
+  };
+}
+
+/** Creates an oracle over the final database snapshot. */
+export function createDatabaseOracle(
+  options: OracleOptions<JsonValue | undefined>,
+): BehavioralOracle {
+  return createSpecializedOracle(
+    'database',
+    options,
+    (context) => context.database,
+  );
+}
+
+/** Creates an oracle over the final durable workspace state. */
+export function createWorkspaceStateOracle(
+  options: OracleOptions<JsonValue | undefined>,
+): BehavioralOracle {
+  return createSpecializedOracle(
+    'workspace-state',
+    options,
+    (context) => context.workspace,
+  );
+}
+
+/** Creates an oracle over the assistant's final answer and grounding context. */
+export function createAnswerGroundingOracle(
+  options: OracleOptions<string>,
+): BehavioralOracle {
+  return createSpecializedOracle(
+    'answer-grounding',
+    options,
+    (context) => context.finalAnswer,
+  );
+}
+
+/** Creates an oracle over errors observed during the run. */
+export function createErrorOracle(
+  options: OracleOptions<readonly ObservedError[]>,
+): BehavioralOracle {
+  return createSpecializedOracle('error', options, (context) => context.errors);
+}
+
+/** Creates an oracle over mutations for enforcing read/write policies. */
+export function createPolicyOracle(
+  options: OracleOptions<readonly ObservedMutation[]>,
+): BehavioralOracle {
+  return createSpecializedOracle(
+    'policy',
+    options,
+    (context) => context.mutations,
+  );
+}
+
+/** Evaluates oracles in declaration order and normalizes their results. */
+export async function evaluateOracles(
+  oracles: readonly BehavioralOracle[],
+  context: OracleContext,
+): Promise<OracleResult[]> {
+  const results: OracleResult[] = [];
+  for (const oracle of oracles) {
+    const evaluation = await oracle.evaluate(context);
+    results.push(
+      OracleResultSchema.parse({
+        oracleId: oracle.id,
+        kind: oracle.kind,
+        pass: evaluation.pass,
+        score: evaluation.score ?? (evaluation.pass ? 1 : 0),
+        reason: evaluation.reason,
+        evidence: evaluation.evidence ?? {},
+        metadata: evaluation.metadata ?? {},
+      }),
+    );
+  }
+  return results;
+}
+
+/** Aggregate status and mean score for a set of oracle results. */
+export function summarizeOracleResults(results: readonly OracleResult[]): {
+  pass: boolean;
+  score: number;
+} {
+  return {
+    pass: results.every((result) => result.pass),
+    score:
+      results.length === 0
+        ? 0
+        : results.reduce((sum, result) => sum + result.score, 0) /
+          results.length,
+  };
+}

--- a/packages/evals/src/oracle.ts
+++ b/packages/evals/src/oracle.ts
@@ -1,6 +1,6 @@
 import {z} from 'zod';
 import type {JsonObject, JsonValue} from './json';
-import {JsonObjectSchema} from './json';
+import {JsonObjectSchema, JsonValueSchema} from './json';
 import type {ScenarioDefinition} from './scenario';
 
 /** Supported evaluator-neutral oracle categories. */
@@ -13,15 +13,17 @@ export const OracleKindSchema = z.enum([
 ]);
 
 /** Structured result produced by one behavioral oracle. */
-export const OracleResultSchema = z.looseObject({
-  oracleId: z.string().min(1),
-  kind: OracleKindSchema,
-  pass: z.boolean(),
-  score: z.number().min(0).max(1),
-  reason: z.string().min(1),
-  evidence: JsonObjectSchema.default(() => ({})),
-  metadata: JsonObjectSchema.default(() => ({})),
-});
+export const OracleResultSchema = z
+  .looseObject({
+    oracleId: z.string().min(1),
+    kind: OracleKindSchema,
+    pass: z.boolean(),
+    score: z.number().min(0).max(1),
+    reason: z.string().min(1),
+    evidence: JsonObjectSchema.default(() => ({})),
+    metadata: JsonObjectSchema.default(() => ({})),
+  })
+  .catchall(JsonValueSchema);
 
 /** Structured result produced by one behavioral oracle. */
 export type OracleResult = z.infer<typeof OracleResultSchema>;
@@ -145,12 +147,28 @@ export function createPolicyOracle(
 /**
  * Evaluates oracles in declaration order and normalizes their results.
  *
- * @throws When a scenario expectation has no matching oracle implementation.
+ * @throws When oracle IDs are duplicated or a scenario expectation has no
+ * matching oracle implementation.
  */
 export async function evaluateOracles(
   oracles: readonly BehavioralOracle[],
   context: OracleContext,
 ): Promise<OracleResult[]> {
+  const duplicateOracleIds = Array.from(
+    new Set(
+      oracles
+        .map((oracle) => oracle.id)
+        .filter(
+          (oracleId, index, oracleIds) => oracleIds.indexOf(oracleId) !== index,
+        ),
+    ),
+  );
+  if (duplicateOracleIds.length > 0) {
+    throw new Error(
+      `Duplicate oracle implementations: ${duplicateOracleIds.join(', ')}.`,
+    );
+  }
+
   const availableOracleIds = new Set(oracles.map((oracle) => oracle.id));
   const missingOracleIds = Array.from(
     new Set(

--- a/packages/evals/src/promptfoo/index.ts
+++ b/packages/evals/src/promptfoo/index.ts
@@ -28,23 +28,44 @@ export function toPromptfooProviderResponse(
   };
 }
 
-/** Converts oracle results into one Promptfoo assertion result. */
+/**
+ * Converts oracle results into one Promptfoo assertion result.
+ *
+ * @throws When multiple results use the same oracle ID.
+ */
 export function toPromptfooAssertionResult(
   results: readonly OracleResult[],
 ): PromptfooAssertionResult {
   const parsedResults = results.map((result) =>
     OracleResultSchema.parse(result),
   );
+  const duplicateOracleIds = Array.from(
+    new Set(
+      parsedResults
+        .map((result) => result.oracleId)
+        .filter(
+          (oracleId, index, oracleIds) => oracleIds.indexOf(oracleId) !== index,
+        ),
+    ),
+  );
+  if (duplicateOracleIds.length > 0) {
+    throw new Error(
+      `Duplicate oracle result IDs: ${duplicateOracleIds.join(', ')}.`,
+    );
+  }
+
   const summary = summarizeOracleResults(parsedResults);
   const failures = parsedResults.filter((result) => !result.pass);
   return {
     ...summary,
     reason:
-      failures.length === 0
-        ? `${parsedResults.length} SQLRooms oracle${parsedResults.length === 1 ? '' : 's'} passed.`
-        : failures
-            .map((result) => `${result.oracleId}: ${result.reason}`)
-            .join('; '),
+      parsedResults.length === 0
+        ? 'No SQLRooms oracle results were produced.'
+        : failures.length === 0
+          ? `${parsedResults.length} SQLRooms oracle${parsedResults.length === 1 ? '' : 's'} passed.`
+          : failures
+              .map((result) => `${result.oracleId}: ${result.reason}`)
+              .join('; '),
     namedScores: Object.fromEntries(
       parsedResults.map((result) => [result.oracleId, result.score]),
     ),

--- a/packages/evals/src/promptfoo/index.ts
+++ b/packages/evals/src/promptfoo/index.ts
@@ -1,0 +1,52 @@
+import type {OracleResult} from '../oracle';
+import {OracleResultSchema, summarizeOracleResults} from '../oracle';
+import type {RunEvidence} from '../evidence';
+import {RunEvidenceSchema} from '../evidence';
+
+/** Promptfoo-compatible provider response without a Promptfoo dependency. */
+export type PromptfooProviderResponse = {
+  output: string;
+  metadata: Record<string, unknown>;
+};
+
+/** Promptfoo-compatible assertion result without a Promptfoo dependency. */
+export type PromptfooAssertionResult = {
+  pass: boolean;
+  score: number;
+  reason: string;
+  namedScores: Record<string, number>;
+};
+
+/** Stores validated SQLRooms evidence in Promptfoo provider metadata. */
+export function toPromptfooProviderResponse(
+  evidence: RunEvidence,
+): PromptfooProviderResponse {
+  const parsed = RunEvidenceSchema.parse(evidence);
+  return {
+    output: parsed.finalAnswer,
+    metadata: {sqlroomsEvidence: parsed},
+  };
+}
+
+/** Converts oracle results into one Promptfoo assertion result. */
+export function toPromptfooAssertionResult(
+  results: readonly OracleResult[],
+): PromptfooAssertionResult {
+  const parsedResults = results.map((result) =>
+    OracleResultSchema.parse(result),
+  );
+  const summary = summarizeOracleResults(parsedResults);
+  const failures = parsedResults.filter((result) => !result.pass);
+  return {
+    ...summary,
+    reason:
+      failures.length === 0
+        ? `${parsedResults.length} SQLRooms oracle${parsedResults.length === 1 ? '' : 's'} passed.`
+        : failures
+            .map((result) => `${result.oracleId}: ${result.reason}`)
+            .join('; '),
+    namedScores: Object.fromEntries(
+      parsedResults.map((result) => [result.oracleId, result.score]),
+    ),
+  };
+}

--- a/packages/evals/src/scenario.ts
+++ b/packages/evals/src/scenario.ts
@@ -1,0 +1,44 @@
+import {z} from 'zod';
+import {JsonObjectSchema} from './json';
+
+/** Stable scenario identifier format used in run history. */
+export const ScenarioIdSchema = z
+  .string()
+  .regex(
+    /^[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*$/,
+    'Scenario IDs must be lowercase dot- or dash-separated identifiers.',
+  );
+
+/** One user turn in an evaluator-neutral behavioral scenario. */
+export const ScenarioTurnSchema = z.object({
+  id: z.string().min(1),
+  input: z.string().min(1),
+});
+
+/** An outcome contract evaluated after a scenario run. */
+export const ScenarioExpectationSchema = z.object({
+  oracleId: z.string().min(1),
+  description: z.string().min(1),
+  config: JsonObjectSchema.default({}),
+});
+
+/** Versioned, evaluator-neutral behavioral scenario definition. */
+export const ScenarioDefinitionSchema = z.looseObject({
+  id: ScenarioIdSchema,
+  version: z.number().int().positive(),
+  title: z.string().min(1),
+  description: z.string().min(1).optional(),
+  compatibleProfiles: z.array(z.string().min(1)).min(1),
+  fixture: JsonObjectSchema.default({}),
+  turns: z.array(ScenarioTurnSchema).min(1),
+  expectations: z.array(ScenarioExpectationSchema).min(1),
+  metadata: JsonObjectSchema.default({}),
+});
+
+/** A parsed behavioral scenario. */
+export type ScenarioDefinition = z.infer<typeof ScenarioDefinitionSchema>;
+
+/** Parses and validates a behavioral scenario definition. */
+export function defineScenario(input: unknown): ScenarioDefinition {
+  return ScenarioDefinitionSchema.parse(input);
+}

--- a/packages/evals/src/scenario.ts
+++ b/packages/evals/src/scenario.ts
@@ -19,7 +19,7 @@ export const ScenarioTurnSchema = z.object({
 export const ScenarioExpectationSchema = z.object({
   oracleId: z.string().min(1),
   description: z.string().min(1),
-  config: JsonObjectSchema.default({}),
+  config: JsonObjectSchema.default(() => ({})),
 });
 
 /** Versioned, evaluator-neutral behavioral scenario definition. */
@@ -29,10 +29,10 @@ export const ScenarioDefinitionSchema = z.looseObject({
   title: z.string().min(1),
   description: z.string().min(1).optional(),
   compatibleProfiles: z.array(z.string().min(1)).min(1),
-  fixture: JsonObjectSchema.default({}),
+  fixture: JsonObjectSchema.default(() => ({})),
   turns: z.array(ScenarioTurnSchema).min(1),
   expectations: z.array(ScenarioExpectationSchema).min(1),
-  metadata: JsonObjectSchema.default({}),
+  metadata: JsonObjectSchema.default(() => ({})),
 });
 
 /** A parsed behavioral scenario. */

--- a/packages/evals/src/scriptedModel.ts
+++ b/packages/evals/src/scriptedModel.ts
@@ -1,0 +1,220 @@
+import type {
+  LanguageModelV3,
+  LanguageModelV3CallOptions,
+  LanguageModelV3Content,
+  LanguageModelV3FinishReason,
+  LanguageModelV3GenerateResult,
+  LanguageModelV3StreamPart,
+  LanguageModelV3Usage,
+} from '@ai-sdk/provider';
+import type {JsonObject} from './json';
+
+/** One text or tool-call output emitted by a scripted model step. */
+export type ScriptedModelContent =
+  | {type: 'text'; text: string}
+  | {
+      type: 'tool-call';
+      toolName: string;
+      input: JsonObject;
+      toolCallId?: string;
+    };
+
+/** Declarative checks for the AI SDK call that consumes a scripted step. */
+export type ScriptedModelExpectation = {
+  promptIncludes?: readonly string[];
+  availableToolNames?: readonly string[];
+};
+
+/** One deterministic response in a scripted AI SDK model. */
+export type ScriptedModelStep = {
+  content: readonly ScriptedModelContent[];
+  finishReason?: LanguageModelV3FinishReason['unified'];
+  expectation?: ScriptedModelExpectation;
+  usage?: Partial<{
+    inputTokens: number;
+    outputTokens: number;
+  }>;
+};
+
+/** Handle returned with a scripted language model and its observed calls. */
+export type ScriptedLanguageModel = {
+  model: LanguageModelV3;
+  calls: LanguageModelV3CallOptions[];
+  remainingSteps(): number;
+  assertComplete(): void;
+};
+
+function promptText(options: LanguageModelV3CallOptions): string {
+  return options.prompt
+    .flatMap((message) =>
+      typeof message.content === 'string'
+        ? [message.content]
+        : message.content.flatMap((part) =>
+            part.type === 'text' || part.type === 'reasoning'
+              ? [part.text]
+              : [],
+          ),
+    )
+    .join('\n');
+}
+
+function validateExpectation(
+  expectation: ScriptedModelExpectation | undefined,
+  options: LanguageModelV3CallOptions,
+) {
+  if (!expectation) return;
+  const text = promptText(options);
+  for (const expectedText of expectation.promptIncludes ?? []) {
+    if (!text.includes(expectedText)) {
+      throw new Error(
+        `Scripted model expected prompt to include ${JSON.stringify(expectedText)}.`,
+      );
+    }
+  }
+
+  if (expectation.availableToolNames) {
+    const actualNames = (options.tools ?? []).map((tool) => tool.name).sort();
+    const expectedNames = [...expectation.availableToolNames].sort();
+    if (JSON.stringify(actualNames) !== JSON.stringify(expectedNames)) {
+      throw new Error(
+        `Scripted model expected tools ${expectedNames.join(', ') || '(none)'}, received ${actualNames.join(', ') || '(none)'}.`,
+      );
+    }
+  }
+}
+
+function usage(step: ScriptedModelStep): LanguageModelV3Usage {
+  const inputTokens = step.usage?.inputTokens ?? 0;
+  const outputTokens = step.usage?.outputTokens ?? 0;
+  return {
+    inputTokens: {
+      total: inputTokens,
+      noCache: inputTokens,
+      cacheRead: 0,
+      cacheWrite: 0,
+    },
+    outputTokens: {
+      total: outputTokens,
+      text: outputTokens,
+      reasoning: 0,
+    },
+  };
+}
+
+function finishReason(step: ScriptedModelStep): LanguageModelV3FinishReason {
+  const unified =
+    step.finishReason ??
+    (step.content.some((content) => content.type === 'tool-call')
+      ? 'tool-calls'
+      : 'stop');
+  return {unified, raw: unified};
+}
+
+function content(
+  step: ScriptedModelStep,
+  stepIndex: number,
+): LanguageModelV3Content[] {
+  return step.content.map((part, partIndex) =>
+    part.type === 'text'
+      ? part
+      : {
+          type: 'tool-call' as const,
+          toolCallId: part.toolCallId ?? `scripted-${stepIndex}-${partIndex}`,
+          toolName: part.toolName,
+          input: JSON.stringify(part.input),
+        },
+  );
+}
+
+function streamParts(
+  generated: LanguageModelV3GenerateResult,
+): LanguageModelV3StreamPart[] {
+  const parts: LanguageModelV3StreamPart[] = [
+    {type: 'stream-start', warnings: []},
+  ];
+  generated.content.forEach((part, index) => {
+    if (part.type === 'text') {
+      const id = `text-${index}`;
+      parts.push(
+        {type: 'text-start', id},
+        {type: 'text-delta', id, delta: part.text},
+        {type: 'text-end', id},
+      );
+    } else if (part.type === 'tool-call') {
+      parts.push(part);
+    }
+  });
+  parts.push({
+    type: 'finish',
+    usage: generated.usage,
+    finishReason: generated.finishReason,
+  });
+  return parts;
+}
+
+/** Creates a network-free AI SDK v3 language model from ordered responses. */
+export function createScriptedLanguageModel({
+  steps,
+  provider = 'sqlrooms-scripted',
+  modelId = 'scripted-v1',
+}: {
+  steps: readonly ScriptedModelStep[];
+  provider?: string;
+  modelId?: string;
+}): ScriptedLanguageModel {
+  const queue = [...steps];
+  const calls: LanguageModelV3CallOptions[] = [];
+  let stepIndex = 0;
+
+  const generate = (
+    options: LanguageModelV3CallOptions,
+  ): LanguageModelV3GenerateResult => {
+    const step = queue.shift();
+    if (!step) {
+      throw new Error('Scripted model received more calls than configured.');
+    }
+    calls.push(options);
+    validateExpectation(step.expectation, options);
+    const result: LanguageModelV3GenerateResult = {
+      content: content(step, stepIndex),
+      finishReason: finishReason(step),
+      usage: usage(step),
+      warnings: [],
+      response: {modelId},
+    };
+    stepIndex += 1;
+    return result;
+  };
+
+  const model: LanguageModelV3 = {
+    specificationVersion: 'v3',
+    provider,
+    modelId,
+    supportedUrls: {},
+    doGenerate: async (options) => generate(options),
+    doStream: async (options) => {
+      const generated = generate(options);
+      return {
+        stream: new ReadableStream<LanguageModelV3StreamPart>({
+          start(controller) {
+            for (const part of streamParts(generated)) controller.enqueue(part);
+            controller.close();
+          },
+        }),
+      };
+    },
+  };
+
+  return {
+    model,
+    calls,
+    remainingSteps: () => queue.length,
+    assertComplete: () => {
+      if (queue.length > 0) {
+        throw new Error(
+          `Scripted model has ${queue.length} unconsumed step${queue.length === 1 ? '' : 's'}.`,
+        );
+      }
+    },
+  };
+}

--- a/packages/evals/tsconfig.json
+++ b/packages/evals/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@sqlrooms/preset-typescript/base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "src/__tests__"]
+}

--- a/packages/evals/typedoc.js
+++ b/packages/evals/typedoc.js
@@ -1,0 +1,3 @@
+import config from '@sqlrooms/preset-typedoc';
+
+export default config(import.meta.url);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3633,6 +3633,31 @@ importers:
         specifier: ^29.4.4
         version: 29.4.9(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@24.12.4))(typescript@5.9.3)
 
+  packages/evals:
+    dependencies:
+      '@ai-sdk/provider':
+        specifier: ^3.0.10
+        version: 3.0.10
+      zod:
+        specifier: 4.1.13
+        version: 4.1.13
+    devDependencies:
+      '@jest/globals':
+        specifier: ^30.3.0
+        version: 30.4.1
+      '@sqlrooms/preset-jest':
+        specifier: workspace:*
+        version: link:../preset-jest
+      ai:
+        specifier: ^6.0.177
+        version: 6.0.177(zod@4.1.13)
+      jest:
+        specifier: ^30.1.3
+        version: 30.4.2(@types/node@24.12.4)
+      ts-jest:
+        specifier: ^29.4.4
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@24.12.4))(typescript@5.9.3)
+
   packages/kepler:
     dependencies:
       '@dnd-kit/core':


### PR DESCRIPTION
## Summary

- add private evaluator-neutral `@sqlrooms/evals`
- define versioned scenarios, composable outcome oracles, and v1 run evidence
- add a network-free AI SDK v3 scripted model with tool-loop and streaming coverage
- isolate structural Promptfoo metadata/assertion helpers behind `@sqlrooms/evals/promptfoo`
- intentionally omit a generic execution adapter until a second target exists

## Validation

- `pnpm --filter @sqlrooms/evals test --runInBand` (11 tests)
- `pnpm --filter @sqlrooms/evals lint`
- `pnpm --filter @sqlrooms/evals build`
- `pnpm build`
- `pnpm knip`
- `pnpm check-circular-deps`
- `pnpm typecheck`
- pre-push workspace tests

## Stack

This draft is stacked on #860. Merge #859, then #860, before retargeting this PR to `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `@sqlrooms/evals` package for defining validated evaluation scenarios and reusable behavioral checks.
  - Added versioned run evidence with serialization, validation, and metadata preservation.
  - Added Promptfoo-compatible result helpers and deterministic, network-free model scripting.
  - Added database, workspace, answer, error, and policy evaluation support.

- **Documentation**
  - Added package documentation and usage examples.

- **Tests**
  - Added comprehensive coverage for scenarios, evidence, oracle evaluation, Promptfoo integration, and scripted model behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->