### PR TITLE
chore(mcp): mark package private

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@sqlrooms/mcp",
   "version": "0.29.0-rc.10",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sqlrooms/sqlrooms.git"

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -48,8 +48,5 @@
     "@types/jest": "^30.0.0",
     "jest": "^30.3.0",
     "ts-jest": "^29.4.4"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }


### PR DESCRIPTION
## Summary

- mark the MCP workspace package as private to prevent publishing

## Validation

- parsed packages/mcp/package.json as JSON
- ran git diff --check