### PR TITLE
feat(evals): add trajectory comparison

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env.local and provide an OpenRouter API key.
+OPENROUTER_API_KEY=

--- a/apps/sqlrooms-cli-ui/evals/README.md
+++ b/apps/sqlrooms-cli-ui/evals/README.md
@@ -8,16 +8,22 @@ in the evidence envelope.
 
 ## Run locally
 
-Build workspace packages, set an OpenRouter key, and run either the whole suite
-or one scenario. `evals:nightly` first creates the Node provider bundle used by
-Promptfoo, avoiding browser-only CSS/module imports from application barrels:
+Build workspace packages, copy the local environment template, set an OpenRouter
+key in `.env.local`, and run either the whole suite or one scenario.
+`evals:nightly` first creates the Node provider bundle used by Promptfoo,
+avoiding browser-only CSS/module imports from application barrels:
 
 ```sh
 pnpm build
-export OPENROUTER_API_KEY=...
+cp .env.example .env.local
+# Edit .env.local and set OPENROUTER_API_KEY.
 pnpm evals:nightly
 pnpm evals:nightly --filter-pattern 'worksheet.create-chart-map'
 ```
+
+An existing environment variable takes precedence over `.env.local`. The
+nightly GitHub Actions workflow supplies `OPENROUTER_API_KEY` from GitHub
+Secrets, so CI does not depend on a local environment file.
 
 The model revision, temperature, maximum steps, scenario/profile versions, and
 three repetitions are pinned in `promptfooconfig.yaml`. Promptfoo stores its

--- a/apps/sqlrooms-cli-ui/evals/promptfooconfig.yaml
+++ b/apps/sqlrooms-cli-ui/evals/promptfooconfig.yaml
@@ -21,7 +21,7 @@ tests:
     assert:
       - type: javascript
         metric: sqlrooms-oracles
-        value: return context.metadata.sqlroomsAssertion
+        value: context.metadata.sqlroomsAssertion
   - description: worksheet.mutate-chart-map@1
     vars:
       scenarioId: worksheet.mutate-chart-map
@@ -33,7 +33,7 @@ tests:
     assert:
       - type: javascript
         metric: sqlrooms-oracles
-        value: return context.metadata.sqlroomsAssertion
+        value: context.metadata.sqlroomsAssertion
 
 evaluateOptions:
   repeat: 3

--- a/apps/sqlrooms-cli-ui/src/__tests__/createCliAiInstructions.test.ts
+++ b/apps/sqlrooms-cli-ui/src/__tests__/createCliAiInstructions.test.ts
@@ -51,10 +51,7 @@ describe('createCliAiInstructions', () => {
       const instructions = createCliAiInstructions(store, profile);
 
       expect(instructions).toContain(
-        'For a block type that block_document_agent does not expose in an existing Worksheet',
-      );
-      expect(instructions).toContain(
-        'use the corresponding registered block-document command with the existing artifact ID',
+        'For a block type that block_document_agent does not expose in an existing Worksheet, use the corresponding registered block-document command with the existing artifact ID.',
       );
     },
   );

--- a/apps/sqlrooms-cli-ui/src/__tests__/createCliAiInstructions.test.ts
+++ b/apps/sqlrooms-cli-ui/src/__tests__/createCliAiInstructions.test.ts
@@ -38,7 +38,24 @@ describe('createCliAiInstructions', () => {
       'For Worksheet block types that the tool does not expose, such as Python, pivot, document, or SQL-query blocks, use the corresponding registered block-document commands',
     );
     expect(instructions).toContain(
-      'asks to edit or add content to an existing Worksheet',
+      'asks to edit or add a block type exposed by block_document_agent to an existing Worksheet',
     );
   });
+
+  it.each([
+    DEFAULT_CLI_CAPABILITY_PROFILE,
+    WORKSHEET_CHARTS_MAPS_CLI_CAPABILITY_PROFILE,
+  ])(
+    'routes unsupported existing Worksheet blocks through commands for $name',
+    (profile) => {
+      const instructions = createCliAiInstructions(store, profile);
+
+      expect(instructions).toContain(
+        'For a block type that block_document_agent does not expose in an existing Worksheet',
+      );
+      expect(instructions).toContain(
+        'use the corresponding registered block-document command with the existing artifact ID',
+      );
+    },
+  );
 });

--- a/apps/sqlrooms-cli-ui/src/__tests__/createCliAiInstructions.test.ts
+++ b/apps/sqlrooms-cli-ui/src/__tests__/createCliAiInstructions.test.ts
@@ -1,0 +1,44 @@
+import type {StoreApi} from 'zustand';
+import {createCliAiInstructions} from '../createCliAiInstructions';
+import {
+  DEFAULT_CLI_CAPABILITY_PROFILE,
+  WORKSHEET_CHARTS_MAPS_CLI_CAPABILITY_PROFILE,
+} from '../profiles';
+import type {RoomState} from '../store-types';
+
+const store = {
+  getState: () => ({
+    db: {
+      tables: [],
+      currentDatabase: 'memory',
+    },
+  }),
+} as unknown as StoreApi<RoomState>;
+
+describe('createCliAiInstructions', () => {
+  it.each([
+    DEFAULT_CLI_CAPABILITY_PROFILE,
+    WORKSHEET_CHARTS_MAPS_CLI_CAPABILITY_PROFILE,
+  ])('routes new Worksheets through the nested agent for $name', (profile) => {
+    const instructions = createCliAiInstructions(store, profile);
+
+    expect(instructions).toContain(
+      'execute block-document.create exactly once',
+    );
+    expect(instructions).toContain(
+      'returned result.data.artifactId as the new blockDocumentId',
+    );
+    expect(instructions).toContain(
+      'takes precedence over any Worksheet artifact ID in run context',
+    );
+    expect(instructions).toContain(
+      'do not create its requested chart or map blocks through generic block-document commands',
+    );
+    expect(instructions).toContain(
+      'For Worksheet block types that the tool does not expose, such as Python, pivot, document, or SQL-query blocks, use the corresponding registered block-document commands',
+    );
+    expect(instructions).toContain(
+      'asks to edit or add content to an existing Worksheet',
+    );
+  });
+});

--- a/apps/sqlrooms-cli-ui/src/__tests__/createCliBlockDocumentCommands.test.ts
+++ b/apps/sqlrooms-cli-ui/src/__tests__/createCliBlockDocumentCommands.test.ts
@@ -219,6 +219,9 @@ describe('createCliBlockDocumentCommands', () => {
     expect(result).toMatchObject({success: true});
     const mapId = (result as any).data.mapId as string;
     expect(mapsById[mapId]).toMatchObject({title: 'New Earthquake Map'});
+    expect(mapsById[mapId].config.datasets.earthquakes.source.tableName).toBe(
+      '"main"."earthquakes"',
+    );
     expect(invokeCommand).toHaveBeenCalledWith(
       'block-document.create-stateful-block',
       expect.objectContaining({blockType: 'map', blockInstanceId: mapId}),
@@ -268,7 +271,7 @@ describe('createCliBlockDocumentCommands', () => {
       geometryColumn: '__sqlrooms_geom',
       geometryEncodingHint: 'wkb',
       source: {
-        tableName: 'earthquakes',
+        tableName: '"main"."earthquakes"',
         transformSql: expect.stringContaining('ST_AsWKB'),
       },
     });

--- a/apps/sqlrooms-cli-ui/src/ai/__tests__/createCliBlockDocumentAgentTool.test.ts
+++ b/apps/sqlrooms-cli-ui/src/ai/__tests__/createCliBlockDocumentAgentTool.test.ts
@@ -95,6 +95,18 @@ describe('createCliBlockDocumentAgentTool', () => {
     )) as {success: boolean; finalOutput: string; error?: string};
   }
 
+  it('describes the wrapped create result and unsupported-block fallback', () => {
+    const agentTool = createCliBlockDocumentAgentTool(createOptions()) as any;
+
+    expect(agentTool.description).toContain('result.data.artifactId');
+    expect(agentTool.description).toContain(
+      'even when another Worksheet is in run context',
+    );
+    expect(agentTool.description).toContain(
+      'Use registered block-document commands for requested block types this tool does not expose',
+    );
+  });
+
   it.each([
     {
       blockType: 'dashboard',

--- a/apps/sqlrooms-cli-ui/src/ai/createCliBlockDocumentAgentTool.ts
+++ b/apps/sqlrooms-cli-ui/src/ai/createCliBlockDocumentAgentTool.ts
@@ -579,12 +579,14 @@ export function createCliBlockDocumentAgentTool(
   } = options;
 
   return tool({
-    description: `An AI agent that creates DATA ANALYSIS WORKSHEETS with:
+    description: `An AI agent that builds content inside an existing DATA ANALYSIS WORKSHEET with:
 - CHART BLOCKS (histograms, scatter plots, heatmaps, etc.)
 - TEXT BLOCKS (headings, paragraphs, lists)
 ${dashboardBlocksEnabled ? '- DASHBOARD BLOCKS (interactive dashboards for multi-faceted exploration)' : ''}
 ${dataTableBlocksEnabled ? '- DATA TABLE EXPLORER BLOCKS' : ''}
 ${htmlAppBlocksEnabled ? '- HTML APP BLOCKS (custom browser apps powered by window.sqlrooms.query/queryRows)' : ''}
+
+This tool requires the target Worksheet's blockDocumentId and does not create the Worksheet artifact container. For an explicit new-Worksheet request, first execute the block-document.create command exactly once even when another Worksheet is in run context, then call this tool with the returned result.data.artifactId as blockDocumentId. Delegate the block types listed above to this agent instead of creating charts or maps through generic commands. Use registered block-document commands for requested block types this tool does not expose, such as Python, pivot, document, or SQL-query blocks.
 
 ${
   dashboardBlocksEnabled

--- a/apps/sqlrooms-cli-ui/src/createCliAiInstructions.ts
+++ b/apps/sqlrooms-cli-ui/src/createCliAiInstructions.ts
@@ -38,6 +38,15 @@ This SQLRooms session exposes worksheet artifacts with text, chart, and direct m
 - Use standalone chart tools only for inline chat visualizations or when no worksheet target is available.
 `;
 
+const WORKSHEET_AGENT_ROUTING_INSTRUCTIONS = `
+The ${CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME} tool edits an existing Worksheet and requires its blockDocumentId; it does not create the Worksheet artifact container.
+
+- An explicit request to create a new Worksheet takes precedence over any Worksheet artifact ID in run context. For that request, use the command tools to execute block-document.create exactly once, then use the returned result.data.artifactId as the new blockDocumentId.
+- Delegate requested block types exposed by the current profile's ${CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME} to it. This includes text and charts, plus maps, dashboards, data tables, or HTML apps when the tool description lists them. For Worksheet block types that the tool does not expose, such as Python, pivot, document, or SQL-query blocks, use the corresponding registered block-document commands after creating the container.
+- After creating the Worksheet container, do not create its requested chart or map blocks through generic block-document commands. The Worksheet agent owns those block writes and has the specialized authoring contracts needed to produce valid content.
+- When the user asks to edit or add content to an existing Worksheet and its artifact ID is available in run context, call ${CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME} with that ID directly and do not create another Worksheet.
+`;
+
 /** Builds the production CLI assistant instructions for a capability profile. */
 export function createCliAiInstructions(
   store: StoreApi<RoomState>,
@@ -48,6 +57,7 @@ export function createCliAiInstructions(
     profile.name === 'worksheet-charts-maps'
       ? WORKSHEET_CHARTS_MAPS_AI_INSTRUCTIONS.trim()
       : STABLE_SQLROOMS_CLI_AI_INSTRUCTIONS.trim(),
+    WORKSHEET_AGENT_ROUTING_INSTRUCTIONS.trim(),
     profile.ai.instructionSets.includes('experimental')
       ? EXPERIMENTAL_SQLROOMS_CLI_AI_INSTRUCTIONS.trim()
       : '',

--- a/apps/sqlrooms-cli-ui/src/createCliAiInstructions.ts
+++ b/apps/sqlrooms-cli-ui/src/createCliAiInstructions.ts
@@ -44,7 +44,8 @@ The ${CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME} tool edits an existing Worksheet and r
 - An explicit request to create a new Worksheet takes precedence over any Worksheet artifact ID in run context. For that request, use the command tools to execute block-document.create exactly once, then use the returned result.data.artifactId as the new blockDocumentId.
 - Delegate requested block types exposed by the current profile's ${CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME} to it. This includes text and charts, plus maps, dashboards, data tables, or HTML apps when the tool description lists them. For Worksheet block types that the tool does not expose, such as Python, pivot, document, or SQL-query blocks, use the corresponding registered block-document commands after creating the container.
 - After creating the Worksheet container, do not create its requested chart or map blocks through generic block-document commands. The Worksheet agent owns those block writes and has the specialized authoring contracts needed to produce valid content.
-- When the user asks to edit or add content to an existing Worksheet and its artifact ID is available in run context, call ${CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME} with that ID directly and do not create another Worksheet.
+- When the user asks to edit or add a block type exposed by ${CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME} to an existing Worksheet and its artifact ID is available in run context, call ${CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME} with that ID directly and do not create another Worksheet.
+- For a block type that ${CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME} does not expose in an existing Worksheet, use the corresponding registered block-document command with the existing artifact ID.
 `;
 
 /** Builds the production CLI assistant instructions for a capability profile. */

--- a/apps/sqlrooms-cli-ui/src/evals/__tests__/createCliEvalTarget.test.ts
+++ b/apps/sqlrooms-cli-ui/src/evals/__tests__/createCliEvalTarget.test.ts
@@ -63,6 +63,22 @@ describe('createCliEvalTarget', () => {
     }
   });
 
+  it('uses the target timeout for the underlying chat run', async () => {
+    const scripted = createScriptedLanguageModel({
+      steps: [{content: [{type: 'text', text: 'Done.'}]}],
+    });
+    const target = createCliEvalTarget({
+      model: scripted.model,
+      timeoutMs: 180_000,
+    });
+
+    try {
+      expect(target.store.getState().ai.timeouts.runMs).toBe(180_000);
+    } finally {
+      await target.dispose();
+    }
+  });
+
   it('runs the production chat and nested worksheet tool loop without a browser or network', async () => {
     const scripted = createScriptedLanguageModel({
       steps: [

--- a/apps/sqlrooms-cli-ui/src/evals/__tests__/loadLocalEvalEnvironment.test.ts
+++ b/apps/sqlrooms-cli-ui/src/evals/__tests__/loadLocalEvalEnvironment.test.ts
@@ -1,0 +1,38 @@
+import {describe, expect, it, jest} from '@jest/globals';
+import {loadLocalEvalEnvironment} from '../loadLocalEvalEnvironment';
+
+describe('loadLocalEvalEnvironment', () => {
+  it('keeps an externally supplied key authoritative', () => {
+    const load = jest.fn<(path: string) => void>();
+
+    loadLocalEvalEnvironment({OPENROUTER_API_KEY: 'github-secret'}, load);
+
+    expect(load).not.toHaveBeenCalled();
+  });
+
+  it('loads the repository-local environment when the key is unset', () => {
+    const load = jest.fn<(path: string) => void>();
+
+    loadLocalEvalEnvironment({}, load);
+
+    expect(load).toHaveBeenCalledWith('.env.local');
+  });
+
+  it('allows the local environment file to be absent', () => {
+    const missing = Object.assign(new Error('missing'), {code: 'ENOENT'});
+    const load = jest.fn<(path: string) => void>(() => {
+      throw missing;
+    });
+
+    expect(() => loadLocalEvalEnvironment({}, load)).not.toThrow();
+  });
+
+  it('surfaces other environment-file errors', () => {
+    const invalid = Object.assign(new Error('invalid'), {code: 'EINVAL'});
+    const load = jest.fn<(path: string) => void>(() => {
+      throw invalid;
+    });
+
+    expect(() => loadLocalEvalEnvironment({}, load)).toThrow(invalid);
+  });
+});

--- a/apps/sqlrooms-cli-ui/src/evals/__tests__/openRouterCost.test.ts
+++ b/apps/sqlrooms-cli-ui/src/evals/__tests__/openRouterCost.test.ts
@@ -1,0 +1,74 @@
+import {describe, expect, it} from '@jest/globals';
+import {createOpenRouterCostTracker} from '../openRouterCost';
+
+const RATES = {
+  inputCostUsdPerMillionTokens: 0.08,
+  outputCostUsdPerMillionTokens: 0.18,
+};
+
+describe('createOpenRouterCostTracker', () => {
+  it('accumulates provider-reported cost across streamed model calls', () => {
+    const tracker = createOpenRouterCostTracker(RATES);
+    const first = tracker.metadataExtractor.createStreamExtractor();
+    first.processChunk({choices: [{delta: {content: 'Hello'}}]});
+    first.processChunk({usage: {cost: 0.012}});
+    expect(first.buildMetadata()).toEqual({
+      openrouter: {costUsd: 0.012},
+    });
+
+    const second = tracker.metadataExtractor.createStreamExtractor();
+    second.processChunk({usage: {cost: 0.003}});
+    second.buildMetadata();
+
+    expect(
+      tracker.resolveCost({inputTokens: 1_000_000, outputTokens: 1_000_000}),
+    ).toEqual({costUsd: 0.015, source: 'provider-reported'});
+  });
+
+  it('uses pinned model rates when OpenRouter omits billed cost', () => {
+    const tracker = createOpenRouterCostTracker(RATES);
+
+    expect(
+      tracker.resolveCost({inputTokens: 2_000_000, outputTokens: 500_000}),
+    ).toEqual({costUsd: 0.25, source: 'estimated'});
+  });
+
+  it('preserves a provider-reported zero cost', async () => {
+    const tracker = createOpenRouterCostTracker(RATES);
+
+    expect(
+      await tracker.metadataExtractor.extractMetadata({
+        parsedBody: {usage: {cost: 0}},
+      }),
+    ).toEqual({openrouter: {costUsd: 0}});
+    expect(tracker.resolveCost({inputTokens: 10_000})).toEqual({
+      costUsd: 0,
+      source: 'provider-reported',
+    });
+  });
+
+  it('falls back when one streamed response has usage but no cost', () => {
+    const tracker = createOpenRouterCostTracker(RATES);
+    const reported = tracker.metadataExtractor.createStreamExtractor();
+    reported.processChunk({
+      usage: {
+        cost: 0.012,
+        prompt_tokens: 1_000_000,
+        completion_tokens: 500_000,
+      },
+    });
+    reported.buildMetadata();
+    const omitted = tracker.metadataExtractor.createStreamExtractor();
+    omitted.processChunk({
+      usage: {
+        prompt_tokens: 500_000,
+        completion_tokens: 1_000_000,
+      },
+    });
+    omitted.buildMetadata();
+
+    expect(
+      tracker.resolveCost({inputTokens: 10_000, outputTokens: 10_000}),
+    ).toEqual({costUsd: 0.39, source: 'estimated'});
+  });
+});

--- a/apps/sqlrooms-cli-ui/src/evals/__tests__/promptfooProvider.test.ts
+++ b/apps/sqlrooms-cli-ui/src/evals/__tests__/promptfooProvider.test.ts
@@ -1,0 +1,115 @@
+import {afterAll, beforeEach, describe, expect, it, jest} from '@jest/globals';
+import type {RunEvidence} from '@sqlrooms/evals';
+import {CREATE_WORKSHEET_CHART_MAP_SCENARIO} from '../scenarios';
+
+const runMock = jest.fn<() => Promise<RunEvidence>>();
+const disposeMock = jest.fn<() => Promise<void>>();
+const resolveCostMock =
+  jest.fn<
+    (
+      usage: RunEvidence['usage'],
+    ) =>
+      | {costUsd: number; source: 'provider-reported' | 'estimated'}
+      | undefined
+  >();
+
+jest.unstable_mockModule('../createCliEvalTarget', () => ({
+  createCliEvalTarget: () => ({run: runMock, dispose: disposeMock}),
+}));
+jest.unstable_mockModule('../openRouterCost', () => ({
+  createOpenRouterCostTracker: () => ({
+    metadataExtractor: {},
+    resolveCost: resolveCostMock,
+  }),
+}));
+jest.unstable_mockModule('@ai-sdk/openai-compatible', () => ({
+  createOpenAICompatible: () => ({languageModel: () => ({})}),
+}));
+
+const {default: SqlroomsCliEvalProvider} = await import('../promptfooProvider');
+const originalOpenRouterApiKey = process.env.OPENROUTER_API_KEY;
+
+function runEvidence(): RunEvidence {
+  const timestamp = '2026-08-21T12:00:00.000Z';
+  return {
+    schemaVersion: 1,
+    runId: 'provider-cost-test',
+    scenario: {
+      id: CREATE_WORKSHEET_CHART_MAP_SCENARIO.id,
+      version: CREATE_WORKSHEET_CHART_MAP_SCENARIO.version,
+      repetition: 0,
+    },
+    target: {
+      type: 'cli-in-process',
+      profileName: 'worksheet-charts-maps',
+      profileVersion: 1,
+    },
+    model: {
+      provider: 'openrouter',
+      modelId: 'test-model',
+      settings: {},
+    },
+    timing: {startedAt: timestamp, endedAt: timestamp, latencyMs: 0},
+    status: 'passed',
+    promptTurns: CREATE_WORKSHEET_CHART_MAP_SCENARIO.turns,
+    finalAnswer: 'Created a chart and map from analytics.events.',
+    events: [],
+    usage: {inputTokens: 100, outputTokens: 20, totalTokens: 120},
+    oracleResults: [
+      {
+        oracleId: 'grounded-answer',
+        kind: 'answer-grounding',
+        pass: true,
+        score: 1,
+        reason: 'The answer is grounded.',
+        evidence: {},
+        metadata: {},
+      },
+    ],
+    metadata: {},
+  };
+}
+
+beforeEach(() => {
+  process.env.OPENROUTER_API_KEY = 'test-key';
+  runMock.mockReset().mockResolvedValue(runEvidence());
+  disposeMock.mockReset().mockResolvedValue(undefined);
+  resolveCostMock.mockReset();
+});
+
+afterAll(() => {
+  if (originalOpenRouterApiKey === undefined) {
+    delete process.env.OPENROUTER_API_KEY;
+  } else {
+    process.env.OPENROUTER_API_KEY = originalOpenRouterApiKey;
+  }
+});
+
+describe('SqlroomsCliEvalProvider cost propagation', () => {
+  it.each([
+    ['provider-reported', 0.012],
+    ['estimated', 0.0000116],
+  ] as const)(
+    'returns %s cost and its evidence source',
+    async (source, costUsd) => {
+      resolveCostMock.mockReturnValue({costUsd, source});
+      const provider = new SqlroomsCliEvalProvider({});
+
+      const response = await provider.callApi(
+        CREATE_WORKSHEET_CHART_MAP_SCENARIO.turns[0]!.input,
+        {vars: {scenarioId: CREATE_WORKSHEET_CHART_MAP_SCENARIO.id}},
+      );
+
+      expect(response).toMatchObject({
+        cost: costUsd,
+        metadata: {
+          sqlroomsEvidence: {
+            usage: {costUsd},
+            metadata: {cost: {source}},
+          },
+        },
+      });
+      expect(disposeMock).toHaveBeenCalledTimes(1);
+    },
+  );
+});

--- a/apps/sqlrooms-cli-ui/src/evals/__tests__/scenarios.test.ts
+++ b/apps/sqlrooms-cli-ui/src/evals/__tests__/scenarios.test.ts
@@ -178,4 +178,36 @@ describe('CLI behavioral scenario oracles', () => {
       await oracle?.evaluate(context(MUTATE_WORKSHEET_SCENARIO, valid)),
     ).toMatchObject({pass: true});
   });
+
+  it('accepts a grounded answer that explicitly says the decoy table was not used', async () => {
+    const oracle = createCliScenarioOracles(
+      CREATE_WORKSHEET_CHART_MAP_SCENARIO,
+    ).find((candidate) => candidate.id === 'grounded-answer');
+    if (!oracle) throw new Error('Missing grounded-answer oracle.');
+
+    const result = await oracle.evaluate({
+      scenario: CREATE_WORKSHEET_CHART_MAP_SCENARIO,
+      finalAnswer:
+        'Created a chart and map from analytics.events. archive.events was explicitly not used.',
+      errors: [],
+      mutations: [],
+      metadata: {},
+    });
+
+    expect(result.pass).toBe(true);
+  });
+
+  it('recognizes a canonical quoted table identity in map dataset state', async () => {
+    const current = workspace();
+    const oracle = createCliScenarioOracles(
+      CREATE_WORKSHEET_CHART_MAP_SCENARIO,
+    ).find((candidate) => candidate.id === 'canonical-bindings');
+    if (!oracle) throw new Error('Missing canonical-bindings oracle.');
+
+    const result = await oracle.evaluate(
+      context(CREATE_WORKSHEET_CHART_MAP_SCENARIO, current),
+    );
+
+    expect(result.pass).toBe(true);
+  });
 });

--- a/apps/sqlrooms-cli-ui/src/evals/__tests__/scenarios.test.ts
+++ b/apps/sqlrooms-cli-ui/src/evals/__tests__/scenarios.test.ts
@@ -179,40 +179,27 @@ describe('CLI behavioral scenario oracles', () => {
     ).toMatchObject({pass: true});
   });
 
-  it('accepts a grounded answer that explicitly says the decoy table was not used', async () => {
+  it('requires the grounded answer to name the intended chart and map result', async () => {
     const oracle = createCliScenarioOracles(
       CREATE_WORKSHEET_CHART_MAP_SCENARIO,
     ).find((candidate) => candidate.id === 'grounded-answer');
     if (!oracle) throw new Error('Missing grounded-answer oracle.');
 
-    const result = await oracle.evaluate({
-      scenario: CREATE_WORKSHEET_CHART_MAP_SCENARIO,
-      finalAnswer:
-        'Created a chart and map from analytics.events. archive.events was explicitly not used.',
-      errors: [],
-      mutations: [],
-      metadata: {},
-    });
+    const evaluate = (finalAnswer: string) =>
+      oracle.evaluate({
+        scenario: CREATE_WORKSHEET_CHART_MAP_SCENARIO,
+        finalAnswer,
+        errors: [],
+        mutations: [],
+        metadata: {},
+      });
 
-    expect(result.pass).toBe(true);
-  });
-
-  it('rejects a grounded answer that claims the decoy table was used', async () => {
-    const oracle = createCliScenarioOracles(
-      CREATE_WORKSHEET_CHART_MAP_SCENARIO,
-    ).find((candidate) => candidate.id === 'grounded-answer');
-    if (!oracle) throw new Error('Missing grounded-answer oracle.');
-
-    const result = await oracle.evaluate({
-      scenario: CREATE_WORKSHEET_CHART_MAP_SCENARIO,
-      finalAnswer:
-        'Created a chart and map from analytics.events, but archive.events was also used.',
-      errors: [],
-      mutations: [],
-      metadata: {},
-    });
-
-    expect(result.pass).toBe(false);
+    expect(
+      await evaluate('Created a chart and map from analytics.events.'),
+    ).toMatchObject({pass: true});
+    expect(
+      await evaluate('Created a chart from analytics.events.'),
+    ).toMatchObject({pass: false});
   });
 
   it('recognizes a canonical quoted table identity in map dataset state', async () => {

--- a/apps/sqlrooms-cli-ui/src/evals/__tests__/scenarios.test.ts
+++ b/apps/sqlrooms-cli-ui/src/evals/__tests__/scenarios.test.ts
@@ -197,6 +197,24 @@ describe('CLI behavioral scenario oracles', () => {
     expect(result.pass).toBe(true);
   });
 
+  it('rejects a grounded answer that claims the decoy table was used', async () => {
+    const oracle = createCliScenarioOracles(
+      CREATE_WORKSHEET_CHART_MAP_SCENARIO,
+    ).find((candidate) => candidate.id === 'grounded-answer');
+    if (!oracle) throw new Error('Missing grounded-answer oracle.');
+
+    const result = await oracle.evaluate({
+      scenario: CREATE_WORKSHEET_CHART_MAP_SCENARIO,
+      finalAnswer:
+        'Created a chart and map from analytics.events, but archive.events was also used.',
+      errors: [],
+      mutations: [],
+      metadata: {},
+    });
+
+    expect(result.pass).toBe(false);
+  });
+
   it('recognizes a canonical quoted table identity in map dataset state', async () => {
     const current = workspace();
     const oracle = createCliScenarioOracles(

--- a/apps/sqlrooms-cli-ui/src/evals/loadLocalEvalEnvironment.ts
+++ b/apps/sqlrooms-cli-ui/src/evals/loadLocalEvalEnvironment.ts
@@ -1,0 +1,17 @@
+import {loadEnvFile} from 'node:process';
+
+type EnvFileLoader = (path: string) => void;
+
+/** Loads local eval credentials without overriding an existing environment. */
+export function loadLocalEvalEnvironment(
+  environment: NodeJS.ProcessEnv = process.env,
+  load: EnvFileLoader = loadEnvFile,
+): void {
+  if (environment.OPENROUTER_API_KEY) return;
+
+  try {
+    load('.env.local');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+}

--- a/apps/sqlrooms-cli-ui/src/evals/openRouterCost.ts
+++ b/apps/sqlrooms-cli-ui/src/evals/openRouterCost.ts
@@ -1,0 +1,146 @@
+import type {MetadataExtractor} from '@ai-sdk/openai-compatible';
+
+type TokenUsage = {
+  inputTokens?: number;
+  outputTokens?: number;
+};
+
+export type OpenRouterCost = {
+  costUsd: number;
+  source: 'provider-reported' | 'estimated';
+};
+
+export type OpenRouterCostTrackerOptions = {
+  inputCostUsdPerMillionTokens: number;
+  outputCostUsdPerMillionTokens: number;
+};
+
+function reportedCostUsd(value: unknown): number | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const usage = (value as {usage?: unknown}).usage;
+  if (!usage || typeof usage !== 'object') return undefined;
+  const cost = (usage as {cost?: unknown}).cost;
+  return typeof cost === 'number' && Number.isFinite(cost) && cost >= 0
+    ? cost
+    : undefined;
+}
+
+function reportedTokenUsage(value: unknown): TokenUsage | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const usage = (value as {usage?: unknown}).usage;
+  if (!usage || typeof usage !== 'object') return undefined;
+  const {prompt_tokens: inputTokens, completion_tokens: outputTokens} =
+    usage as {
+      prompt_tokens?: unknown;
+      completion_tokens?: unknown;
+    };
+  const validInputTokens =
+    typeof inputTokens === 'number' &&
+    Number.isFinite(inputTokens) &&
+    inputTokens >= 0
+      ? inputTokens
+      : undefined;
+  const validOutputTokens =
+    typeof outputTokens === 'number' &&
+    Number.isFinite(outputTokens) &&
+    outputTokens >= 0
+      ? outputTokens
+      : undefined;
+  return validInputTokens === undefined && validOutputTokens === undefined
+    ? undefined
+    : {inputTokens: validInputTokens, outputTokens: validOutputTokens};
+}
+
+function estimatedCostUsd(
+  usage: TokenUsage | undefined,
+  options: OpenRouterCostTrackerOptions,
+): number | undefined {
+  if (!usage) return undefined;
+  return (
+    ((usage.inputTokens ?? 0) * options.inputCostUsdPerMillionTokens) /
+      1_000_000 +
+    ((usage.outputTokens ?? 0) * options.outputCostUsdPerMillionTokens) /
+      1_000_000
+  );
+}
+
+/** Collects OpenRouter's billed cost from AI SDK response metadata. */
+export function createOpenRouterCostTracker(
+  options: OpenRouterCostTrackerOptions,
+): {
+  metadataExtractor: MetadataExtractor;
+  resolveCost(usage: TokenUsage | undefined): OpenRouterCost | undefined;
+} {
+  let totalReportedCostUsd: number | undefined;
+  let totalReportedUsage: TokenUsage | undefined;
+  let usageWithoutReportedCost = false;
+
+  const record = (
+    costUsd: number | undefined,
+    usage: TokenUsage | undefined,
+  ) => {
+    if (costUsd !== undefined) {
+      totalReportedCostUsd = (totalReportedCostUsd ?? 0) + costUsd;
+    }
+    if (usage) {
+      totalReportedUsage = {
+        inputTokens:
+          (totalReportedUsage?.inputTokens ?? 0) + (usage.inputTokens ?? 0),
+        outputTokens:
+          (totalReportedUsage?.outputTokens ?? 0) + (usage.outputTokens ?? 0),
+      };
+    }
+  };
+
+  return {
+    metadataExtractor: {
+      async extractMetadata({parsedBody}) {
+        const costUsd = reportedCostUsd(parsedBody);
+        const usage = reportedTokenUsage(parsedBody);
+        if (
+          costUsd === undefined &&
+          parsedBody &&
+          typeof parsedBody === 'object' &&
+          (parsedBody as {usage?: unknown}).usage
+        ) {
+          usageWithoutReportedCost = true;
+        }
+        record(costUsd, usage);
+        return costUsd === undefined ? undefined : {openrouter: {costUsd}};
+      },
+      createStreamExtractor() {
+        let costUsd: number | undefined;
+        let usage: TokenUsage | undefined;
+        let sawUsage = false;
+        return {
+          processChunk(parsedChunk) {
+            sawUsage ||= Boolean(
+              parsedChunk &&
+              typeof parsedChunk === 'object' &&
+              (parsedChunk as {usage?: unknown}).usage,
+            );
+            costUsd = reportedCostUsd(parsedChunk) ?? costUsd;
+            usage = reportedTokenUsage(parsedChunk) ?? usage;
+          },
+          buildMetadata() {
+            if (sawUsage && costUsd === undefined) {
+              usageWithoutReportedCost = true;
+            }
+            record(costUsd, usage);
+            return costUsd === undefined ? undefined : {openrouter: {costUsd}};
+          },
+        };
+      },
+    },
+    resolveCost(usage) {
+      if (totalReportedCostUsd !== undefined && !usageWithoutReportedCost) {
+        return {
+          costUsd: totalReportedCostUsd,
+          source: 'provider-reported',
+        };
+      }
+      const costUsd = estimatedCostUsd(totalReportedUsage ?? usage, options);
+      return costUsd === undefined ? undefined : {costUsd, source: 'estimated'};
+    },
+  };
+}

--- a/apps/sqlrooms-cli-ui/src/evals/promptfooProvider.ts
+++ b/apps/sqlrooms-cli-ui/src/evals/promptfooProvider.ts
@@ -1,13 +1,22 @@
-import {createOpenAICompatible} from '@ai-sdk/openai-compatible';
+import {
+  createOpenAICompatible,
+  type MetadataExtractor,
+} from '@ai-sdk/openai-compatible';
 import {
   toPromptfooAssertionResult,
   toPromptfooProviderResponse,
 } from '@sqlrooms/evals/promptfoo';
 import type {LanguageModel} from 'ai';
 import {createCliEvalTarget} from './createCliEvalTarget';
+import {loadLocalEvalEnvironment} from './loadLocalEvalEnvironment';
+import {createOpenRouterCostTracker} from './openRouterCost';
 import {CLI_BEHAVIORAL_SCENARIOS, createCliScenarioOracles} from './scenarios';
 
+loadLocalEvalEnvironment();
+
 const MODEL_ID = 'deepseek/deepseek-v4-flash-0731';
+const MODEL_INPUT_COST_USD_PER_MILLION_TOKENS = 0.08;
+const MODEL_OUTPUT_COST_USD_PER_MILLION_TOKENS = 0.18;
 const MAX_STEPS = 24;
 const TEMPERATURE = 0;
 
@@ -38,7 +47,9 @@ function requiredEnvironment(name: string): string {
   return value;
 }
 
-function createPinnedOpenRouterModel(): LanguageModel {
+function createPinnedOpenRouterModel(
+  metadataExtractor: MetadataExtractor,
+): LanguageModel {
   const provider = createOpenAICompatible({
     name: 'openrouter',
     apiKey: requiredEnvironment('OPENROUTER_API_KEY'),
@@ -47,6 +58,8 @@ function createPinnedOpenRouterModel(): LanguageModel {
       'HTTP-Referer': 'https://github.com/sqlrooms/sqlrooms',
       'X-Title': 'SQLRooms behavioral evals',
     },
+    includeUsage: true,
+    metadataExtractor,
   });
   return provider.languageModel(MODEL_ID, {
     transformRequestBody: (body) => ({...body, temperature: TEMPERATURE}),
@@ -100,8 +113,12 @@ export default class SqlroomsCliEvalProvider {
     }
 
     const repeatIndex = context?.repeatIndex ?? 0;
+    const costTracker = createOpenRouterCostTracker({
+      inputCostUsdPerMillionTokens: MODEL_INPUT_COST_USD_PER_MILLION_TOKENS,
+      outputCostUsdPerMillionTokens: MODEL_OUTPUT_COST_USD_PER_MILLION_TOKENS,
+    });
     const target = createCliEvalTarget({
-      model: createPinnedOpenRouterModel(),
+      model: createPinnedOpenRouterModel(costTracker.metadataExtractor),
       modelProvider: 'openrouter',
       modelId: MODEL_ID,
       configuredRevision: MODEL_ID,
@@ -113,11 +130,22 @@ export default class SqlroomsCliEvalProvider {
     });
 
     try {
-      const evidence = await target.run({
+      const runEvidence = await target.run({
         scenario,
         oracles: createCliScenarioOracles(scenario),
         repetition: repeatIndex,
       });
+      const cost = costTracker.resolveCost(runEvidence.usage);
+      const evidence = cost
+        ? {
+            ...runEvidence,
+            usage: {...runEvidence.usage, costUsd: cost.costUsd},
+            metadata: {
+              ...runEvidence.metadata,
+              cost: {source: cost.source},
+            },
+          }
+        : runEvidence;
       const response = toPromptfooProviderResponse(evidence);
       const assertion = toPromptfooAssertionResult(evidence.oracleResults);
       return {

--- a/apps/sqlrooms-cli-ui/src/evals/scenarios.ts
+++ b/apps/sqlrooms-cli-ui/src/evals/scenarios.ts
@@ -11,29 +11,6 @@ import {CLI_EVAL_TARGET_TABLE} from './fixture';
 
 const CLI_EVAL_DECOY_TABLES = new Set(['archive.events', '"archive"."events"']);
 
-function positivelyClaimsDecoyUse(answer: string): boolean {
-  return answer
-    .toLowerCase()
-    .split(/[;!?]|\.(?=\s|$)|\bbut\b/)
-    .some((clause) => {
-      const mentionsDecoy = [...CLI_EVAL_DECOY_TABLES].some((table) =>
-        clause.includes(table),
-      );
-      if (!mentionsDecoy) return false;
-
-      const negatesUse =
-        /\b(?:not|never)\b(?:\s+\w+){0,2}\s+\b(?:use|used|using)\b/.test(
-          clause,
-        ) ||
-        /\bwithout\s+(?:using\s+)?/.test(clause) ||
-        /n't\s+(?:use|used|using)\b/.test(clause);
-      const claimsUse = /\b(?:use|used|using|from|source|sourced)\b/.test(
-        clause,
-      );
-      return claimsUse && !negatesUse;
-    });
-}
-
 type WorkspaceSnapshot = {
   artifacts: {artifactsById: Record<string, {type: string}>};
   worksheets: Array<{
@@ -450,13 +427,12 @@ export function createCliScenarioOracles(
             normalized.includes('analytics.events')
           : normalized.includes('analytics.events') &&
             normalized.includes('chart') &&
-            normalized.includes('map') &&
-            !positivelyClaimsDecoyUse(answer);
+            normalized.includes('map');
         return {
           pass,
           reason: pass
             ? 'The final answer describes the durable result and intended table.'
-            : 'The final answer omits or contradicts the requested durable result.',
+            : 'The final answer omits the requested durable result or intended table.',
           evidence: {answer},
         };
       },

--- a/apps/sqlrooms-cli-ui/src/evals/scenarios.ts
+++ b/apps/sqlrooms-cli-ui/src/evals/scenarios.ts
@@ -11,6 +11,29 @@ import {CLI_EVAL_TARGET_TABLE} from './fixture';
 
 const CLI_EVAL_DECOY_TABLES = new Set(['archive.events', '"archive"."events"']);
 
+function positivelyClaimsDecoyUse(answer: string): boolean {
+  return answer
+    .toLowerCase()
+    .split(/[;!?]|\.(?=\s|$)|\bbut\b/)
+    .some((clause) => {
+      const mentionsDecoy = [...CLI_EVAL_DECOY_TABLES].some((table) =>
+        clause.includes(table),
+      );
+      if (!mentionsDecoy) return false;
+
+      const negatesUse =
+        /\b(?:not|never)\b(?:\s+\w+){0,2}\s+\b(?:use|used|using)\b/.test(
+          clause,
+        ) ||
+        /\bwithout\s+(?:using\s+)?/.test(clause) ||
+        /n't\s+(?:use|used|using)\b/.test(clause);
+      const claimsUse = /\b(?:use|used|using|from|source|sourced)\b/.test(
+        clause,
+      );
+      return claimsUse && !negatesUse;
+    });
+}
+
 type WorkspaceSnapshot = {
   artifacts: {artifactsById: Record<string, {type: string}>};
   worksheets: Array<{
@@ -427,7 +450,8 @@ export function createCliScenarioOracles(
             normalized.includes('analytics.events')
           : normalized.includes('analytics.events') &&
             normalized.includes('chart') &&
-            normalized.includes('map');
+            normalized.includes('map') &&
+            !positivelyClaimsDecoyUse(answer);
         return {
           pass,
           reason: pass

--- a/apps/sqlrooms-cli-ui/src/evals/scenarios.ts
+++ b/apps/sqlrooms-cli-ui/src/evals/scenarios.ts
@@ -9,6 +9,8 @@ import {
 } from '@sqlrooms/evals';
 import {CLI_EVAL_TARGET_TABLE} from './fixture';
 
+const CLI_EVAL_DECOY_TABLES = new Set(['archive.events', '"archive"."events"']);
+
 type WorkspaceSnapshot = {
   artifacts: {artifactsById: Record<string, {type: string}>};
   worksheets: Array<{
@@ -38,7 +40,7 @@ function asJson(value: unknown): JsonValue {
   return JSON.parse(JSON.stringify(value)) as JsonValue;
 }
 
-function hasObjectShape(value: unknown): boolean {
+function hasObjectShape(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value));
 }
 
@@ -219,6 +221,19 @@ function chartAndMap(workspace: WorkspaceSnapshot) {
   };
 }
 
+function mapDatasetTableNames(workspace: WorkspaceSnapshot): string[] {
+  return workspace.maps.flatMap((map) =>
+    Object.values(map.config.datasets).flatMap((dataset) => {
+      if (!hasObjectShape(dataset)) return [];
+      const source = dataset.source;
+      if (!hasObjectShape(source) || typeof source.tableName !== 'string') {
+        return [];
+      }
+      return [source.tableName];
+    }),
+  );
+}
+
 /** Deterministic state and policy oracles for a pinned CLI scenario. */
 export function createCliScenarioOracles(
   scenario: ScenarioDefinition,
@@ -255,13 +270,16 @@ export function createCliScenarioOracles(
       evaluate: (value) => {
         const workspace = snapshot(value);
         const {charts} = chartAndMap(workspace);
+        const mapTables = mapDatasetTableNames(workspace);
         const pass =
           charts.some(
             (chart) =>
               chart.tableName === CLI_EVAL_TARGET_TABLE &&
               hasFieldBinding(chart.config, 'category') &&
               hasFieldBinding(chart.config, 'metric'),
-          ) && workspace.maps.some(hasCanonicalMapBinding);
+          ) &&
+          workspace.maps.some(hasCanonicalMapBinding) &&
+          !mapTables.some((tableName) => CLI_EVAL_DECOY_TABLES.has(tableName));
         return {
           pass,
           reason: pass
@@ -270,6 +288,7 @@ export function createCliScenarioOracles(
           evidence: {
             chartTables: charts.map((chart) => chart.tableName ?? null),
             chartConfigs: asJson(charts.map((chart) => chart.config ?? null)),
+            mapTables,
             maps: asJson(workspace.maps),
           },
         };
@@ -408,12 +427,11 @@ export function createCliScenarioOracles(
             normalized.includes('analytics.events')
           : normalized.includes('analytics.events') &&
             normalized.includes('chart') &&
-            normalized.includes('map') &&
-            !normalized.includes('archive.events');
+            normalized.includes('map');
         return {
           pass,
           reason: pass
-            ? 'The final answer describes the durable result without the decoy table.'
+            ? 'The final answer describes the durable result and intended table.'
             : 'The final answer omits or contradicts the requested durable result.',
           evidence: {answer},
         };

--- a/apps/sqlrooms-eval-observatory/README.md
+++ b/apps/sqlrooms-eval-observatory/README.md
@@ -12,3 +12,11 @@ pnpm --filter sqlrooms-eval-observatory dev
 The Node adapter opens Promptfoo SQLite files read-only and normalizes their
 schema before this app sees any data. The browser can load multiple retained CI
 summaries and requires no central service.
+
+Runs with explicit nested-agent or parent/child tool evidence also get a linked
+`@sqlrooms/cosmos` trajectory view. Simple runs deliberately remain in the
+ordered event list. Graph nodes are derived from the normalized SQLRooms
+evidence model, never directly from Promptfoo spans, and selecting a node shows
+its exact recorded input, output, duration, status, and explicitly related
+oracle evidence. When a baseline is available, graph-worthy trajectories appear
+side by side.

--- a/apps/sqlrooms-eval-observatory/jest.config.js
+++ b/apps/sqlrooms-eval-observatory/jest.config.js
@@ -3,12 +3,14 @@ import nodeConfig from '@sqlrooms/preset-jest/node.js';
 /** @type {import('jest').Config} */
 export default {
   ...nodeConfig,
+  preset: undefined,
   moduleNameMapper: {
     ...nodeConfig.moduleNameMapper,
     '^@sqlrooms/evals/promptfoo/read-model$':
       '<rootDir>/../../packages/evals/src/promptfoo/readModel.ts',
   },
   transform: {
+    ...nodeConfig.transform,
     '^.+\\.tsx?$': [
       'ts-jest',
       {

--- a/apps/sqlrooms-eval-observatory/jest.config.js
+++ b/apps/sqlrooms-eval-observatory/jest.config.js
@@ -1,0 +1,20 @@
+import nodeConfig from '@sqlrooms/preset-jest/node.js';
+
+/** @type {import('jest').Config} */
+export default {
+  ...nodeConfig,
+  moduleNameMapper: {
+    ...nodeConfig.moduleNameMapper,
+    '^@sqlrooms/evals/promptfoo/read-model$':
+      '<rootDir>/../../packages/evals/src/promptfoo/readModel.ts',
+  },
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: 'tsconfig.app.json',
+        useESM: true,
+      },
+    ],
+  },
+};

--- a/apps/sqlrooms-eval-observatory/package.json
+++ b/apps/sqlrooms-eval-observatory/package.json
@@ -8,6 +8,7 @@
     "dev": "vite --host --port 3200",
     "lint": "eslint .",
     "preview": "vite preview",
+    "test": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -18,10 +19,13 @@
     "react-dom": "^19.2.0"
   },
   "devDependencies": {
+    "@jest/globals": "^30.3.0",
+    "@sqlrooms/preset-jest": "workspace:*",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.2.0",
     "eslint": "^9.36.0",
+    "ts-jest": "^29.4.4",
     "typescript": "^5.9.2",
     "vite": "^8.2.0"
   }

--- a/apps/sqlrooms-eval-observatory/package.json
+++ b/apps/sqlrooms-eval-observatory/package.json
@@ -11,7 +11,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@sqlrooms/cosmos": "workspace:*",
     "@sqlrooms/evals": "workspace:*",
+    "@sqlrooms/room-store": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },

--- a/apps/sqlrooms-eval-observatory/src/EvalObservatory.tsx
+++ b/apps/sqlrooms-eval-observatory/src/EvalObservatory.tsx
@@ -58,6 +58,13 @@ function Json({value}: {value: unknown}) {
   return <pre>{JSON.stringify(value, null, 2)}</pre>;
 }
 
+export function baselineIdAfterRunSelection(
+  baselineId: string | undefined,
+  selectedRunId: string,
+): string | undefined {
+  return baselineId === selectedRunId ? undefined : baselineId;
+}
+
 export function EvalObservatory() {
   const [runs, setRuns] = useState<ObservatoryRun[]>([]);
   const [error, setError] = useState('');
@@ -84,11 +91,12 @@ export function EvalObservatory() {
     () => (baseline ? createObservatoryTrajectory(baseline) : undefined),
     [baseline],
   );
-  const selectedTrajectoryNode = findTrajectoryNode(
+  const selectedTrajectoryNodeMatch = findTrajectoryNode(
     selectedNodeId,
     selectedTrajectory,
     baselineTrajectory,
   );
+  const selectedTrajectoryNode = selectedTrajectoryNodeMatch?.node;
   const grouped = useMemo(() => {
     const result = new Map<string, ObservatoryRun[]>();
     for (const run of filtered) {
@@ -313,6 +321,9 @@ export function EvalObservatory() {
                             aria-pressed={selectedId === run.id}
                             onClick={() => {
                               setSelectedId(run.id);
+                              setBaselineId((current) =>
+                                baselineIdAfterRunSelection(current, run.id),
+                              );
                               setSelectedNodeId(undefined);
                             }}
                           >
@@ -397,7 +408,8 @@ export function EvalObservatory() {
                         selectedTrajectoryNode.data.message,
                       relatedOracleEvidence: relatedOracles(
                         selectedTrajectoryNode,
-                        selectedTrajectoryNode.id.startsWith(`${selected.id}:`)
+                        selectedTrajectoryNodeMatch?.trajectory ===
+                          selectedTrajectory
                           ? selected
                           : baseline,
                       ),
@@ -444,14 +456,21 @@ export function EvalObservatory() {
   );
 }
 
-function findTrajectoryNode(
+export function findTrajectoryNode(
   nodeId: string | undefined,
   ...trajectories: Array<ObservatoryTrajectory | undefined>
-): ObservatoryTrajectoryNode | undefined {
+):
+  | {
+      node: ObservatoryTrajectoryNode;
+      trajectory: ObservatoryTrajectory;
+    }
+  | undefined {
   if (!nodeId) return undefined;
-  return trajectories
-    .flatMap((trajectory) => trajectory?.nodes ?? [])
-    .find((node) => node.id === nodeId);
+  for (const trajectory of trajectories) {
+    const node = trajectory?.nodes.find((candidate) => candidate.id === nodeId);
+    if (trajectory && node) return {node, trajectory};
+  }
+  return undefined;
 }
 
 function relatedOracles(
@@ -463,7 +482,7 @@ function relatedOracles(
     .filter((oracle) => node.relatedOracleIds.includes(oracle.oracleId));
 }
 
-function TrajectoryComparison({
+export function TrajectoryComparison({
   selected,
   baseline,
   selectedNodeId,
@@ -474,7 +493,7 @@ function TrajectoryComparison({
   selectedNodeId?: string;
   onSelectNode: (nodeId?: string) => void;
 }) {
-  if (!selected.graphRecommended && !baseline?.graphRecommended) {
+  if (!selected.graphRecommended) {
     return (
       <div className="trajectory-note">
         <strong>Graph omitted.</strong> {selected.recommendationReason}

--- a/apps/sqlrooms-eval-observatory/src/EvalObservatory.tsx
+++ b/apps/sqlrooms-eval-observatory/src/EvalObservatory.tsx
@@ -1,13 +1,22 @@
 import {
   ObservatoryExportSchema,
   compareObservatoryRuns,
+  createObservatoryTrajectory,
   filterObservatoryRuns,
   findAutomaticBaseline,
   summarizeObservatoryRuns,
   type ObservatoryRun,
   type ObservatoryRunFilters,
+  type ObservatoryTrajectory,
+  type ObservatoryTrajectoryNode,
 } from '@sqlrooms/evals/promptfoo/read-model';
-import {useMemo, useState} from 'react';
+import {lazy, Suspense, useMemo, useState} from 'react';
+
+const TrajectoryGraph = lazy(() =>
+  import('./TrajectoryGraph').then((module) => ({
+    default: module.TrajectoryGraph,
+  })),
+);
 
 type GroupKey =
   | 'none'
@@ -56,6 +65,7 @@ export function EvalObservatory() {
   const [groupBy, setGroupBy] = useState<GroupKey>('scenario');
   const [selectedId, setSelectedId] = useState<string>();
   const [baselineId, setBaselineId] = useState<string>();
+  const [selectedNodeId, setSelectedNodeId] = useState<string>();
   const filtered = useMemo(
     () => filterObservatoryRuns(runs, filters),
     [runs, filters],
@@ -66,6 +76,19 @@ export function EvalObservatory() {
     ? findAutomaticBaseline(runs, selected)
     : undefined;
   const baseline = runs.find((run) => run.id === baselineId) ?? defaultBaseline;
+  const selectedTrajectory = useMemo(
+    () => (selected ? createObservatoryTrajectory(selected) : undefined),
+    [selected],
+  );
+  const baselineTrajectory = useMemo(
+    () => (baseline ? createObservatoryTrajectory(baseline) : undefined),
+    [baseline],
+  );
+  const selectedTrajectoryNode = findTrajectoryNode(
+    selectedNodeId,
+    selectedTrajectory,
+    baselineTrajectory,
+  );
   const grouped = useMemo(() => {
     const result = new Map<string, ObservatoryRun[]>();
     for (const run of filtered) {
@@ -288,7 +311,10 @@ export function EvalObservatory() {
                             type="button"
                             className="run-select"
                             aria-pressed={selectedId === run.id}
-                            onClick={() => setSelectedId(run.id)}
+                            onClick={() => {
+                              setSelectedId(run.id);
+                              setSelectedNodeId(undefined);
+                            }}
                           >
                             {run.scenario.id}@{run.scenario.version ?? '?'}
                           </button>
@@ -325,9 +351,10 @@ export function EvalObservatory() {
                   Compare with
                   <select
                     value={baseline?.id ?? ''}
-                    onChange={(event) =>
-                      setBaselineId(event.target.value || undefined)
-                    }
+                    onChange={(event) => {
+                      setBaselineId(event.target.value || undefined);
+                      setSelectedNodeId(undefined);
+                    }}
                   >
                     <option value="">Last known good</option>
                     {runs
@@ -343,6 +370,40 @@ export function EvalObservatory() {
               {baseline && (
                 <Json value={compareObservatoryRuns(selected, baseline)} />
               )}
+              {selectedTrajectory && (
+                <TrajectoryComparison
+                  selected={selectedTrajectory}
+                  baseline={baselineTrajectory}
+                  selectedNodeId={selectedNodeId}
+                  onSelectNode={setSelectedNodeId}
+                />
+              )}
+              {selectedTrajectoryNode && (
+                <section className="trajectory-node-detail">
+                  <p className="eyebrow">Selected trajectory item</p>
+                  <h3>
+                    {selectedTrajectoryNode.kind}:{' '}
+                    {selectedTrajectoryNode.label}
+                  </h3>
+                  <Json
+                    value={{
+                      status: selectedTrajectoryNode.status,
+                      durationMs: selectedTrajectoryNode.durationMs,
+                      timestamp: selectedTrajectoryNode.timestamp,
+                      input: selectedTrajectoryNode.data.input,
+                      output: selectedTrajectoryNode.data.output,
+                      error: selectedTrajectoryNode.data.errorText,
+                      relatedOracleEvidence: relatedOracles(
+                        selectedTrajectoryNode,
+                        selectedTrajectoryNode.id.startsWith(`${selected.id}:`)
+                          ? selected
+                          : baseline,
+                      ),
+                      raw: selectedTrajectoryNode.data,
+                    }}
+                  />
+                </section>
+              )}
               <div className="detail-grid">
                 <Detail title="Prompt turns">
                   <Json value={selected.promptTurns} />
@@ -357,7 +418,11 @@ export function EvalObservatory() {
                   <Json value={selected.graderFeedback ?? null} />
                 </Detail>
                 <Detail title="Ordered events">
-                  <Json value={selected.events} />
+                  <EventList
+                    trajectory={selectedTrajectory}
+                    selectedNodeId={selectedNodeId}
+                    onSelectNode={setSelectedNodeId}
+                  />
                 </Detail>
                 <Detail title="Promptfoo spans">
                   <Json value={selected.spans} />
@@ -374,6 +439,128 @@ export function EvalObservatory() {
         </>
       )}
     </main>
+  );
+}
+
+function findTrajectoryNode(
+  nodeId: string | undefined,
+  ...trajectories: Array<ObservatoryTrajectory | undefined>
+): ObservatoryTrajectoryNode | undefined {
+  if (!nodeId) return undefined;
+  return trajectories
+    .flatMap((trajectory) => trajectory?.nodes ?? [])
+    .find((node) => node.id === nodeId);
+}
+
+function relatedOracles(
+  node: ObservatoryTrajectoryNode,
+  ...runs: Array<ObservatoryRun | undefined>
+) {
+  return runs
+    .flatMap((run) => run?.oracleResults ?? [])
+    .filter((oracle) => node.relatedOracleIds.includes(oracle.oracleId));
+}
+
+function TrajectoryComparison({
+  selected,
+  baseline,
+  selectedNodeId,
+  onSelectNode,
+}: {
+  selected: ObservatoryTrajectory;
+  baseline?: ObservatoryTrajectory;
+  selectedNodeId?: string;
+  onSelectNode: (nodeId?: string) => void;
+}) {
+  if (!selected.graphRecommended && !baseline?.graphRecommended) {
+    return (
+      <div className="trajectory-note">
+        <strong>Graph omitted.</strong> {selected.recommendationReason}
+      </div>
+    );
+  }
+  return (
+    <section className="trajectory-comparison">
+      <div className="trajectory-heading">
+        <div>
+          <p className="eyebrow">Delegated trajectory</p>
+          <h3>Linked execution graph</h3>
+        </div>
+        <p>
+          Purple links are explicit parent/child relationships. The ordered
+          event list remains the source for linear inspection.
+        </p>
+      </div>
+      <Suspense
+        fallback={<div className="trajectory-note">Loading graph…</div>}
+      >
+        <div className={`trajectory-graphs ${baseline ? 'has-baseline' : ''}`}>
+          <article>
+            <h4>Selected · {selected.runId}</h4>
+            <div className="trajectory-canvas">
+              <TrajectoryGraph
+                trajectory={selected}
+                selectedNodeId={selectedNodeId}
+                onSelectNode={onSelectNode}
+              />
+            </div>
+            <small>{selected.recommendationReason}</small>
+          </article>
+          {baseline && (
+            <article>
+              <h4>Baseline · {baseline.runId}</h4>
+              {baseline.graphRecommended ? (
+                <div className="trajectory-canvas">
+                  <TrajectoryGraph
+                    trajectory={baseline}
+                    selectedNodeId={selectedNodeId}
+                    onSelectNode={onSelectNode}
+                  />
+                </div>
+              ) : (
+                <div className="trajectory-note">
+                  Graph omitted. {baseline.recommendationReason}
+                </div>
+              )}
+              <small>{baseline.recommendationReason}</small>
+            </article>
+          )}
+        </div>
+      </Suspense>
+    </section>
+  );
+}
+
+function EventList({
+  trajectory,
+  selectedNodeId,
+  onSelectNode,
+}: {
+  trajectory?: ObservatoryTrajectory;
+  selectedNodeId?: string;
+  onSelectNode: (nodeId?: string) => void;
+}) {
+  const events = (trajectory?.nodes ?? []).filter(
+    (node) => node.sequence !== undefined,
+  );
+  if (events.length === 0) return <p className="answer">No events recorded.</p>;
+  return (
+    <ol className="event-list">
+      {events.map((node) => (
+        <li key={node.id}>
+          <button
+            type="button"
+            className={selectedNodeId === node.id ? 'selected' : ''}
+            onClick={() => onSelectNode(node.id)}
+          >
+            <span>{node.sequence}</span>
+            <strong>{node.kind}</strong>
+            <span>{node.label}</span>
+            <small>{node.status ?? 'recorded'}</small>
+          </button>
+        </li>
+      ))}
+    </ol>
   );
 }
 

--- a/apps/sqlrooms-eval-observatory/src/EvalObservatory.tsx
+++ b/apps/sqlrooms-eval-observatory/src/EvalObservatory.tsx
@@ -552,7 +552,7 @@ export function TrajectoryComparison({
   );
 }
 
-function EventList({
+export function EventList({
   trajectory,
   selectedNodeId,
   onSelectNode,
@@ -572,6 +572,7 @@ function EventList({
           <button
             type="button"
             className={selectedNodeId === node.id ? 'selected' : ''}
+            aria-pressed={selectedNodeId === node.id}
             onClick={() => onSelectNode(node.id)}
           >
             <span>{node.sequence}</span>

--- a/apps/sqlrooms-eval-observatory/src/EvalObservatory.tsx
+++ b/apps/sqlrooms-eval-observatory/src/EvalObservatory.tsx
@@ -392,7 +392,9 @@ export function EvalObservatory() {
                       timestamp: selectedTrajectoryNode.timestamp,
                       input: selectedTrajectoryNode.data.input,
                       output: selectedTrajectoryNode.data.output,
-                      error: selectedTrajectoryNode.data.errorText,
+                      error:
+                        selectedTrajectoryNode.data.errorText ??
+                        selectedTrajectoryNode.data.message,
                       relatedOracleEvidence: relatedOracles(
                         selectedTrajectoryNode,
                         selectedTrajectoryNode.id.startsWith(`${selected.id}:`)

--- a/apps/sqlrooms-eval-observatory/src/EvalObservatory.tsx
+++ b/apps/sqlrooms-eval-observatory/src/EvalObservatory.tsx
@@ -97,6 +97,12 @@ export function EvalObservatory() {
     baselineTrajectory,
   );
   const selectedTrajectoryNode = selectedTrajectoryNodeMatch?.node;
+  const selectedTrajectoryNodeOwner = findTrajectoryNodeOwner(
+    selectedTrajectoryNodeMatch,
+    selectedTrajectory,
+    selected,
+    baseline,
+  );
   const grouped = useMemo(() => {
     const result = new Map<string, ObservatoryRun[]>();
     for (const run of filtered) {
@@ -389,9 +395,11 @@ export function EvalObservatory() {
                   onSelectNode={setSelectedNodeId}
                 />
               )}
-              {selectedTrajectoryNode && (
+              {selectedTrajectoryNode && selectedTrajectoryNodeOwner && (
                 <section className="trajectory-node-detail">
-                  <p className="eyebrow">Selected trajectory item</p>
+                  <p className="eyebrow">
+                    {selectedTrajectoryNodeOwner.label} trajectory item
+                  </p>
                   <h3>
                     {selectedTrajectoryNode.kind}:{' '}
                     {selectedTrajectoryNode.label}
@@ -408,10 +416,7 @@ export function EvalObservatory() {
                         selectedTrajectoryNode.data.message,
                       relatedOracleEvidence: relatedOracles(
                         selectedTrajectoryNode,
-                        selectedTrajectoryNodeMatch?.trajectory ===
-                          selectedTrajectory
-                          ? selected
-                          : baseline,
+                        selectedTrajectoryNodeOwner.run,
                       ),
                       raw: selectedTrajectoryNode.data,
                     }}
@@ -473,7 +478,22 @@ export function findTrajectoryNode(
   return undefined;
 }
 
-function relatedOracles(
+export function findTrajectoryNodeOwner(
+  match: ReturnType<typeof findTrajectoryNode>,
+  selectedTrajectory: ObservatoryTrajectory | undefined,
+  selected: ObservatoryRun | undefined,
+  baseline: ObservatoryRun | undefined,
+):
+  | {label: 'Selected'; run: ObservatoryRun | undefined}
+  | {label: 'Baseline'; run: ObservatoryRun | undefined}
+  | undefined {
+  if (!match) return undefined;
+  return match.trajectory === selectedTrajectory
+    ? {label: 'Selected', run: selected}
+    : {label: 'Baseline', run: baseline};
+}
+
+export function relatedOracles(
   node: ObservatoryTrajectoryNode,
   ...runs: Array<ObservatoryRun | undefined>
 ) {
@@ -539,9 +559,7 @@ export function TrajectoryComparison({
                   />
                 </div>
               ) : (
-                <div className="trajectory-note">
-                  Graph omitted. {baseline.recommendationReason}
-                </div>
+                <div className="trajectory-note">Graph omitted.</div>
               )}
               <small>{baseline.recommendationReason}</small>
             </article>

--- a/apps/sqlrooms-eval-observatory/src/TrajectoryGraph.tsx
+++ b/apps/sqlrooms-eval-observatory/src/TrajectoryGraph.tsx
@@ -107,7 +107,7 @@ export function TrajectoryGraph({
       enableDrag: true,
       fitViewOnInit: true,
       fitViewDelay: 250,
-      linkArrows: true,
+      linkDefaultArrows: true,
       linkWidth: 1,
       pointSizeScale: 1,
       renderFocusedPointRing: true,

--- a/apps/sqlrooms-eval-observatory/src/TrajectoryGraph.tsx
+++ b/apps/sqlrooms-eval-observatory/src/TrajectoryGraph.tsx
@@ -1,0 +1,147 @@
+import {
+  CosmosGraph,
+  CosmosGraphControls,
+  createCosmosSlice,
+  type CosmosSliceState,
+  type GraphConfigInterface,
+} from '@sqlrooms/cosmos';
+import type {
+  ObservatoryTrajectory,
+  ObservatoryTrajectoryNode,
+} from '@sqlrooms/evals/promptfoo/read-model';
+import {
+  createBaseRoomSlice,
+  createRoomStore,
+  RoomStateProvider,
+  type BaseRoomStoreState,
+} from '@sqlrooms/room-store';
+import {useMemo, useState} from 'react';
+
+type GraphRoomState = BaseRoomStoreState & CosmosSliceState;
+
+function createGraphRoomStore() {
+  return createRoomStore<GraphRoomState>((set, get, store) => ({
+    ...createBaseRoomSlice()(set, get, store),
+    ...createCosmosSlice()(set, get, store),
+  })).roomStore;
+}
+
+function color(node: ObservatoryTrajectoryNode): readonly number[] {
+  if (node.status === 'failed' || node.status === 'error') {
+    return [0.89, 0.25, 0.2, 1];
+  }
+  if (node.kind === 'oracle') return [0.96, 0.66, 0.18, 1];
+  if (node.kind === 'nested-agent') return [0.51, 0.34, 0.91, 1];
+  if (node.kind === 'tool') return [0.15, 0.65, 0.48, 1];
+  if (node.kind === 'model') return [0.2, 0.53, 0.86, 1];
+  if (node.kind === 'run') return [0.95, 0.95, 0.9, 1];
+  return [0.55, 0.61, 0.57, 1];
+}
+
+function graphArrays(trajectory: ObservatoryTrajectory) {
+  const indexById = new Map(
+    trajectory.nodes.map((node, index) => [node.id, index]),
+  );
+  const positions: number[] = [];
+  const sizes: number[] = [];
+  const colors: number[] = [];
+  for (const [index, node] of trajectory.nodes.entries()) {
+    const sequence = node.sequence ?? index;
+    const lane =
+      node.kind === 'oracle'
+        ? 2
+        : node.kind === 'nested-agent'
+          ? -1
+          : node.kind === 'model'
+            ? -2
+            : node.kind === 'run'
+              ? 0
+              : 1;
+    positions.push(sequence * 24, lane * 22);
+    sizes.push(
+      node.kind === 'run'
+        ? 9
+        : 5 + Math.min(5, Math.log10((node.durationMs ?? 0) + 1)),
+    );
+    colors.push(...color(node));
+  }
+  const linkIndexes: number[] = [];
+  const linkColors: number[] = [];
+  for (const link of trajectory.links) {
+    const source = indexById.get(link.sourceId);
+    const target = indexById.get(link.targetId);
+    if (source === undefined || target === undefined) continue;
+    linkIndexes.push(source, target);
+    linkColors.push(
+      ...(link.kind === 'parent'
+        ? [0.67, 0.47, 0.95, 0.8]
+        : [0.58, 0.65, 0.6, 0.45]),
+    );
+  }
+  return {
+    pointPositions: new Float32Array(positions),
+    pointSizes: new Float32Array(sizes),
+    pointColors: new Float32Array(colors),
+    linkIndexes: new Float32Array(linkIndexes),
+    linkColors: new Float32Array(linkColors),
+  };
+}
+
+export function TrajectoryGraph({
+  trajectory,
+  selectedNodeId,
+  onSelectNode,
+}: {
+  trajectory: ObservatoryTrajectory;
+  selectedNodeId?: string;
+  onSelectNode: (nodeId?: string) => void;
+}) {
+  const [roomStore] = useState(createGraphRoomStore);
+  const arrays = useMemo(() => graphArrays(trajectory), [trajectory]);
+  const focusedPointIndex = trajectory.nodes.findIndex(
+    (node) => node.id === selectedNodeId,
+  );
+  const config = useMemo<GraphConfigInterface>(
+    () => ({
+      backgroundColor: '#132019',
+      enableDrag: true,
+      fitViewOnInit: true,
+      fitViewDelay: 250,
+      linkArrows: true,
+      linkWidth: 1,
+      pointSizeScale: 1,
+      renderFocusedPointRing: true,
+      focusedPointRingColor: '#ffffff',
+      renderHoveredPointRing: true,
+      hoveredPointRingColor: '#ffffff',
+      simulationGravity: 0.15,
+      simulationRepulsion: 0.7,
+      simulationLinkSpring: 0.8,
+      simulationLinkDistance: 14,
+      simulationDecay: 500,
+      onClick: (index: number | undefined) =>
+        onSelectNode(
+          index === undefined ? undefined : trajectory.nodes[index]?.id,
+        ),
+    }),
+    [onSelectNode, trajectory.nodes],
+  );
+
+  return (
+    <RoomStateProvider roomStore={roomStore}>
+      <CosmosGraph
+        config={config}
+        focusedPointIndex={
+          focusedPointIndex < 0 ? undefined : focusedPointIndex
+        }
+        {...arrays}
+        renderPointTooltip={(index) => {
+          const node = trajectory.nodes[index];
+          return node ? `${node.kind}: ${node.label}` : '';
+        }}
+      >
+        <CosmosGraphControls />
+      </CosmosGraph>
+    </RoomStateProvider>
+  );
+}

--- a/apps/sqlrooms-eval-observatory/src/__tests__/EvalObservatory.test.tsx
+++ b/apps/sqlrooms-eval-observatory/src/__tests__/EvalObservatory.test.tsx
@@ -2,6 +2,7 @@ import {describe, expect, it} from '@jest/globals';
 import type {ObservatoryTrajectory} from '@sqlrooms/evals/promptfoo/read-model';
 import {renderToStaticMarkup} from 'react-dom/server';
 import {
+  EventList,
   TrajectoryComparison,
   baselineIdAfterRunSelection,
   findTrajectoryNode,
@@ -59,5 +60,20 @@ describe('EvalObservatory trajectory comparison', () => {
     expect(markup).toContain('The ordered event list is clearer.');
     expect(markup).not.toContain('trajectory-canvas');
     expect(markup).not.toContain('Selected · selected');
+  });
+
+  it('exposes the selected event state semantically', () => {
+    const selected = trajectory('selected', true);
+    selected.nodes[0]!.sequence = 0;
+
+    const markup = renderToStaticMarkup(
+      <EventList
+        trajectory={selected}
+        selectedNodeId="selected:run"
+        onSelectNode={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain('aria-pressed="true"');
   });
 });

--- a/apps/sqlrooms-eval-observatory/src/__tests__/EvalObservatory.test.tsx
+++ b/apps/sqlrooms-eval-observatory/src/__tests__/EvalObservatory.test.tsx
@@ -1,0 +1,63 @@
+import {describe, expect, it} from '@jest/globals';
+import type {ObservatoryTrajectory} from '@sqlrooms/evals/promptfoo/read-model';
+import {renderToStaticMarkup} from 'react-dom/server';
+import {
+  TrajectoryComparison,
+  baselineIdAfterRunSelection,
+  findTrajectoryNode,
+} from '../EvalObservatory';
+
+function trajectory(
+  runId: string,
+  graphRecommended: boolean,
+): ObservatoryTrajectory {
+  return {
+    runId,
+    graphRecommended,
+    recommendationReason: graphRecommended
+      ? 'Delegation is present.'
+      : 'The ordered event list is clearer.',
+    nodes: [
+      {
+        id: `${runId}:run`,
+        kind: 'run',
+        label: runId,
+        data: {},
+        relatedOracleIds: [],
+      },
+    ],
+    links: [],
+  };
+}
+
+describe('EvalObservatory trajectory comparison', () => {
+  it('clears a baseline only when selecting that baseline run', () => {
+    expect(baselineIdAfterRunSelection('run-b', 'run-b')).toBeUndefined();
+    expect(baselineIdAfterRunSelection('run-c', 'run-b')).toBe('run-c');
+  });
+
+  it('returns the owning trajectory for node IDs containing colons', () => {
+    const selected = trajectory('foo', true);
+    const baseline = trajectory('foo:bar', true);
+
+    expect(findTrajectoryNode('foo:bar:run', selected, baseline)).toEqual({
+      node: baseline.nodes[0],
+      trajectory: baseline,
+    });
+  });
+
+  it('omits the selected graph when only the baseline recommends one', () => {
+    const markup = renderToStaticMarkup(
+      <TrajectoryComparison
+        selected={trajectory('selected', false)}
+        baseline={trajectory('baseline', true)}
+        onSelectNode={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain('Graph omitted.');
+    expect(markup).toContain('The ordered event list is clearer.');
+    expect(markup).not.toContain('trajectory-canvas');
+    expect(markup).not.toContain('Selected · selected');
+  });
+});

--- a/apps/sqlrooms-eval-observatory/src/__tests__/EvalObservatory.test.tsx
+++ b/apps/sqlrooms-eval-observatory/src/__tests__/EvalObservatory.test.tsx
@@ -1,11 +1,16 @@
 import {describe, expect, it} from '@jest/globals';
-import type {ObservatoryTrajectory} from '@sqlrooms/evals/promptfoo/read-model';
+import type {
+  ObservatoryRun,
+  ObservatoryTrajectory,
+} from '@sqlrooms/evals/promptfoo/read-model';
 import {renderToStaticMarkup} from 'react-dom/server';
 import {
   EventList,
   TrajectoryComparison,
   baselineIdAfterRunSelection,
   findTrajectoryNode,
+  findTrajectoryNodeOwner,
+  relatedOracles,
 } from '../EvalObservatory';
 
 function trajectory(
@@ -31,6 +36,23 @@ function trajectory(
   };
 }
 
+function runWithOracle(id: string, oracleId: string): ObservatoryRun {
+  return {
+    id,
+    oracleResults: [
+      {
+        oracleId,
+        kind: 'workspace-state',
+        pass: true,
+        score: 1,
+        reason: `${oracleId} passed.`,
+        evidence: {},
+        metadata: {},
+      },
+    ],
+  } as ObservatoryRun;
+}
+
 describe('EvalObservatory trajectory comparison', () => {
   it('clears a baseline only when selecting that baseline run', () => {
     expect(baselineIdAfterRunSelection('run-b', 'run-b')).toBeUndefined();
@@ -45,6 +67,50 @@ describe('EvalObservatory trajectory comparison', () => {
       node: baseline.nodes[0],
       trajectory: baseline,
     });
+  });
+
+  it('uses each trajectory owner for its label and oracle evidence', () => {
+    const selectedTrajectory = trajectory('selected', true);
+    const baselineTrajectory = trajectory('baseline', true);
+    selectedTrajectory.nodes[0]!.relatedOracleIds = ['selected-oracle'];
+    baselineTrajectory.nodes[0]!.relatedOracleIds = ['baseline-oracle'];
+    const selectedRun = runWithOracle('selected', 'selected-oracle');
+    const baselineRun = runWithOracle('baseline', 'baseline-oracle');
+    const selectedMatch = findTrajectoryNode(
+      'selected:run',
+      selectedTrajectory,
+      baselineTrajectory,
+    );
+    const baselineMatch = findTrajectoryNode(
+      'baseline:run',
+      selectedTrajectory,
+      baselineTrajectory,
+    );
+    if (!selectedMatch || !baselineMatch) {
+      throw new Error('Expected both trajectory nodes.');
+    }
+
+    const selectedOwner = findTrajectoryNodeOwner(
+      selectedMatch,
+      selectedTrajectory,
+      selectedRun,
+      baselineRun,
+    );
+    const baselineOwner = findTrajectoryNodeOwner(
+      baselineMatch,
+      selectedTrajectory,
+      selectedRun,
+      baselineRun,
+    );
+
+    expect(selectedOwner?.label).toBe('Selected');
+    expect(relatedOracles(selectedMatch.node, selectedOwner?.run)).toEqual(
+      selectedRun.oracleResults,
+    );
+    expect(baselineOwner?.label).toBe('Baseline');
+    expect(relatedOracles(baselineMatch.node, baselineOwner?.run)).toEqual(
+      baselineRun.oracleResults,
+    );
   });
 
   it('omits the selected graph when only the baseline recommends one', () => {

--- a/apps/sqlrooms-eval-observatory/src/styles.css
+++ b/apps/sqlrooms-eval-observatory/src/styles.css
@@ -256,6 +256,123 @@ code {
   padding: 2px 5px;
   border-radius: 4px;
 }
+.trajectory-comparison {
+  margin-top: 24px;
+  padding: 18px;
+  border: 1px solid #405249;
+  border-radius: 12px;
+  background: #101b16;
+}
+.trajectory-heading {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 16px;
+}
+.trajectory-heading h3,
+.trajectory-node-detail h3 {
+  margin: 5px 0 0;
+}
+.trajectory-heading > p {
+  max-width: 540px;
+  margin: 0;
+  color: #aebdb3;
+  font-size: 13px;
+}
+.trajectory-graphs {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 14px;
+}
+.trajectory-graphs.has-baseline {
+  grid-template-columns: 1fr 1fr;
+}
+.trajectory-graphs article {
+  min-width: 0;
+}
+.trajectory-graphs h4 {
+  margin: 0 0 8px;
+  font-size: 12px;
+  color: #c7d6cc;
+}
+.trajectory-graphs small {
+  display: block;
+  margin-top: 8px;
+  color: #93a49a;
+}
+.trajectory-canvas {
+  height: 360px;
+  overflow: hidden;
+  border: 1px solid #34473d;
+  border-radius: 9px;
+  background: #132019;
+}
+.trajectory-note {
+  margin-top: 20px;
+  padding: 14px;
+  border: 1px dashed #52675b;
+  border-radius: 9px;
+  color: #b7c7bd;
+}
+.trajectory-node-detail {
+  margin-top: 14px;
+  border: 1px solid #5d7467;
+  border-radius: 10px;
+  overflow: hidden;
+}
+.trajectory-node-detail > :not(pre) {
+  padding-right: 16px;
+  padding-left: 16px;
+}
+.trajectory-node-detail .eyebrow {
+  padding-top: 14px;
+}
+.trajectory-node-detail h3 {
+  padding-bottom: 14px;
+}
+.event-list {
+  max-height: 420px;
+  overflow: auto;
+  margin: 0;
+  padding: 8px;
+  list-style: none;
+  background: #101b16;
+}
+.event-list button {
+  display: grid;
+  grid-template-columns: 34px 110px minmax(140px, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 9px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: #cfe4d6;
+  text-align: left;
+  cursor: pointer;
+}
+.event-list button:hover,
+.event-list button.selected {
+  background: #294036;
+}
+.event-list small {
+  color: #8fa198;
+}
+/* @sqlrooms/cosmos uses these utility classes for its canvas shell. */
+.relative {
+  position: relative;
+}
+.absolute {
+  position: absolute;
+}
+.h-full {
+  height: 100%;
+}
+.w-full {
+  width: 100%;
+}
 @media (max-width: 1050px) {
   main {
     padding: 24px;
@@ -267,6 +384,9 @@ code {
     grid-template-columns: repeat(4, 1fr);
   }
   .detail-grid {
+    grid-template-columns: 1fr;
+  }
+  .trajectory-graphs.has-baseline {
     grid-template-columns: 1fr;
   }
 }

--- a/apps/sqlrooms-eval-observatory/vite.config.ts
+++ b/apps/sqlrooms-eval-observatory/vite.config.ts
@@ -4,4 +4,8 @@ import {defineConfig} from 'vite';
 export default defineConfig({
   plugins: [react()],
   build: {target: 'esnext'},
+  resolve: {
+    // gl-bench's browser entry is a global script; Cosmos imports its ESM entry.
+    mainFields: ['module', 'browser', 'jsnext:main', 'jsnext'],
+  },
 });

--- a/packages/deck/__tests__/createOrUpdateDeckMapResource.test.ts
+++ b/packages/deck/__tests__/createOrUpdateDeckMapResource.test.ts
@@ -85,9 +85,106 @@ describe('createOrUpdateDeckMapResource', () => {
     expect(h.writeMap).toHaveBeenCalledWith({
       mapId: 'map-1',
       title: 'Places',
-      config,
+      config: {
+        ...config,
+        datasets: {
+          places: {source: {tableName: 'main.places'}},
+        },
+      },
       selectedTable: 'main.places',
     });
+  });
+
+  test('canonicalizes table-backed dataset sources before writing', async () => {
+    const h = host({
+      findTable: jest.fn((tableName) =>
+        tableName === 'analytics.events'
+          ? {tableIdentity: '"analytics"."events"'}
+          : undefined,
+      ),
+    });
+    const transformedConfig: DeckMapConfig = {
+      ...config,
+      datasets: {
+        places: {
+          source: {
+            tableName: 'analytics.events',
+            transformSql:
+              'SELECT * FROM __sqlrooms_source WHERE longitude IS NOT NULL',
+          },
+        },
+      },
+    };
+
+    await createOrUpdateDeckMapResource(h, {
+      blockDocumentId: 'worksheet-1',
+      config: transformedConfig,
+      createMapId: () => 'map-1',
+    });
+
+    expect(h.writeMap).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          datasets: {
+            places: {
+              source: {
+                tableName: '"analytics"."events"',
+                transformSql:
+                  'SELECT * FROM __sqlrooms_source WHERE longitude IS NOT NULL',
+              },
+            },
+          },
+        }),
+      }),
+    );
+  });
+
+  test('rejects table transforms that bypass the reserved source relation', async () => {
+    const h = host();
+    const invalidTransformConfig: DeckMapConfig = {
+      ...config,
+      datasets: {
+        places: {
+          source: {
+            tableName: 'places',
+            transformSql: 'SELECT * FROM places',
+          },
+        },
+      },
+    };
+
+    await expect(
+      createOrUpdateDeckMapResource(h, {
+        blockDocumentId: 'worksheet-1',
+        config: invalidTransformConfig,
+        createMapId: () => 'map-1',
+      }),
+    ).rejects.toThrow(
+      'Deck table dataset transformSql must reference __sqlrooms_source.',
+    );
+    expect(h.createMapBlock).not.toHaveBeenCalled();
+    expect(h.writeMap).not.toHaveBeenCalled();
+  });
+
+  test('rejects unresolved ambiguous dataset table sources', async () => {
+    const h = host({findTable: jest.fn(() => undefined)});
+    const ambiguousConfig: DeckMapConfig = {
+      ...config,
+      datasets: {
+        places: {source: {tableName: 'events'}},
+      },
+    };
+
+    await expect(
+      createOrUpdateDeckMapResource(h, {
+        blockDocumentId: 'worksheet-1',
+        config: ambiguousConfig,
+        tableName: 'analytics.events',
+        createMapId: () => 'map-1',
+      }),
+    ).rejects.toThrow('Dataset "places" table "events" was not found.');
+    expect(h.createMapBlock).not.toHaveBeenCalled();
+    expect(h.writeMap).not.toHaveBeenCalled();
   });
 
   test('uses a requested map id when create mode recovers a missing block', async () => {

--- a/packages/deck/src/createOrUpdateDeckMapResource.ts
+++ b/packages/deck/src/createOrUpdateDeckMapResource.ts
@@ -1,5 +1,6 @@
 import type {DeckMapResource} from './DeckMapsSlice';
-import type {DeckMapConfig} from './mapConfig';
+import {createDeckTableDatasetSql} from './datasets/tableDatasetSql';
+import {isDeckMapTableDatasetSource, type DeckMapConfig} from './mapConfig';
 import {
   getFirstDatasetSourceTableName,
   hasSqlOnlyDatasetSource,
@@ -79,6 +80,37 @@ export type CreateOrUpdateDeckMapResourceResult = {
   created: boolean;
 };
 
+function resolveTableDatasetSources(
+  host: Pick<CreateOrUpdateDeckMapResourceHost, 'findTable'>,
+  config: DeckMapConfig,
+): DeckMapConfig {
+  let changed = false;
+  const datasets = Object.fromEntries(
+    Object.entries(config.datasets).map(([datasetId, dataset]) => {
+      const source = dataset.source;
+      if (!isDeckMapTableDatasetSource(source)) return [datasetId, dataset];
+
+      const table = host.findTable(source.tableName);
+      if (!table) {
+        throw new Error(
+          `Dataset "${datasetId}" table "${source.tableName}" was not found.`,
+        );
+      }
+      const canonicalSource = {
+        ...source,
+        tableName: table.tableIdentity,
+      };
+      createDeckTableDatasetSql(canonicalSource);
+      if (canonicalSource.tableName === source.tableName) {
+        return [datasetId, dataset];
+      }
+      changed = true;
+      return [datasetId, {...dataset, source: canonicalSource}];
+    }),
+  );
+  return changed ? {...config, datasets} : config;
+}
+
 /** Resource-native worksheet map orchestration with metadata-after-map-write ordering. */
 export async function createOrUpdateDeckMapResource(
   host: CreateOrUpdateDeckMapResourceHost,
@@ -110,9 +142,10 @@ export async function createOrUpdateDeckMapResource(
         replaceDatasets: params.replaceDatasets,
       })
     : params.config;
-  assertDeckMapResourceConfig(preparedConfig);
+  const resolvedConfig = resolveTableDatasetSources(host, preparedConfig);
+  assertDeckMapResourceConfig(resolvedConfig);
   const tableName =
-    requestedTable ?? getFirstDatasetSourceTableName(preparedConfig);
+    requestedTable ?? getFirstDatasetSourceTableName(resolvedConfig);
   if (
     (params.requireTableNameForSqlOnlyUpdate ?? true) &&
     existingBlock &&
@@ -149,7 +182,7 @@ export async function createOrUpdateDeckMapResource(
   await host.writeMap({
     mapId: block.mapId,
     title,
-    config: preparedConfig,
+    config: resolvedConfig,
     selectedTable: table?.tableIdentity,
   });
   if (existingBlock) {

--- a/packages/evals/README.md
+++ b/packages/evals/README.md
@@ -21,6 +21,10 @@ adapter uses Node's built-in SQLite API.
   a side-effect-free Markdown report renderer. The adapter validates known
   tables and columns, preserves unknown metadata, and exports portable JSON.
   Promptfoo remains a storage/runner boundary, not the core package interface.
+- The observatory trajectory model derives ordered and explicit parent/child
+  relationships from normalized SQLRooms run evidence, never Promptfoo spans.
+  It also reports whether a delegated run benefits from a graph or is clearer
+  as an ordered list.
 - The scripted model implements the AI SDK v3 language-model contract and can
   assert prompt/tool wiring without credentials or network access.
 

--- a/packages/evals/src/__tests__/trajectory.test.ts
+++ b/packages/evals/src/__tests__/trajectory.test.ts
@@ -1,0 +1,105 @@
+import {describe, expect, it} from '@jest/globals';
+import type {ObservatoryRun} from '../promptfoo/readModel';
+import {createObservatoryTrajectory} from '../promptfoo/trajectory';
+
+function run(events: ObservatoryRun['events']): ObservatoryRun {
+  return {
+    id: 'run-1',
+    evalId: 'eval-1',
+    createdAt: '2026-08-19T12:00:00.000Z',
+    scenario: {id: 'worksheet.create-chart-map', version: 1, repetition: 0},
+    profile: {name: 'worksheet-charts-maps', version: 1},
+    repository: {commitSha: 'abc123'},
+    model: {provider: 'openrouter', modelId: 'deepseek'},
+    status: 'failed',
+    counts: {tools: 1, nestedAgents: 1, errors: 0},
+    promptTurns: [{id: 'create', input: 'Create a worksheet.'}],
+    answer: 'Done.',
+    oracleResults: [
+      {
+        oracleId: 'workspace-shape',
+        kind: 'workspace-state',
+        pass: false,
+        score: 0,
+        reason: 'Missing map.',
+        evidence: {},
+        metadata: {},
+      },
+    ],
+    events,
+    spans: [
+      {
+        traceId: 'trace-1',
+        spanId: 'span-1',
+        name: 'promptfoo-only-span',
+        startTime: 1,
+        attributes: {},
+      },
+    ],
+    unknownMetadata: {},
+  };
+}
+
+describe('observatory trajectory read model', () => {
+  it('links explicit nested tool relationships without consuming spans', () => {
+    const trajectory = createObservatoryTrajectory(
+      run([
+        {
+          sequence: 0,
+          timestamp: '2026-08-19T12:00:00.100Z',
+          type: 'nested-agent',
+          name: 'worksheet-agent',
+          data: {toolCallId: 'parent', state: 'complete'},
+        },
+        {
+          sequence: 1,
+          timestamp: '2026-08-19T12:00:00.200Z',
+          type: 'tool',
+          name: 'create_chart',
+          data: {
+            toolCallId: 'child',
+            parentToolCallId: 'parent',
+            durationMs: 42,
+            input: {title: 'Metric'},
+          },
+        },
+      ]),
+    );
+
+    expect(trajectory.graphRecommended).toBe(true);
+    expect(trajectory.links).toContainEqual({
+      sourceId: 'run-1:event:0',
+      targetId: 'run-1:event:1',
+      kind: 'parent',
+    });
+    expect(trajectory.nodes).toEqual(
+      expect.not.arrayContaining([
+        expect.objectContaining({label: 'promptfoo-only-span'}),
+      ]),
+    );
+    expect(trajectory.nodes).toContainEqual(
+      expect.objectContaining({
+        id: 'run-1:event:1',
+        durationMs: 42,
+        data: expect.objectContaining({input: {title: 'Metric'}}),
+      }),
+    );
+  });
+
+  it('keeps simple runs in the ordered-list workflow', () => {
+    const trajectory = createObservatoryTrajectory(
+      run([
+        {
+          sequence: 0,
+          timestamp: '2026-08-19T12:00:00.100Z',
+          type: 'tool',
+          name: 'list_tables',
+          data: {},
+        },
+      ]),
+    );
+
+    expect(trajectory.graphRecommended).toBe(false);
+    expect(trajectory.recommendationReason).toContain('ordered event list');
+  });
+});

--- a/packages/evals/src/evidence.ts
+++ b/packages/evals/src/evidence.ts
@@ -1,7 +1,7 @@
 import {z} from 'zod';
-import {JsonObjectSchema, JsonValueSchema} from './json';
-import {OracleResultSchema} from './oracle';
-import {ScenarioIdSchema} from './scenario';
+import {JsonObjectSchema, JsonValueSchema} from './json.js';
+import {OracleResultSchema} from './oracle.js';
+import {ScenarioIdSchema} from './scenario.js';
 
 /** Current version of the durable run-evidence envelope. */
 export const RUN_EVIDENCE_SCHEMA_VERSION = 1 as const;

--- a/packages/evals/src/index.ts
+++ b/packages/evals/src/index.ts
@@ -5,8 +5,8 @@
  * @packageDocumentation
  */
 
-export * from './evidence';
-export * from './json';
-export * from './oracle';
-export * from './scenario';
-export * from './scriptedModel';
+export * from './evidence.js';
+export * from './json.js';
+export * from './oracle.js';
+export * from './scenario.js';
+export * from './scriptedModel.js';

--- a/packages/evals/src/oracle.ts
+++ b/packages/evals/src/oracle.ts
@@ -1,7 +1,7 @@
 import {z} from 'zod';
-import type {JsonObject, JsonValue} from './json';
-import {JsonObjectSchema, JsonValueSchema} from './json';
-import type {ScenarioDefinition} from './scenario';
+import type {JsonObject, JsonValue} from './json.js';
+import {JsonObjectSchema, JsonValueSchema} from './json.js';
+import type {ScenarioDefinition} from './scenario.js';
 
 /** Supported evaluator-neutral oracle categories. */
 export const OracleKindSchema = z.enum([

--- a/packages/evals/src/promptfoo/calibration.ts
+++ b/packages/evals/src/promptfoo/calibration.ts
@@ -1,4 +1,4 @@
-import type {ObservatoryRun} from './readModel';
+import type {ObservatoryRun} from './readModel.js';
 
 /** Failure classes used while calibrating behavioral canaries. */
 export type EvalFailureClass =

--- a/packages/evals/src/promptfoo/export.ts
+++ b/packages/evals/src/promptfoo/export.ts
@@ -1,7 +1,7 @@
 import {mkdir, writeFile} from 'node:fs/promises';
 import {dirname} from 'node:path';
-import {renderObservatoryMarkdown} from './markdown';
-import {exportPromptfooSqlite} from './sqlite';
+import {renderObservatoryMarkdown} from './markdown.js';
+import {exportPromptfooSqlite} from './sqlite.js';
 
 function argument(name: string): string | undefined {
   const index = process.argv.indexOf(name);

--- a/packages/evals/src/promptfoo/index.ts
+++ b/packages/evals/src/promptfoo/index.ts
@@ -1,12 +1,12 @@
-import type {OracleResult} from '../oracle';
-import {OracleResultSchema, summarizeOracleResults} from '../oracle';
-import type {RunEvidence} from '../evidence';
-import {RunEvidenceSchema} from '../evidence';
+import type {OracleResult} from '../oracle.js';
+import {OracleResultSchema, summarizeOracleResults} from '../oracle.js';
+import type {RunEvidence} from '../evidence.js';
+import {RunEvidenceSchema} from '../evidence.js';
 
-export * from './readModel';
-export * from './calibration';
-export * from './markdown';
-export * from './sqlite';
+export * from './readModel.js';
+export * from './calibration.js';
+export * from './markdown.js';
+export * from './sqlite.js';
 
 /** Promptfoo-compatible provider response without a Promptfoo dependency. */
 export type PromptfooProviderResponse = {

--- a/packages/evals/src/promptfoo/markdown.ts
+++ b/packages/evals/src/promptfoo/markdown.ts
@@ -1,4 +1,4 @@
-import {summarizeObservatoryRuns, type ObservatoryExport} from './readModel';
+import {summarizeObservatoryRuns, type ObservatoryExport} from './readModel.js';
 
 function aggregate(values: readonly string[], fallback: string): string {
   const distinct = [...new Set(values)];

--- a/packages/evals/src/promptfoo/readModel.ts
+++ b/packages/evals/src/promptfoo/readModel.ts
@@ -1,9 +1,9 @@
 import {z} from 'zod';
-import {JsonObjectSchema, JsonValueSchema} from '../json';
-import {OracleResultSchema} from '../oracle';
-import {RunEvidenceEventSchema} from '../evidence';
+import {JsonObjectSchema, JsonValueSchema} from '../json.js';
+import {OracleResultSchema} from '../oracle.js';
+import {RunEvidenceEventSchema} from '../evidence.js';
 
-export * from './trajectory';
+export * from './trajectory.js';
 
 /** Promptfoo-independent span retained for run diagnosis. */
 export const ObservatorySpanSchema = z.looseObject({

--- a/packages/evals/src/promptfoo/readModel.ts
+++ b/packages/evals/src/promptfoo/readModel.ts
@@ -3,6 +3,8 @@ import {JsonObjectSchema, JsonValueSchema} from '../json';
 import {OracleResultSchema} from '../oracle';
 import {RunEvidenceEventSchema} from '../evidence';
 
+export * from './trajectory';
+
 /** Promptfoo-independent span retained for run diagnosis. */
 export const ObservatorySpanSchema = z.looseObject({
   traceId: z.string(),

--- a/packages/evals/src/promptfoo/sqlite.ts
+++ b/packages/evals/src/promptfoo/sqlite.ts
@@ -1,12 +1,12 @@
 import {DatabaseSync} from 'node:sqlite';
-import {RunEvidenceSchema, type RunEvidence} from '../evidence';
-import type {JsonObject, JsonValue} from '../json';
+import {RunEvidenceSchema, type RunEvidence} from '../evidence.js';
+import type {JsonObject, JsonValue} from '../json.js';
 import {
   ObservatoryExportSchema,
   ObservatoryRunSchema,
   type ObservatoryExport,
   type ObservatoryRun,
-} from './readModel';
+} from './readModel.js';
 
 type SqlRow = Record<string, unknown>;
 

--- a/packages/evals/src/promptfoo/trajectory.ts
+++ b/packages/evals/src/promptfoo/trajectory.ts
@@ -1,5 +1,5 @@
-import type {JsonObject, JsonValue} from '../json';
-import type {ObservatoryRun} from './readModel';
+import type {JsonObject, JsonValue} from '../json.js';
+import type {ObservatoryRun} from './readModel.js';
 
 /** Semantic node in a runner-independent observatory trajectory. */
 export type ObservatoryTrajectoryNode = {

--- a/packages/evals/src/promptfoo/trajectory.ts
+++ b/packages/evals/src/promptfoo/trajectory.ts
@@ -1,0 +1,171 @@
+import type {JsonObject, JsonValue} from '../json';
+import type {ObservatoryRun} from './readModel';
+
+/** Semantic node in a runner-independent observatory trajectory. */
+export type ObservatoryTrajectoryNode = {
+  id: string;
+  kind:
+    | 'run'
+    | 'oracle'
+    | 'model'
+    | 'tool'
+    | 'nested-agent'
+    | 'approval'
+    | 'error'
+    | 'mutation';
+  label: string;
+  status?: string;
+  sequence?: number;
+  timestamp?: string;
+  durationMs?: number;
+  data: JsonObject;
+  relatedOracleIds: string[];
+};
+
+/** Semantic relationship in a runner-independent observatory trajectory. */
+export type ObservatoryTrajectoryLink = {
+  sourceId: string;
+  targetId: string;
+  kind: 'contains' | 'order' | 'parent' | 'assertion';
+};
+
+/** Trajectory view derived only from normalized SQLRooms run evidence. */
+export type ObservatoryTrajectory = {
+  runId: string;
+  nodes: ObservatoryTrajectoryNode[];
+  links: ObservatoryTrajectoryLink[];
+  graphRecommended: boolean;
+  recommendationReason: string;
+};
+
+function stringValue(value: JsonValue | undefined): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function numberValue(value: JsonValue | undefined): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function oracleIds(data: JsonObject): string[] {
+  const one = stringValue(data.oracleId);
+  const many = Array.isArray(data.oracleIds)
+    ? data.oracleIds.filter(
+        (value): value is string => typeof value === 'string',
+      )
+    : [];
+  return [...new Set([...(one ? [one] : []), ...many])];
+}
+
+/**
+ * Builds an optional trajectory graph from the normalized run model.
+ *
+ * Promptfoo spans are intentionally excluded. Parent links are emitted only
+ * when SQLRooms evidence carries explicit tool-call identities.
+ */
+export function createObservatoryTrajectory(
+  run: ObservatoryRun,
+): ObservatoryTrajectory {
+  const runNodeId = `${run.id}:run`;
+  const orderedEvents = [...run.events].sort(
+    (left, right) => left.sequence - right.sequence,
+  );
+  const nodes: ObservatoryTrajectoryNode[] = [
+    {
+      id: runNodeId,
+      kind: 'run',
+      label: run.scenario.id,
+      status: run.status,
+      data: {
+        scenarioVersion: run.scenario.version ?? null,
+        repetition: run.scenario.repetition ?? null,
+      },
+      relatedOracleIds: run.oracleResults.map((result) => result.oracleId),
+    },
+  ];
+  const links: ObservatoryTrajectoryLink[] = [];
+  const nodeIdByToolCall = new Map<string, string>();
+
+  for (const event of orderedEvents) {
+    const id = `${run.id}:event:${event.sequence}`;
+    const toolCallId = stringValue(event.data.toolCallId);
+    if (toolCallId) nodeIdByToolCall.set(toolCallId, id);
+    nodes.push({
+      id,
+      kind: event.type,
+      label: event.name ?? event.type,
+      status:
+        stringValue(event.data.state) ??
+        (event.type === 'error' || stringValue(event.data.errorText)
+          ? 'error'
+          : undefined),
+      sequence: event.sequence,
+      timestamp: event.timestamp,
+      durationMs: numberValue(event.data.durationMs),
+      data: event.data,
+      relatedOracleIds: oracleIds(event.data),
+    });
+  }
+
+  const eventNodes = nodes.filter(
+    (node): node is ObservatoryTrajectoryNode & {sequence: number} =>
+      node.sequence !== undefined,
+  );
+  if (eventNodes[0]) {
+    links.push({
+      sourceId: runNodeId,
+      targetId: eventNodes[0].id,
+      kind: 'contains',
+    });
+  }
+  for (let index = 1; index < eventNodes.length; index += 1) {
+    links.push({
+      sourceId: eventNodes[index - 1]!.id,
+      targetId: eventNodes[index]!.id,
+      kind: 'order',
+    });
+  }
+  for (const node of eventNodes) {
+    const parentToolCallId = stringValue(node.data.parentToolCallId);
+    const parentId = parentToolCallId
+      ? nodeIdByToolCall.get(parentToolCallId)
+      : undefined;
+    if (parentId) {
+      links.push({sourceId: parentId, targetId: node.id, kind: 'parent'});
+    }
+  }
+
+  for (const result of run.oracleResults) {
+    const id = `${run.id}:oracle:${result.oracleId}`;
+    nodes.push({
+      id,
+      kind: 'oracle',
+      label: result.oracleId,
+      status: result.pass ? 'passed' : 'failed',
+      data: {
+        reason: result.reason,
+        score: result.score,
+        evidence: result.evidence,
+        metadata: result.metadata,
+      },
+      relatedOracleIds: [result.oracleId],
+    });
+    links.push({sourceId: runNodeId, targetId: id, kind: 'assertion'});
+  }
+
+  const nestedCount = eventNodes.filter(
+    (node) => node.kind === 'nested-agent',
+  ).length;
+  const parentCount = links.filter((link) => link.kind === 'parent').length;
+  const graphRecommended = nestedCount > 0 || parentCount > 0;
+  return {
+    runId: run.id,
+    nodes,
+    links,
+    graphRecommended,
+    recommendationReason: graphRecommended
+      ? `${nestedCount} nested-agent event(s) and ${parentCount} explicit parent link(s) make delegation difficult to read linearly.`
+      : 'No nested or delegated trajectory is present; the ordered event list is clearer.',
+  };
+}

--- a/packages/evals/src/scenario.ts
+++ b/packages/evals/src/scenario.ts
@@ -1,5 +1,5 @@
 import {z} from 'zod';
-import {JsonObjectSchema} from './json';
+import {JsonObjectSchema} from './json.js';
 
 /** Stable scenario identifier format used in run history. */
 export const ScenarioIdSchema = z

--- a/packages/evals/src/scriptedModel.ts
+++ b/packages/evals/src/scriptedModel.ts
@@ -7,7 +7,7 @@ import type {
   LanguageModelV3StreamPart,
   LanguageModelV3Usage,
 } from '@ai-sdk/provider';
-import type {JsonObject} from './json';
+import type {JsonObject} from './json.js';
 
 /** One text or tool-call output emitted by a scripted model step. */
 export type ScriptedModelContent =

--- a/packages/evals/tsconfig.json
+++ b/packages/evals/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "@sqlrooms/preset-typescript/base.json",
   "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "outDir": "dist"
   },
   "include": ["src"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,6 +365,12 @@ importers:
         specifier: 19.2.1
         version: 19.2.1(react@19.2.1)
     devDependencies:
+      '@jest/globals':
+        specifier: ^30.3.0
+        version: 30.4.1
+      '@sqlrooms/preset-jest':
+        specifier: workspace:*
+        version: link:../../packages/preset-jest
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -377,6 +383,9 @@ importers:
       eslint:
         specifier: ^9.36.0
         version: 9.39.4(jiti@2.7.0)
+      ts-jest:
+        specifier: ^29.4.4
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@24.12.4))(typescript@5.9.3)
       typescript:
         specifier: 5.9.3
         version: 5.9.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -349,9 +349,15 @@ importers:
 
   apps/sqlrooms-eval-observatory:
     dependencies:
+      '@sqlrooms/cosmos':
+        specifier: workspace:*
+        version: link:../../packages/cosmos
       '@sqlrooms/evals':
         specifier: workspace:*
         version: link:../../packages/evals
+      '@sqlrooms/room-store':
+        specifier: workspace:*
+        version: link:../../packages/room-store
       react:
         specifier: 19.2.1
         version: 19.2.1


### PR DESCRIPTION
## Summary

- add a Promptfoo-independent trajectory read model derived from normalized SQLRooms evidence
- render nested/delegated runs with a lazy-loaded `@sqlrooms/cosmos` graph
- link run-table, ordered-event, graph, and exact node-detail selection
- compare graph-worthy selected and baseline runs side by side
- keep simple runs in the ordered list and preserve Promptfoo spans as separate raw detail

## Stack

- Base: #864 (Stages 4–8)
- This PR: Stage 9 implementation

## Validation

- full pre-push typecheck and test suite
- `pnpm knip`
- `pnpm check-circular-deps`
- focused evals/observatory lint, typecheck, tests, and builds
- local production build rendered with no browser console warnings or errors

## Evidence boundary

This draft intentionally leaves the empirical Stage 9 claims open. Real Stage 8 and live-session debugging evidence is still required before stabilizing trajectory semantics or claiming that the graph materially shortens diagnosis. No Promptfoo span is converted into a graph node or edge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added interactive trajectory graphs with node selection, execution details, oracle evidence, and baseline comparisons.
  - Added structured reporting for nested agents and parent-child tool relationships.
  - Added OpenRouter cost tracking with reported and estimated usage costs.
  - Improved CLI guidance for creating and editing Worksheets, including chart and map handling.

- **Bug Fixes**
  - Validated and canonicalized map dataset table references.

- **Documentation**
  - Updated evaluation setup, environment configuration, and trajectory reporting guidance.

- **Tests**
  - Expanded coverage for Worksheets, maps, trajectories, costs, and agent-tool behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->