### PR TITLE
fix(deck): sync heatmap color scale with settings UI

### DIFF
--- a/packages/deck/__tests__/heatmapDefaults.test.ts
+++ b/packages/deck/__tests__/heatmapDefaults.test.ts
@@ -1,0 +1,25 @@
+import {describe, expect, test} from '@jest/globals';
+import {
+  DEFAULT_HEATMAP_COLOR_RANGE,
+  DEFAULT_HEATMAP_SCHEME,
+  detectHeatmapScheme,
+  heatmapSchemeToColorRange,
+} from '../src/json/heatmapDefaults';
+
+describe('heatmapDefaults', () => {
+  test('missing colorRange uses the renderer default scheme', () => {
+    expect(detectHeatmapScheme(undefined)).toBe(DEFAULT_HEATMAP_SCHEME);
+    expect(detectHeatmapScheme([])).toBe(DEFAULT_HEATMAP_SCHEME);
+    expect(DEFAULT_HEATMAP_SCHEME).toBe('YlOrRd');
+  });
+
+  test('detects the default heatmap range as YlOrRd', () => {
+    expect(detectHeatmapScheme(DEFAULT_HEATMAP_COLOR_RANGE)).toBe('YlOrRd');
+  });
+
+  test('detects a Viridis range chosen in the settings picker', () => {
+    expect(detectHeatmapScheme(heatmapSchemeToColorRange('Viridis'))).toBe(
+      'Viridis',
+    );
+  });
+});

--- a/packages/deck/__tests__/mapLayerConfigUtils.test.ts
+++ b/packages/deck/__tests__/mapLayerConfigUtils.test.ts
@@ -16,6 +16,7 @@ import {
   setDeckMapLayerFlatColor,
   setDeckMapLayerGeometryColumn,
   setDeckMapLayerType,
+  DECK_MAP_DEFAULT_LAYER_COLOR,
   updateDeckMapLayer,
   usesExtrusionSettings,
   usesGeometryColumnSetting,
@@ -96,6 +97,52 @@ describe('mapLayerConfigUtils', () => {
 
     expect(getDeckMapLayerRecords(nextConfig)[0]?.colorRange).toEqual(
       customRange,
+    );
+  });
+
+  it('writes the default fill color when switching heatmap to point', () => {
+    const heatmapConfig = setDeckMapLayerType(
+      config,
+      0,
+      'GeoArrowHeatmapLayer',
+    );
+    const withoutFill = updateDeckMapLayer(heatmapConfig, 0, (layer) => {
+      const next = {...layer};
+      delete next.getFillColor;
+      return next;
+    });
+
+    const nextConfig = setDeckMapLayerType(
+      withoutFill,
+      0,
+      'GeoArrowScatterplotLayer',
+    );
+    const layer = getDeckMapLayerRecords(nextConfig)[0];
+
+    expect(layer?.['@@type']).toBe('GeoArrowScatterplotLayer');
+    expect(layer?.getFillColor).toEqual([...DECK_MAP_DEFAULT_LAYER_COLOR]);
+  });
+
+  it('keeps an existing fill color when switching heatmap back to point', () => {
+    const customFill = [255, 0, 0, 255];
+    const withFill = updateDeckMapLayer(config, 0, (layer) => ({
+      ...layer,
+      getFillColor: customFill,
+    }));
+    const heatmapConfig = setDeckMapLayerType(
+      withFill,
+      0,
+      'GeoArrowHeatmapLayer',
+    );
+
+    const nextConfig = setDeckMapLayerType(
+      heatmapConfig,
+      0,
+      'GeoArrowScatterplotLayer',
+    );
+
+    expect(getDeckMapLayerRecords(nextConfig)[0]?.getFillColor).toEqual(
+      customFill,
     );
   });
 

--- a/packages/deck/__tests__/mapLayerConfigUtils.test.ts
+++ b/packages/deck/__tests__/mapLayerConfigUtils.test.ts
@@ -26,6 +26,7 @@ import {
   getDeckMapColorScaleOpacity,
   getDeckMapLayerChannelOpacityPercent,
 } from '../src/mapLayerConfigUtils';
+import {DEFAULT_HEATMAP_COLOR_RANGE} from '../src/json/heatmapDefaults';
 
 const config = {
   spec: {
@@ -66,7 +67,36 @@ describe('mapLayerConfigUtils', () => {
       id: 'points',
       _sqlroomsBinding: {dataset: 'places'},
     });
+    expect(getDeckMapLayerRecords(nextConfig)[0]?.colorRange).toEqual(
+      DEFAULT_HEATMAP_COLOR_RANGE,
+    );
     expect(config.spec.layers[0]['@@type']).toBe('GeoArrowScatterplotLayer');
+  });
+
+  it('keeps an existing heatmap colorRange when switching to heatmap', () => {
+    const customRange = [
+      [0, 0, 0, 255],
+      [255, 255, 255, 255],
+    ];
+    const heatmapConfig = setDeckMapLayerType(
+      config,
+      0,
+      'GeoArrowHeatmapLayer',
+    );
+    const withCustomRange = updateDeckMapLayer(heatmapConfig, 0, (layer) => ({
+      ...layer,
+      colorRange: customRange,
+    }));
+
+    const nextConfig = setDeckMapLayerType(
+      withCustomRange,
+      0,
+      'GeoArrowHeatmapLayer',
+    );
+
+    expect(getDeckMapLayerRecords(nextConfig)[0]?.colorRange).toEqual(
+      customRange,
+    );
   });
 
   it('forces column radius to meters and strips point radius leftovers', () => {

--- a/packages/deck/src/MapSettings.tsx
+++ b/packages/deck/src/MapSettings.tsx
@@ -97,8 +97,11 @@ import {
 } from './MapSettingsControls';
 import {regenerateMapConfigForTable} from './mapConfigUtils';
 import {useDeckMapDatasetSchema} from './useDeckMapDatasetSchema';
+import {
+  detectHeatmapScheme,
+  heatmapSchemeToColorRange,
+} from './json/heatmapDefaults';
 
-const HEATMAP_COLOR_STEPS = 6;
 const EMPTY_COLUMNS: DataTable['columns'] = [];
 
 function getColorScaleColumnKind(
@@ -156,49 +159,6 @@ export function resolveColorScaleFieldAndType(
     field,
     type: resolveColorScaleTypeForField(columns, field, preferredType),
   };
-}
-
-function schemeToColorRange(
-  scheme: string,
-): Array<[number, number, number, number]> {
-  const interpolator =
-    continuousSequentialInterpolators[
-      scheme as keyof typeof continuousSequentialInterpolators
-    ];
-  if (!interpolator) {
-    return continuousSequentialInterpolators.Viridis
-      ? Array.from({length: HEATMAP_COLOR_STEPS}, (_, i) =>
-          parseColorString(
-            continuousSequentialInterpolators.Viridis(
-              i / (HEATMAP_COLOR_STEPS - 1),
-            ),
-          ),
-        )
-      : [];
-  }
-  return Array.from({length: HEATMAP_COLOR_STEPS}, (_, i) =>
-    parseColorString(interpolator(i / (HEATMAP_COLOR_STEPS - 1))),
-  );
-}
-
-function detectHeatmapScheme(colorRange: unknown): string {
-  if (!Array.isArray(colorRange) || colorRange.length === 0) return 'Viridis';
-  for (const scheme of continuousSequentialSchemes) {
-    const sampled = schemeToColorRange(scheme);
-    if (sampled.length === colorRange.length) {
-      const matches = sampled.every((color, idx) => {
-        const actual = colorRange[idx];
-        if (!Array.isArray(actual)) return false;
-        return (
-          Math.abs(color[0] - actual[0]) < 2 &&
-          Math.abs(color[1] - actual[1]) < 2 &&
-          Math.abs(color[2] - actual[2]) < 2
-        );
-      });
-      if (matches) return scheme;
-    }
-  }
-  return 'Viridis';
 }
 
 export interface DeckMapSettingsPanelProps {
@@ -1568,7 +1528,8 @@ export const DeckMapSettingsPanel: FC<DeckMapSettingsPanelProps> = ({
                                   activeLayerIndex,
                                   (layer) => ({
                                     ...layer,
-                                    colorRange: schemeToColorRange(value),
+                                    colorRange:
+                                      heatmapSchemeToColorRange(value),
                                   }),
                                 ),
                               )

--- a/packages/deck/src/json/heatmapDefaults.ts
+++ b/packages/deck/src/json/heatmapDefaults.ts
@@ -1,24 +1,71 @@
 import {
   continuousSequentialInterpolators,
+  continuousSequentialSchemes,
   parseColorString,
+  type ContinuousSequentialScheme,
+  type ResolvedRGBA,
 } from '@sqlrooms/color-scales';
 
 const HEATMAP_COLOR_STEPS = 6;
 
-/** Default color range for heatmap layers (YlOrRd, matching deck.gl's built-in default). */
-export const DEFAULT_HEATMAP_COLOR_RANGE: Array<
-  [number, number, number, number]
-> = continuousSequentialInterpolators.YlOrRd
-  ? Array.from({length: HEATMAP_COLOR_STEPS}, (_, i) =>
-      parseColorString(
-        continuousSequentialInterpolators.YlOrRd(i / (HEATMAP_COLOR_STEPS - 1)),
-      ),
-    )
-  : [
-      [255, 255, 178, 255],
-      [254, 178, 76, 255],
-      [253, 141, 60, 255],
-      [240, 59, 32, 255],
-      [189, 0, 38, 255],
-      [128, 0, 38, 255],
-    ];
+/** Default heatmap scheme (YlOrRd, matching deck.gl's built-in default). */
+export const DEFAULT_HEATMAP_SCHEME: ContinuousSequentialScheme = 'YlOrRd';
+
+const FALLBACK_YLORRD: ResolvedRGBA[] = [
+  [255, 255, 178, 255],
+  [254, 178, 76, 255],
+  [253, 141, 60, 255],
+  [240, 59, 32, 255],
+  [189, 0, 38, 255],
+  [128, 0, 38, 255],
+];
+
+function sampleInterpolator(
+  interpolator: (t: number) => string,
+): ResolvedRGBA[] {
+  return Array.from({length: HEATMAP_COLOR_STEPS}, (_, i) =>
+    parseColorString(interpolator(i / (HEATMAP_COLOR_STEPS - 1))),
+  );
+}
+
+/** Sample a sequential scheme into a heatmap `colorRange`. */
+export function heatmapSchemeToColorRange(scheme: string): ResolvedRGBA[] {
+  const interpolator =
+    continuousSequentialInterpolators[
+      scheme as keyof typeof continuousSequentialInterpolators
+    ] ?? continuousSequentialInterpolators[DEFAULT_HEATMAP_SCHEME];
+  if (!interpolator) {
+    return FALLBACK_YLORRD.map((color) => [...color] as ResolvedRGBA);
+  }
+  return sampleInterpolator(interpolator);
+}
+
+/**
+ * Named scheme for a heatmap `colorRange`. Missing or unrecognized ranges
+ * fall back to {@link DEFAULT_HEATMAP_SCHEME} so the settings picker matches
+ * the renderer default.
+ */
+export function detectHeatmapScheme(colorRange: unknown): string {
+  if (!Array.isArray(colorRange) || colorRange.length === 0) {
+    return DEFAULT_HEATMAP_SCHEME;
+  }
+  for (const scheme of continuousSequentialSchemes) {
+    const sampled = heatmapSchemeToColorRange(scheme);
+    if (sampled.length !== colorRange.length) continue;
+    const matches = sampled.every((color, idx) => {
+      const actual = colorRange[idx];
+      if (!Array.isArray(actual)) return false;
+      return (
+        Math.abs(color[0] - actual[0]) < 2 &&
+        Math.abs(color[1] - actual[1]) < 2 &&
+        Math.abs(color[2] - actual[2]) < 2
+      );
+    });
+    if (matches) return scheme;
+  }
+  return DEFAULT_HEATMAP_SCHEME;
+}
+
+/** Default color range for heatmap layers. */
+export const DEFAULT_HEATMAP_COLOR_RANGE: ResolvedRGBA[] =
+  heatmapSchemeToColorRange(DEFAULT_HEATMAP_SCHEME);

--- a/packages/deck/src/mapLayerConfigUtils.ts
+++ b/packages/deck/src/mapLayerConfigUtils.ts
@@ -472,7 +472,7 @@ export function setDeckMapLayerType(
       }
       return nextLayer;
     }
-    // deck.gl paints missing fill as opaque black; the settings picker shows blue.
+
     const colorAccessors = getDeckMapColorAccessorOptions(layerType);
     if (
       colorAccessors.some((option) => option.value === 'getFillColor') &&

--- a/packages/deck/src/mapLayerConfigUtils.ts
+++ b/packages/deck/src/mapLayerConfigUtils.ts
@@ -1,6 +1,7 @@
 import type {ColorScaleConfig, ColorScaleScheme} from '@sqlrooms/color-scales';
 import type {DeckMapConfig} from './mapConfig';
 import type {DeckAutoLayerType} from './types';
+import {DEFAULT_HEATMAP_COLOR_RANGE} from './json/heatmapDefaults';
 import {isColorScaleFunction} from './json/layerConfig';
 
 export type DeckMapLayerRecord = Record<string, unknown>;
@@ -462,6 +463,15 @@ export function setDeckMapLayerType(
       '@@type': layerType,
     };
     const lt = layerType.toLowerCase();
+    if (lt === 'geoarrowheatmaplayer' || lt === 'heatmaplayer') {
+      if (
+        !Array.isArray(nextLayer.colorRange) ||
+        nextLayer.colorRange.length === 0
+      ) {
+        nextLayer.colorRange = DEFAULT_HEATMAP_COLOR_RANGE;
+      }
+      return nextLayer;
+    }
     if (
       lt === 'geoarrowcolumnlayer' ||
       lt === 'columnlayer' ||

--- a/packages/deck/src/mapLayerConfigUtils.ts
+++ b/packages/deck/src/mapLayerConfigUtils.ts
@@ -472,6 +472,15 @@ export function setDeckMapLayerType(
       }
       return nextLayer;
     }
+    // deck.gl paints missing fill as opaque black; the settings picker shows blue.
+    const colorAccessors = getDeckMapColorAccessorOptions(layerType);
+    if (
+      colorAccessors.some((option) => option.value === 'getFillColor') &&
+      nextLayer.getFillColor === undefined &&
+      nextLayer.filled !== false
+    ) {
+      nextLayer.getFillColor = [...DECK_MAP_DEFAULT_LAYER_COLOR];
+    }
     if (
       lt === 'geoarrowcolumnlayer' ||
       lt === 'columnlayer' ||

--- a/packages/deck/src/mapLayerConfigUtils.ts
+++ b/packages/deck/src/mapLayerConfigUtils.ts
@@ -463,7 +463,7 @@ export function setDeckMapLayerType(
       '@@type': layerType,
     };
     const lt = layerType.toLowerCase();
-    if (lt === 'geoarrowheatmaplayer' || lt === 'heatmaplayer') {
+    if (lt === 'geoarrowheatmaplayer') {
       if (
         !Array.isArray(nextLayer.colorRange) ||
         nextLayer.colorRange.length === 0
@@ -481,11 +481,7 @@ export function setDeckMapLayerType(
     ) {
       nextLayer.getFillColor = [...DECK_MAP_DEFAULT_LAYER_COLOR];
     }
-    if (
-      lt === 'geoarrowcolumnlayer' ||
-      lt === 'columnlayer' ||
-      lt === 'deckcolumnlayer'
-    ) {
+    if (lt === 'geoarrowcolumnlayer') {
       const radius =
         typeof nextLayer.radius === 'number' &&
         Number.isFinite(nextLayer.radius) &&


### PR DESCRIPTION
## Summary
- New heatmaps rendered as YlOrRd while the settings picker showed Viridis, because the map and UI used different fallbacks when `colorRange` was omitted.
- Share a single YlOrRd default across the renderer, legend, and settings picker, and write that `colorRange` when switching a layer to heatmap.

## Test plan
- [x] Create a heatmap and confirm the map and color-scale dropdown both show YlOrRd.
- [x] Change the dropdown to another scheme (e.g. Viridis) and confirm the heatmap updates.
- [x] Switch away from heatmap and back, and confirm a previously chosen `colorRange` is kept.
- [x] Switch away from heatmap to point, and confirm point fill is valid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Heatmap layers now receive a default color range automatically.
  - Custom heatmap color ranges are preserved when changing layer types.
  - Heatmap schemes can be detected and converted into color ranges.
  - Default fill colors are restored when switching between heatmap and point layers.

- **Bug Fixes**
  - Improved preservation of layer colors and settings during layer-type changes.

- **Tests**
  - Added coverage for heatmap defaults, scheme detection, color conversion, and layer switching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->