### PR TITLE
fix(artifacts,ai-config): give Node consumers a React-free entry point

### DIFF
--- a/packages/ai-config/src/migration/AnalysisSession-v0.25.0.ts
+++ b/packages/ai-config/src/migration/AnalysisSession-v0.25.0.ts
@@ -96,7 +96,7 @@ function migrateStreamMessage(streamMessage: unknown) {
   }
 
   const parts = (streamMessage as {parts: Record<string, unknown>[]}).parts;
-  const newParts = [];
+  const newParts: Record<string, unknown>[] = [];
 
   for (const part of parts) {
     if (part.type === 'text') {

--- a/packages/artifacts/README.md
+++ b/packages/artifacts/README.md
@@ -154,6 +154,37 @@ The artifact shell still owns workspace metadata such as id, title, tabs,
 current selection, and AI context. The stateful block definition owns the
 feature-specific rendering and backing-state lifecycle.
 
+## Entry Points
+
+| Import                       | Contains                                                                                                            | Pulls React |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `@sqlrooms/artifacts`        | Slices, components, artifact types — the full package                                                               | Yes         |
+| `@sqlrooms/artifacts/config` | Serializable shapes only: `ArtifactMetadata`, `ArtifactsSliceConfig`, `ArtifactType`, `ArtifactSessionLink(Schema)` | No          |
+| `@sqlrooms/artifacts/ai`     | Assistant tools for artifact context                                                                                | No          |
+
+Prefer `@sqlrooms/artifacts/config` when you only need the persisted data model
+and want to stay out of the React dependency — a test runner, a config
+migration, or server-side code:
+
+```ts
+import {
+  ArtifactMetadata,
+  ArtifactSessionLinkSchema,
+} from '@sqlrooms/artifacts/config';
+
+const link = ArtifactSessionLinkSchema.parse(row);
+```
+
+Import these shapes from `/config` rather than from an internal module path such
+as `@sqlrooms/artifacts/dist/ArtifactsSliceConfig`. The subpath is the supported
+surface and will keep working when the underlying modules are reorganized;
+internal paths have moved before.
+
+All entries target bundlers and transpilers (`moduleResolution: "bundler"`), so
+emitted re-exports are extensionless. Being React-free is what makes `/config`
+and `/ai` usable from Node toolchains, not native `node` resolution of the
+published files.
+
 ## AI Context Tools
 
 `@sqlrooms/artifacts/ai` provides reusable assistant tools for artifact context:

--- a/packages/artifacts/package.json
+++ b/packages/artifacts/package.json
@@ -15,6 +15,11 @@
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
+    "./config": {
+      "types": "./dist/config.d.ts",
+      "import": "./dist/config.js",
+      "default": "./dist/config.js"
+    },
     "./ai": {
       "types": "./dist/ai/index.d.ts",
       "import": "./dist/ai/index.js",

--- a/packages/artifacts/src/ArtifactsSliceConfig.ts
+++ b/packages/artifacts/src/ArtifactsSliceConfig.ts
@@ -1,8 +1,10 @@
 import {z} from 'zod';
 
+/** Discriminator for an artifact's kind, e.g. `"map"` or `"worksheet"`. */
 export const ArtifactType = z.string();
 export type ArtifactType = z.infer<typeof ArtifactType>;
 
+/** Identity and display fields persisted for a single artifact. */
 export const ArtifactMetadata = z.object({
   id: z.string(),
   type: ArtifactType,
@@ -10,6 +12,7 @@ export const ArtifactMetadata = z.object({
 });
 export type ArtifactMetadata = z.infer<typeof ArtifactMetadata>;
 
+/** Serializable artifacts slice state: the artifacts and their ordering. */
 export const ArtifactsSliceConfig = z.object({
   artifactsById: z.record(z.string(), ArtifactMetadata).default({}),
   artifactOrder: z.array(z.string()).default([]),

--- a/packages/artifacts/src/config.ts
+++ b/packages/artifacts/src/config.ts
@@ -2,19 +2,31 @@
  * React-free entry point for the artifact data model.
  *
  * The package root re-exports slices and components and therefore pulls in
- * React, so a Node consumer that only needs the serializable shapes — a test
- * runner, a migration script, a server-side tool — has to either parse the ESM
- * build or reach into `src/…` internals. Reaching in is brittle: these types
- * have already moved between modules once, silently breaking importers.
+ * React, so a consumer that only needs the serializable shapes — a test runner,
+ * a migration script, a server-side tool — previously had to reach into
+ * `src/…` internals. That is brittle: these types have already moved between
+ * modules once, silently breaking importers that had reached in.
  *
  * This entry is that stable, dependency-light surface. It must not import
  * anything beyond zod and sibling schema modules.
+ *
+ * Resolution is the same as every other entry in this package: the build
+ * targets bundlers and transpilers (`moduleResolution: "bundler"`), so emitted
+ * re-exports are extensionless and native Node ESM cannot resolve them
+ * directly. Being React-free is what makes this entry usable from Node
+ * toolchains; making the whole package resolvable by bare `node` is a separate,
+ * package-wide build question.
  */
 export {
   ArtifactMetadata,
   ArtifactsSliceConfig,
   ArtifactType,
 } from './ArtifactsSliceConfig';
+/**
+ * Type-only aliases. Each schema above is exported as both a value and a type
+ * under one name; these `*Type` aliases let a consumer name the inferred type
+ * without importing the runtime schema.
+ */
 export type {
   ArtifactMetadata as ArtifactMetadataType,
   ArtifactsSliceConfig as ArtifactsSliceConfigType,

--- a/packages/artifacts/src/config.ts
+++ b/packages/artifacts/src/config.ts
@@ -1,0 +1,25 @@
+/**
+ * React-free entry point for the artifact data model.
+ *
+ * The package root re-exports slices and components and therefore pulls in
+ * React, so a Node consumer that only needs the serializable shapes — a test
+ * runner, a migration script, a server-side tool — has to either parse the ESM
+ * build or reach into `src/…` internals. Reaching in is brittle: these types
+ * have already moved between modules once, silently breaking importers.
+ *
+ * This entry is that stable, dependency-light surface. It must not import
+ * anything beyond zod and sibling schema modules.
+ */
+export {
+  ArtifactMetadata,
+  ArtifactsSliceConfig,
+  ArtifactType,
+} from './ArtifactsSliceConfig';
+export type {
+  ArtifactMetadata as ArtifactMetadataType,
+  ArtifactsSliceConfig as ArtifactsSliceConfigType,
+  ArtifactType as ArtifactTypeType,
+} from './ArtifactsSliceConfig';
+
+export {ArtifactSessionLinkSchema} from './ai/ArtifactSessionLink';
+export type {ArtifactSessionLink} from './ai/ArtifactSessionLink';


### PR DESCRIPTION
## Summary

Two small changes so a Node consumer can import the artifact data model without parsing the ESM build or reaching into `src/…` internals.

## `ai-config`: fix an inferred `never[]`

`const newParts = []` in the v0.25.0 migration infers `never[]`, so both `newParts.push(...)` calls below it fail:

```
src/migration/AnalysisSession-v0.25.0.ts(104,21): error TS2345:
  Argument of type '{ type: string; text: unknown; }' is not assignable to parameter of type 'never'.
src/migration/AnalysisSession-v0.25.0.ts(129,23): error TS2345: ...
```

The package itself compiles because the file is only typechecked in isolation. But any project that pulls this source into its own program — a monorepo host mapping the package to source, say — inherits two errors it cannot fix from the outside. One annotation resolves both.

## `artifacts`: add a React-free `./config` subpath

`ArtifactMetadata`, `ArtifactsSliceConfig`, `ArtifactType` and `ArtifactSessionLink(Schema)` only import zod. But the package root also re-exports slices and components, so it pulls React, and today the only way to reach those shapes from Node is to import an internal module path.

That's brittle in a way that has already bitten: `ArtifactSessionLink` moved out of `ArtifactsSliceConfig`, and importers that had reached in broke silently — the symbol resolved to `undefined` rather than failing at import.

`src/ai/` is already React-free and needs no change. This gives the config layer the same property, so both are usable from a test runner, a migration script, or a server-side tool.

## Why no CJS build

A dual build would fix the "cannot parse ESM" half, but not the reason a Node consumer can't use the root entry in the first place — React. Subpaths address the actual cause, so I've left the build alone.

## Verification

- Both packages typecheck; `ai-config` tests pass.
- `tsc` emits `dist/config.js` and `dist/config.d.ts`, so the subpath resolves from the published build.
- Downstream check: a host that was carrying **three** hand-written re-export shims to work around exactly this deleted all three and kept its suite green — 38 suites / 441 tests, typecheck clean.

Note: `artifacts`' own jest suites fail to parse on `main` and still do here. Pre-existing and deliberately untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public configuration export for artifact metadata, slice settings, artifact types, and session links.
  * Configuration utilities can now be accessed without loading React-specific functionality.

* **Refactor**
  * Improved type clarity in legacy analysis-session migration logic without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->