### PR TITLE
fix(cli): route worksheet creation through agent

### DIFF
--- a/apps/sqlrooms-cli-ui/src/__tests__/createCliAiInstructions.test.ts
+++ b/apps/sqlrooms-cli-ui/src/__tests__/createCliAiInstructions.test.ts
@@ -1,0 +1,38 @@
+import type {StoreApi} from 'zustand';
+import {createCliAiInstructions} from '../createCliAiInstructions';
+import {
+  DEFAULT_CLI_CAPABILITY_PROFILE,
+  WORKSHEET_CHARTS_MAPS_CLI_CAPABILITY_PROFILE,
+} from '../profiles';
+import type {RoomState} from '../store-types';
+
+const store = {
+  getState: () => ({
+    db: {
+      tables: [],
+      currentDatabase: 'memory',
+    },
+  }),
+} as unknown as StoreApi<RoomState>;
+
+describe('createCliAiInstructions', () => {
+  it.each([
+    DEFAULT_CLI_CAPABILITY_PROFILE,
+    WORKSHEET_CHARTS_MAPS_CLI_CAPABILITY_PROFILE,
+  ])('routes new Worksheets through the nested agent for $name', (profile) => {
+    const instructions = createCliAiInstructions(store, profile);
+
+    expect(instructions).toContain(
+      'execute block-document.create exactly once',
+    );
+    expect(instructions).toContain(
+      'returned data.artifactId as blockDocumentId',
+    );
+    expect(instructions).toContain(
+      'do not create its requested chart or map blocks through generic block-document commands',
+    );
+    expect(instructions).toContain(
+      'call block_document_agent with that ID directly and do not create another Worksheet',
+    );
+  });
+});

--- a/apps/sqlrooms-cli-ui/src/__tests__/createCliAiInstructions.test.ts
+++ b/apps/sqlrooms-cli-ui/src/__tests__/createCliAiInstructions.test.ts
@@ -26,13 +26,19 @@ describe('createCliAiInstructions', () => {
       'execute block-document.create exactly once',
     );
     expect(instructions).toContain(
-      'returned data.artifactId as blockDocumentId',
+      'returned result.data.artifactId as the new blockDocumentId',
+    );
+    expect(instructions).toContain(
+      'takes precedence over any Worksheet artifact ID in run context',
     );
     expect(instructions).toContain(
       'do not create its requested chart or map blocks through generic block-document commands',
     );
     expect(instructions).toContain(
-      'call block_document_agent with that ID directly and do not create another Worksheet',
+      'For Worksheet block types that the tool does not expose, such as Python, pivot, document, or SQL-query blocks, use the corresponding registered block-document commands',
+    );
+    expect(instructions).toContain(
+      'asks to edit or add content to an existing Worksheet',
     );
   });
 });

--- a/apps/sqlrooms-cli-ui/src/ai/__tests__/createCliBlockDocumentAgentTool.test.ts
+++ b/apps/sqlrooms-cli-ui/src/ai/__tests__/createCliBlockDocumentAgentTool.test.ts
@@ -95,6 +95,18 @@ describe('createCliBlockDocumentAgentTool', () => {
     )) as {success: boolean; finalOutput: string; error?: string};
   }
 
+  it('describes the wrapped create result and unsupported-block fallback', () => {
+    const agentTool = createCliBlockDocumentAgentTool(createOptions()) as any;
+
+    expect(agentTool.description).toContain('result.data.artifactId');
+    expect(agentTool.description).toContain(
+      'even when another Worksheet is in run context',
+    );
+    expect(agentTool.description).toContain(
+      'Use registered block-document commands for requested block types this tool does not expose',
+    );
+  });
+
   it.each([
     {
       blockType: 'dashboard',

--- a/apps/sqlrooms-cli-ui/src/ai/createCliBlockDocumentAgentTool.ts
+++ b/apps/sqlrooms-cli-ui/src/ai/createCliBlockDocumentAgentTool.ts
@@ -586,7 +586,7 @@ ${dashboardBlocksEnabled ? '- DASHBOARD BLOCKS (interactive dashboards for multi
 ${dataTableBlocksEnabled ? '- DATA TABLE EXPLORER BLOCKS' : ''}
 ${htmlAppBlocksEnabled ? '- HTML APP BLOCKS (custom browser apps powered by window.sqlrooms.query/queryRows)' : ''}
 
-This tool requires the target Worksheet's blockDocumentId and does not create the Worksheet artifact container. For a new Worksheet, first execute the block-document.create command exactly once, then call this tool with the returned data.artifactId as blockDocumentId. Delegate the requested Worksheet blocks to this agent instead of creating charts or maps through generic commands.
+This tool requires the target Worksheet's blockDocumentId and does not create the Worksheet artifact container. For an explicit new-Worksheet request, first execute the block-document.create command exactly once even when another Worksheet is in run context, then call this tool with the returned result.data.artifactId as blockDocumentId. Delegate the block types listed above to this agent instead of creating charts or maps through generic commands. Use registered block-document commands for requested block types this tool does not expose, such as Python, pivot, document, or SQL-query blocks.
 
 ${
   dashboardBlocksEnabled

--- a/apps/sqlrooms-cli-ui/src/ai/createCliBlockDocumentAgentTool.ts
+++ b/apps/sqlrooms-cli-ui/src/ai/createCliBlockDocumentAgentTool.ts
@@ -579,12 +579,14 @@ export function createCliBlockDocumentAgentTool(
   } = options;
 
   return tool({
-    description: `An AI agent that creates DATA ANALYSIS WORKSHEETS with:
+    description: `An AI agent that builds content inside an existing DATA ANALYSIS WORKSHEET with:
 - CHART BLOCKS (histograms, scatter plots, heatmaps, etc.)
 - TEXT BLOCKS (headings, paragraphs, lists)
 ${dashboardBlocksEnabled ? '- DASHBOARD BLOCKS (interactive dashboards for multi-faceted exploration)' : ''}
 ${dataTableBlocksEnabled ? '- DATA TABLE EXPLORER BLOCKS' : ''}
 ${htmlAppBlocksEnabled ? '- HTML APP BLOCKS (custom browser apps powered by window.sqlrooms.query/queryRows)' : ''}
+
+This tool requires the target Worksheet's blockDocumentId and does not create the Worksheet artifact container. For a new Worksheet, first execute the block-document.create command exactly once, then call this tool with the returned data.artifactId as blockDocumentId. Delegate the requested Worksheet blocks to this agent instead of creating charts or maps through generic commands.
 
 ${
   dashboardBlocksEnabled

--- a/apps/sqlrooms-cli-ui/src/createCliAiInstructions.ts
+++ b/apps/sqlrooms-cli-ui/src/createCliAiInstructions.ts
@@ -41,9 +41,10 @@ This SQLRooms session exposes worksheet artifacts with text, chart, and direct m
 const WORKSHEET_AGENT_ROUTING_INSTRUCTIONS = `
 The ${CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME} tool edits an existing Worksheet and requires its blockDocumentId; it does not create the Worksheet artifact container.
 
-- When the user requests a new Worksheet and no Worksheet artifact ID is available in run context, use the command tools to execute block-document.create exactly once. Then call ${CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME} with the returned data.artifactId as blockDocumentId and delegate all requested text, chart, map, and other block creation to it.
+- An explicit request to create a new Worksheet takes precedence over any Worksheet artifact ID in run context. For that request, use the command tools to execute block-document.create exactly once, then use the returned result.data.artifactId as the new blockDocumentId.
+- Delegate requested block types exposed by the current profile's ${CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME} to it. This includes text and charts, plus maps, dashboards, data tables, or HTML apps when the tool description lists them. For Worksheet block types that the tool does not expose, such as Python, pivot, document, or SQL-query blocks, use the corresponding registered block-document commands after creating the container.
 - After creating the Worksheet container, do not create its requested chart or map blocks through generic block-document commands. The Worksheet agent owns those block writes and has the specialized authoring contracts needed to produce valid content.
-- When a Worksheet artifact ID is already available in run context, call ${CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME} with that ID directly and do not create another Worksheet.
+- When the user asks to edit or add content to an existing Worksheet and its artifact ID is available in run context, call ${CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME} with that ID directly and do not create another Worksheet.
 `;
 
 /** Builds the production CLI assistant instructions for a capability profile. */

--- a/apps/sqlrooms-cli-ui/src/createCliAiInstructions.ts
+++ b/apps/sqlrooms-cli-ui/src/createCliAiInstructions.ts
@@ -38,6 +38,14 @@ This SQLRooms session exposes worksheet artifacts with text, chart, and direct m
 - Use standalone chart tools only for inline chat visualizations or when no worksheet target is available.
 `;
 
+const WORKSHEET_AGENT_ROUTING_INSTRUCTIONS = `
+The ${CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME} tool edits an existing Worksheet and requires its blockDocumentId; it does not create the Worksheet artifact container.
+
+- When the user requests a new Worksheet and no Worksheet artifact ID is available in run context, use the command tools to execute block-document.create exactly once. Then call ${CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME} with the returned data.artifactId as blockDocumentId and delegate all requested text, chart, map, and other block creation to it.
+- After creating the Worksheet container, do not create its requested chart or map blocks through generic block-document commands. The Worksheet agent owns those block writes and has the specialized authoring contracts needed to produce valid content.
+- When a Worksheet artifact ID is already available in run context, call ${CLI_BLOCK_DOCUMENT_AGENT_TOOL_NAME} with that ID directly and do not create another Worksheet.
+`;
+
 /** Builds the production CLI assistant instructions for a capability profile. */
 export function createCliAiInstructions(
   store: StoreApi<RoomState>,
@@ -48,6 +56,7 @@ export function createCliAiInstructions(
     profile.name === 'worksheet-charts-maps'
       ? WORKSHEET_CHARTS_MAPS_AI_INSTRUCTIONS.trim()
       : STABLE_SQLROOMS_CLI_AI_INSTRUCTIONS.trim(),
+    WORKSHEET_AGENT_ROUTING_INSTRUCTIONS.trim(),
     profile.ai.instructionSets.includes('experimental')
       ? EXPERIMENTAL_SQLROOMS_CLI_AI_INSTRUCTIONS.trim()
       : '',


### PR DESCRIPTION
## Summary

- clarify that `block_document_agent` edits an existing Worksheet and requires `blockDocumentId`
- route new Worksheet requests through `block-document.create` exactly once, then hand the returned artifact ID to the specialized Worksheet agent
- prevent generic chart/map commands from bypassing the agent-specific authoring contracts
- cover the routing instructions for both default and worksheet-charts-maps profiles

## Validation

- `pnpm build`
- `pnpm --filter sqlrooms-cli-app test --runInBand` — 77 tests passed
- `pnpm --filter sqlrooms-cli-app typecheck`
- `pnpm --filter sqlrooms-cli-app lint`
- focused Prettier check
- pre-push: knip, full workspace typecheck, circular dependency check, full workspace tests
- targeted production eval `eval-3Il-2026-08-21T11:55:25` — 3/3 passed, 0 failures, 0 errors

Each behavioral repetition issued exactly one `block-document.create`, exactly one `block_document_agent` call, and zero generic chart/map writes.

## Stack

- stacked on #865 (`implement-eval-trajectory-comparison`)