### PR TITLE
fix(ai): keep chat content responsive when panels shrink

### DIFF
--- a/packages/ai-core/__tests__/ChatMessagesContainer.test.tsx
+++ b/packages/ai-core/__tests__/ChatMessagesContainer.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * @jest-environment jsdom
+ */
+import React, {act} from 'react';
+import {jest} from '@jest/globals';
+import {createRoot, type Root} from 'react-dom/client';
+import {RoomStateProvider} from '@sqlrooms/room-store';
+import {createStore} from 'zustand';
+import {TransformStream} from 'node:stream/web';
+import type {ChatSessionSchema} from '@sqlrooms/ai-config';
+import type {AiSliceState} from '../src/AiSlice';
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+Object.assign(globalThis, {
+  TransformStream,
+  ResizeObserver: ResizeObserverStub,
+  IS_REACT_ACT_ENVIRONMENT: true,
+  requestAnimationFrame: (callback: FrameRequestCallback) => {
+    callback(0);
+    return 1;
+  },
+  cancelAnimationFrame: () => {},
+});
+
+const {ChatMessagesContainer} =
+  await import('../src/components/ChatMessagesContainer');
+
+function renderMessages() {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const session: ChatSessionSchema = {
+    id: 'session-1',
+    name: 'Test chat',
+    modelProvider: 'openai',
+    model: 'gpt-4.1',
+    createdAt: new Date(),
+    uiMessages: [],
+    messagesRevision: 0,
+    prompt: '',
+    isRunning: false,
+  };
+  const store = createStore<AiSliceState>(() => ({
+    ai: {
+      config: {
+        currentSessionId: session.id,
+        sessions: [session],
+        sessionForks: {},
+      },
+      getCurrentSession: () => session,
+      getSessionForkOrigin: () => undefined,
+      getIsRunning: () => false,
+      switchSession: jest.fn(),
+    } as unknown as AiSliceState['ai'],
+  }));
+
+  act(() => {
+    root.render(
+      <RoomStateProvider roomStore={store}>
+        <ChatMessagesContainer />
+      </RoomStateProvider>,
+    );
+  });
+
+  return {container, root};
+}
+
+function cleanup(container: HTMLElement, root: Root) {
+  act(() => root.unmount());
+  container.remove();
+}
+
+describe('ChatMessagesContainer', () => {
+  it('uses native scrolling and updates the scroll-to-bottom button state', () => {
+    const {container, root} = renderMessages();
+    const scrollContainer = container.querySelector<HTMLDivElement>(
+      '.scrollbar-thin.overflow-y-auto',
+    );
+    const scrollButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Scroll to bottom"]',
+    );
+
+    expect(scrollContainer).not.toBeNull();
+    expect(scrollButton).not.toBeNull();
+
+    let scrollTop = 0;
+    Object.defineProperties(scrollContainer!, {
+      scrollTop: {
+        configurable: true,
+        get: () => scrollTop,
+        set: (value: number) => {
+          scrollTop = value;
+        },
+      },
+      scrollHeight: {configurable: true, value: 1_000},
+      clientHeight: {configurable: true, value: 300},
+    });
+    const scrollTo = jest.fn(({top}: ScrollToOptions) => {
+      scrollTop = Math.min(Number(top), 700);
+      scrollContainer!.dispatchEvent(new Event('scroll'));
+    });
+    Object.defineProperty(scrollContainer!, 'scrollTo', {
+      configurable: true,
+      value: scrollTo,
+    });
+
+    act(() => {
+      scrollContainer!.dispatchEvent(new Event('scroll'));
+    });
+
+    expect(scrollButton!.classList.contains('opacity-100')).toBe(true);
+
+    act(() => {
+      scrollButton!.click();
+    });
+
+    expect(scrollTo).toHaveBeenCalledWith({
+      top: 1_000,
+      behavior: 'smooth',
+    });
+    expect(scrollTop).toBe(700);
+    expect(scrollButton!.classList.contains('opacity-0')).toBe(true);
+
+    cleanup(container, root);
+  });
+});

--- a/packages/ai-core/__tests__/ChatMessagesContainer.test.tsx
+++ b/packages/ai-core/__tests__/ChatMessagesContainer.test.tsx
@@ -30,7 +30,7 @@ Object.assign(globalThis, {
 const {ChatMessagesContainer} =
   await import('../src/components/ChatMessagesContainer');
 
-function renderMessages() {
+function renderMessages({isRunning = false}: {isRunning?: boolean} = {}) {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const root = createRoot(container);
@@ -43,7 +43,7 @@ function renderMessages() {
     uiMessages: [],
     messagesRevision: 0,
     prompt: '',
-    isRunning: false,
+    isRunning,
   };
   const store = createStore<AiSliceState>(() => ({
     ai: {
@@ -54,7 +54,7 @@ function renderMessages() {
       },
       getCurrentSession: () => session,
       getSessionForkOrigin: () => undefined,
-      getIsRunning: () => false,
+      getIsRunning: () => isRunning,
       switchSession: jest.fn(),
     } as unknown as AiSliceState['ai'],
   }));
@@ -125,6 +125,24 @@ describe('ChatMessagesContainer', () => {
     });
     expect(scrollTop).toBe(700);
     expect(scrollButton!.classList.contains('opacity-0')).toBe(true);
+
+    cleanup(container, root);
+  });
+
+  it('shows animated dots instead of the chevron while chat is running', () => {
+    const scrollTo = jest.fn();
+    Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
+      configurable: true,
+      value: scrollTo,
+    });
+
+    const {container, root} = renderMessages({isRunning: true});
+    const scrollButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Scroll to bottom"]',
+    );
+
+    expect(scrollButton?.querySelectorAll('.animate-bounce')).toHaveLength(3);
+    expect(scrollButton?.querySelector('.lucide-chevron-down')).toBeNull();
 
     cleanup(container, root);
   });

--- a/packages/ai-core/src/components/ChatMessagesContainer.tsx
+++ b/packages/ai-core/src/components/ChatMessagesContainer.tsx
@@ -46,6 +46,19 @@ function ChatForkProvenance({
   );
 }
 
+function RunningDots() {
+  return (
+    <span
+      aria-hidden="true"
+      className="flex h-5 w-5 items-center justify-center gap-0.5"
+    >
+      <span className="h-1 w-1 animate-bounce rounded-full bg-current [animation-delay:-0.3s] motion-reduce:animate-none" />
+      <span className="h-1 w-1 animate-bounce rounded-full bg-current [animation-delay:-0.15s] motion-reduce:animate-none" />
+      <span className="h-1 w-1 animate-bounce rounded-full bg-current motion-reduce:animate-none" />
+    </span>
+  );
+}
+
 export const ChatMessagesContainer: React.FC<{
   className?: string;
   customMarkdownComponents?: Partial<Components>;
@@ -162,7 +175,7 @@ export const ChatMessagesContainer: React.FC<{
           )}
           aria-label="Scroll to bottom"
         >
-          <ChevronDown className="h-5 w-5" />
+          {isRunning ? <RunningDots /> : <ChevronDown className="h-5 w-5" />}
         </button>
       </div>
     </div>

--- a/packages/ai-core/src/components/ChatMessagesContainer.tsx
+++ b/packages/ai-core/src/components/ChatMessagesContainer.tsx
@@ -126,7 +126,7 @@ export const ChatMessagesContainer: React.FC<{
     <div className={cn('relative flex h-full w-full flex-col', className)}>
       <ScrollArea
         viewportRef={containerRef}
-        className="flex w-full grow flex-col gap-5"
+        className="flex w-full min-w-0 grow flex-col gap-5 [&_[data-radix-scroll-area-viewport]>div]:!block [&_[data-radix-scroll-area-viewport]>div]:!w-full [&_[data-radix-scroll-area-viewport]>div]:!min-w-0"
       >
         <div className="px-3">
           {chatTurns.map((chatTurn) => (

--- a/packages/ai-core/src/components/ChatMessagesContainer.tsx
+++ b/packages/ai-core/src/components/ChatMessagesContainer.tsx
@@ -1,4 +1,4 @@
-import {cn, ScrollArea, ScrollBar} from '@sqlrooms/ui';
+import {cn} from '@sqlrooms/ui';
 import {ChevronDown, SplitIcon} from 'lucide-react';
 import type {UIMessage} from 'ai';
 import React, {useEffect, useRef} from 'react';
@@ -124,9 +124,9 @@ export const ChatMessagesContainer: React.FC<{
 
   return (
     <div className={cn('relative flex h-full w-full flex-col', className)}>
-      <ScrollArea
-        viewportRef={containerRef}
-        className="flex w-full min-w-0 grow flex-col gap-5 [&>[data-radix-scroll-area-viewport]>div]:!block [&>[data-radix-scroll-area-viewport]>div]:!w-full [&>[data-radix-scroll-area-viewport]>div]:!min-w-0"
+      <div
+        ref={containerRef}
+        className="scrollbar-thin flex min-h-0 w-full min-w-0 grow flex-col gap-5 overflow-x-hidden overflow-y-auto"
       >
         <div className="px-3">
           {chatTurns.map((chatTurn) => (
@@ -151,8 +151,7 @@ export const ChatMessagesContainer: React.FC<{
           {isRunning && <ActiveStatus status={activeStatus} className="pb-4" />}
           <div className="h-10 w-full shrink-0" />
         </div>
-        <ScrollBar orientation="vertical" />
-      </ScrollArea>
+      </div>
       <div className="pointer-events-none absolute inset-x-0 bottom-0 flex justify-center">
         <button
           onClick={scrollToBottom}

--- a/packages/ai-core/src/components/ChatMessagesContainer.tsx
+++ b/packages/ai-core/src/components/ChatMessagesContainer.tsx
@@ -126,7 +126,7 @@ export const ChatMessagesContainer: React.FC<{
     <div className={cn('relative flex h-full w-full flex-col', className)}>
       <ScrollArea
         viewportRef={containerRef}
-        className="flex w-full min-w-0 grow flex-col gap-5 [&_[data-radix-scroll-area-viewport]>div]:!block [&_[data-radix-scroll-area-viewport]>div]:!w-full [&_[data-radix-scroll-area-viewport]>div]:!min-w-0"
+        className="flex w-full min-w-0 grow flex-col gap-5 [&>[data-radix-scroll-area-viewport]>div]:!block [&>[data-radix-scroll-area-viewport]>div]:!w-full [&>[data-radix-scroll-area-viewport]>div]:!min-w-0"
       >
         <div className="px-3">
           {chatTurns.map((chatTurn) => (

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -182,6 +182,18 @@ function SettingsPanel({onClose}: {onClose: () => void}) {
 - **Custom Styling**: Extend components with custom styles using Tailwind CSS
 - **Animation**: Smooth transitions and animations for interactive elements
 
+## Native scrolling
+
+Use the `scrollbar-thin` utility for simple native overflow containers that
+should use a thin, theme-aware scrollbar:
+
+```tsx
+<div className="scrollbar-thin overflow-y-auto">{/* content */}</div>
+```
+
+Use `ScrollArea` instead when a surface needs custom horizontal or
+bidirectional scrollbar behavior.
+
 ## TabStrip
 
 `TabStrip` supports a `fontSize` prop for sizing tab labels, inline rename

--- a/packages/ui/tailwind-preset.css
+++ b/packages/ui/tailwind-preset.css
@@ -222,6 +222,25 @@
     appearance: none;
     margin: 0;
   }
+
+  .scrollbar-thin {
+    scrollbar-color: hsl(var(--border)) transparent;
+    scrollbar-width: thin;
+  }
+
+  .scrollbar-thin::-webkit-scrollbar {
+    width: 0.375rem;
+    height: 0.375rem;
+  }
+
+  .scrollbar-thin::-webkit-scrollbar-thumb {
+    background-color: hsl(var(--border));
+    border-radius: 9999px;
+  }
+
+  .scrollbar-thin::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
 }
 
 @layer components {


### PR DESCRIPTION
## Summary

- constrain the Radix scroll-area content wrapper to the current chat viewport width
- prevent Vega charts and message text from retaining a stale intrinsic width after panel resizing
- preserve vertical scrolling without introducing horizontal overflow

## Validation

- reproduced and verified live at localhost: chart and prose tracked panel resizing in both directions without a reload
- `pnpm --filter @sqlrooms/ai-core typecheck`
- `pnpm --filter @sqlrooms/ai-core lint`
- `pnpm --filter @sqlrooms/ai-core test --runInBand` (31 suites, 178 tests)
- `pnpm build`
- pre-push checks: knip, workspace typecheck, circular dependency check, and workspace tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved chat message scrolling with native overflow behavior, consistent sizing, and a slimmer themed scrollbar.
  * Preserved full-width chat content and stable layout behavior while scrolling.
  * Added animated dots to the scroll-to-bottom button while a chat response is in progress.

* **Documentation**
  * Added guidance for using thin native scrollbars and choosing custom scroll areas for horizontal or bidirectional scrolling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->