### PR TITLE
feat(cli): add in-process eval target

### DIFF
--- a/apps/sqlrooms-cli-ui/jest.config.js
+++ b/apps/sqlrooms-cli-ui/jest.config.js
@@ -3,6 +3,12 @@ import nodeConfig from '@sqlrooms/preset-jest/node.js';
 /** @type {import('jest').Config} */
 export default {
   ...nodeConfig,
+  moduleNameMapper: {
+    ...nodeConfig.moduleNameMapper,
+    '^@sqlrooms/duckdb-node$':
+      '<rootDir>/../../packages/duckdb-node/src/index.ts',
+    '^@sqlrooms/evals$': '<rootDir>/../../packages/evals/src/index.ts',
+  },
   transform: {
     '^.+\\.tsx?$': [
       'ts-jest',

--- a/apps/sqlrooms-cli-ui/package.json
+++ b/apps/sqlrooms-cli-ui/package.json
@@ -49,6 +49,8 @@
   },
   "devDependencies": {
     "@jest/globals": "^30.3.0",
+    "@sqlrooms/duckdb-node": "workspace:*",
+    "@sqlrooms/evals": "workspace:*",
     "@sqlrooms/preset-jest": "workspace:*",
     "@tailwindcss/vite": "^4.1.18",
     "@types/react": "^19.2.7",

--- a/apps/sqlrooms-cli-ui/src/artifactTypes.tsx
+++ b/apps/sqlrooms-cli-ui/src/artifactTypes.tsx
@@ -31,6 +31,7 @@ import {
   DEFAULT_CLI_CAPABILITY_PROFILE,
   type CliCapabilityProfile,
 } from './profiles';
+import {createCliWorksheetArtifactDefinition} from './createCliWorksheetArtifactDefinition';
 
 type FeatureStability = 'stable' | 'experimental';
 
@@ -130,19 +131,9 @@ export function createCliArtifactTypes({
   profile?: CliCapabilityProfile;
 } = {}) {
   const worksheetDefinition: ArtifactTypeDefinition<RoomState> = {
-    label: 'Worksheet',
-    defaultTitle: 'Worksheet',
+    ...createCliWorksheetArtifactDefinition(),
     icon: FileStackIcon,
     component: WorksheetArtifact,
-    onCreate: ({artifactId, store}) => {
-      store.getState().blockDocuments.ensureBlockDocument(artifactId);
-    },
-    onEnsure: ({artifactId, store}) => {
-      store.getState().blockDocuments.ensureBlockDocument(artifactId);
-    },
-    onDelete: ({artifactId, store}) => {
-      store.getState().blockDocuments.removeBlockDocument(artifactId);
-    },
   };
 
   const notebookDefinition: ArtifactTypeDefinition<RoomState> = {

--- a/apps/sqlrooms-cli-ui/src/context/createArtifactContextAiTools.ts
+++ b/apps/sqlrooms-cli-ui/src/context/createArtifactContextAiTools.ts
@@ -5,7 +5,10 @@ import {
   type ArtifactContextToolsOptions,
 } from '@sqlrooms/artifacts/ai';
 import type {StoreApi} from 'zustand';
-import {cliCapabilityProfile} from '../runtimeEnvironment';
+import {
+  DEFAULT_CLI_CAPABILITY_PROFILE,
+  type CliCapabilityProfile,
+} from '../profiles';
 import type {RoomState} from '../store-types';
 
 function readCliArtifact({
@@ -156,10 +159,9 @@ function readCliArtifact({
 
 function createArtifactContextOptions(
   store: StoreApi<RoomState>,
+  profile: CliCapabilityProfile,
 ): ArtifactContextToolsOptions<RoomState> {
-  const supportedArtifactTypes = new Set<string>(
-    cliCapabilityProfile.artifacts.runContext,
-  );
+  const supportedArtifactTypes = new Set<string>(profile.artifacts.runContext);
   const getContextSessionId = (
     state: RoomState,
     context?: ArtifactContextToolExecutionContext,
@@ -190,16 +192,20 @@ export function makeArtifactPrimaryForAiRun(
   store: StoreApi<RoomState>,
   artifactId: string,
   context?: ArtifactContextToolExecutionContext,
+  profile: CliCapabilityProfile = DEFAULT_CLI_CAPABILITY_PROFILE,
 ) {
   return makeReusableArtifactPrimaryForAiRun(
-    createArtifactContextOptions(store),
+    createArtifactContextOptions(store, profile),
     artifactId,
     context,
   );
 }
 
-export function createArtifactContextAiTools(store: StoreApi<RoomState>) {
+export function createArtifactContextAiTools(
+  store: StoreApi<RoomState>,
+  profile: CliCapabilityProfile = DEFAULT_CLI_CAPABILITY_PROFILE,
+) {
   return createReusableArtifactContextAiTools(
-    createArtifactContextOptions(store),
+    createArtifactContextOptions(store, profile),
   );
 }

--- a/apps/sqlrooms-cli-ui/src/createBlockDocumentAgent.ts
+++ b/apps/sqlrooms-cli-ui/src/createBlockDocumentAgent.ts
@@ -86,8 +86,10 @@ export function blockDocumentAgentTool(
   store: StoreApi<RoomState>,
   {
     profile = DEFAULT_CLI_CAPABILITY_PROFILE,
+    getModel,
   }: {
     profile?: CliCapabilityProfile;
+    getModel?: BaseAgentToolOptions<RoomState>['getModel'];
   } = {},
 ) {
   const blockDocumentAdapter = createCliBlockDocumentAiAdapter(store);
@@ -95,18 +97,20 @@ export function blockDocumentAgentTool(
 
   const baseOptions: BaseAgentToolOptions<RoomState> = {
     store,
-    getModel: ({state}) => {
-      const currentSession = state.ai.getCurrentSession();
-      const provider = currentSession?.modelProvider || 'openai';
-      const modelId = currentSession?.model || 'gpt-4.1';
+    getModel:
+      getModel ??
+      (({state}) => {
+        const currentSession = state.ai.getCurrentSession();
+        const provider = currentSession?.modelProvider || 'openai';
+        const modelId = currentSession?.model || 'gpt-4.1';
 
-      return createOpenAICompatible({
-        apiKey: state.ai.getApiKeyFromSettings(),
-        name: provider || '',
-        baseURL:
-          state.ai.getBaseUrlFromSettings() || 'https://api.openai.com/v1',
-      }).chatModel(modelId);
-    },
+        return createOpenAICompatible({
+          apiKey: state.ai.getApiKeyFromSettings(),
+          name: provider || '',
+          baseURL:
+            state.ai.getBaseUrlFromSettings() || 'https://api.openai.com/v1',
+        }).chatModel(modelId);
+      }),
     createDataTools: () =>
       createDefaultAiTools(store, {query: {}, tables: true, commands: false}),
     runSubAgent: ({agent, prompt, parentToolCallId, abortSignal}) =>

--- a/apps/sqlrooms-cli-ui/src/createCliAiInstructions.ts
+++ b/apps/sqlrooms-cli-ui/src/createCliAiInstructions.ts
@@ -1,0 +1,57 @@
+import {createDefaultAiInstructions} from '@sqlrooms/ai';
+import type {StoreApi} from 'zustand';
+import {CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME} from './ai/constants';
+import type {CliCapabilityProfile} from './profiles';
+import type {RoomState} from './store-types';
+
+const STABLE_SQLROOMS_CLI_AI_INSTRUCTIONS = `
+In the SQLRooms CLI app, a Worksheet is a block document artifact. When the user asks to create, edit, inspect, or add content to a worksheet, target the current worksheet artifact using block-document commands and block-document agent tools. Use the word Worksheet in user-facing replies, but use block-document tool names and command IDs when invoking tools. The artifact type may still be "worksheet"; its editable content model is a block document.
+
+When the user's primary context artifact is a worksheet or dashboard and they ask to add, update, or create a visualization, chart, or dashboard surface, mutate that artifact through the appropriate agent tool instead of creating a separate artifact, chat-only chart, or markdown image.
+
+- Use ${CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME} when the primary artifact is a worksheet, or when the user explicitly asks to create/edit a top-level worksheet artifact.
+- If run context contains a kind:"block" item, call ${CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME} with blockDocumentId from that item and targetBlock = {blockId, blockType, blockInstanceId}. The user is asking about that exact worksheet block; do not retarget another block.
+- For dashboard artifacts, call dashboard_agent.
+- Use the standalone chart and chart_image_for_markdown tools only when the user wants an inline chat visualization or no target artifact is available.
+`;
+
+const EXPERIMENTAL_SQLROOMS_CLI_AI_INSTRUCTIONS = `
+Experimental SQLRooms tools are available in this session. Use them for app, map, and generated interactive visualization requests when they match the user's target artifact.
+
+- If the primary artifact is a worksheet and the user asks for an app, HTML app, D3 app, Chart.js app, browser app, or generated interactive visualization inside it, call ${CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME}. The worksheet agent should create/reuse the worksheet html-app block, then call embedded_html_app_agent with the block's appId.
+- Do not use top-level html_app_agent to populate worksheet stateful blocks inside worksheets.
+- For worksheet map requests, call ${CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME}. It should add or reuse a direct worksheet map block, not create a dashboard block just to hold the map.
+- For generated HTML, D3, Chart.js, or browser app visualizations only when the primary artifact is an html-app artifact or no worksheet/dashboard artifact is the requested target, write through html_app_agent. html_app_agent requires appId and never creates artifacts or worksheet blocks.
+- If the primary artifact is an html-app artifact, call html_app_agent with appId set to the current artifact id and update it instead of creating a new html-app artifact.
+- For incremental edits to an existing html-app artifact, such as changing title, labels, colors, styles, layout, controls, or interactions, call html_app_agent directly with the current appId and the user's edit request. Do not inspect tables or schemas first unless the user explicitly asks to change the app's data/query behavior.
+- If a new top-level html-app artifact is needed, first execute the html-app.create-artifact command, then call html_app_agent with appId set to the returned artifactId.
+- For HTML app undo, redo, or restoring an earlier version, use list_commands and execute_command with html-app.undo-revision, html-app.redo-revision, or html-app.restore-revision. Do not rewrite, delete, or edit chat messages to perform app undo/redo.
+- If an embedded worksheet HTML app target is ambiguous, ask the user to select the app/block or provide appId instead of mutating a guessed app.
+`;
+
+const WORKSHEET_CHARTS_MAPS_AI_INSTRUCTIONS = `
+This SQLRooms session exposes worksheet artifacts with text, chart, and direct map blocks.
+
+- Use ${CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME} for worksheet creation, analysis, charts, maps, block edits, and block reordering.
+- If run context contains a kind:"block" item, pass its blockDocumentId and targetBlock fields unchanged so only that worksheet block is edited.
+- For worksheet maps, use the worksheet agent's direct map tool. Preserve existing map datasets and layers for incremental edits.
+- Use standalone chart tools only for inline chat visualizations or when no worksheet target is available.
+`;
+
+/** Builds the production CLI assistant instructions for a capability profile. */
+export function createCliAiInstructions(
+  store: StoreApi<RoomState>,
+  profile: CliCapabilityProfile,
+): string {
+  return [
+    createDefaultAiInstructions(store),
+    profile.name === 'worksheet-charts-maps'
+      ? WORKSHEET_CHARTS_MAPS_AI_INSTRUCTIONS.trim()
+      : STABLE_SQLROOMS_CLI_AI_INSTRUCTIONS.trim(),
+    profile.ai.instructionSets.includes('experimental')
+      ? EXPERIMENTAL_SQLROOMS_CLI_AI_INSTRUCTIONS.trim()
+      : '',
+  ]
+    .filter(Boolean)
+    .join('\n\n');
+}

--- a/apps/sqlrooms-cli-ui/src/createCliAiTools.ts
+++ b/apps/sqlrooms-cli-ui/src/createCliAiTools.ts
@@ -1,0 +1,74 @@
+import {createDefaultAiTools} from '@sqlrooms/ai';
+import type {LanguageModel, Tool} from 'ai';
+import type {StoreApi} from 'zustand';
+import {blockDocumentAgentTool} from './createBlockDocumentAgent';
+import {createArtifactContextAiTools} from './context/createArtifactContextAiTools';
+import type {CliCapabilityProfile} from './profiles';
+import type {RoomState} from './store-types';
+import {CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME} from './ai/constants';
+
+/** Inputs that let production and headless targets share CLI tool composition. */
+export type CreateCliAiToolsOptions = {
+  store: StoreApi<RoomState>;
+  profile: CliCapabilityProfile;
+  webContainerTools?: Record<string, Tool>;
+  nestedAgentModel?: LanguageModel;
+  createDashboardAgentTool?: (
+    store: StoreApi<RoomState>,
+    options: {deckMapsEnabled: boolean},
+  ) => Tool;
+  createHtmlAppAgentTool?: (store: StoreApi<RoomState>) => Tool;
+  createStandaloneChartTool?: () => Tool;
+  createChartImageTool?: (store: StoreApi<RoomState>) => Tool;
+};
+
+/** Creates exactly the top-level AI tool groups enabled by a CLI profile. */
+export function createCliAiTools({
+  store,
+  profile,
+  webContainerTools = {},
+  nestedAgentModel,
+  createDashboardAgentTool,
+  createHtmlAppAgentTool,
+  createStandaloneChartTool,
+  createChartImageTool,
+}: CreateCliAiToolsOptions): Record<string, Tool> {
+  const enabledTools = new Set(profile.ai.topLevelToolGroups);
+  const tools: Record<string, Tool> = {};
+  if (enabledTools.has('default-data-analysis')) {
+    Object.assign(tools, createDefaultAiTools(store, {query: {}}));
+  }
+  if (enabledTools.has('artifact-context')) {
+    Object.assign(tools, createArtifactContextAiTools(store, profile));
+  }
+  if (enabledTools.has('dashboard-agent')) {
+    if (!createDashboardAgentTool) {
+      throw new Error('Dashboard agent factory is required by this profile.');
+    }
+    tools.dashboard_agent = createDashboardAgentTool(store, {
+      deckMapsEnabled: profile.dashboard.deckMaps,
+    });
+  }
+  if (enabledTools.has('html-app-agent')) {
+    if (!createHtmlAppAgentTool) {
+      throw new Error('HTML app agent factory is required by this profile.');
+    }
+    tools.html_app_agent = createHtmlAppAgentTool(store);
+  }
+  if (enabledTools.has('worksheet-agent')) {
+    tools[CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME] = blockDocumentAgentTool(store, {
+      profile,
+      ...(nestedAgentModel ? {getModel: () => nestedAgentModel} : {}),
+    });
+  }
+  if (enabledTools.has('webcontainer')) {
+    Object.assign(tools, webContainerTools);
+  }
+  if (enabledTools.has('chart') && createStandaloneChartTool) {
+    tools.chart = createStandaloneChartTool();
+  }
+  if (enabledTools.has('chart-image-for-markdown') && createChartImageTool) {
+    tools.chart_image_for_markdown = createChartImageTool(store);
+  }
+  return tools;
+}

--- a/apps/sqlrooms-cli-ui/src/createCliWorksheetArtifactDefinition.ts
+++ b/apps/sqlrooms-cli-ui/src/createCliWorksheetArtifactDefinition.ts
@@ -1,5 +1,23 @@
-import type {ArtifactTypeDefinition} from '@sqlrooms/artifacts';
+import {
+  defineArtifactTypes,
+  type ArtifactTypeDefinition,
+} from '@sqlrooms/artifacts';
+import {CLI_ARTIFACT_TYPES, type CliArtifactType} from './artifactTypeIds';
+import type {CliCapabilityProfile} from './profiles';
 import type {RoomState} from './store-types';
+
+const CLI_ARTIFACT_TITLES = {
+  worksheet: 'Worksheet',
+  dashboard: 'Dashboard',
+  pivot: 'Pivot',
+  notebook: 'Notebook',
+  document: 'Document',
+  'sql-query': 'SQL Query',
+  'html-app': 'HTML App',
+  python: 'Python',
+  canvas: 'Canvas',
+  'app-builder': 'App Builder',
+} as const satisfies Record<CliArtifactType, string>;
 
 /** Production lifecycle definition shared by the browser and headless targets. */
 export function createCliWorksheetArtifactDefinition(): ArtifactTypeDefinition<RoomState> {
@@ -16,4 +34,24 @@ export function createCliWorksheetArtifactDefinition(): ArtifactTypeDefinition<R
       store.getState().blockDocuments.removeBlockDocument(artifactId);
     },
   };
+}
+
+/** Builds a UI-free artifact registry with the selected profile's capabilities. */
+export function createCliHeadlessArtifactTypes(profile: CliCapabilityProfile) {
+  const definitions = Object.fromEntries(
+    CLI_ARTIFACT_TYPES.map((type) => [
+      type,
+      {
+        ...(type === 'worksheet'
+          ? createCliWorksheetArtifactDefinition()
+          : {
+              label: CLI_ARTIFACT_TITLES[type],
+              defaultTitle: CLI_ARTIFACT_TITLES[type],
+            }),
+        canCreate: profile.artifacts.creatable.includes(type),
+      } satisfies ArtifactTypeDefinition<RoomState>,
+    ]),
+  ) as Record<CliArtifactType, ArtifactTypeDefinition<RoomState>>;
+
+  return defineArtifactTypes(definitions);
 }

--- a/apps/sqlrooms-cli-ui/src/createCliWorksheetArtifactDefinition.ts
+++ b/apps/sqlrooms-cli-ui/src/createCliWorksheetArtifactDefinition.ts
@@ -1,0 +1,19 @@
+import type {ArtifactTypeDefinition} from '@sqlrooms/artifacts';
+import type {RoomState} from './store-types';
+
+/** Production lifecycle definition shared by the browser and headless targets. */
+export function createCliWorksheetArtifactDefinition(): ArtifactTypeDefinition<RoomState> {
+  return {
+    label: 'Worksheet',
+    defaultTitle: 'Worksheet',
+    onCreate: ({artifactId, store}) => {
+      store.getState().blockDocuments.ensureBlockDocument(artifactId);
+    },
+    onEnsure: ({artifactId, store}) => {
+      store.getState().blockDocuments.ensureBlockDocument(artifactId);
+    },
+    onDelete: ({artifactId, store}) => {
+      store.getState().blockDocuments.removeBlockDocument(artifactId);
+    },
+  };
+}

--- a/apps/sqlrooms-cli-ui/src/evals/README.md
+++ b/apps/sqlrooms-cli-ui/src/evals/README.md
@@ -1,0 +1,31 @@
+# CLI in-process eval target
+
+The target runs the production `worksheet-charts-maps` profile in Node. It
+reuses the CLI profile resolver, command and tool composition, AI slice, local
+chat transport, run-context code, worksheet agent, block-document commands,
+document/deck state, and `@sqlrooms/duckdb-node`.
+
+The target-specific layer only provides an in-memory fixture, an injected AI
+SDK model, lifecycle control, durable-state snapshots, and conversion to the
+shared `@sqlrooms/evals` evidence envelope. Mock runs require neither browser
+globals nor network access.
+
+## Fidelity matrix
+
+| Surface                            | Mode    | Notes                                                       |
+| ---------------------------------- | ------- | ----------------------------------------------------------- |
+| Capability profile                 | Reused  | Resolved by the production profile resolver                 |
+| AI slice and chat transport        | Reused  | Executes the local production transport in process          |
+| Top-level and worksheet tools      | Reused  | Composed by the same profile-driven factory                 |
+| Nested worksheet agent             | Reused  | Model is injected through the agent's production model seam |
+| Run context                        | Reused  | Uses the production resolver and formatter                  |
+| Commands                           | Reused  | Registers the same profile-selected command factories       |
+| DuckDB                             | Adapted | Node connector replaces the browser/server connector        |
+| Worksheet/chart/map state          | Reused  | Real artifact, document, chart-block, and deck-map state    |
+| Persistence and CRDT               | Omitted | Each target is intentionally isolated and ephemeral         |
+| React renderers and browser layout | Omitted | Structural state is graded before rendering quality         |
+| Standalone chat chart/image tools  | Omitted | UI-only leaves; worksheet chart tools remain real           |
+| WebContainer, Python, dashboards   | Omitted | Disabled by `worksheet-charts-maps`                         |
+
+Always call `dispose()` in `finally`; it cancels AI runtime resources, removes
+registered commands, waits for schema refresh, and closes native DuckDB.

--- a/apps/sqlrooms-cli-ui/src/evals/__tests__/createCliEvalTarget.test.ts
+++ b/apps/sqlrooms-cli-ui/src/evals/__tests__/createCliEvalTarget.test.ts
@@ -1,11 +1,13 @@
 import {describe, expect, it, jest} from '@jest/globals';
 import {
   createAnswerGroundingOracle,
+  createErrorOracle,
   createScriptedLanguageModel,
   createWorkspaceStateOracle,
   defineScenario,
   type JsonValue,
 } from '@sqlrooms/evals';
+import {CLI_ARTIFACT_TYPES} from '../../artifactTypeIds';
 import {createCliEvalTarget} from '../createCliEvalTarget';
 import {CLI_EVAL_TARGET_TABLE} from '../fixture';
 
@@ -24,6 +26,39 @@ function workspaceFacts(workspace: JsonValue | undefined) {
 }
 
 describe('createCliEvalTarget', () => {
+  it('builds artifact capabilities and commands from the selected profile', async () => {
+    const scripted = createScriptedLanguageModel({steps: []});
+    const target = createCliEvalTarget({model: scripted.model});
+
+    try {
+      await target.initialize();
+      const state = target.store.getState();
+      expect(Object.keys(state.artifacts.artifactTypes).sort()).toEqual(
+        [...CLI_ARTIFACT_TYPES].sort(),
+      );
+      expect(
+        Object.fromEntries(
+          CLI_ARTIFACT_TYPES.map((type) => [
+            type,
+            state.artifacts.artifactTypes[type]?.canCreate,
+          ]),
+        ),
+      ).toEqual(
+        Object.fromEntries(
+          CLI_ARTIFACT_TYPES.map((type) => [type, type === 'worksheet']),
+        ),
+      );
+      expect(
+        state.commands
+          .listCommands()
+          .map((command) => command.id)
+          .filter((id) => id.endsWith('.create-artifact')),
+      ).toEqual(['worksheet.create-artifact']);
+    } finally {
+      await target.dispose();
+    }
+  });
+
   it('runs the production chat and nested worksheet tool loop without a browser or network', async () => {
     const scripted = createScriptedLanguageModel({
       steps: [
@@ -200,6 +235,168 @@ describe('createCliEvalTarget', () => {
     }
   }, 30_000);
 
+  it('resets workspace and session state before every run', async () => {
+    const scripted = createScriptedLanguageModel({
+      steps: [
+        {content: [{type: 'text', text: 'First run complete.'}]},
+        {content: [{type: 'text', text: 'Second run complete.'}]},
+      ],
+    });
+    const target = createCliEvalTarget({model: scripted.model});
+    const scenario = defineScenario({
+      id: 'cli.repeated-run',
+      version: 1,
+      title: 'Repeated isolated run',
+      compatibleProfiles: ['worksheet-charts-maps'],
+      turns: [{id: 'run', input: 'Complete this isolated run.'}],
+      expectations: [{oracleId: 'answer', description: 'The run completes.'}],
+    });
+    const oracles = [
+      createAnswerGroundingOracle({
+        id: 'answer',
+        evaluate: (answer) => ({
+          pass: answer.includes('run complete'),
+          reason: 'The scripted run completed.',
+        }),
+      }),
+    ];
+
+    try {
+      await target.run({scenario, oracles});
+      target.store.getState().deckMaps.ensureMap('stale-map');
+
+      const evidence = await target.run({scenario, oracles});
+      const initialState = evidence.metadata.initialState as {
+        artifacts: {artifactsById: Record<string, unknown>};
+        maps: unknown[];
+      };
+      const finalState = workspaceFacts(evidence.finalState);
+
+      expect(Object.keys(initialState.artifacts.artifactsById)).toHaveLength(0);
+      expect(initialState.maps).toHaveLength(0);
+      expect(finalState.worksheets).toHaveLength(1);
+      expect(finalState.maps).toHaveLength(0);
+      expect(target.store.getState().ai.config.sessions).toHaveLength(1);
+      scripted.assertComplete();
+    } finally {
+      await target.dispose();
+    }
+  }, 30_000);
+
+  it('cancels and awaits a timed-out session before returning evidence', async () => {
+    const scripted = createScriptedLanguageModel({
+      steps: [{content: [{type: 'text', text: 'Too late.'}]}],
+    });
+    let abortObserved = false;
+    let cancellationSettled = false;
+    const slowModel = {
+      ...scripted.model,
+      doStream: async (
+        callOptions: Parameters<typeof scripted.model.doStream>[0],
+      ) => {
+        await new Promise<void>((resolve, reject) => {
+          const fallback = setTimeout(resolve, 1_000);
+          callOptions.abortSignal?.addEventListener(
+            'abort',
+            () => {
+              abortObserved = true;
+              clearTimeout(fallback);
+              setTimeout(() => {
+                cancellationSettled = true;
+                reject(new DOMException('Aborted', 'AbortError'));
+              }, 10);
+            },
+            {once: true},
+          );
+        });
+        return scripted.model.doStream(callOptions);
+      },
+    };
+    const target = createCliEvalTarget({model: slowModel, timeoutMs: 5});
+
+    try {
+      const evidence = await target.run({
+        scenario: defineScenario({
+          id: 'cli.timeout',
+          version: 1,
+          title: 'Timeout cancellation',
+          compatibleProfiles: ['worksheet-charts-maps'],
+          turns: [{id: 'run', input: 'Wait for the timeout.'}],
+          expectations: [
+            {oracleId: 'answer', description: 'The timeout is captured.'},
+          ],
+        }),
+        oracles: [
+          createAnswerGroundingOracle({
+            id: 'answer',
+            evaluate: () => ({pass: true, reason: 'Timeout captured.'}),
+          }),
+        ],
+      });
+
+      expect(evidence.status).toBe('error');
+      expect(abortObserved).toBe(true);
+      expect(cancellationSettled).toBe(true);
+      expect(JSON.stringify(evidence)).toContain('timed out');
+    } finally {
+      await target.dispose();
+    }
+  }, 30_000);
+
+  it('redacts sensitive values across the complete evidence envelope', async () => {
+    const secret = 'provider-secret-token';
+    const scripted = createScriptedLanguageModel({
+      steps: [
+        {
+          expectation: {promptIncludes: [secret]},
+          content: [{type: 'text', text: `Completed with ${secret}.`}],
+        },
+      ],
+    });
+    const target = createCliEvalTarget({
+      model: scripted.model,
+      sensitiveValues: [secret],
+      repository: {
+        commitSha: `sha-${secret}`,
+        dirty: false,
+        workflowUrl: `https://example.test/run?token=${secret}`,
+      },
+    });
+
+    try {
+      const evidence = await target.run({
+        scenario: defineScenario({
+          id: 'cli.redaction',
+          version: 1,
+          title: 'Complete evidence redaction',
+          compatibleProfiles: ['worksheet-charts-maps'],
+          turns: [{id: 'run', input: `Use ${secret} safely.`}],
+          expectations: [
+            {oracleId: 'answer', description: 'The answer is evaluated.'},
+          ],
+        }),
+        oracles: [
+          createAnswerGroundingOracle({
+            id: 'answer',
+            evaluate: (answer) => ({
+              pass: answer.includes(secret),
+              reason: `Observed ${secret}.`,
+              evidence: {answer, secret},
+            }),
+          }),
+        ],
+      });
+
+      const serialized = JSON.stringify(evidence);
+      expect(evidence.status).toBe('passed');
+      expect(serialized).toContain('[REDACTED]');
+      expect(serialized).not.toContain(secret);
+      scripted.assertComplete();
+    } finally {
+      await target.dispose();
+    }
+  }, 30_000);
+
   it('records actionable redacted transport errors', async () => {
     const secret = 'provider-secret-token';
     const scripted = createScriptedLanguageModel({
@@ -230,6 +427,15 @@ describe('createCliEvalTarget', () => {
             {oracleId: 'error', description: 'The error is retained safely.'},
           ],
         }),
+        oracles: [
+          createErrorOracle({
+            id: 'error',
+            evaluate: (errors) => ({
+              pass: errors.length > 0,
+              reason: 'The transport error was captured.',
+            }),
+          }),
+        ],
       });
 
       const serialized = JSON.stringify(evidence);

--- a/apps/sqlrooms-cli-ui/src/evals/__tests__/createCliEvalTarget.test.ts
+++ b/apps/sqlrooms-cli-ui/src/evals/__tests__/createCliEvalTarget.test.ts
@@ -264,24 +264,139 @@ describe('createCliEvalTarget', () => {
     try {
       await target.run({scenario, oracles});
       target.store.getState().deckMaps.ensureMap('stale-map');
+      const connector = await target.store.getState().db.getConnector();
+      await connector.execute('CREATE TABLE derived_events AS SELECT 1 AS id')
+        .result;
+      await target.store.getState().db.refreshTableSchemas();
+      const roomConfig = target.store.getState().room.config;
+      target.store.getState().room.setConfig({
+        ...roomConfig,
+        dataSources: [
+          {
+            type: 'sql',
+            sqlQuery: 'SELECT 1 AS id',
+            tableName: 'derived_events',
+          },
+        ],
+      });
+      expect(target.store.getState().room.config.dataSources).toHaveLength(1);
 
       const evidence = await target.run({scenario, oracles});
       const initialState = evidence.metadata.initialState as {
         artifacts: {artifactsById: Record<string, unknown>};
         maps: unknown[];
+        tables: string[];
       };
       const finalState = workspaceFacts(evidence.finalState);
 
       expect(Object.keys(initialState.artifacts.artifactsById)).toHaveLength(0);
       expect(initialState.maps).toHaveLength(0);
+      expect(
+        initialState.tables.some((table) => table.includes('derived_events')),
+      ).toBe(false);
       expect(finalState.worksheets).toHaveLength(1);
       expect(finalState.maps).toHaveLength(0);
+      expect(target.store.getState().room.config.dataSources).toHaveLength(0);
       expect(target.store.getState().ai.config.sessions).toHaveLength(1);
       scripted.assertComplete();
     } finally {
       await target.dispose();
     }
   }, 30_000);
+
+  it('rejects overlapping runs so they cannot mutate the shared store', async () => {
+    const scripted = createScriptedLanguageModel({
+      steps: [{content: [{type: 'text', text: 'First run complete.'}]}],
+    });
+    let signalStarted!: () => void;
+    let releaseStream!: () => void;
+    const started = new Promise<void>((resolve) => {
+      signalStarted = resolve;
+    });
+    const streamGate = new Promise<void>((resolve) => {
+      releaseStream = resolve;
+    });
+    const slowModel = {
+      ...scripted.model,
+      doStream: async (
+        callOptions: Parameters<typeof scripted.model.doStream>[0],
+      ) => {
+        signalStarted();
+        await streamGate;
+        return scripted.model.doStream(callOptions);
+      },
+    };
+    const target = createCliEvalTarget({model: slowModel});
+    const scenario = defineScenario({
+      id: 'cli.concurrent-run',
+      version: 1,
+      title: 'Concurrent run isolation',
+      compatibleProfiles: ['worksheet-charts-maps'],
+      turns: [{id: 'run', input: 'Complete this run.'}],
+      expectations: [{oracleId: 'answer', description: 'The run completes.'}],
+    });
+    const oracles = [
+      createAnswerGroundingOracle({
+        id: 'answer',
+        evaluate: () => ({pass: true, reason: 'The first run completed.'}),
+      }),
+    ];
+
+    try {
+      const firstRun = target.run({scenario, oracles});
+      await started;
+      await expect(target.run({scenario, oracles})).rejects.toThrow(
+        'already has a run in progress',
+      );
+      releaseStream();
+      await expect(firstRun).resolves.toMatchObject({status: 'passed'});
+      scripted.assertComplete();
+    } finally {
+      releaseStream();
+      await target.dispose();
+    }
+  }, 30_000);
+
+  it('associates artifacts created by AI commands with the invoking session', async () => {
+    const scripted = createScriptedLanguageModel({steps: []});
+    const target = createCliEvalTarget({model: scripted.model});
+
+    try {
+      await target.initialize();
+      const initialArtifactId = target.store
+        .getState()
+        .artifacts.createArtifact({
+          type: 'worksheet',
+          title: 'Initial worksheet',
+        });
+      const sessionId = target.store
+        .getState()
+        .artifactAi.createArtifactScopedSession();
+      expect(sessionId).toBeDefined();
+
+      const result = await target.store.getState().commands.invokeCommand(
+        'worksheet.create-artifact',
+        {title: 'Created by AI'},
+        {
+          surface: 'ai',
+          actor: 'eval-test',
+          metadata: {aiSessionId: sessionId},
+        },
+      );
+      const createdArtifactId = (result.data as {artifactId?: string})
+        .artifactId;
+
+      expect(initialArtifactId).toBeDefined();
+      expect(createdArtifactId).toBeDefined();
+      expect(
+        target.store
+          .getState()
+          .artifactAi.hasSessionArtifactLink(sessionId!, createdArtifactId!),
+      ).toBe(true);
+    } finally {
+      await target.dispose();
+    }
+  });
 
   it('cancels and awaits a timed-out session before returning evidence', async () => {
     const scripted = createScriptedLanguageModel({

--- a/apps/sqlrooms-cli-ui/src/evals/__tests__/createCliEvalTarget.test.ts
+++ b/apps/sqlrooms-cli-ui/src/evals/__tests__/createCliEvalTarget.test.ts
@@ -1,0 +1,247 @@
+import {describe, expect, it, jest} from '@jest/globals';
+import {
+  createAnswerGroundingOracle,
+  createScriptedLanguageModel,
+  createWorkspaceStateOracle,
+  defineScenario,
+  type JsonValue,
+} from '@sqlrooms/evals';
+import {createCliEvalTarget} from '../createCliEvalTarget';
+import {CLI_EVAL_TARGET_TABLE} from '../fixture';
+
+function workspaceFacts(workspace: JsonValue | undefined) {
+  return workspace as {
+    worksheets: Array<{
+      blocks: Array<{
+        type: string;
+        tableName?: string;
+        blockType?: string;
+        blockInstanceId?: string;
+      }>;
+    }>;
+    maps: Array<{config: {datasets: Record<string, unknown>}}>;
+  };
+}
+
+describe('createCliEvalTarget', () => {
+  it('runs the production chat and nested worksheet tool loop without a browser or network', async () => {
+    const scripted = createScriptedLanguageModel({
+      steps: [
+        {
+          expectation: {promptIncludes: ['Current artifact: worksheet']},
+          content: [
+            {
+              type: 'tool-call',
+              toolName: 'block_document_agent',
+              input: {
+                reasoning: 'Build the requested worksheet visualizations.',
+                intent: 'Add a metric chart and geographic event map.',
+                blockDocumentId: 'eval-cli.worksheet-chart-map-0',
+                maxSteps: 8,
+              },
+            },
+          ],
+        },
+        {
+          expectation: {
+            promptIncludes: ['worksheet builder AI agent', 'direct map'],
+          },
+          content: [
+            {
+              type: 'tool-call',
+              toolName: 'create_block_document_chart_histogram',
+              input: {
+                tableName: CLI_EVAL_TARGET_TABLE,
+                reasoning: 'Show the distribution of the numeric metric.',
+                settings: {field: 'metric', color: '#2563eb'},
+                title: 'Metric distribution',
+              },
+            },
+            {
+              type: 'tool-call',
+              toolName: 'create_block_document_map_block',
+              input: {
+                reasoning: 'Map event locations from the intended table.',
+                title: 'Event locations',
+                tableName: CLI_EVAL_TARGET_TABLE,
+                config: {
+                  datasets: {
+                    events: {source: {tableName: CLI_EVAL_TARGET_TABLE}},
+                  },
+                  spec: {
+                    layers: [
+                      {
+                        '@@type': 'GeoArrowScatterplotLayer',
+                        _sqlroomsBinding: {
+                          dataset: 'events',
+                          longitudeColumn: 'longitude',
+                          latitudeColumn: 'latitude',
+                        },
+                      },
+                    ],
+                  },
+                  fitToData: {
+                    dataset: 'events',
+                    longitudeColumn: 'longitude',
+                    latitudeColumn: 'latitude',
+                  },
+                },
+              },
+            },
+          ],
+        },
+        {
+          content: [
+            {
+              type: 'text',
+              text: 'Created the metric chart and event map in the worksheet.',
+            },
+          ],
+        },
+        {
+          content: [
+            {
+              type: 'text',
+              text: 'Created a metric distribution chart and event map from analytics.events.',
+            },
+          ],
+        },
+      ],
+    });
+    const target = createCliEvalTarget({model: scripted.model});
+
+    try {
+      const evidence = await target.run({
+        scenario: defineScenario({
+          id: 'cli.worksheet-chart-map',
+          version: 1,
+          title: 'Create a worksheet chart and map',
+          compatibleProfiles: ['worksheet-charts-maps'],
+          fixture: {targetTable: CLI_EVAL_TARGET_TABLE},
+          turns: [
+            {
+              id: 'create',
+              input:
+                'In the current worksheet, chart metric and map latitude/longitude from analytics.events, not archive.events.',
+            },
+          ],
+          expectations: [
+            {oracleId: 'workspace', description: 'Chart and map are durable.'},
+            {
+              oracleId: 'answer',
+              description: 'Answer names the intended table.',
+            },
+          ],
+        }),
+        oracles: [
+          createWorkspaceStateOracle({
+            id: 'workspace',
+            evaluate: (workspace) => {
+              const facts = workspaceFacts(workspace);
+              const [worksheet] = facts.worksheets;
+              const chart = worksheet?.blocks.find(
+                (block) => block.type === 'chart',
+              );
+              const map = worksheet?.blocks.find(
+                (block) =>
+                  block.type === 'statefulBlock' && block.blockType === 'map',
+              );
+              const pass =
+                facts.worksheets.length === 1 &&
+                chart?.tableName === CLI_EVAL_TARGET_TABLE &&
+                Boolean(map?.blockInstanceId) &&
+                facts.maps.length === 1;
+              return {
+                pass,
+                reason: pass
+                  ? 'One worksheet contains a canonical chart and direct map.'
+                  : 'Expected canonical chart/map state was not materialized.',
+                evidence: {
+                  worksheetCount: facts.worksheets.length,
+                  chartTable: chart?.tableName ?? null,
+                  mapCount: facts.maps.length,
+                },
+              };
+            },
+          }),
+          createAnswerGroundingOracle({
+            id: 'answer',
+            evaluate: (answer) => ({
+              pass: answer.includes('analytics.events'),
+              reason: 'The final answer identifies the intended table.',
+              evidence: {answer},
+            }),
+          }),
+        ],
+      });
+
+      expect(evidence.status).toBe('passed');
+      expect(evidence.target).toEqual({
+        type: 'cli-in-process',
+        profileName: 'worksheet-charts-maps',
+        profileVersion: 1,
+      });
+      expect(
+        evidence.events.some((event) => event.type === 'nested-agent'),
+      ).toBe(true);
+      expect(evidence.events.some((event) => event.type === 'mutation')).toBe(
+        true,
+      );
+      expect(evidence.events.map((event) => event.name)).toEqual(
+        expect.arrayContaining([
+          'create_block_document_chart_histogram',
+          'create_block_document_map_block',
+        ]),
+      );
+      expect(evidence.oracleResults.every((result) => result.pass)).toBe(true);
+      scripted.assertComplete();
+    } finally {
+      await target.dispose();
+    }
+  }, 30_000);
+
+  it('records actionable redacted transport errors', async () => {
+    const secret = 'provider-secret-token';
+    const scripted = createScriptedLanguageModel({
+      steps: [
+        {
+          expectation: {promptIncludes: [secret]},
+          content: [{type: 'text', text: 'unreachable'}],
+        },
+      ],
+    });
+    const target = createCliEvalTarget({
+      model: scripted.model,
+      sensitiveValues: [secret],
+    });
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    try {
+      const evidence = await target.run({
+        scenario: defineScenario({
+          id: 'cli.transport-error',
+          version: 1,
+          title: 'Transport error evidence',
+          compatibleProfiles: ['worksheet-charts-maps'],
+          turns: [{id: 'run', input: 'Trigger the scripted mismatch.'}],
+          expectations: [
+            {oracleId: 'error', description: 'The error is retained safely.'},
+          ],
+        }),
+      });
+
+      const serialized = JSON.stringify(evidence);
+      expect(evidence.status).toBe('error');
+      expect(evidence.events.some((event) => event.type === 'error')).toBe(
+        true,
+      );
+      expect(serialized).toContain('[REDACTED]');
+      expect(serialized).not.toContain(secret);
+    } finally {
+      await target.dispose();
+      consoleError.mockRestore();
+    }
+  }, 30_000);
+});

--- a/apps/sqlrooms-cli-ui/src/evals/createCliEvalTarget.ts
+++ b/apps/sqlrooms-cli-ui/src/evals/createCliEvalTarget.ts
@@ -1,5 +1,5 @@
 import {createArtifactAiSlice} from '@sqlrooms/artifacts/ai';
-import {createArtifactsSlice, defineArtifactTypes} from '@sqlrooms/artifacts';
+import {createArtifactsSlice} from '@sqlrooms/artifacts';
 import {createAiSlice, getChatRequestErrorMessage} from '@sqlrooms/ai';
 import {createDeckMapsSlice, ensureDeckMapResourceState} from '@sqlrooms/deck';
 import {createBlockDocumentsSlice} from '@sqlrooms/documents';
@@ -22,7 +22,7 @@ import type {StoreApi} from 'zustand';
 import {createStore} from 'zustand/vanilla';
 import {createCliAiInstructions} from '../createCliAiInstructions';
 import {createCliAiTools} from '../createCliAiTools';
-import {createCliWorksheetArtifactDefinition} from '../createCliWorksheetArtifactDefinition';
+import {createCliHeadlessArtifactTypes} from '../createCliWorksheetArtifactDefinition';
 import {formatRunContextInstructions} from '../context/formatRunContextInstructions';
 import {getRunContext} from '../context/getRunContext';
 import {
@@ -38,6 +38,10 @@ import {createCliEvalDuckDbOptions} from './fixture';
 import {snapshotCliEvalState} from './snapshot';
 
 const DEFAULT_TIMEOUT_MS = 20_000;
+
+class CliEvalTimeoutError extends Error {
+  override name = 'CliEvalTimeoutError';
+}
 
 function getLanguageModelIdentity(model: LanguageModel): {
   provider: string;
@@ -119,6 +123,32 @@ function redact(value: string, sensitiveValues: readonly string[]): string {
   );
 }
 
+function redactEvidenceValue(
+  value: unknown,
+  sensitiveValues: readonly string[],
+): unknown {
+  if (typeof value === 'string') return redact(value, sensitiveValues);
+  if (Array.isArray(value)) {
+    return value.map((item) => redactEvidenceValue(item, sensitiveValues));
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [
+        redact(key, sensitiveValues),
+        redactEvidenceValue(item, sensitiveValues),
+      ]),
+    );
+  }
+  return value;
+}
+
+function redactRunEvidence(
+  evidence: RunEvidence,
+  sensitiveValues: readonly string[],
+): RunEvidence {
+  return redactEvidenceValue(evidence, sensitiveValues) as RunEvidence;
+}
+
 function observedError(
   error: unknown,
   sensitiveValues: readonly string[],
@@ -142,7 +172,11 @@ function waitForSession(
     let sawRunning = false;
     const timeout = setTimeout(() => {
       unsubscribe();
-      reject(new Error(`CLI eval session timed out after ${timeoutMs}ms.`));
+      reject(
+        new CliEvalTimeoutError(
+          `CLI eval session timed out after ${timeoutMs}ms.`,
+        ),
+      );
     }, timeoutMs);
     const inspect = () => {
       const session = store
@@ -158,6 +192,65 @@ function waitForSession(
     const unsubscribe = store.subscribe(inspect);
     inspect();
   });
+}
+
+async function cancelSessionAndWait(
+  store: StoreApi<RoomState>,
+  sessionId: string,
+): Promise<void> {
+  const ai = store.getState().ai;
+  const chat = ai.getSessionChat(sessionId);
+  const abortController = ai.getAbortController(sessionId);
+  ai.cancelAnalysis(sessionId);
+  try {
+    await chat?.stop();
+  } catch {
+    // Cancellation errors are represented by the original eval failure.
+  }
+  const deadline = Date.now() + DEFAULT_TIMEOUT_MS;
+  while (
+    abortController &&
+    store.getState().ai.getAbortController(sessionId) === abortController
+  ) {
+    if (Date.now() >= deadline) {
+      throw new Error(`CLI eval session ${sessionId} failed to stop.`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+}
+
+async function resetCliEvalWorkspace(
+  store: StoreApi<RoomState>,
+): Promise<void> {
+  const sessionIds = store
+    .getState()
+    .ai.config.sessions.map((session) => session.id);
+  for (const sessionId of sessionIds) {
+    const session = store
+      .getState()
+      .ai.config.sessions.find((candidate) => candidate.id === sessionId);
+    if (session?.isRunning) await cancelSessionAndWait(store, sessionId);
+    store.getState().artifactAi.removeAllLinksForSession(sessionId);
+    store.getState().ai.deleteSession(sessionId);
+  }
+
+  const artifactIds = Object.keys(
+    store.getState().artifacts.config.artifactsById,
+  );
+  for (const artifactId of artifactIds) {
+    store.getState().artifactAi.removeAllLinksForArtifact(artifactId);
+    store.getState().artifacts.deleteArtifact(artifactId);
+  }
+
+  for (const artifactId of Object.keys(
+    store.getState().blockDocuments.config.artifacts,
+  )) {
+    store.getState().blockDocuments.removeBlockDocument(artifactId);
+  }
+  for (const mapId of Object.keys(store.getState().deckMaps.config.mapsById)) {
+    store.getState().deckMaps.removeMap(mapId);
+  }
+  store.getState().artifactAi.setConfig({sessionArtifactLinks: []});
 }
 
 function eventsFromMessages(
@@ -255,9 +348,7 @@ function createHeadlessStore(
 } {
   const modelIdentity = getLanguageModelIdentity(model);
   const connector = createNodeDuckDbConnector(createCliEvalDuckDbOptions());
-  const artifactTypes = defineArtifactTypes({
-    worksheet: createCliWorksheetArtifactDefinition(),
-  });
+  const artifactTypes = createCliHeadlessArtifactTypes(profile);
   const roomStore = createStore<RoomState>()((set, get, store) => {
     const typedStore = store as StoreApi<RoomState>;
     const tools = createCliAiTools({
@@ -361,6 +452,7 @@ export function createCliEvalTarget(
         );
       }
       await this.initialize();
+      await resetCliEvalWorkspace(store);
       const startedAt = now();
       const initialState = snapshotCliEvalState(store.getState());
       const errors: ObservedError[] = [];
@@ -394,6 +486,9 @@ export function createCliEvalTarget(
           await completion;
         }
       } catch (error) {
+        if (error instanceof CliEvalTimeoutError && sessionId) {
+          await cancelSessionAndWait(store, sessionId);
+        }
         errors.push(observedError(error, options.sensitiveValues ?? []));
       }
 
@@ -448,7 +543,7 @@ export function createCliEvalTarget(
           data: {kind: mutations[0]!.kind},
         });
       }
-      return RunEvidenceSchema.parse({
+      const evidence = RunEvidenceSchema.parse({
         schemaVersion: RUN_EVIDENCE_SCHEMA_VERSION,
         runId: `${scenario.id}-${repetition}-${startedAt.getTime()}`,
         scenario: {id: scenario.id, version: scenario.version, repetition},
@@ -476,6 +571,7 @@ export function createCliEvalTarget(
         oracleResults,
         metadata: {initialState},
       });
+      return redactRunEvidence(evidence, options.sensitiveValues ?? []);
     },
     async dispose() {
       if (disposed) return;

--- a/apps/sqlrooms-cli-ui/src/evals/createCliEvalTarget.ts
+++ b/apps/sqlrooms-cli-ui/src/evals/createCliEvalTarget.ts
@@ -23,6 +23,7 @@ import {createStore} from 'zustand/vanilla';
 import {createCliAiInstructions} from '../createCliAiInstructions';
 import {createCliAiTools} from '../createCliAiTools';
 import {createCliHeadlessArtifactTypes} from '../createCliWorksheetArtifactDefinition';
+import {artifactChatAssociationMiddleware} from '../artifactChatAssociation';
 import {formatRunContextInstructions} from '../context/formatRunContextInstructions';
 import {getRunContext} from '../context/getRunContext';
 import {
@@ -251,6 +252,12 @@ async function resetCliEvalWorkspace(
     store.getState().deckMaps.removeMap(mapId);
   }
   store.getState().artifactAi.setConfig({sessionArtifactLinks: []});
+
+  const roomConfig = store.getState().room.config;
+  store.getState().room.setConfig({...roomConfig, dataSources: []});
+  await store.getState().db.destroy();
+  await store.getState().db.initialize();
+  await store.getState().db.refreshTableSchemas();
 }
 
 function eventsFromMessages(
@@ -342,6 +349,7 @@ function eventsFromMessages(
 function createHeadlessStore(
   profile: CliCapabilityProfile,
   model: LanguageModel,
+  timeoutMs: number,
 ): {
   store: StoreApi<RoomState>;
   connector: ReturnType<typeof createNodeDuckDbConnector>;
@@ -360,6 +368,9 @@ function createHeadlessStore(
       ...createRoomShellSlice({
         connector,
         config: {title: 'SQLRooms Eval', dataSources: []},
+        createCommandProps: {
+          middleware: [artifactChatAssociationMiddleware as any],
+        },
       })(set, get, store),
       ...createArtifactsSlice<RoomState>({artifactTypes})(set, get, store),
       ...createArtifactAiSlice<RoomState>({autoSync: false})(set, get, store),
@@ -413,7 +424,7 @@ function createHeadlessStore(
           getRunContext(typedStore, sessionId, {profile}),
         formatRunContextInstructions: ({runContext}) =>
           formatRunContextInstructions(runContext, typedStore),
-        timeouts: {runMs: DEFAULT_TIMEOUT_MS},
+        timeouts: {runMs: timeoutMs},
       })(set, get, store),
     };
     return state as unknown as RoomState;
@@ -429,10 +440,16 @@ export function createCliEvalTarget(
     profileName: 'worksheet-charts-maps',
   });
   const modelIdentity = getLanguageModelIdentity(options.model);
-  const {store, connector} = createHeadlessStore(profile, options.model);
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const {store, connector} = createHeadlessStore(
+    profile,
+    options.model,
+    timeoutMs,
+  );
   const now = options.now ?? (() => new Date());
   let initialized = false;
   let disposed = false;
+  let runInProgress = false;
 
   return {
     profile,
@@ -446,132 +463,137 @@ export function createCliEvalTarget(
       initialized = true;
     },
     async run({scenario, oracles = [], repetition = 0}) {
-      if (!scenario.compatibleProfiles.includes(profile.name)) {
-        throw new Error(
-          `Scenario ${scenario.id} does not support profile ${profile.name}.`,
-        );
+      if (runInProgress) {
+        throw new Error('CLI eval target already has a run in progress.');
       }
-      await this.initialize();
-      await resetCliEvalWorkspace(store);
-      const startedAt = now();
-      const initialState = snapshotCliEvalState(store.getState());
-      const errors: ObservedError[] = [];
-      let sessionId = '';
+      runInProgress = true;
       try {
-        const worksheetId = store.getState().artifacts.createArtifact({
-          id: `eval-${scenario.id}-${repetition}`,
-          type: 'worksheet',
-          title: 'Evaluation Worksheet',
-        });
-        sessionId =
+        if (!scenario.compatibleProfiles.includes(profile.name)) {
+          throw new Error(
+            `Scenario ${scenario.id} does not support profile ${profile.name}.`,
+          );
+        }
+        await this.initialize();
+        await resetCliEvalWorkspace(store);
+        const startedAt = now();
+        const initialState = snapshotCliEvalState(store.getState());
+        const errors: ObservedError[] = [];
+        let sessionId = '';
+        try {
+          const worksheetId = store.getState().artifacts.createArtifact({
+            id: `eval-${scenario.id}-${repetition}`,
+            type: 'worksheet',
+            title: 'Evaluation Worksheet',
+          });
+          sessionId =
+            store
+              .getState()
+              .artifactAi.createArtifactScopedSession(
+                scenario.title,
+                options.modelProvider ?? modelIdentity.provider,
+                options.modelId ?? modelIdentity.modelId,
+              ) ?? '';
+          if (!sessionId)
+            throw new Error('Failed to create an eval AI session.');
           store
             .getState()
-            .artifactAi.createArtifactScopedSession(
-              scenario.title,
-              options.modelProvider ?? modelIdentity.provider,
-              options.modelId ?? modelIdentity.modelId,
-            ) ?? '';
-        if (!sessionId) throw new Error('Failed to create an eval AI session.');
-        store
-          .getState()
-          .artifactAi.addSessionArtifactLink(sessionId, worksheetId);
-        for (const turn of scenario.turns) {
-          store.getState().ai.setPrompt(sessionId, turn.input);
-          const completion = waitForSession(
-            store,
-            sessionId,
-            options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-          );
-          await store.getState().ai.startAnalysis(sessionId);
-          await completion;
+            .artifactAi.addSessionArtifactLink(sessionId, worksheetId);
+          for (const turn of scenario.turns) {
+            store.getState().ai.setPrompt(sessionId, turn.input);
+            const completion = waitForSession(store, sessionId, timeoutMs);
+            await store.getState().ai.startAnalysis(sessionId);
+            await completion;
+          }
+        } catch (error) {
+          if (error instanceof CliEvalTimeoutError && sessionId) {
+            await cancelSessionAndWait(store, sessionId);
+          }
+          errors.push(observedError(error, options.sensitiveValues ?? []));
         }
-      } catch (error) {
-        if (error instanceof CliEvalTimeoutError && sessionId) {
-          await cancelSessionAndWait(store, sessionId);
-        }
-        errors.push(observedError(error, options.sensitiveValues ?? []));
-      }
 
-      const endedAt = now();
-      const session = store
-        .getState()
-        .ai.config.sessions.find((candidate) => candidate.id === sessionId);
-      const messages = (session?.uiMessages ?? []) as UIMessage[];
-      errors.push(
-        ...errorsFromMessages(messages, options.sensitiveValues ?? []),
-      );
-      const finalAnswer = textFromMessages(messages);
-      const finalState = snapshotCliEvalState(store.getState());
-      const mutations: ObservedMutation[] =
-        JSON.stringify(initialState) === JSON.stringify(finalState)
-          ? []
-          : [{kind: 'workspace-state', data: {finalState}}];
-      const oracleResults = await evaluateOracles(oracles, {
-        scenario,
-        workspace: finalState,
-        database: {tables: finalState.tables},
-        finalAnswer,
-        errors,
-        mutations,
-        metadata: {},
-      });
-      const summary = summarizeOracleResults(oracleResults);
-      const status =
-        errors.length > 0 ? 'error' : summary.pass ? 'passed' : 'failed';
-      const events = eventsFromMessages(
-        messages,
-        startedAt,
-        (session?.agentProgress ?? {}) as Parameters<
-          typeof eventsFromMessages
-        >[2],
-      );
-      for (const error of errors) {
-        events.push({
-          sequence: events.length,
-          timestamp: endedAt.toISOString(),
-          type: 'error',
-          name: error.name,
-          data: {message: error.message, ...(error.metadata ?? {})},
+        const endedAt = now();
+        const session = store
+          .getState()
+          .ai.config.sessions.find((candidate) => candidate.id === sessionId);
+        const messages = (session?.uiMessages ?? []) as UIMessage[];
+        errors.push(
+          ...errorsFromMessages(messages, options.sensitiveValues ?? []),
+        );
+        const finalAnswer = textFromMessages(messages);
+        const finalState = snapshotCliEvalState(store.getState());
+        const mutations: ObservedMutation[] =
+          JSON.stringify(initialState) === JSON.stringify(finalState)
+            ? []
+            : [{kind: 'workspace-state', data: {finalState}}];
+        const oracleResults = await evaluateOracles(oracles, {
+          scenario,
+          workspace: finalState,
+          database: {tables: finalState.tables},
+          finalAnswer,
+          errors,
+          mutations,
+          metadata: {},
         });
-      }
-      if (mutations.length > 0) {
-        events.push({
-          sequence: events.length,
-          timestamp: endedAt.toISOString(),
-          type: 'mutation',
-          name: 'workspace-state',
-          data: {kind: mutations[0]!.kind},
+        const summary = summarizeOracleResults(oracleResults);
+        const status =
+          errors.length > 0 ? 'error' : summary.pass ? 'passed' : 'failed';
+        const events = eventsFromMessages(
+          messages,
+          startedAt,
+          (session?.agentProgress ?? {}) as Parameters<
+            typeof eventsFromMessages
+          >[2],
+        );
+        for (const error of errors) {
+          events.push({
+            sequence: events.length,
+            timestamp: endedAt.toISOString(),
+            type: 'error',
+            name: error.name,
+            data: {message: error.message, ...(error.metadata ?? {})},
+          });
+        }
+        if (mutations.length > 0) {
+          events.push({
+            sequence: events.length,
+            timestamp: endedAt.toISOString(),
+            type: 'mutation',
+            name: 'workspace-state',
+            data: {kind: mutations[0]!.kind},
+          });
+        }
+        const evidence = RunEvidenceSchema.parse({
+          schemaVersion: RUN_EVIDENCE_SCHEMA_VERSION,
+          runId: `${scenario.id}-${repetition}-${startedAt.getTime()}`,
+          scenario: {id: scenario.id, version: scenario.version, repetition},
+          target: {
+            type: 'cli-in-process',
+            profileName: profile.name,
+            profileVersion: profile.version,
+          },
+          repository: options.repository,
+          model: {
+            provider: options.modelProvider ?? modelIdentity.provider,
+            modelId: options.modelId ?? modelIdentity.modelId,
+            settings: {},
+          },
+          timing: {
+            startedAt: startedAt.toISOString(),
+            endedAt: endedAt.toISOString(),
+            latencyMs: Math.max(0, endedAt.getTime() - startedAt.getTime()),
+          },
+          status,
+          promptTurns: scenario.turns,
+          finalAnswer,
+          events,
+          finalState,
+          oracleResults,
+          metadata: {initialState},
         });
+        return redactRunEvidence(evidence, options.sensitiveValues ?? []);
+      } finally {
+        runInProgress = false;
       }
-      const evidence = RunEvidenceSchema.parse({
-        schemaVersion: RUN_EVIDENCE_SCHEMA_VERSION,
-        runId: `${scenario.id}-${repetition}-${startedAt.getTime()}`,
-        scenario: {id: scenario.id, version: scenario.version, repetition},
-        target: {
-          type: 'cli-in-process',
-          profileName: profile.name,
-          profileVersion: profile.version,
-        },
-        repository: options.repository,
-        model: {
-          provider: options.modelProvider ?? modelIdentity.provider,
-          modelId: options.modelId ?? modelIdentity.modelId,
-          settings: {},
-        },
-        timing: {
-          startedAt: startedAt.toISOString(),
-          endedAt: endedAt.toISOString(),
-          latencyMs: Math.max(0, endedAt.getTime() - startedAt.getTime()),
-        },
-        status,
-        promptTurns: scenario.turns,
-        finalAnswer,
-        events,
-        finalState,
-        oracleResults,
-        metadata: {initialState},
-      });
-      return redactRunEvidence(evidence, options.sensitiveValues ?? []);
     },
     async dispose() {
       if (disposed) return;

--- a/apps/sqlrooms-cli-ui/src/evals/createCliEvalTarget.ts
+++ b/apps/sqlrooms-cli-ui/src/evals/createCliEvalTarget.ts
@@ -549,7 +549,7 @@ export function createCliEvalTarget(
             sequence: events.length,
             timestamp: endedAt.toISOString(),
             type: 'error',
-            name: error.name,
+            ...(error.name ? {name: error.name} : {}),
             data: {message: error.message, ...(error.metadata ?? {})},
           });
         }

--- a/apps/sqlrooms-cli-ui/src/evals/createCliEvalTarget.ts
+++ b/apps/sqlrooms-cli-ui/src/evals/createCliEvalTarget.ts
@@ -1,0 +1,487 @@
+import {createArtifactAiSlice} from '@sqlrooms/artifacts/ai';
+import {createArtifactsSlice, defineArtifactTypes} from '@sqlrooms/artifacts';
+import {createAiSlice, getChatRequestErrorMessage} from '@sqlrooms/ai';
+import {createDeckMapsSlice, ensureDeckMapResourceState} from '@sqlrooms/deck';
+import {createBlockDocumentsSlice} from '@sqlrooms/documents';
+import {createNodeDuckDbConnector} from '@sqlrooms/duckdb-node';
+import {
+  RUN_EVIDENCE_SCHEMA_VERSION,
+  RunEvidenceSchema,
+  evaluateOracles,
+  summarizeOracleResults,
+  type BehavioralOracle,
+  type JsonObject,
+  type ObservedError,
+  type ObservedMutation,
+  type RunEvidence,
+  type ScenarioDefinition,
+} from '@sqlrooms/evals';
+import {createRoomShellSlice} from '@sqlrooms/room-shell';
+import type {LanguageModel, UIMessage} from 'ai';
+import type {StoreApi} from 'zustand';
+import {createStore} from 'zustand/vanilla';
+import {createCliAiInstructions} from '../createCliAiInstructions';
+import {createCliAiTools} from '../createCliAiTools';
+import {createCliWorksheetArtifactDefinition} from '../createCliWorksheetArtifactDefinition';
+import {formatRunContextInstructions} from '../context/formatRunContextInstructions';
+import {getRunContext} from '../context/getRunContext';
+import {
+  resolveCliCapabilityProfile,
+  type CliCapabilityProfile,
+} from '../profiles';
+import {
+  registerCliCapabilityProfileCommands,
+  unregisterCliCapabilityProfileCommands,
+} from '../registerCliCapabilityProfileCommands';
+import type {RoomState} from '../store-types';
+import {createCliEvalDuckDbOptions} from './fixture';
+import {snapshotCliEvalState} from './snapshot';
+
+const DEFAULT_TIMEOUT_MS = 20_000;
+
+function getLanguageModelIdentity(model: LanguageModel): {
+  provider: string;
+  modelId: string;
+} {
+  return typeof model === 'string'
+    ? {provider: 'gateway', modelId: model}
+    : {provider: model.provider, modelId: model.modelId};
+}
+
+export type CliEvalTargetOptions = {
+  model: LanguageModel;
+  modelProvider?: string;
+  modelId?: string;
+  repository?: RunEvidence['repository'];
+  timeoutMs?: number;
+  sensitiveValues?: readonly string[];
+  now?: () => Date;
+};
+
+export type CliEvalRunOptions = {
+  scenario: ScenarioDefinition;
+  oracles?: readonly BehavioralOracle[];
+  repetition?: number;
+};
+
+export type CliEvalTarget = {
+  readonly profile: CliCapabilityProfile;
+  readonly store: StoreApi<RoomState>;
+  initialize(): Promise<void>;
+  run(options: CliEvalRunOptions): Promise<RunEvidence>;
+  dispose(): Promise<void>;
+};
+
+function textFromMessages(messages: readonly UIMessage[]): string {
+  const lastAssistant = [...messages]
+    .reverse()
+    .find((message) => message.role === 'assistant');
+  return (lastAssistant?.parts ?? [])
+    .filter(
+      (part): part is Extract<typeof part, {type: 'text'}> =>
+        part.type === 'text',
+    )
+    .map((part) => part.text)
+    .join('\n');
+}
+
+function errorsFromMessages(
+  messages: readonly UIMessage[],
+  sensitiveValues: readonly string[],
+): ObservedError[] {
+  const errors = new Set<string>();
+  for (const message of messages) {
+    const metadataError = getChatRequestErrorMessage(message)?.error;
+    if (metadataError) errors.add(metadataError);
+    for (const part of message.parts ?? []) {
+      if (!part || typeof part !== 'object') continue;
+      const record = part as {type?: unknown; data?: unknown};
+      if (
+        record.type === 'data-sqlrooms-chat-error' &&
+        record.data &&
+        typeof record.data === 'object'
+      ) {
+        const error = (record.data as {error?: unknown}).error;
+        if (typeof error === 'string') errors.add(error);
+      }
+    }
+  }
+  return [...errors].map((error) =>
+    observedError(new Error(error), sensitiveValues),
+  );
+}
+
+function redact(value: string, sensitiveValues: readonly string[]): string {
+  return sensitiveValues.reduce(
+    (result, secret) =>
+      secret ? result.split(secret).join('[REDACTED]') : result,
+    value,
+  );
+}
+
+function observedError(
+  error: unknown,
+  sensitiveValues: readonly string[],
+): ObservedError {
+  const source = error instanceof Error ? error : new Error(String(error));
+  return {
+    name: source.name,
+    message: redact(source.message, sensitiveValues),
+    metadata: source.stack
+      ? {stack: redact(source.stack, sensitiveValues)}
+      : {},
+  };
+}
+
+function waitForSession(
+  store: StoreApi<RoomState>,
+  sessionId: string,
+  timeoutMs: number,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let sawRunning = false;
+    const timeout = setTimeout(() => {
+      unsubscribe();
+      reject(new Error(`CLI eval session timed out after ${timeoutMs}ms.`));
+    }, timeoutMs);
+    const inspect = () => {
+      const session = store
+        .getState()
+        .ai.config.sessions.find((candidate) => candidate.id === sessionId);
+      sawRunning ||= Boolean(session?.isRunning);
+      if (session && sawRunning && !session.isRunning) {
+        clearTimeout(timeout);
+        unsubscribe();
+        resolve();
+      }
+    };
+    const unsubscribe = store.subscribe(inspect);
+    inspect();
+  });
+}
+
+function eventsFromMessages(
+  messages: readonly UIMessage[],
+  startedAt: Date,
+  agentProgress: Record<
+    string,
+    Array<{
+      toolCallId: string;
+      toolName: string;
+      input?: unknown;
+      output?: unknown;
+      errorText?: string;
+      state: string;
+      agentToolCalls?: unknown[];
+      startedAt?: number;
+      completedAt?: number;
+    }>
+  > = {},
+): RunEvidence['events'] {
+  let sequence = 0;
+  const events: RunEvidence['events'] = [];
+  const pushAgentCalls = (
+    calls: (typeof agentProgress)[string],
+    parentToolCallId: string,
+  ) => {
+    for (const call of calls) {
+      events.push({
+        sequence: sequence++,
+        timestamp: new Date(
+          call.startedAt ?? startedAt.getTime() + sequence,
+        ).toISOString(),
+        type: call.agentToolCalls ? 'nested-agent' : 'tool',
+        name: call.toolName,
+        data: JSON.parse(
+          JSON.stringify({
+            toolCallId: call.toolCallId,
+            parentToolCallId,
+            state: call.state,
+            input: call.input ?? null,
+            output: call.output ?? null,
+            errorText: call.errorText ?? null,
+            durationMs:
+              call.startedAt !== undefined && call.completedAt !== undefined
+                ? Math.max(0, call.completedAt - call.startedAt)
+                : null,
+          }),
+        ) as JsonObject,
+      });
+      if (call.agentToolCalls) {
+        pushAgentCalls(
+          call.agentToolCalls as (typeof agentProgress)[string],
+          call.toolCallId,
+        );
+      }
+    }
+  };
+  for (const message of messages) {
+    for (const part of message.parts ?? []) {
+      const timestamp = new Date(startedAt.getTime() + sequence).toISOString();
+      if (part.type === 'text' && part.text) {
+        events.push({
+          sequence: sequence++,
+          timestamp,
+          type: 'model',
+          data: {role: message.role, text: part.text},
+        });
+        continue;
+      }
+      if (part.type.startsWith('tool-')) {
+        const name = part.type.slice('tool-'.length);
+        const toolCallId = (part as {toolCallId?: unknown}).toolCallId;
+        events.push({
+          sequence: sequence++,
+          timestamp,
+          type: name === 'block_document_agent' ? 'nested-agent' : 'tool',
+          name,
+          data: JSON.parse(JSON.stringify(part)) as JsonObject,
+        });
+        if (typeof toolCallId === 'string' && agentProgress[toolCallId]) {
+          pushAgentCalls(agentProgress[toolCallId], toolCallId);
+        }
+      }
+    }
+  }
+  return events;
+}
+
+function createHeadlessStore(
+  profile: CliCapabilityProfile,
+  model: LanguageModel,
+): {
+  store: StoreApi<RoomState>;
+  connector: ReturnType<typeof createNodeDuckDbConnector>;
+} {
+  const modelIdentity = getLanguageModelIdentity(model);
+  const connector = createNodeDuckDbConnector(createCliEvalDuckDbOptions());
+  const artifactTypes = defineArtifactTypes({
+    worksheet: createCliWorksheetArtifactDefinition(),
+  });
+  const roomStore = createStore<RoomState>()((set, get, store) => {
+    const typedStore = store as StoreApi<RoomState>;
+    const tools = createCliAiTools({
+      store: typedStore,
+      profile,
+      nestedAgentModel: model,
+    });
+    const state = {
+      ...createRoomShellSlice({
+        connector,
+        config: {title: 'SQLRooms Eval', dataSources: []},
+      })(set, get, store),
+      ...createArtifactsSlice<RoomState>({artifactTypes})(set, get, store),
+      ...createArtifactAiSlice<RoomState>({autoSync: false})(set, get, store),
+      ...createDeckMapsSlice()(set, get, store),
+      ...createBlockDocumentsSlice<RoomState>({
+        onCreateOwnedStatefulBlock: ({
+          blockInstanceId,
+          blockType,
+          getState,
+        }) => {
+          if (blockType === 'map') {
+            ensureDeckMapResourceState(getState(), blockInstanceId);
+          }
+        },
+        onDeleteOwnedStatefulBlock: ({
+          blockInstanceId,
+          blockType,
+          getState,
+        }) => {
+          if (blockType === 'map')
+            getState().deckMaps.removeMap(blockInstanceId);
+        },
+      })(set, get, store),
+      dashboard: {
+        initialize: async () => {
+          registerCliCapabilityProfileCommands(
+            typedStore,
+            profile,
+            artifactTypes,
+          );
+        },
+        destroy: async () => {
+          unregisterCliCapabilityProfileCommands(typedStore);
+        },
+        ensureDashboardArtifact: () => {},
+        addDataTableExplorerForTable: () => undefined,
+        getCurrentDashboardArtifactId: () => undefined,
+        createDashboardArtifact: () => {
+          throw new Error(
+            'Dashboard capabilities are disabled for this profile.',
+          );
+        },
+      },
+      ...createAiSlice({
+        tools,
+        defaultProvider: modelIdentity.provider,
+        defaultModel: modelIdentity.modelId,
+        getCustomModel: () => model,
+        getInstructions: () => createCliAiInstructions(typedStore, profile),
+        getRunContext: (sessionId) =>
+          getRunContext(typedStore, sessionId, {profile}),
+        formatRunContextInstructions: ({runContext}) =>
+          formatRunContextInstructions(runContext, typedStore),
+        timeouts: {runMs: DEFAULT_TIMEOUT_MS},
+      })(set, get, store),
+    };
+    return state as unknown as RoomState;
+  });
+  return {store: roomStore, connector};
+}
+
+/** Creates an isolated, in-process CLI eval target using production wiring. */
+export function createCliEvalTarget(
+  options: CliEvalTargetOptions,
+): CliEvalTarget {
+  const profile = resolveCliCapabilityProfile({
+    profileName: 'worksheet-charts-maps',
+  });
+  const modelIdentity = getLanguageModelIdentity(options.model);
+  const {store, connector} = createHeadlessStore(profile, options.model);
+  const now = options.now ?? (() => new Date());
+  let initialized = false;
+  let disposed = false;
+
+  return {
+    profile,
+    store,
+    async initialize() {
+      if (disposed)
+        throw new Error('Cannot initialize a disposed CLI eval target.');
+      if (initialized) return;
+      await store.getState().room.initialize();
+      await store.getState().db.refreshTableSchemas();
+      initialized = true;
+    },
+    async run({scenario, oracles = [], repetition = 0}) {
+      if (!scenario.compatibleProfiles.includes(profile.name)) {
+        throw new Error(
+          `Scenario ${scenario.id} does not support profile ${profile.name}.`,
+        );
+      }
+      await this.initialize();
+      const startedAt = now();
+      const initialState = snapshotCliEvalState(store.getState());
+      const errors: ObservedError[] = [];
+      let sessionId = '';
+      try {
+        const worksheetId = store.getState().artifacts.createArtifact({
+          id: `eval-${scenario.id}-${repetition}`,
+          type: 'worksheet',
+          title: 'Evaluation Worksheet',
+        });
+        sessionId =
+          store
+            .getState()
+            .artifactAi.createArtifactScopedSession(
+              scenario.title,
+              options.modelProvider ?? modelIdentity.provider,
+              options.modelId ?? modelIdentity.modelId,
+            ) ?? '';
+        if (!sessionId) throw new Error('Failed to create an eval AI session.');
+        store
+          .getState()
+          .artifactAi.addSessionArtifactLink(sessionId, worksheetId);
+        for (const turn of scenario.turns) {
+          store.getState().ai.setPrompt(sessionId, turn.input);
+          const completion = waitForSession(
+            store,
+            sessionId,
+            options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+          );
+          await store.getState().ai.startAnalysis(sessionId);
+          await completion;
+        }
+      } catch (error) {
+        errors.push(observedError(error, options.sensitiveValues ?? []));
+      }
+
+      const endedAt = now();
+      const session = store
+        .getState()
+        .ai.config.sessions.find((candidate) => candidate.id === sessionId);
+      const messages = (session?.uiMessages ?? []) as UIMessage[];
+      errors.push(
+        ...errorsFromMessages(messages, options.sensitiveValues ?? []),
+      );
+      const finalAnswer = textFromMessages(messages);
+      const finalState = snapshotCliEvalState(store.getState());
+      const mutations: ObservedMutation[] =
+        JSON.stringify(initialState) === JSON.stringify(finalState)
+          ? []
+          : [{kind: 'workspace-state', data: {finalState}}];
+      const oracleResults = await evaluateOracles(oracles, {
+        scenario,
+        workspace: finalState,
+        database: {tables: finalState.tables},
+        finalAnswer,
+        errors,
+        mutations,
+        metadata: {},
+      });
+      const summary = summarizeOracleResults(oracleResults);
+      const status =
+        errors.length > 0 ? 'error' : summary.pass ? 'passed' : 'failed';
+      const events = eventsFromMessages(
+        messages,
+        startedAt,
+        (session?.agentProgress ?? {}) as Parameters<
+          typeof eventsFromMessages
+        >[2],
+      );
+      for (const error of errors) {
+        events.push({
+          sequence: events.length,
+          timestamp: endedAt.toISOString(),
+          type: 'error',
+          name: error.name,
+          data: {message: error.message, ...(error.metadata ?? {})},
+        });
+      }
+      if (mutations.length > 0) {
+        events.push({
+          sequence: events.length,
+          timestamp: endedAt.toISOString(),
+          type: 'mutation',
+          name: 'workspace-state',
+          data: {kind: mutations[0]!.kind},
+        });
+      }
+      return RunEvidenceSchema.parse({
+        schemaVersion: RUN_EVIDENCE_SCHEMA_VERSION,
+        runId: `${scenario.id}-${repetition}-${startedAt.getTime()}`,
+        scenario: {id: scenario.id, version: scenario.version, repetition},
+        target: {
+          type: 'cli-in-process',
+          profileName: profile.name,
+          profileVersion: profile.version,
+        },
+        repository: options.repository,
+        model: {
+          provider: options.modelProvider ?? modelIdentity.provider,
+          modelId: options.modelId ?? modelIdentity.modelId,
+          settings: {},
+        },
+        timing: {
+          startedAt: startedAt.toISOString(),
+          endedAt: endedAt.toISOString(),
+          latencyMs: Math.max(0, endedAt.getTime() - startedAt.getTime()),
+        },
+        status,
+        promptTurns: scenario.turns,
+        finalAnswer,
+        events,
+        finalState,
+        oracleResults,
+        metadata: {initialState},
+      });
+    },
+    async dispose() {
+      if (disposed) return;
+      disposed = true;
+      if (initialized) await store.getState().room.destroy();
+      else await connector.destroy();
+    },
+  };
+}

--- a/apps/sqlrooms-cli-ui/src/evals/fixture.ts
+++ b/apps/sqlrooms-cli-ui/src/evals/fixture.ts
@@ -1,0 +1,40 @@
+import type {NodeDuckDbConnectorOptions} from '@sqlrooms/duckdb-node';
+
+/** Canonical table requested by the deterministic CLI eval fixture. */
+export const CLI_EVAL_TARGET_TABLE = '"analytics"."events"';
+
+/**
+ * Small geospatial fixture with deliberately ambiguous table names.
+ * Distinct metrics make use of the intended canonical table observable.
+ */
+export const CLI_EVAL_FIXTURE_SQL = `
+CREATE SCHEMA analytics;
+CREATE SCHEMA archive;
+
+CREATE TABLE analytics.events (
+  observed_at TIMESTAMP,
+  category VARCHAR,
+  metric DOUBLE,
+  latitude DOUBLE,
+  longitude DOUBLE
+);
+INSERT INTO analytics.events VALUES
+  ('2026-08-01 09:00:00', 'alpha', 11.0, 47.3769, 8.5417),
+  ('2026-08-02 09:00:00', 'beta', 19.0, 46.9480, 7.4474),
+  ('2026-08-03 09:00:00', 'alpha', 23.0, 46.2044, 6.1432);
+
+CREATE TABLE archive.events (
+  observed_at TIMESTAMP,
+  category VARCHAR,
+  metric DOUBLE,
+  latitude DOUBLE,
+  longitude DOUBLE
+);
+INSERT INTO archive.events VALUES
+  ('2020-01-01 00:00:00', 'legacy', 9001.0, 0.0, 0.0);
+`;
+
+/** Creates Node DuckDB options for an isolated in-memory eval database. */
+export function createCliEvalDuckDbOptions(): NodeDuckDbConnectorOptions {
+  return {dbPath: ':memory:', initializationQuery: CLI_EVAL_FIXTURE_SQL};
+}

--- a/apps/sqlrooms-cli-ui/src/evals/snapshot.ts
+++ b/apps/sqlrooms-cli-ui/src/evals/snapshot.ts
@@ -1,0 +1,25 @@
+import type {JsonObject, JsonValue} from '@sqlrooms/evals';
+import {getTableIdentity} from '@sqlrooms/duckdb';
+import type {RoomState} from '../store-types';
+
+function toJsonValue(value: unknown): JsonValue {
+  return JSON.parse(JSON.stringify(value)) as JsonValue;
+}
+
+/** Captures the durable CLI state used by target-neutral behavioral oracles. */
+export function snapshotCliEvalState(state: RoomState): JsonObject {
+  const worksheets = Object.values(state.artifacts.config.artifactsById)
+    .filter((artifact) => artifact.type === 'worksheet')
+    .map((artifact) => ({
+      id: artifact.id,
+      title: artifact.title,
+      blocks: state.blockDocuments.getBlocks(artifact.id),
+    }));
+  const maps = Object.values(state.deckMaps.config.mapsById);
+  return {
+    artifacts: toJsonValue(state.artifacts.config),
+    worksheets: toJsonValue(worksheets),
+    maps: toJsonValue(maps),
+    tables: state.db.tables.map((table) => getTableIdentity(table.table)),
+  };
+}

--- a/apps/sqlrooms-cli-ui/src/registerCliCapabilityProfileCommands.ts
+++ b/apps/sqlrooms-cli-ui/src/registerCliCapabilityProfileCommands.ts
@@ -1,0 +1,133 @@
+import {
+  createBlockDocumentCommands,
+  createDocumentCommands,
+  type BlockDocumentBlock,
+} from '@sqlrooms/documents';
+import {createMosaicDashboardCommands} from '@sqlrooms/mosaic';
+import {createPythonBlockCommands} from '@sqlrooms/python/block';
+import {
+  registerCommandsForOwner,
+  unregisterCommandsForOwner,
+} from '@sqlrooms/room-shell';
+import type {StoreApi} from 'zustand';
+import {
+  CLI_BLOCK_DOCUMENT_COMMAND_OWNER,
+  createCliBlockDocumentCommands,
+} from './createCliBlockDocumentCommands';
+import {
+  createDashboardCommands,
+  DASHBOARD_COMMAND_OWNER,
+} from './createDashboardCommands';
+import {
+  createHtmlAppRevisionCommands,
+  HTML_APP_REVISION_COMMAND_OWNER,
+} from './createHtmlAppRevisionCommands';
+import type {CliCapabilityProfile} from './profiles';
+import {createStatefulBlockCommandTypes} from './statefulBlockArtifactConfigs';
+import type {RoomState} from './store-types';
+
+export const DOCUMENT_COMMAND_OWNER = '@sqlrooms/documents';
+export const MOSAIC_DASHBOARD_COMMAND_OWNER = '@sqlrooms/mosaic/dashboard';
+export const BLOCK_DOCUMENT_COMMAND_OWNER =
+  '@sqlrooms/documents/block-document';
+export const BLOCK_DOCUMENT_PYTHON_COMMAND_OWNER =
+  '@sqlrooms/python/block-document';
+
+const BLOCK_DOCUMENT_OPTIONS = {
+  artifactType: 'worksheet',
+  artifactLabel: 'Worksheet',
+  commandNamespace: 'block-document',
+  commandGroup: 'Worksheet',
+  defaultTitle: 'Worksheet',
+} as const;
+
+const WORKSHEET_CHARTS_MAPS_ALLOWED_BLOCK_TYPES = [
+  'heading',
+  'paragraph',
+  'list',
+  'todo',
+  'chart',
+  'statefulBlock',
+] as const satisfies readonly BlockDocumentBlock['type'][];
+
+/** Registers the command groups enabled by one production CLI profile. */
+export function registerCliCapabilityProfileCommands(
+  store: StoreApi<RoomState>,
+  profile: CliCapabilityProfile,
+  artifactTypes: RoomState['artifacts']['artifactTypes'],
+): void {
+  registerCommandsForOwner(
+    store,
+    DASHBOARD_COMMAND_OWNER,
+    createDashboardCommands({artifactTypes}),
+  );
+  if (profile.commands.includes('mosaic-dashboard')) {
+    registerCommandsForOwner(
+      store,
+      MOSAIC_DASHBOARD_COMMAND_OWNER,
+      createMosaicDashboardCommands<RoomState>(),
+    );
+  }
+  if (profile.commands.includes('document')) {
+    registerCommandsForOwner(
+      store,
+      DOCUMENT_COMMAND_OWNER,
+      createDocumentCommands<RoomState>(),
+    );
+  }
+  if (profile.commands.includes('block-document')) {
+    registerCommandsForOwner(
+      store,
+      BLOCK_DOCUMENT_COMMAND_OWNER,
+      createBlockDocumentCommands<RoomState>({
+        ...BLOCK_DOCUMENT_OPTIONS,
+        statefulBlockTypes: createStatefulBlockCommandTypes({profile}),
+        allowedBlockTypes:
+          profile.name === 'worksheet-charts-maps'
+            ? WORKSHEET_CHARTS_MAPS_ALLOWED_BLOCK_TYPES
+            : undefined,
+      }),
+    );
+  }
+  if (profile.commands.includes('cli-block-document')) {
+    registerCommandsForOwner(
+      store,
+      CLI_BLOCK_DOCUMENT_COMMAND_OWNER,
+      createCliBlockDocumentCommands({
+        statefulBlockTypes: profile.blocks.stateful,
+      }),
+    );
+  }
+  if (profile.commands.includes('block-document-python')) {
+    registerCommandsForOwner(
+      store,
+      BLOCK_DOCUMENT_PYTHON_COMMAND_OWNER,
+      createPythonBlockCommands<RoomState>({
+        artifactType: BLOCK_DOCUMENT_OPTIONS.artifactType,
+        artifactLabel: BLOCK_DOCUMENT_OPTIONS.artifactLabel,
+        commandNamespace: BLOCK_DOCUMENT_OPTIONS.commandNamespace,
+        commandGroup: BLOCK_DOCUMENT_OPTIONS.commandGroup,
+      }),
+    );
+  }
+  if (profile.commands.includes('html-app-revision')) {
+    registerCommandsForOwner(
+      store,
+      HTML_APP_REVISION_COMMAND_OWNER,
+      createHtmlAppRevisionCommands(),
+    );
+  }
+}
+
+/** Removes all command groups potentially registered by a CLI profile. */
+export function unregisterCliCapabilityProfileCommands(
+  store: StoreApi<RoomState>,
+): void {
+  unregisterCommandsForOwner(store, DASHBOARD_COMMAND_OWNER);
+  unregisterCommandsForOwner(store, MOSAIC_DASHBOARD_COMMAND_OWNER);
+  unregisterCommandsForOwner(store, DOCUMENT_COMMAND_OWNER);
+  unregisterCommandsForOwner(store, BLOCK_DOCUMENT_COMMAND_OWNER);
+  unregisterCommandsForOwner(store, CLI_BLOCK_DOCUMENT_COMMAND_OWNER);
+  unregisterCommandsForOwner(store, BLOCK_DOCUMENT_PYTHON_COMMAND_OWNER);
+  unregisterCommandsForOwner(store, HTML_APP_REVISION_COMMAND_OWNER);
+}

--- a/apps/sqlrooms-cli-ui/src/store.ts
+++ b/apps/sqlrooms-cli-ui/src/store.ts
@@ -9,9 +9,7 @@ import {
   getAiRunContextPrimaryItem,
   createAiSettingsSlice,
   createAiSlice,
-  createDefaultAiInstructions,
   createDefaultAiToolRenderers,
-  createDefaultAiTools,
 } from '@sqlrooms/ai';
 import {
   createHtmlAppRuntimeSlice,
@@ -45,7 +43,6 @@ import {
   createDefaultChartTypes,
   createDefaultMosaicDashboardPanelRenderers,
   createDashboardFeatureSlices,
-  createMosaicDashboardCommands,
   createMosaicDashboardDataTableExplorerPanelConfig,
   createMosaicSlice,
   defaultAddPanelActions,
@@ -54,11 +51,7 @@ import {
 } from '@sqlrooms/mosaic';
 import {createNotebookSlice, NotebookSliceConfig} from '@sqlrooms/notebook';
 import {createPivotSlice, PivotSliceConfig} from '@sqlrooms/pivot';
-import {
-  createPythonBlockCommands,
-  createPythonSlice,
-  PythonSliceConfig,
-} from '@sqlrooms/python/block';
+import {createPythonSlice, PythonSliceConfig} from '@sqlrooms/python/block';
 import {
   createPyodidePythonRuntimeAdapter,
   type PythonRuntimeHost,
@@ -71,8 +64,6 @@ import {
   DEFAULT_ROOM_TITLE,
   LayoutConfig,
   persistSliceConfigs,
-  registerCommandsForOwner,
-  unregisterCommandsForOwner,
 } from '@sqlrooms/room-shell';
 import {createSqlEditorSlice, SqlEditorSliceConfig} from '@sqlrooms/sql-editor';
 import {
@@ -86,7 +77,6 @@ import {
   WebContainerPersistConfig,
 } from '@sqlrooms/webcontainer';
 import {produce} from 'immer';
-import type {Tool} from 'ai';
 
 import {createHttpDbBridge} from '@sqlrooms/db';
 import {
@@ -95,29 +85,20 @@ import {
 } from '@sqlrooms/db-settings';
 import {
   BlockDocumentsSliceConfig,
-  createBlockDocumentCommands,
   createBlockDocumentsSlice,
-  createDocumentCommands,
   createDocumentsSlice,
   DocumentsSliceConfig,
-  type BlockDocumentBlock,
 } from '@sqlrooms/documents';
 import {createDocumentsCrdtMirror} from '@sqlrooms/documents/crdt';
 import {toast} from '@sqlrooms/ui';
 import {artifactChatAssociationMiddleware} from './artifactChatAssociation';
 import {createCliArtifactTypes} from './artifactTypes';
-import {blockDocumentAgentTool} from './createBlockDocumentAgent';
-import {createArtifactContextAiTools} from './context/createArtifactContextAiTools';
 import {formatRunContextInstructions} from './context/formatRunContextInstructions';
 import {getRunContext} from './context/getRunContext';
-import {
-  createDashboardCommands,
-  DASHBOARD_COMMAND_OWNER,
-} from './createDashboardCommands';
-import {
-  createHtmlAppRevisionCommands,
-  HTML_APP_REVISION_COMMAND_OWNER,
-} from './createHtmlAppRevisionCommands';
+import {createCliAiInstructions} from './createCliAiInstructions';
+import {createCliAiTools} from './createCliAiTools';
+import {dashboardAgentTool} from './createDashboardAgent';
+import {htmlAppAgentTool} from './createHtmlAppAgent';
 import {getDefaultScaffoldTree} from './helpers';
 import {createLayout, migrateCliLayoutConfig} from './layout';
 import {
@@ -141,75 +122,17 @@ import {
   RoomState,
 } from './store-types';
 import {
-  createStatefulBlockCommandTypes,
   getStatefulBlockArtifactConfig,
   isStatefulBlockArtifactType,
 } from './statefulBlockArtifactConfigs';
-import {dashboardAgentTool} from './createDashboardAgent';
-import {htmlAppAgentTool} from './createHtmlAppAgent';
 import {
-  CLI_BLOCK_DOCUMENT_COMMAND_OWNER,
-  createCliBlockDocumentCommands,
-} from './createCliBlockDocumentCommands';
-import {
-  KnownBlockDocumentTools,
-  CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME,
-} from './ai/constants';
+  registerCliCapabilityProfileCommands,
+  unregisterCliCapabilityProfileCommands,
+} from './registerCliCapabilityProfileCommands';
 
 export type {RoomState} from './store-types';
 
-const DOCUMENT_COMMAND_OWNER = '@sqlrooms/documents';
-const MOSAIC_DASHBOARD_COMMAND_OWNER = '@sqlrooms/mosaic/dashboard';
-const BLOCK_DOCUMENT_COMMAND_OWNER = '@sqlrooms/documents/block-document';
-const BLOCK_DOCUMENT_PYTHON_COMMAND_OWNER = '@sqlrooms/python/block-document';
-const WORKSHEET_CHARTS_MAPS_ALLOWED_BLOCK_TYPES = [
-  'heading',
-  'paragraph',
-  'list',
-  'todo',
-  'chart',
-  'statefulBlock',
-] as const satisfies readonly BlockDocumentBlock['type'][];
 const AI_SETTINGS_SAVE_FAILED_TOAST_ID = 'ai-settings-save-failed';
-const STABLE_SQLROOMS_CLI_AI_INSTRUCTIONS = `
-In the SQLRooms CLI app, a Worksheet is a block document artifact. When the user asks to create, edit, inspect, or add content to a worksheet, target the current worksheet artifact using block-document commands and block-document agent tools. Use the word Worksheet in user-facing replies, but use block-document tool names and command IDs when invoking tools. The artifact type may still be "worksheet"; its editable content model is a block document.
-
-When the user's primary context artifact is a worksheet or dashboard and they ask to add, update, or create a visualization, chart, or dashboard surface, mutate that artifact through the appropriate agent tool instead of creating a separate artifact, chat-only chart, or markdown image.
-
-- Use ${CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME} when the primary artifact is a worksheet, or when the user explicitly asks to create/edit a top-level worksheet artifact.
-- If run context contains a kind:"block" item, call ${CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME} with blockDocumentId from that item and targetBlock = {blockId, blockType, blockInstanceId}. The user is asking about that exact worksheet block; do not retarget another block.
-- For dashboard artifacts, call dashboard_agent.
-- Use the standalone chart and chart_image_for_markdown tools only when the user wants an inline chat visualization or no target artifact is available.
-`;
-const EXPERIMENTAL_SQLROOMS_CLI_AI_INSTRUCTIONS = `
-Experimental SQLRooms tools are available in this session. Use them for app, map, and generated interactive visualization requests when they match the user's target artifact.
-
-- If the primary artifact is a worksheet and the user asks for an app, HTML app, D3 app, Chart.js app, browser app, or generated interactive visualization inside it, call ${CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME}. The worksheet agent should create/reuse the worksheet html-app block, then call ${KnownBlockDocumentTools.embedded_html_app_agent} with the block's appId.
-- Do not use top-level html_app_agent to populate worksheet stateful blocks inside worksheets.
-- For worksheet map requests, call ${CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME}. It should add or reuse a direct worksheet map block, not create a dashboard block just to hold the map.
-- For generated HTML, D3, Chart.js, or browser app visualizations only when the primary artifact is an html-app artifact or no worksheet/dashboard artifact is the requested target, write through html_app_agent. html_app_agent requires appId and never creates artifacts or worksheet blocks.
-- If the primary artifact is an html-app artifact, call html_app_agent with appId set to the current artifact id and update it instead of creating a new html-app artifact.
-- For incremental edits to an existing html-app artifact, such as changing title, labels, colors, styles, layout, controls, or interactions, call html_app_agent directly with the current appId and the user's edit request. Do not inspect tables or schemas first unless the user explicitly asks to change the app's data/query behavior.
-- If a new top-level html-app artifact is needed, first execute the html-app.create-artifact command, then call html_app_agent with appId set to the returned artifactId.
-- For HTML app undo, redo, or restoring an earlier version, use list_commands and execute_command with html-app.undo-revision, html-app.redo-revision, or html-app.restore-revision. Do not rewrite, delete, or edit chat messages to perform app undo/redo.
-- If an embedded worksheet HTML app target is ambiguous, ask the user to select the app/block or provide appId instead of mutating a guessed app.
-`;
-const WORKSHEET_CHARTS_MAPS_AI_INSTRUCTIONS = `
-This SQLRooms session exposes worksheet artifacts with text, chart, and direct map blocks.
-
-- Use ${CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME} for worksheet creation, analysis, charts, maps, block edits, and block reordering.
-- If run context contains a kind:"block" item, pass its blockDocumentId and targetBlock fields unchanged so only that worksheet block is edited.
-- For worksheet maps, use the worksheet agent's direct map tool. Preserve existing map datasets and layers for incremental edits.
-- Use standalone chart tools only for inline chat visualizations or when no worksheet target is available.
-`;
-
-const BLOCK_DOCUMENT_OPTIONS = {
-  artifactType: 'worksheet',
-  artifactLabel: 'Worksheet',
-  commandNamespace: 'block-document',
-  commandGroup: 'Worksheet',
-  defaultTitle: 'Worksheet',
-} as const;
 
 const cliArtifactTypes = createCliArtifactTypes({
   profile: cliCapabilityProfile,
@@ -751,81 +674,14 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
 
       const dashboardSlice: RoomState['dashboard'] = {
         initialize: async () => {
-          registerCommandsForOwner(
+          registerCliCapabilityProfileCommands(
             store,
-            DASHBOARD_COMMAND_OWNER,
-            createDashboardCommands({artifactTypes: cliArtifactTypes}),
+            cliCapabilityProfile,
+            cliArtifactTypes,
           );
-          if (cliCapabilityProfile.commands.includes('mosaic-dashboard')) {
-            registerCommandsForOwner(
-              store,
-              MOSAIC_DASHBOARD_COMMAND_OWNER,
-              createMosaicDashboardCommands<RoomState>(),
-            );
-          }
-          if (cliCapabilityProfile.commands.includes('document')) {
-            registerCommandsForOwner(
-              store,
-              DOCUMENT_COMMAND_OWNER,
-              createDocumentCommands<RoomState>(),
-            );
-          }
-          if (cliCapabilityProfile.commands.includes('block-document')) {
-            registerCommandsForOwner(
-              store,
-              BLOCK_DOCUMENT_COMMAND_OWNER,
-              createBlockDocumentCommands<RoomState>({
-                ...BLOCK_DOCUMENT_OPTIONS,
-                statefulBlockTypes: createStatefulBlockCommandTypes({
-                  profile: cliCapabilityProfile,
-                }),
-                allowedBlockTypes:
-                  cliCapabilityProfile.name === 'worksheet-charts-maps'
-                    ? WORKSHEET_CHARTS_MAPS_ALLOWED_BLOCK_TYPES
-                    : undefined,
-              }),
-            );
-          }
-          if (cliCapabilityProfile.commands.includes('cli-block-document')) {
-            registerCommandsForOwner(
-              store,
-              CLI_BLOCK_DOCUMENT_COMMAND_OWNER,
-              createCliBlockDocumentCommands({
-                statefulBlockTypes: cliCapabilityProfile.blocks.stateful,
-              }),
-            );
-          }
-          if (cliCapabilityProfile.commands.includes('block-document-python')) {
-            registerCommandsForOwner(
-              store,
-              BLOCK_DOCUMENT_PYTHON_COMMAND_OWNER,
-              createPythonBlockCommands<RoomState>({
-                artifactType: BLOCK_DOCUMENT_OPTIONS.artifactType,
-                artifactLabel: BLOCK_DOCUMENT_OPTIONS.artifactLabel,
-                commandNamespace: BLOCK_DOCUMENT_OPTIONS.commandNamespace,
-                commandGroup: BLOCK_DOCUMENT_OPTIONS.commandGroup,
-              }),
-            );
-          }
-          if (cliCapabilityProfile.commands.includes('html-app-revision')) {
-            registerCommandsForOwner(
-              store,
-              HTML_APP_REVISION_COMMAND_OWNER,
-              createHtmlAppRevisionCommands(),
-            );
-          }
         },
         destroy: async () => {
-          unregisterCommandsForOwner(store, DASHBOARD_COMMAND_OWNER);
-          unregisterCommandsForOwner(store, MOSAIC_DASHBOARD_COMMAND_OWNER);
-          unregisterCommandsForOwner(store, DOCUMENT_COMMAND_OWNER);
-          unregisterCommandsForOwner(store, BLOCK_DOCUMENT_COMMAND_OWNER);
-          unregisterCommandsForOwner(store, CLI_BLOCK_DOCUMENT_COMMAND_OWNER);
-          unregisterCommandsForOwner(
-            store,
-            BLOCK_DOCUMENT_PYTHON_COMMAND_OWNER,
-          );
-          unregisterCommandsForOwner(store, HTML_APP_REVISION_COMMAND_OWNER);
+          unregisterCliCapabilityProfileCommands(store);
         },
         ensureDashboardArtifact: (artifactId) => {
           const artifact = get().artifacts.getArtifact(artifactId);
@@ -1148,40 +1004,15 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
 
         ...(() => {
           const webContainerToolkit = createWebContainerToolkit(store);
-          const enabledTools = new Set(
-            cliCapabilityProfile.ai.topLevelToolGroups,
-          );
-          const tools: Record<string, Tool> = {};
-          if (enabledTools.has('default-data-analysis')) {
-            Object.assign(tools, createDefaultAiTools(store, {query: {}}));
-          }
-          if (enabledTools.has('artifact-context')) {
-            Object.assign(tools, createArtifactContextAiTools(store));
-          }
-          if (enabledTools.has('dashboard-agent')) {
-            tools.dashboard_agent = dashboardAgentTool(store, {
-              deckMapsEnabled: cliCapabilityProfile.dashboard.deckMaps,
-            });
-          }
-          if (enabledTools.has('html-app-agent')) {
-            tools.html_app_agent = htmlAppAgentTool(store);
-          }
-          if (enabledTools.has('worksheet-agent')) {
-            tools[CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME] = blockDocumentAgentTool(
-              store,
-              {profile: cliCapabilityProfile},
-            );
-          }
-          if (enabledTools.has('webcontainer')) {
-            Object.assign(tools, webContainerToolkit.tools);
-          }
-          if (enabledTools.has('chart')) {
-            tools.chart = createVegaChartTool();
-          }
-          if (enabledTools.has('chart-image-for-markdown')) {
-            tools.chart_image_for_markdown =
-              createChartImageForMarkdownTool(store);
-          }
+          const tools = createCliAiTools({
+            store,
+            profile: cliCapabilityProfile,
+            webContainerTools: webContainerToolkit.tools,
+            createDashboardAgentTool: dashboardAgentTool,
+            createHtmlAppAgentTool: htmlAppAgentTool,
+            createStandaloneChartTool: createVegaChartTool,
+            createChartImageTool: createChartImageForMarkdownTool,
+          });
           return createAiSlice({
             config: AiSliceConfig.parse({sessions: []}),
             defaultProvider: defaultProviderFromConfig as any,
@@ -1192,17 +1023,7 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
               get().aiSettings.config.providers[provider]?.apiKey || '',
             getBaseUrl: () => runtimeConfig.apiBaseUrl || '',
             getInstructions: () =>
-              [
-                createDefaultAiInstructions(store),
-                cliCapabilityProfile.name === 'worksheet-charts-maps'
-                  ? WORKSHEET_CHARTS_MAPS_AI_INSTRUCTIONS.trim()
-                  : STABLE_SQLROOMS_CLI_AI_INSTRUCTIONS.trim(),
-                cliCapabilityProfile.ai.instructionSets.includes('experimental')
-                  ? EXPERIMENTAL_SQLROOMS_CLI_AI_INSTRUCTIONS.trim()
-                  : '',
-              ]
-                .filter(Boolean)
-                .join('\n\n'),
+              createCliAiInstructions(store, cliCapabilityProfile),
             getRunContext: (sessionId) =>
               getRunContext(store, sessionId, {
                 profile: cliCapabilityProfile,

--- a/packages/evals/README.md
+++ b/packages/evals/README.md
@@ -11,9 +11,10 @@ application, React, browser, Promptfoo, or SQLite dependency.
 - Scenarios describe user turns, compatible production profiles, fixtures, and
   target-neutral outcome expectations.
 - Oracles inspect the final answer, database snapshot, workspace state, errors,
-  and mutations. They do not require one exact tool trajectory.
-- Run evidence records ordered events and durable outcomes in a versioned JSON
-  envelope.
+  and mutations. Oracle IDs must be unique and cover every scenario
+  expectation; they do not require one exact tool trajectory.
+- Run evidence records strictly ordered events and durable outcomes in a
+  versioned JSON envelope. Preserved extension fields must contain JSON values.
 - `@sqlrooms/evals/promptfoo` contains only structural conversion helpers for
   provider metadata and assertion results. Promptfoo remains a runner, not the
   core package interface.

--- a/packages/evals/README.md
+++ b/packages/evals/README.md
@@ -1,0 +1,68 @@
+# @sqlrooms/evals
+
+Private, evaluator-neutral behavioral evaluation primitives for SQLRooms.
+
+The package defines versioned scenarios, composable oracle results, a durable
+run-evidence envelope, and a deterministic AI SDK language model. It has no CLI
+application, React, browser, Promptfoo, or SQLite dependency.
+
+## Boundaries
+
+- Scenarios describe user turns, compatible production profiles, fixtures, and
+  target-neutral outcome expectations.
+- Oracles inspect the final answer, database snapshot, workspace state, errors,
+  and mutations. They do not require one exact tool trajectory.
+- Run evidence records ordered events and durable outcomes in a versioned JSON
+  envelope.
+- `@sqlrooms/evals/promptfoo` contains only structural conversion helpers for
+  provider metadata and assertion results. Promptfoo remains a runner, not the
+  core package interface.
+- The scripted model implements the AI SDK v3 language-model contract and can
+  assert prompt/tool wiring without credentials or network access.
+
+No generic execution adapter is defined. The in-process CLI target will be the
+first concrete runner; an adapter seam should be introduced only after a second
+working target such as MCP exists.
+
+## Example
+
+```ts
+import {
+  createWorkspaceStateOracle,
+  defineScenario,
+  evaluateOracles,
+} from '@sqlrooms/evals';
+
+const scenario = defineScenario({
+  id: 'worksheet.create-chart-map',
+  version: 1,
+  title: 'Create a chart and map',
+  compatibleProfiles: ['worksheet-charts-maps'],
+  turns: [{id: 'create', input: 'Create a worksheet with a chart and map.'}],
+  expectations: [
+    {
+      oracleId: 'worksheet-has-chart-map',
+      description: 'The worksheet contains valid chart and map blocks.',
+    },
+  ],
+});
+
+const oracle = createWorkspaceStateOracle({
+  id: 'worksheet-has-chart-map',
+  evaluate: (workspace) => ({
+    pass: workspace !== undefined,
+    reason: workspace
+      ? 'Workspace state captured.'
+      : 'Workspace state missing.',
+  }),
+});
+
+const results = await evaluateOracles([oracle], {
+  scenario,
+  workspace: {artifacts: []},
+  finalAnswer: '',
+  errors: [],
+  mutations: [],
+  metadata: {},
+});
+```

--- a/packages/evals/eslint.config.js
+++ b/packages/evals/eslint.config.js
@@ -1,0 +1,13 @@
+import {config} from '@sqlrooms/preset-eslint/base';
+
+/** @type {import("eslint").Linter.Config[]} */
+export default [
+  ...config,
+  {
+    languageOptions: {
+      parserOptions: {
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+];

--- a/packages/evals/jest.config.js
+++ b/packages/evals/jest.config.js
@@ -1,0 +1,6 @@
+import nodeConfig from '@sqlrooms/preset-jest/node.js';
+
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+export default {
+  ...nodeConfig,
+};

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@sqlrooms/evals",
+  "version": "0.29.0-rc.11",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sqlrooms/sqlrooms.git"
+  },
+  "license": "MIT",
+  "author": "SQLRooms Contributors",
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./promptfoo": {
+      "types": "./dist/promptfoo/index.d.ts",
+      "import": "./dist/promptfoo/index.js",
+      "default": "./dist/promptfoo/index.js"
+    }
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc -w",
+    "lint": "eslint .",
+    "test": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest",
+    "test:watch": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest --watch",
+    "typecheck": "tsc --noEmit",
+    "typedoc": "typedoc"
+  },
+  "dependencies": {
+    "@ai-sdk/provider": "^3.0.10",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@jest/globals": "^30.3.0",
+    "@sqlrooms/preset-jest": "workspace:*",
+    "ai": "^6.0.177",
+    "jest": "^30.1.3",
+    "ts-jest": "^29.4.4"
+  }
+}

--- a/packages/evals/src/__tests__/evidence.test.ts
+++ b/packages/evals/src/__tests__/evidence.test.ts
@@ -1,0 +1,75 @@
+import {describe, expect, it} from '@jest/globals';
+import {
+  parseRunEvidence,
+  RUN_EVIDENCE_SCHEMA_VERSION,
+  serializeRunEvidence,
+} from '../evidence';
+
+describe('run evidence', () => {
+  it('round-trips versioned evidence with unknown metadata preserved', () => {
+    const input = {
+      schemaVersion: RUN_EVIDENCE_SCHEMA_VERSION,
+      runId: 'run-1',
+      scenario: {
+        id: 'worksheet.create-chart-map',
+        version: 1,
+        repetition: 0,
+      },
+      target: {
+        type: 'cli-in-process',
+        profileName: 'worksheet-charts-maps',
+        profileVersion: 1,
+      },
+      repository: {commitSha: 'abc123', dirty: false},
+      model: {
+        provider: 'openrouter',
+        modelId: 'deepseek/deepseek-v4-flash-0731',
+        settings: {temperature: 0},
+      },
+      timing: {
+        startedAt: '2026-08-19T12:00:00.000Z',
+        endedAt: '2026-08-19T12:00:01.000Z',
+        latencyMs: 1000,
+      },
+      status: 'passed' as const,
+      promptTurns: [{id: 'create', input: 'Create a worksheet.'}],
+      finalAnswer: 'Created the worksheet.',
+      events: [
+        {
+          sequence: 0,
+          timestamp: '2026-08-19T12:00:00.500Z',
+          type: 'mutation' as const,
+          data: {artifactId: 'worksheet-1'},
+          futureEventField: 'preserved',
+        },
+      ],
+      finalState: {worksheetCount: 1},
+      oracleResults: [
+        {
+          oracleId: 'workspace',
+          kind: 'workspace-state' as const,
+          pass: true,
+          score: 1,
+          reason: 'Worksheet exists.',
+          evidence: {},
+          metadata: {futureOracleMetadata: {value: 42}},
+        },
+      ],
+      metadata: {futureRunnerMetadata: {traceId: 'trace-1'}},
+      futureEnvelopeField: {retained: true},
+    };
+
+    const parsed = parseRunEvidence(serializeRunEvidence(input));
+
+    expect(parsed.metadata).toEqual(input.metadata);
+    expect(parsed.oracleResults[0]?.metadata).toEqual(
+      input.oracleResults[0]?.metadata,
+    );
+    expect(parsed.events[0]).toHaveProperty('futureEventField', 'preserved');
+    expect(parsed).toHaveProperty('futureEnvelopeField', {retained: true});
+  });
+
+  it('rejects unsupported evidence versions', () => {
+    expect(() => parseRunEvidence({schemaVersion: 2})).toThrow();
+  });
+});

--- a/packages/evals/src/__tests__/evidence.test.ts
+++ b/packages/evals/src/__tests__/evidence.test.ts
@@ -103,4 +103,62 @@ describe('run evidence', () => {
   it('rejects unsupported evidence versions', () => {
     expect(() => parseRunEvidence({schemaVersion: 2})).toThrow();
   });
+
+  it('allocates fresh object defaults for every evidence record', () => {
+    const input = {
+      schemaVersion: RUN_EVIDENCE_SCHEMA_VERSION,
+      runId: 'run-defaults',
+      scenario: {
+        id: 'worksheet.defaults',
+        version: 1,
+        repetition: 0,
+      },
+      target: {
+        type: 'cli-in-process',
+        profileName: 'worksheet-charts-maps',
+        profileVersion: 1,
+      },
+      model: {
+        provider: 'scripted',
+        modelId: 'scripted-v1',
+      },
+      timing: {
+        startedAt: '2026-08-19T12:00:00.000Z',
+        endedAt: '2026-08-19T12:00:00.010Z',
+        latencyMs: 10,
+      },
+      status: 'passed',
+      promptTurns: [],
+      finalAnswer: 'Done.',
+      events: [
+        {
+          sequence: 0,
+          timestamp: '2026-08-19T12:00:00.005Z',
+          type: 'tool',
+        },
+      ],
+      oracleResults: [
+        {
+          oracleId: 'workspace',
+          kind: 'workspace-state',
+          pass: true,
+          score: 1,
+          reason: 'Workspace is valid.',
+        },
+      ],
+    };
+
+    const first = parseRunEvidence(input);
+    const second = parseRunEvidence(input);
+
+    expect(first.metadata).not.toBe(second.metadata);
+    expect(first.model.settings).not.toBe(second.model.settings);
+    expect(first.events[0]?.data).not.toBe(second.events[0]?.data);
+    expect(first.oracleResults[0]?.evidence).not.toBe(
+      second.oracleResults[0]?.evidence,
+    );
+    expect(first.oracleResults[0]?.metadata).not.toBe(
+      second.oracleResults[0]?.metadata,
+    );
+  });
 });

--- a/packages/evals/src/__tests__/evidence.test.ts
+++ b/packages/evals/src/__tests__/evidence.test.ts
@@ -14,25 +14,39 @@ describe('run evidence', () => {
         id: 'worksheet.create-chart-map',
         version: 1,
         repetition: 0,
+        futureScenarioField: 'preserved',
       },
       target: {
         type: 'cli-in-process',
         profileName: 'worksheet-charts-maps',
         profileVersion: 1,
+        futureTargetField: 'preserved',
       },
-      repository: {commitSha: 'abc123', dirty: false},
+      repository: {
+        commitSha: 'abc123',
+        dirty: false,
+        futureRepositoryField: 'preserved',
+      },
       model: {
         provider: 'openrouter',
         modelId: 'deepseek/deepseek-v4-flash-0731',
         settings: {temperature: 0},
+        futureModelField: 'preserved',
       },
       timing: {
         startedAt: '2026-08-19T12:00:00.000Z',
         endedAt: '2026-08-19T12:00:01.000Z',
         latencyMs: 1000,
+        futureTimingField: 'preserved',
       },
       status: 'passed' as const,
-      promptTurns: [{id: 'create', input: 'Create a worksheet.'}],
+      promptTurns: [
+        {
+          id: 'create',
+          input: 'Create a worksheet.',
+          futurePromptField: 'preserved',
+        },
+      ],
       finalAnswer: 'Created the worksheet.',
       events: [
         {
@@ -43,6 +57,10 @@ describe('run evidence', () => {
           futureEventField: 'preserved',
         },
       ],
+      usage: {
+        totalTokens: 10,
+        futureUsageField: 'preserved',
+      },
       finalState: {worksheetCount: 1},
       oracleResults: [
         {
@@ -66,6 +84,19 @@ describe('run evidence', () => {
       input.oracleResults[0]?.metadata,
     );
     expect(parsed.events[0]).toHaveProperty('futureEventField', 'preserved');
+    expect(parsed.scenario).toHaveProperty('futureScenarioField', 'preserved');
+    expect(parsed.target).toHaveProperty('futureTargetField', 'preserved');
+    expect(parsed.repository).toHaveProperty(
+      'futureRepositoryField',
+      'preserved',
+    );
+    expect(parsed.model).toHaveProperty('futureModelField', 'preserved');
+    expect(parsed.timing).toHaveProperty('futureTimingField', 'preserved');
+    expect(parsed.promptTurns[0]).toHaveProperty(
+      'futurePromptField',
+      'preserved',
+    );
+    expect(parsed.usage).toHaveProperty('futureUsageField', 'preserved');
     expect(parsed).toHaveProperty('futureEnvelopeField', {retained: true});
   });
 

--- a/packages/evals/src/__tests__/evidence.test.ts
+++ b/packages/evals/src/__tests__/evidence.test.ts
@@ -104,6 +104,71 @@ describe('run evidence', () => {
     expect(() => parseRunEvidence({schemaVersion: 2})).toThrow();
   });
 
+  it.each([
+    ['duplicate', [0, 0]],
+    ['descending', [1, 0]],
+  ])('rejects %s event sequence values', (_name, sequences) => {
+    expect(() =>
+      parseRunEvidence({
+        schemaVersion: RUN_EVIDENCE_SCHEMA_VERSION,
+        runId: 'run-ordering',
+        scenario: {id: 'worksheet.ordering', version: 1, repetition: 0},
+        target: {
+          type: 'cli-in-process',
+          profileName: 'worksheet-charts-maps',
+          profileVersion: 1,
+        },
+        model: {provider: 'scripted', modelId: 'scripted-v1'},
+        timing: {
+          startedAt: '2026-08-19T12:00:00.000Z',
+          endedAt: '2026-08-19T12:00:00.010Z',
+          latencyMs: 10,
+        },
+        status: 'passed',
+        promptTurns: [],
+        finalAnswer: 'Done.',
+        events: sequences.map((sequence) => ({
+          sequence,
+          timestamp: '2026-08-19T12:00:00.005Z',
+          type: 'tool',
+        })),
+        oracleResults: [],
+      }),
+    ).toThrow('Event sequence values must be strictly increasing.');
+  });
+
+  it.each([
+    ['bigint', BigInt(1)],
+    ['undefined', undefined],
+    ['function', () => 1],
+    ['symbol', Symbol('future')],
+  ])('rejects a non-JSON %s extension value', (_name, value) => {
+    expect(() =>
+      parseRunEvidence({
+        schemaVersion: RUN_EVIDENCE_SCHEMA_VERSION,
+        runId: 'run-json-extension',
+        scenario: {id: 'worksheet.json-extension', version: 1, repetition: 0},
+        target: {
+          type: 'cli-in-process',
+          profileName: 'worksheet-charts-maps',
+          profileVersion: 1,
+        },
+        model: {provider: 'scripted', modelId: 'scripted-v1'},
+        timing: {
+          startedAt: '2026-08-19T12:00:00.000Z',
+          endedAt: '2026-08-19T12:00:00.010Z',
+          latencyMs: 10,
+        },
+        status: 'passed',
+        promptTurns: [],
+        finalAnswer: 'Done.',
+        events: [],
+        oracleResults: [],
+        futureEnvelopeField: value,
+      }),
+    ).toThrow();
+  });
+
   it('allocates fresh object defaults for every evidence record', () => {
     const input = {
       schemaVersion: RUN_EVIDENCE_SCHEMA_VERSION,

--- a/packages/evals/src/__tests__/oracle.test.ts
+++ b/packages/evals/src/__tests__/oracle.test.ts
@@ -1,0 +1,109 @@
+import {describe, expect, it} from '@jest/globals';
+import {
+  createAnswerGroundingOracle,
+  createDatabaseOracle,
+  createErrorOracle,
+  createPolicyOracle,
+  createWorkspaceStateOracle,
+  evaluateOracles,
+  summarizeOracleResults,
+  type OracleContext,
+} from '../oracle';
+import {defineScenario} from '../scenario';
+
+const scenario = defineScenario({
+  id: 'worksheet.verify-outcomes',
+  version: 1,
+  title: 'Verify outcomes',
+  compatibleProfiles: ['worksheet-charts-maps'],
+  turns: [{id: 'verify', input: 'Verify the result.'}],
+  expectations: [{oracleId: 'database', description: 'Database is grounded.'}],
+});
+
+const context: OracleContext = {
+  scenario,
+  database: {canonicalTable: 'analytics.events'},
+  workspace: {worksheetCount: 1},
+  finalAnswer: 'Created one worksheet from analytics.events.',
+  errors: [],
+  mutations: [{kind: 'worksheet.create', targetId: 'worksheet-1'}],
+  metadata: {},
+};
+
+describe('behavioral oracles', () => {
+  it('composes database, workspace, answer, error, and policy checks', async () => {
+    const results = await evaluateOracles(
+      [
+        createDatabaseOracle({
+          id: 'database',
+          evaluate: (database) => ({
+            pass:
+              typeof database === 'object' &&
+              database !== null &&
+              !Array.isArray(database) &&
+              database.canonicalTable === 'analytics.events',
+            reason: 'Canonical table matched.',
+          }),
+        }),
+        createWorkspaceStateOracle({
+          id: 'workspace',
+          evaluate: (workspace) => ({
+            pass: workspace !== undefined,
+            reason: 'Workspace snapshot exists.',
+          }),
+        }),
+        createAnswerGroundingOracle({
+          id: 'answer',
+          evaluate: (answer) => ({
+            pass: answer.includes('analytics.events'),
+            score: 0.8,
+            reason: 'Answer names the selected table.',
+          }),
+        }),
+        createErrorOracle({
+          id: 'errors',
+          evaluate: (errors) => ({
+            pass: errors.length === 0,
+            reason: 'No errors observed.',
+          }),
+        }),
+        createPolicyOracle({
+          id: 'policy',
+          evaluate: (mutations) => ({
+            pass: mutations.length === 1,
+            reason: 'Only the intended mutation occurred.',
+            evidence: {mutationCount: mutations.length},
+          }),
+        }),
+      ],
+      context,
+    );
+
+    expect(results).toHaveLength(5);
+    expect(results.every((result) => result.pass)).toBe(true);
+    expect(summarizeOracleResults(results)).toEqual({pass: true, score: 0.96});
+  });
+
+  it('keeps failure reasons and structured evidence', async () => {
+    const [result] = await evaluateOracles(
+      [
+        createPolicyOracle({
+          id: 'read-only',
+          evaluate: (mutations) => ({
+            pass: mutations.length === 0,
+            reason: 'Read-only scenario mutated workspace state.',
+            evidence: {mutations: mutations.length},
+          }),
+        }),
+      ],
+      context,
+    );
+
+    expect(result).toMatchObject({
+      pass: false,
+      score: 0,
+      reason: 'Read-only scenario mutated workspace state.',
+      evidence: {mutations: 1},
+    });
+  });
+});

--- a/packages/evals/src/__tests__/oracle.test.ts
+++ b/packages/evals/src/__tests__/oracle.test.ts
@@ -146,4 +146,15 @@ describe('behavioral oracles', () => {
       ),
     ).rejects.toThrow('Missing required oracle implementations: workspace.');
   });
+
+  it('rejects duplicate oracle implementations', async () => {
+    const duplicateOracle = createDatabaseOracle({
+      id: 'database',
+      evaluate: () => ({pass: true, reason: 'Database is valid.'}),
+    });
+
+    await expect(
+      evaluateOracles([duplicateOracle, duplicateOracle], context),
+    ).rejects.toThrow('Duplicate oracle implementations: database.');
+  });
 });

--- a/packages/evals/src/__tests__/oracle.test.ts
+++ b/packages/evals/src/__tests__/oracle.test.ts
@@ -106,4 +106,8 @@ describe('behavioral oracles', () => {
       evidence: {mutations: 1},
     });
   });
+
+  it('does not pass when no oracle results were produced', () => {
+    expect(summarizeOracleResults([])).toEqual({pass: false, score: 0});
+  });
 });

--- a/packages/evals/src/__tests__/oracle.test.ts
+++ b/packages/evals/src/__tests__/oracle.test.ts
@@ -96,7 +96,18 @@ describe('behavioral oracles', () => {
           }),
         }),
       ],
-      context,
+      {
+        ...context,
+        scenario: defineScenario({
+          ...scenario,
+          expectations: [
+            {
+              oracleId: 'read-only',
+              description: 'Workspace remains read-only.',
+            },
+          ],
+        }),
+      },
     );
 
     expect(result).toMatchObject({
@@ -109,5 +120,30 @@ describe('behavioral oracles', () => {
 
   it('does not pass when no oracle results were produced', () => {
     expect(summarizeOracleResults([])).toEqual({pass: false, score: 0});
+  });
+
+  it('rejects a passing subset when required oracles are missing', async () => {
+    const scenarioWithMultipleExpectations = defineScenario({
+      ...scenario,
+      expectations: [
+        ...scenario.expectations,
+        {
+          oracleId: 'workspace',
+          description: 'Workspace state is valid.',
+        },
+      ],
+    });
+
+    await expect(
+      evaluateOracles(
+        [
+          createDatabaseOracle({
+            id: 'database',
+            evaluate: () => ({pass: true, reason: 'Database is valid.'}),
+          }),
+        ],
+        {...context, scenario: scenarioWithMultipleExpectations},
+      ),
+    ).rejects.toThrow('Missing required oracle implementations: workspace.');
   });
 });

--- a/packages/evals/src/__tests__/promptfoo.test.ts
+++ b/packages/evals/src/__tests__/promptfoo.test.ts
@@ -1,0 +1,68 @@
+import {describe, expect, it} from '@jest/globals';
+import type {RunEvidence} from '../evidence';
+import {
+  toPromptfooAssertionResult,
+  toPromptfooProviderResponse,
+} from '../promptfoo';
+
+const evidence: RunEvidence = {
+  schemaVersion: 1,
+  runId: 'run-1',
+  scenario: {id: 'worksheet.verify', version: 1, repetition: 0},
+  target: {
+    type: 'cli-in-process',
+    profileName: 'worksheet-charts-maps',
+    profileVersion: 1,
+  },
+  model: {provider: 'scripted', modelId: 'scripted-v1', settings: {}},
+  timing: {
+    startedAt: '2026-08-19T12:00:00.000Z',
+    endedAt: '2026-08-19T12:00:00.010Z',
+    latencyMs: 10,
+  },
+  status: 'passed',
+  promptTurns: [],
+  finalAnswer: 'Done.',
+  events: [],
+  oracleResults: [],
+  metadata: {},
+};
+
+describe('Promptfoo boundary helpers', () => {
+  it('puts validated evidence in provider metadata', () => {
+    expect(toPromptfooProviderResponse(evidence)).toEqual({
+      output: 'Done.',
+      metadata: {sqlroomsEvidence: evidence},
+    });
+  });
+
+  it('converts oracle results to one assertion result', () => {
+    expect(
+      toPromptfooAssertionResult([
+        {
+          oracleId: 'workspace',
+          kind: 'workspace-state',
+          pass: true,
+          score: 1,
+          reason: 'Valid.',
+          evidence: {},
+          metadata: {},
+        },
+        {
+          oracleId: 'answer',
+          kind: 'answer-grounding',
+          pass: false,
+          score: 0.25,
+          reason: 'Missing source.',
+          evidence: {},
+          metadata: {},
+        },
+      ]),
+    ).toEqual({
+      pass: false,
+      score: 0.625,
+      reason: 'answer: Missing source.',
+      namedScores: {workspace: 1, answer: 0.25},
+    });
+  });
+});

--- a/packages/evals/src/__tests__/promptfoo.test.ts
+++ b/packages/evals/src/__tests__/promptfoo.test.ts
@@ -65,4 +65,29 @@ describe('Promptfoo boundary helpers', () => {
       namedScores: {workspace: 1, answer: 0.25},
     });
   });
+
+  it('reports an empty result set as a failure', () => {
+    expect(toPromptfooAssertionResult([])).toEqual({
+      pass: false,
+      score: 0,
+      reason: 'No SQLRooms oracle results were produced.',
+      namedScores: {},
+    });
+  });
+
+  it('rejects duplicate oracle result IDs', () => {
+    const result = {
+      oracleId: 'workspace',
+      kind: 'workspace-state' as const,
+      pass: true,
+      score: 1,
+      reason: 'Valid.',
+      evidence: {},
+      metadata: {},
+    };
+
+    expect(() => toPromptfooAssertionResult([result, result])).toThrow(
+      'Duplicate oracle result IDs: workspace.',
+    );
+  });
 });

--- a/packages/evals/src/__tests__/scenario.test.ts
+++ b/packages/evals/src/__tests__/scenario.test.ts
@@ -1,0 +1,42 @@
+import {describe, expect, it} from '@jest/globals';
+import {defineScenario} from '../scenario';
+
+describe('behavioral scenarios', () => {
+  it('expresses compatible profiles and target-neutral outcomes', () => {
+    const scenario = defineScenario({
+      id: 'worksheet.create-chart-map',
+      version: 1,
+      title: 'Create chart and map',
+      compatibleProfiles: ['worksheet-charts-maps'],
+      fixture: {database: 'ambiguous-geospatial'},
+      turns: [{id: 'create', input: 'Create a worksheet.'}],
+      expectations: [
+        {
+          oracleId: 'workspace-chart-map',
+          description: 'Chart and map blocks exist in one worksheet.',
+        },
+      ],
+      metadata: {owner: 'sqlrooms'},
+    });
+
+    expect(scenario.compatibleProfiles).toEqual(['worksheet-charts-maps']);
+    expect(scenario.expectations[0]).toEqual({
+      oracleId: 'workspace-chart-map',
+      description: 'Chart and map blocks exist in one worksheet.',
+      config: {},
+    });
+  });
+
+  it('rejects unstable scenario identifiers and empty turns', () => {
+    expect(() =>
+      defineScenario({
+        id: 'Worksheet Create',
+        version: 1,
+        title: 'Invalid',
+        compatibleProfiles: ['default'],
+        turns: [],
+        expectations: [],
+      }),
+    ).toThrow('Scenario IDs');
+  });
+});

--- a/packages/evals/src/__tests__/scenario.test.ts
+++ b/packages/evals/src/__tests__/scenario.test.ts
@@ -39,4 +39,26 @@ describe('behavioral scenarios', () => {
       }),
     ).toThrow('Scenario IDs');
   });
+
+  it('allocates fresh object defaults for every parsed scenario', () => {
+    const input = {
+      id: 'worksheet.defaults',
+      version: 1,
+      title: 'Fresh defaults',
+      compatibleProfiles: ['default'],
+      turns: [{id: 'verify', input: 'Verify defaults.'}],
+      expectations: [
+        {oracleId: 'workspace', description: 'Workspace is valid.'},
+      ],
+    };
+
+    const first = defineScenario(input);
+    const second = defineScenario(input);
+
+    expect(first.fixture).not.toBe(second.fixture);
+    expect(first.metadata).not.toBe(second.metadata);
+    expect(first.expectations[0]?.config).not.toBe(
+      second.expectations[0]?.config,
+    );
+  });
 });

--- a/packages/evals/src/__tests__/scriptedModel.test.ts
+++ b/packages/evals/src/__tests__/scriptedModel.test.ts
@@ -1,0 +1,88 @@
+import {describe, expect, it} from '@jest/globals';
+import {generateText, stepCountIs, tool} from 'ai';
+import {z} from 'zod';
+import {createScriptedLanguageModel} from '../scriptedModel';
+
+describe('scripted AI SDK model', () => {
+  it('drives a deterministic tool loop and records calls', async () => {
+    const scripted = createScriptedLanguageModel({
+      steps: [
+        {
+          expectation: {
+            promptIncludes: ['Inspect the worksheet'],
+            availableToolNames: ['inspect_workspace'],
+          },
+          content: [
+            {
+              type: 'tool-call',
+              toolName: 'inspect_workspace',
+              input: {worksheetId: 'worksheet-1'},
+            },
+          ],
+        },
+        {
+          content: [{type: 'text', text: 'The worksheet is valid.'}],
+          usage: {inputTokens: 10, outputTokens: 5},
+        },
+      ],
+    });
+
+    const result = await generateText({
+      model: scripted.model,
+      prompt: 'Inspect the worksheet.',
+      tools: {
+        inspect_workspace: tool({
+          description: 'Inspect durable workspace state.',
+          inputSchema: z.object({worksheetId: z.string()}),
+          execute: async ({worksheetId}) => ({worksheetId, valid: true}),
+        }),
+      },
+      stopWhen: stepCountIs(2),
+    });
+
+    expect(result.text).toBe('The worksheet is valid.');
+    expect(scripted.calls).toHaveLength(2);
+    expect(scripted.remainingSteps()).toBe(0);
+    expect(() => scripted.assertComplete()).not.toThrow();
+  });
+
+  it('fails clearly when script expectations or call counts diverge', async () => {
+    const scripted = createScriptedLanguageModel({
+      steps: [
+        {
+          expectation: {promptIncludes: ['expected prompt']},
+          content: [{type: 'text', text: 'unused'}],
+        },
+      ],
+    });
+
+    await expect(
+      scripted.model.doGenerate({prompt: [{role: 'user', content: []}]}),
+    ).rejects.toThrow('expected prompt');
+    expect(() => scripted.assertComplete()).not.toThrow();
+    await expect(
+      scripted.model.doGenerate({prompt: [{role: 'user', content: []}]}),
+    ).rejects.toThrow('more calls than configured');
+  });
+
+  it('supports the AI SDK streaming model path', async () => {
+    const scripted = createScriptedLanguageModel({
+      steps: [{content: [{type: 'text', text: 'streamed result'}]}],
+    });
+    const result = await scripted.model.doStream({
+      prompt: [{role: 'user', content: [{type: 'text', text: 'stream'}]}],
+    });
+    const parts = [];
+    for await (const part of result.stream) parts.push(part);
+
+    expect(parts).toContainEqual({
+      type: 'text-delta',
+      id: 'text-0',
+      delta: 'streamed result',
+    });
+    expect(parts.at(-1)).toMatchObject({
+      type: 'finish',
+      finishReason: {unified: 'stop'},
+    });
+  });
+});

--- a/packages/evals/src/evidence.ts
+++ b/packages/evals/src/evidence.ts
@@ -7,76 +7,102 @@ import {ScenarioIdSchema} from './scenario';
 export const RUN_EVIDENCE_SCHEMA_VERSION = 1 as const;
 
 /** Ordered event captured while a behavioral scenario runs. */
-export const RunEvidenceEventSchema = z.looseObject({
-  sequence: z.number().int().nonnegative(),
-  timestamp: z.string().datetime(),
-  type: z.enum([
-    'model',
-    'tool',
-    'nested-agent',
-    'approval',
-    'error',
-    'mutation',
-  ]),
-  name: z.string().min(1).optional(),
-  data: JsonObjectSchema.default(() => ({})),
-});
+export const RunEvidenceEventSchema = z
+  .looseObject({
+    sequence: z.number().int().nonnegative(),
+    timestamp: z.string().datetime(),
+    type: z.enum([
+      'model',
+      'tool',
+      'nested-agent',
+      'approval',
+      'error',
+      'mutation',
+    ]),
+    name: z.string().min(1).optional(),
+    data: JsonObjectSchema.default(() => ({})),
+  })
+  .catchall(JsonValueSchema);
 
 /** Versioned evidence persisted for one behavioral scenario run. */
-export const RunEvidenceSchema = z.looseObject({
-  schemaVersion: z.literal(RUN_EVIDENCE_SCHEMA_VERSION),
-  runId: z.string().min(1),
-  scenario: z.looseObject({
-    id: ScenarioIdSchema,
-    version: z.number().int().positive(),
-    repetition: z.number().int().nonnegative(),
-  }),
-  target: z.looseObject({
-    type: z.string().min(1),
-    profileName: z.string().min(1),
-    profileVersion: z.number().int().positive(),
-  }),
-  repository: z
-    .looseObject({
-      commitSha: z.string().min(1),
-      dirty: z.boolean(),
-      workflowUrl: z.string().url().optional(),
-    })
-    .optional(),
-  model: z.looseObject({
-    provider: z.string().min(1),
-    modelId: z.string().min(1),
-    configuredRevision: z.string().min(1).optional(),
-    upstreamProvider: z.string().min(1).optional(),
-    settings: JsonObjectSchema.default(() => ({})),
-  }),
-  timing: z.looseObject({
-    startedAt: z.string().datetime(),
-    endedAt: z.string().datetime(),
-    latencyMs: z.number().nonnegative(),
-  }),
-  status: z.enum(['passed', 'failed', 'error', 'cancelled']),
-  promptTurns: z.array(
-    z.looseObject({
-      id: z.string().min(1),
-      input: z.string(),
+export const RunEvidenceSchema = z
+  .looseObject({
+    schemaVersion: z.literal(RUN_EVIDENCE_SCHEMA_VERSION),
+    runId: z.string().min(1),
+    scenario: z
+      .looseObject({
+        id: ScenarioIdSchema,
+        version: z.number().int().positive(),
+        repetition: z.number().int().nonnegative(),
+      })
+      .catchall(JsonValueSchema),
+    target: z
+      .looseObject({
+        type: z.string().min(1),
+        profileName: z.string().min(1),
+        profileVersion: z.number().int().positive(),
+      })
+      .catchall(JsonValueSchema),
+    repository: z
+      .looseObject({
+        commitSha: z.string().min(1),
+        dirty: z.boolean(),
+        workflowUrl: z.string().url().optional(),
+      })
+      .catchall(JsonValueSchema)
+      .optional(),
+    model: z
+      .looseObject({
+        provider: z.string().min(1),
+        modelId: z.string().min(1),
+        configuredRevision: z.string().min(1).optional(),
+        upstreamProvider: z.string().min(1).optional(),
+        settings: JsonObjectSchema.default(() => ({})),
+      })
+      .catchall(JsonValueSchema),
+    timing: z
+      .looseObject({
+        startedAt: z.string().datetime(),
+        endedAt: z.string().datetime(),
+        latencyMs: z.number().nonnegative(),
+      })
+      .catchall(JsonValueSchema),
+    status: z.enum(['passed', 'failed', 'error', 'cancelled']),
+    promptTurns: z.array(
+      z
+        .looseObject({
+          id: z.string().min(1),
+          input: z.string(),
+        })
+        .catchall(JsonValueSchema),
+    ),
+    finalAnswer: z.string(),
+    events: z.array(RunEvidenceEventSchema).superRefine((events, context) => {
+      for (let index = 1; index < events.length; index += 1) {
+        if (events[index]!.sequence <= events[index - 1]!.sequence) {
+          context.addIssue({
+            code: 'custom',
+            message: 'Event sequence values must be strictly increasing.',
+            path: [index, 'sequence'],
+          });
+        }
+      }
     }),
-  ),
-  finalAnswer: z.string(),
-  events: z.array(RunEvidenceEventSchema),
-  usage: z
-    .looseObject({
-      inputTokens: z.number().nonnegative().optional(),
-      outputTokens: z.number().nonnegative().optional(),
-      totalTokens: z.number().nonnegative().optional(),
-      costUsd: z.number().nonnegative().optional(),
-      grader: JsonObjectSchema.optional(),
-    })
-    .optional(),
-  finalState: JsonValueSchema.optional(),
-  oracleResults: z.array(OracleResultSchema),
-  metadata: JsonObjectSchema.default(() => ({})),
-});
+    usage: z
+      .looseObject({
+        inputTokens: z.number().nonnegative().optional(),
+        outputTokens: z.number().nonnegative().optional(),
+        totalTokens: z.number().nonnegative().optional(),
+        costUsd: z.number().nonnegative().optional(),
+        grader: JsonObjectSchema.optional(),
+      })
+      .catchall(JsonValueSchema)
+      .optional(),
+    finalState: JsonValueSchema.optional(),
+    oracleResults: z.array(OracleResultSchema),
+    metadata: JsonObjectSchema.default(() => ({})),
+  })
+  .catchall(JsonValueSchema);
 
 /** Parsed run-evidence envelope. */
 export type RunEvidence = z.infer<typeof RunEvidenceSchema>;

--- a/packages/evals/src/evidence.ts
+++ b/packages/evals/src/evidence.ts
@@ -1,0 +1,94 @@
+import {z} from 'zod';
+import {JsonObjectSchema, JsonValueSchema} from './json';
+import {OracleResultSchema} from './oracle';
+import {ScenarioIdSchema} from './scenario';
+
+/** Current version of the durable run-evidence envelope. */
+export const RUN_EVIDENCE_SCHEMA_VERSION = 1 as const;
+
+/** Ordered event captured while a behavioral scenario runs. */
+export const RunEvidenceEventSchema = z.looseObject({
+  sequence: z.number().int().nonnegative(),
+  timestamp: z.string().datetime(),
+  type: z.enum([
+    'model',
+    'tool',
+    'nested-agent',
+    'approval',
+    'error',
+    'mutation',
+  ]),
+  name: z.string().min(1).optional(),
+  data: JsonObjectSchema.default({}),
+});
+
+/** Versioned evidence persisted for one behavioral scenario run. */
+export const RunEvidenceSchema = z.looseObject({
+  schemaVersion: z.literal(RUN_EVIDENCE_SCHEMA_VERSION),
+  runId: z.string().min(1),
+  scenario: z.object({
+    id: ScenarioIdSchema,
+    version: z.number().int().positive(),
+    repetition: z.number().int().nonnegative(),
+  }),
+  target: z.object({
+    type: z.string().min(1),
+    profileName: z.string().min(1),
+    profileVersion: z.number().int().positive(),
+  }),
+  repository: z
+    .object({
+      commitSha: z.string().min(1),
+      dirty: z.boolean(),
+      workflowUrl: z.string().url().optional(),
+    })
+    .optional(),
+  model: z.object({
+    provider: z.string().min(1),
+    modelId: z.string().min(1),
+    configuredRevision: z.string().min(1).optional(),
+    upstreamProvider: z.string().min(1).optional(),
+    settings: JsonObjectSchema.default({}),
+  }),
+  timing: z.object({
+    startedAt: z.string().datetime(),
+    endedAt: z.string().datetime(),
+    latencyMs: z.number().nonnegative(),
+  }),
+  status: z.enum(['passed', 'failed', 'error', 'cancelled']),
+  promptTurns: z.array(
+    z.object({
+      id: z.string().min(1),
+      input: z.string(),
+    }),
+  ),
+  finalAnswer: z.string(),
+  events: z.array(RunEvidenceEventSchema),
+  usage: z
+    .object({
+      inputTokens: z.number().nonnegative().optional(),
+      outputTokens: z.number().nonnegative().optional(),
+      totalTokens: z.number().nonnegative().optional(),
+      costUsd: z.number().nonnegative().optional(),
+      grader: JsonObjectSchema.optional(),
+    })
+    .optional(),
+  finalState: JsonValueSchema.optional(),
+  oracleResults: z.array(OracleResultSchema),
+  metadata: JsonObjectSchema.default({}),
+});
+
+/** Parsed run-evidence envelope. */
+export type RunEvidence = z.infer<typeof RunEvidenceSchema>;
+
+/** Parses an object or serialized JSON run-evidence envelope. */
+export function parseRunEvidence(input: unknown): RunEvidence {
+  return RunEvidenceSchema.parse(
+    typeof input === 'string' ? JSON.parse(input) : input,
+  );
+}
+
+/** Serializes validated run evidence for storage in runner metadata. */
+export function serializeRunEvidence(evidence: RunEvidence): string {
+  return JSON.stringify(RunEvidenceSchema.parse(evidence));
+}

--- a/packages/evals/src/evidence.ts
+++ b/packages/evals/src/evidence.ts
@@ -19,7 +19,7 @@ export const RunEvidenceEventSchema = z.looseObject({
     'mutation',
   ]),
   name: z.string().min(1).optional(),
-  data: JsonObjectSchema.default({}),
+  data: JsonObjectSchema.default(() => ({})),
 });
 
 /** Versioned evidence persisted for one behavioral scenario run. */
@@ -48,7 +48,7 @@ export const RunEvidenceSchema = z.looseObject({
     modelId: z.string().min(1),
     configuredRevision: z.string().min(1).optional(),
     upstreamProvider: z.string().min(1).optional(),
-    settings: JsonObjectSchema.default({}),
+    settings: JsonObjectSchema.default(() => ({})),
   }),
   timing: z.looseObject({
     startedAt: z.string().datetime(),
@@ -75,7 +75,7 @@ export const RunEvidenceSchema = z.looseObject({
     .optional(),
   finalState: JsonValueSchema.optional(),
   oracleResults: z.array(OracleResultSchema),
-  metadata: JsonObjectSchema.default({}),
+  metadata: JsonObjectSchema.default(() => ({})),
 });
 
 /** Parsed run-evidence envelope. */

--- a/packages/evals/src/evidence.ts
+++ b/packages/evals/src/evidence.ts
@@ -26,38 +26,38 @@ export const RunEvidenceEventSchema = z.looseObject({
 export const RunEvidenceSchema = z.looseObject({
   schemaVersion: z.literal(RUN_EVIDENCE_SCHEMA_VERSION),
   runId: z.string().min(1),
-  scenario: z.object({
+  scenario: z.looseObject({
     id: ScenarioIdSchema,
     version: z.number().int().positive(),
     repetition: z.number().int().nonnegative(),
   }),
-  target: z.object({
+  target: z.looseObject({
     type: z.string().min(1),
     profileName: z.string().min(1),
     profileVersion: z.number().int().positive(),
   }),
   repository: z
-    .object({
+    .looseObject({
       commitSha: z.string().min(1),
       dirty: z.boolean(),
       workflowUrl: z.string().url().optional(),
     })
     .optional(),
-  model: z.object({
+  model: z.looseObject({
     provider: z.string().min(1),
     modelId: z.string().min(1),
     configuredRevision: z.string().min(1).optional(),
     upstreamProvider: z.string().min(1).optional(),
     settings: JsonObjectSchema.default({}),
   }),
-  timing: z.object({
+  timing: z.looseObject({
     startedAt: z.string().datetime(),
     endedAt: z.string().datetime(),
     latencyMs: z.number().nonnegative(),
   }),
   status: z.enum(['passed', 'failed', 'error', 'cancelled']),
   promptTurns: z.array(
-    z.object({
+    z.looseObject({
       id: z.string().min(1),
       input: z.string(),
     }),
@@ -65,7 +65,7 @@ export const RunEvidenceSchema = z.looseObject({
   finalAnswer: z.string(),
   events: z.array(RunEvidenceEventSchema),
   usage: z
-    .object({
+    .looseObject({
       inputTokens: z.number().nonnegative().optional(),
       outputTokens: z.number().nonnegative().optional(),
       totalTokens: z.number().nonnegative().optional(),

--- a/packages/evals/src/index.ts
+++ b/packages/evals/src/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Evaluator-neutral behavioral scenario, oracle, evidence, and scripted-model
+ * primitives for SQLRooms.
+ *
+ * @packageDocumentation
+ */
+
+export * from './evidence';
+export * from './json';
+export * from './oracle';
+export * from './scenario';
+export * from './scriptedModel';

--- a/packages/evals/src/json.ts
+++ b/packages/evals/src/json.ts
@@ -1,0 +1,28 @@
+import {z} from 'zod';
+
+/** A JSON primitive value. */
+export type JsonPrimitive = string | number | boolean | null;
+
+/** A JSON object with recursively serializable values. */
+export type JsonObject = {[key: string]: JsonValue};
+
+/** A value that can be serialized losslessly as JSON. */
+export type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
+
+/** Runtime schema for recursively serializable JSON values. */
+export const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.array(JsonValueSchema),
+    z.record(z.string(), JsonValueSchema),
+  ]),
+);
+
+/** Runtime schema for JSON objects. */
+export const JsonObjectSchema: z.ZodType<JsonObject> = z.record(
+  z.string(),
+  JsonValueSchema,
+);

--- a/packages/evals/src/oracle.ts
+++ b/packages/evals/src/oracle.ts
@@ -142,11 +142,29 @@ export function createPolicyOracle(
   );
 }
 
-/** Evaluates oracles in declaration order and normalizes their results. */
+/**
+ * Evaluates oracles in declaration order and normalizes their results.
+ *
+ * @throws When a scenario expectation has no matching oracle implementation.
+ */
 export async function evaluateOracles(
   oracles: readonly BehavioralOracle[],
   context: OracleContext,
 ): Promise<OracleResult[]> {
+  const availableOracleIds = new Set(oracles.map((oracle) => oracle.id));
+  const missingOracleIds = Array.from(
+    new Set(
+      context.scenario.expectations
+        .map((expectation) => expectation.oracleId)
+        .filter((oracleId) => !availableOracleIds.has(oracleId)),
+    ),
+  );
+  if (missingOracleIds.length > 0) {
+    throw new Error(
+      `Missing required oracle implementations: ${missingOracleIds.join(', ')}.`,
+    );
+  }
+
   const results: OracleResult[] = [];
   for (const oracle of oracles) {
     const evaluation = await oracle.evaluate(context);

--- a/packages/evals/src/oracle.ts
+++ b/packages/evals/src/oracle.ts
@@ -171,7 +171,7 @@ export function summarizeOracleResults(results: readonly OracleResult[]): {
   score: number;
 } {
   return {
-    pass: results.every((result) => result.pass),
+    pass: results.length > 0 && results.every((result) => result.pass),
     score:
       results.length === 0
         ? 0

--- a/packages/evals/src/oracle.ts
+++ b/packages/evals/src/oracle.ts
@@ -19,8 +19,8 @@ export const OracleResultSchema = z.looseObject({
   pass: z.boolean(),
   score: z.number().min(0).max(1),
   reason: z.string().min(1),
-  evidence: JsonObjectSchema.default({}),
-  metadata: JsonObjectSchema.default({}),
+  evidence: JsonObjectSchema.default(() => ({})),
+  metadata: JsonObjectSchema.default(() => ({})),
 });
 
 /** Structured result produced by one behavioral oracle. */

--- a/packages/evals/src/oracle.ts
+++ b/packages/evals/src/oracle.ts
@@ -1,0 +1,181 @@
+import {z} from 'zod';
+import type {JsonObject, JsonValue} from './json';
+import {JsonObjectSchema} from './json';
+import type {ScenarioDefinition} from './scenario';
+
+/** Supported evaluator-neutral oracle categories. */
+export const OracleKindSchema = z.enum([
+  'database',
+  'workspace-state',
+  'answer-grounding',
+  'error',
+  'policy',
+]);
+
+/** Structured result produced by one behavioral oracle. */
+export const OracleResultSchema = z.looseObject({
+  oracleId: z.string().min(1),
+  kind: OracleKindSchema,
+  pass: z.boolean(),
+  score: z.number().min(0).max(1),
+  reason: z.string().min(1),
+  evidence: JsonObjectSchema.default({}),
+  metadata: JsonObjectSchema.default({}),
+});
+
+/** Structured result produced by one behavioral oracle. */
+export type OracleResult = z.infer<typeof OracleResultSchema>;
+
+/** Error observed during a behavioral run. */
+export type ObservedError = {
+  name?: string;
+  message: string;
+  code?: string;
+  metadata?: JsonObject;
+};
+
+/** Durable mutation observed during a behavioral run. */
+export type ObservedMutation = {
+  kind: string;
+  targetId?: string;
+  data?: JsonObject;
+};
+
+/** Target-neutral material available to behavioral oracles. */
+export type OracleContext = {
+  scenario: ScenarioDefinition;
+  database?: JsonValue;
+  workspace?: JsonValue;
+  finalAnswer: string;
+  errors: readonly ObservedError[];
+  mutations: readonly ObservedMutation[];
+  metadata: JsonObject;
+};
+
+/** Unnormalized outcome returned by an oracle implementation. */
+export type OracleEvaluation = {
+  pass: boolean;
+  score?: number;
+  reason: string;
+  evidence?: JsonObject;
+  metadata?: JsonObject;
+};
+
+/** An evaluator-neutral oracle. */
+export type BehavioralOracle = {
+  readonly id: string;
+  readonly kind: z.infer<typeof OracleKindSchema>;
+  evaluate(
+    context: OracleContext,
+  ): OracleEvaluation | Promise<OracleEvaluation>;
+};
+
+/** Definition for an oracle over one selected part of the run context. */
+export type OracleOptions<TValue> = {
+  id: string;
+  evaluate(
+    value: TValue,
+    context: OracleContext,
+  ): OracleEvaluation | Promise<OracleEvaluation>;
+};
+
+function createSpecializedOracle<TValue>(
+  kind: BehavioralOracle['kind'],
+  options: OracleOptions<TValue>,
+  select: (context: OracleContext) => TValue,
+): BehavioralOracle {
+  return {
+    id: options.id,
+    kind,
+    evaluate: (context) => options.evaluate(select(context), context),
+  };
+}
+
+/** Creates an oracle over the final database snapshot. */
+export function createDatabaseOracle(
+  options: OracleOptions<JsonValue | undefined>,
+): BehavioralOracle {
+  return createSpecializedOracle(
+    'database',
+    options,
+    (context) => context.database,
+  );
+}
+
+/** Creates an oracle over the final durable workspace state. */
+export function createWorkspaceStateOracle(
+  options: OracleOptions<JsonValue | undefined>,
+): BehavioralOracle {
+  return createSpecializedOracle(
+    'workspace-state',
+    options,
+    (context) => context.workspace,
+  );
+}
+
+/** Creates an oracle over the assistant's final answer and grounding context. */
+export function createAnswerGroundingOracle(
+  options: OracleOptions<string>,
+): BehavioralOracle {
+  return createSpecializedOracle(
+    'answer-grounding',
+    options,
+    (context) => context.finalAnswer,
+  );
+}
+
+/** Creates an oracle over errors observed during the run. */
+export function createErrorOracle(
+  options: OracleOptions<readonly ObservedError[]>,
+): BehavioralOracle {
+  return createSpecializedOracle('error', options, (context) => context.errors);
+}
+
+/** Creates an oracle over mutations for enforcing read/write policies. */
+export function createPolicyOracle(
+  options: OracleOptions<readonly ObservedMutation[]>,
+): BehavioralOracle {
+  return createSpecializedOracle(
+    'policy',
+    options,
+    (context) => context.mutations,
+  );
+}
+
+/** Evaluates oracles in declaration order and normalizes their results. */
+export async function evaluateOracles(
+  oracles: readonly BehavioralOracle[],
+  context: OracleContext,
+): Promise<OracleResult[]> {
+  const results: OracleResult[] = [];
+  for (const oracle of oracles) {
+    const evaluation = await oracle.evaluate(context);
+    results.push(
+      OracleResultSchema.parse({
+        oracleId: oracle.id,
+        kind: oracle.kind,
+        pass: evaluation.pass,
+        score: evaluation.score ?? (evaluation.pass ? 1 : 0),
+        reason: evaluation.reason,
+        evidence: evaluation.evidence ?? {},
+        metadata: evaluation.metadata ?? {},
+      }),
+    );
+  }
+  return results;
+}
+
+/** Aggregate status and mean score for a set of oracle results. */
+export function summarizeOracleResults(results: readonly OracleResult[]): {
+  pass: boolean;
+  score: number;
+} {
+  return {
+    pass: results.every((result) => result.pass),
+    score:
+      results.length === 0
+        ? 0
+        : results.reduce((sum, result) => sum + result.score, 0) /
+          results.length,
+  };
+}

--- a/packages/evals/src/oracle.ts
+++ b/packages/evals/src/oracle.ts
@@ -1,6 +1,6 @@
 import {z} from 'zod';
 import type {JsonObject, JsonValue} from './json';
-import {JsonObjectSchema} from './json';
+import {JsonObjectSchema, JsonValueSchema} from './json';
 import type {ScenarioDefinition} from './scenario';
 
 /** Supported evaluator-neutral oracle categories. */
@@ -13,15 +13,17 @@ export const OracleKindSchema = z.enum([
 ]);
 
 /** Structured result produced by one behavioral oracle. */
-export const OracleResultSchema = z.looseObject({
-  oracleId: z.string().min(1),
-  kind: OracleKindSchema,
-  pass: z.boolean(),
-  score: z.number().min(0).max(1),
-  reason: z.string().min(1),
-  evidence: JsonObjectSchema.default(() => ({})),
-  metadata: JsonObjectSchema.default(() => ({})),
-});
+export const OracleResultSchema = z
+  .looseObject({
+    oracleId: z.string().min(1),
+    kind: OracleKindSchema,
+    pass: z.boolean(),
+    score: z.number().min(0).max(1),
+    reason: z.string().min(1),
+    evidence: JsonObjectSchema.default(() => ({})),
+    metadata: JsonObjectSchema.default(() => ({})),
+  })
+  .catchall(JsonValueSchema);
 
 /** Structured result produced by one behavioral oracle. */
 export type OracleResult = z.infer<typeof OracleResultSchema>;
@@ -145,12 +147,28 @@ export function createPolicyOracle(
 /**
  * Evaluates oracles in declaration order and normalizes their results.
  *
- * @throws When a scenario expectation has no matching oracle implementation.
+ * @throws When oracle IDs are duplicated or a scenario expectation has no
+ * matching oracle implementation.
  */
 export async function evaluateOracles(
   oracles: readonly BehavioralOracle[],
   context: OracleContext,
 ): Promise<OracleResult[]> {
+  const duplicateOracleIds = Array.from(
+    new Set(
+      oracles
+        .map((oracle) => oracle.id)
+        .filter(
+          (oracleId, index, oracleIds) => oracleIds.indexOf(oracleId) !== index,
+        ),
+    ),
+  );
+  if (duplicateOracleIds.length > 0) {
+    throw new Error(
+      `Duplicate oracle implementations: ${duplicateOracleIds.join(', ')}.`,
+    );
+  }
+
   const availableOracleIds = new Set(oracles.map((oracle) => oracle.id));
   const missingOracleIds = Array.from(
     new Set(

--- a/packages/evals/src/promptfoo/index.ts
+++ b/packages/evals/src/promptfoo/index.ts
@@ -28,23 +28,44 @@ export function toPromptfooProviderResponse(
   };
 }
 
-/** Converts oracle results into one Promptfoo assertion result. */
+/**
+ * Converts oracle results into one Promptfoo assertion result.
+ *
+ * @throws When multiple results use the same oracle ID.
+ */
 export function toPromptfooAssertionResult(
   results: readonly OracleResult[],
 ): PromptfooAssertionResult {
   const parsedResults = results.map((result) =>
     OracleResultSchema.parse(result),
   );
+  const duplicateOracleIds = Array.from(
+    new Set(
+      parsedResults
+        .map((result) => result.oracleId)
+        .filter(
+          (oracleId, index, oracleIds) => oracleIds.indexOf(oracleId) !== index,
+        ),
+    ),
+  );
+  if (duplicateOracleIds.length > 0) {
+    throw new Error(
+      `Duplicate oracle result IDs: ${duplicateOracleIds.join(', ')}.`,
+    );
+  }
+
   const summary = summarizeOracleResults(parsedResults);
   const failures = parsedResults.filter((result) => !result.pass);
   return {
     ...summary,
     reason:
-      failures.length === 0
-        ? `${parsedResults.length} SQLRooms oracle${parsedResults.length === 1 ? '' : 's'} passed.`
-        : failures
-            .map((result) => `${result.oracleId}: ${result.reason}`)
-            .join('; '),
+      parsedResults.length === 0
+        ? 'No SQLRooms oracle results were produced.'
+        : failures.length === 0
+          ? `${parsedResults.length} SQLRooms oracle${parsedResults.length === 1 ? '' : 's'} passed.`
+          : failures
+              .map((result) => `${result.oracleId}: ${result.reason}`)
+              .join('; '),
     namedScores: Object.fromEntries(
       parsedResults.map((result) => [result.oracleId, result.score]),
     ),

--- a/packages/evals/src/promptfoo/index.ts
+++ b/packages/evals/src/promptfoo/index.ts
@@ -1,0 +1,52 @@
+import type {OracleResult} from '../oracle';
+import {OracleResultSchema, summarizeOracleResults} from '../oracle';
+import type {RunEvidence} from '../evidence';
+import {RunEvidenceSchema} from '../evidence';
+
+/** Promptfoo-compatible provider response without a Promptfoo dependency. */
+export type PromptfooProviderResponse = {
+  output: string;
+  metadata: Record<string, unknown>;
+};
+
+/** Promptfoo-compatible assertion result without a Promptfoo dependency. */
+export type PromptfooAssertionResult = {
+  pass: boolean;
+  score: number;
+  reason: string;
+  namedScores: Record<string, number>;
+};
+
+/** Stores validated SQLRooms evidence in Promptfoo provider metadata. */
+export function toPromptfooProviderResponse(
+  evidence: RunEvidence,
+): PromptfooProviderResponse {
+  const parsed = RunEvidenceSchema.parse(evidence);
+  return {
+    output: parsed.finalAnswer,
+    metadata: {sqlroomsEvidence: parsed},
+  };
+}
+
+/** Converts oracle results into one Promptfoo assertion result. */
+export function toPromptfooAssertionResult(
+  results: readonly OracleResult[],
+): PromptfooAssertionResult {
+  const parsedResults = results.map((result) =>
+    OracleResultSchema.parse(result),
+  );
+  const summary = summarizeOracleResults(parsedResults);
+  const failures = parsedResults.filter((result) => !result.pass);
+  return {
+    ...summary,
+    reason:
+      failures.length === 0
+        ? `${parsedResults.length} SQLRooms oracle${parsedResults.length === 1 ? '' : 's'} passed.`
+        : failures
+            .map((result) => `${result.oracleId}: ${result.reason}`)
+            .join('; '),
+    namedScores: Object.fromEntries(
+      parsedResults.map((result) => [result.oracleId, result.score]),
+    ),
+  };
+}

--- a/packages/evals/src/scenario.ts
+++ b/packages/evals/src/scenario.ts
@@ -1,0 +1,44 @@
+import {z} from 'zod';
+import {JsonObjectSchema} from './json';
+
+/** Stable scenario identifier format used in run history. */
+export const ScenarioIdSchema = z
+  .string()
+  .regex(
+    /^[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*$/,
+    'Scenario IDs must be lowercase dot- or dash-separated identifiers.',
+  );
+
+/** One user turn in an evaluator-neutral behavioral scenario. */
+export const ScenarioTurnSchema = z.object({
+  id: z.string().min(1),
+  input: z.string().min(1),
+});
+
+/** An outcome contract evaluated after a scenario run. */
+export const ScenarioExpectationSchema = z.object({
+  oracleId: z.string().min(1),
+  description: z.string().min(1),
+  config: JsonObjectSchema.default({}),
+});
+
+/** Versioned, evaluator-neutral behavioral scenario definition. */
+export const ScenarioDefinitionSchema = z.looseObject({
+  id: ScenarioIdSchema,
+  version: z.number().int().positive(),
+  title: z.string().min(1),
+  description: z.string().min(1).optional(),
+  compatibleProfiles: z.array(z.string().min(1)).min(1),
+  fixture: JsonObjectSchema.default({}),
+  turns: z.array(ScenarioTurnSchema).min(1),
+  expectations: z.array(ScenarioExpectationSchema).min(1),
+  metadata: JsonObjectSchema.default({}),
+});
+
+/** A parsed behavioral scenario. */
+export type ScenarioDefinition = z.infer<typeof ScenarioDefinitionSchema>;
+
+/** Parses and validates a behavioral scenario definition. */
+export function defineScenario(input: unknown): ScenarioDefinition {
+  return ScenarioDefinitionSchema.parse(input);
+}

--- a/packages/evals/src/scenario.ts
+++ b/packages/evals/src/scenario.ts
@@ -19,7 +19,7 @@ export const ScenarioTurnSchema = z.object({
 export const ScenarioExpectationSchema = z.object({
   oracleId: z.string().min(1),
   description: z.string().min(1),
-  config: JsonObjectSchema.default({}),
+  config: JsonObjectSchema.default(() => ({})),
 });
 
 /** Versioned, evaluator-neutral behavioral scenario definition. */
@@ -29,10 +29,10 @@ export const ScenarioDefinitionSchema = z.looseObject({
   title: z.string().min(1),
   description: z.string().min(1).optional(),
   compatibleProfiles: z.array(z.string().min(1)).min(1),
-  fixture: JsonObjectSchema.default({}),
+  fixture: JsonObjectSchema.default(() => ({})),
   turns: z.array(ScenarioTurnSchema).min(1),
   expectations: z.array(ScenarioExpectationSchema).min(1),
-  metadata: JsonObjectSchema.default({}),
+  metadata: JsonObjectSchema.default(() => ({})),
 });
 
 /** A parsed behavioral scenario. */

--- a/packages/evals/src/scriptedModel.ts
+++ b/packages/evals/src/scriptedModel.ts
@@ -1,0 +1,220 @@
+import type {
+  LanguageModelV3,
+  LanguageModelV3CallOptions,
+  LanguageModelV3Content,
+  LanguageModelV3FinishReason,
+  LanguageModelV3GenerateResult,
+  LanguageModelV3StreamPart,
+  LanguageModelV3Usage,
+} from '@ai-sdk/provider';
+import type {JsonObject} from './json';
+
+/** One text or tool-call output emitted by a scripted model step. */
+export type ScriptedModelContent =
+  | {type: 'text'; text: string}
+  | {
+      type: 'tool-call';
+      toolName: string;
+      input: JsonObject;
+      toolCallId?: string;
+    };
+
+/** Declarative checks for the AI SDK call that consumes a scripted step. */
+export type ScriptedModelExpectation = {
+  promptIncludes?: readonly string[];
+  availableToolNames?: readonly string[];
+};
+
+/** One deterministic response in a scripted AI SDK model. */
+export type ScriptedModelStep = {
+  content: readonly ScriptedModelContent[];
+  finishReason?: LanguageModelV3FinishReason['unified'];
+  expectation?: ScriptedModelExpectation;
+  usage?: Partial<{
+    inputTokens: number;
+    outputTokens: number;
+  }>;
+};
+
+/** Handle returned with a scripted language model and its observed calls. */
+export type ScriptedLanguageModel = {
+  model: LanguageModelV3;
+  calls: LanguageModelV3CallOptions[];
+  remainingSteps(): number;
+  assertComplete(): void;
+};
+
+function promptText(options: LanguageModelV3CallOptions): string {
+  return options.prompt
+    .flatMap((message) =>
+      typeof message.content === 'string'
+        ? [message.content]
+        : message.content.flatMap((part) =>
+            part.type === 'text' || part.type === 'reasoning'
+              ? [part.text]
+              : [],
+          ),
+    )
+    .join('\n');
+}
+
+function validateExpectation(
+  expectation: ScriptedModelExpectation | undefined,
+  options: LanguageModelV3CallOptions,
+) {
+  if (!expectation) return;
+  const text = promptText(options);
+  for (const expectedText of expectation.promptIncludes ?? []) {
+    if (!text.includes(expectedText)) {
+      throw new Error(
+        `Scripted model expected prompt to include ${JSON.stringify(expectedText)}.`,
+      );
+    }
+  }
+
+  if (expectation.availableToolNames) {
+    const actualNames = (options.tools ?? []).map((tool) => tool.name).sort();
+    const expectedNames = [...expectation.availableToolNames].sort();
+    if (JSON.stringify(actualNames) !== JSON.stringify(expectedNames)) {
+      throw new Error(
+        `Scripted model expected tools ${expectedNames.join(', ') || '(none)'}, received ${actualNames.join(', ') || '(none)'}.`,
+      );
+    }
+  }
+}
+
+function usage(step: ScriptedModelStep): LanguageModelV3Usage {
+  const inputTokens = step.usage?.inputTokens ?? 0;
+  const outputTokens = step.usage?.outputTokens ?? 0;
+  return {
+    inputTokens: {
+      total: inputTokens,
+      noCache: inputTokens,
+      cacheRead: 0,
+      cacheWrite: 0,
+    },
+    outputTokens: {
+      total: outputTokens,
+      text: outputTokens,
+      reasoning: 0,
+    },
+  };
+}
+
+function finishReason(step: ScriptedModelStep): LanguageModelV3FinishReason {
+  const unified =
+    step.finishReason ??
+    (step.content.some((content) => content.type === 'tool-call')
+      ? 'tool-calls'
+      : 'stop');
+  return {unified, raw: unified};
+}
+
+function content(
+  step: ScriptedModelStep,
+  stepIndex: number,
+): LanguageModelV3Content[] {
+  return step.content.map((part, partIndex) =>
+    part.type === 'text'
+      ? part
+      : {
+          type: 'tool-call' as const,
+          toolCallId: part.toolCallId ?? `scripted-${stepIndex}-${partIndex}`,
+          toolName: part.toolName,
+          input: JSON.stringify(part.input),
+        },
+  );
+}
+
+function streamParts(
+  generated: LanguageModelV3GenerateResult,
+): LanguageModelV3StreamPart[] {
+  const parts: LanguageModelV3StreamPart[] = [
+    {type: 'stream-start', warnings: []},
+  ];
+  generated.content.forEach((part, index) => {
+    if (part.type === 'text') {
+      const id = `text-${index}`;
+      parts.push(
+        {type: 'text-start', id},
+        {type: 'text-delta', id, delta: part.text},
+        {type: 'text-end', id},
+      );
+    } else if (part.type === 'tool-call') {
+      parts.push(part);
+    }
+  });
+  parts.push({
+    type: 'finish',
+    usage: generated.usage,
+    finishReason: generated.finishReason,
+  });
+  return parts;
+}
+
+/** Creates a network-free AI SDK v3 language model from ordered responses. */
+export function createScriptedLanguageModel({
+  steps,
+  provider = 'sqlrooms-scripted',
+  modelId = 'scripted-v1',
+}: {
+  steps: readonly ScriptedModelStep[];
+  provider?: string;
+  modelId?: string;
+}): ScriptedLanguageModel {
+  const queue = [...steps];
+  const calls: LanguageModelV3CallOptions[] = [];
+  let stepIndex = 0;
+
+  const generate = (
+    options: LanguageModelV3CallOptions,
+  ): LanguageModelV3GenerateResult => {
+    const step = queue.shift();
+    if (!step) {
+      throw new Error('Scripted model received more calls than configured.');
+    }
+    calls.push(options);
+    validateExpectation(step.expectation, options);
+    const result: LanguageModelV3GenerateResult = {
+      content: content(step, stepIndex),
+      finishReason: finishReason(step),
+      usage: usage(step),
+      warnings: [],
+      response: {modelId},
+    };
+    stepIndex += 1;
+    return result;
+  };
+
+  const model: LanguageModelV3 = {
+    specificationVersion: 'v3',
+    provider,
+    modelId,
+    supportedUrls: {},
+    doGenerate: async (options) => generate(options),
+    doStream: async (options) => {
+      const generated = generate(options);
+      return {
+        stream: new ReadableStream<LanguageModelV3StreamPart>({
+          start(controller) {
+            for (const part of streamParts(generated)) controller.enqueue(part);
+            controller.close();
+          },
+        }),
+      };
+    },
+  };
+
+  return {
+    model,
+    calls,
+    remainingSteps: () => queue.length,
+    assertComplete: () => {
+      if (queue.length > 0) {
+        throw new Error(
+          `Scripted model has ${queue.length} unconsumed step${queue.length === 1 ? '' : 's'}.`,
+        );
+      }
+    },
+  };
+}

--- a/packages/evals/tsconfig.json
+++ b/packages/evals/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@sqlrooms/preset-typescript/base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "src/__tests__"]
+}

--- a/packages/evals/typedoc.js
+++ b/packages/evals/typedoc.js
@@ -1,0 +1,3 @@
+import config from '@sqlrooms/preset-typedoc';
+
+export default config(import.meta.url);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3633,6 +3633,31 @@ importers:
         specifier: ^29.4.4
         version: 29.4.9(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@24.12.4))(typescript@5.9.3)
 
+  packages/evals:
+    dependencies:
+      '@ai-sdk/provider':
+        specifier: ^3.0.10
+        version: 3.0.10
+      zod:
+        specifier: 4.1.13
+        version: 4.1.13
+    devDependencies:
+      '@jest/globals':
+        specifier: ^30.3.0
+        version: 30.4.1
+      '@sqlrooms/preset-jest':
+        specifier: workspace:*
+        version: link:../preset-jest
+      ai:
+        specifier: ^6.0.177
+        version: 6.0.177(zod@4.1.13)
+      jest:
+        specifier: ^30.1.3
+        version: 30.4.2(@types/node@24.12.4)
+      ts-jest:
+        specifier: ^29.4.4
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@24.12.4))(typescript@5.9.3)
+
   packages/kepler:
     dependencies:
       '@dnd-kit/core':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,6 +298,12 @@ importers:
       '@jest/globals':
         specifier: ^30.3.0
         version: 30.4.1
+      '@sqlrooms/duckdb-node':
+        specifier: workspace:*
+        version: link:../../packages/duckdb-node
+      '@sqlrooms/evals':
+        specifier: workspace:*
+        version: link:../../packages/evals
       '@sqlrooms/preset-jest':
         specifier: workspace:*
         version: link:../../packages/preset-jest


### PR DESCRIPTION
## Summary

- add an isolated Node-based CLI eval target for the production `worksheet-charts-maps` profile
- reuse production AI instructions, profile-selected tools and commands, local chat transport, run context, worksheet agent, and durable worksheet/deck state
- seed ambiguous `analytics.events` and `archive.events` geospatial fixtures in `@sqlrooms/duckdb-node`
- inject one AI SDK model through both top-level and nested-agent model seams
- emit v1 run evidence with ordered model, nested-agent, tool, mutation, error, and final-state data
- document the production/headless fidelity matrix and guarantee explicit teardown

## Validation

- `pnpm --filter sqlrooms-cli-app test --runInBand` (16 suites, 72 tests)
- `pnpm --filter sqlrooms-cli-app lint`
- `pnpm --filter sqlrooms-cli-app typecheck`
- `pnpm --filter sqlrooms-cli-app build`
- `pnpm build`
- `pnpm knip`
- `pnpm check-circular-deps`
- pre-push workspace typecheck and test suites

## Stack

This Stage 4 draft is stacked on #862. Merge #859, #860, and #862 before retargeting this PR to `main`.