### PR TITLE
feat(evals): report run costs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env.local and provide an OpenRouter API key.
+OPENROUTER_API_KEY=

--- a/apps/sqlrooms-cli-ui/evals/README.md
+++ b/apps/sqlrooms-cli-ui/evals/README.md
@@ -8,16 +8,22 @@ in the evidence envelope.
 
 ## Run locally
 
-Build workspace packages, set an OpenRouter key, and run either the whole suite
-or one scenario. `evals:nightly` first creates the Node provider bundle used by
-Promptfoo, avoiding browser-only CSS/module imports from application barrels:
+Build workspace packages, copy the local environment template, set an OpenRouter
+key in `.env.local`, and run either the whole suite or one scenario.
+`evals:nightly` first creates the Node provider bundle used by Promptfoo,
+avoiding browser-only CSS/module imports from application barrels:
 
 ```sh
 pnpm build
-export OPENROUTER_API_KEY=...
+cp .env.example .env.local
+# Edit .env.local and set OPENROUTER_API_KEY.
 pnpm evals:nightly
 pnpm evals:nightly --filter-pattern 'worksheet.create-chart-map'
 ```
+
+An existing environment variable takes precedence over `.env.local`. The
+nightly GitHub Actions workflow supplies `OPENROUTER_API_KEY` from GitHub
+Secrets, so CI does not depend on a local environment file.
 
 The model revision, temperature, maximum steps, scenario/profile versions, and
 three repetitions are pinned in `promptfooconfig.yaml`. Promptfoo stores its

--- a/apps/sqlrooms-cli-ui/src/evals/__tests__/loadLocalEvalEnvironment.test.ts
+++ b/apps/sqlrooms-cli-ui/src/evals/__tests__/loadLocalEvalEnvironment.test.ts
@@ -1,0 +1,38 @@
+import {describe, expect, it, jest} from '@jest/globals';
+import {loadLocalEvalEnvironment} from '../loadLocalEvalEnvironment';
+
+describe('loadLocalEvalEnvironment', () => {
+  it('keeps an externally supplied key authoritative', () => {
+    const load = jest.fn<(path: string) => void>();
+
+    loadLocalEvalEnvironment({OPENROUTER_API_KEY: 'github-secret'}, load);
+
+    expect(load).not.toHaveBeenCalled();
+  });
+
+  it('loads the repository-local environment when the key is unset', () => {
+    const load = jest.fn<(path: string) => void>();
+
+    loadLocalEvalEnvironment({}, load);
+
+    expect(load).toHaveBeenCalledWith('.env.local');
+  });
+
+  it('allows the local environment file to be absent', () => {
+    const missing = Object.assign(new Error('missing'), {code: 'ENOENT'});
+    const load = jest.fn<(path: string) => void>(() => {
+      throw missing;
+    });
+
+    expect(() => loadLocalEvalEnvironment({}, load)).not.toThrow();
+  });
+
+  it('surfaces other environment-file errors', () => {
+    const invalid = Object.assign(new Error('invalid'), {code: 'EINVAL'});
+    const load = jest.fn<(path: string) => void>(() => {
+      throw invalid;
+    });
+
+    expect(() => loadLocalEvalEnvironment({}, load)).toThrow(invalid);
+  });
+});

--- a/apps/sqlrooms-cli-ui/src/evals/__tests__/openRouterCost.test.ts
+++ b/apps/sqlrooms-cli-ui/src/evals/__tests__/openRouterCost.test.ts
@@ -1,0 +1,63 @@
+import {describe, expect, it} from '@jest/globals';
+import {createOpenRouterCostTracker} from '../openRouterCost';
+
+const RATES = {
+  inputCostUsdPerMillionTokens: 0.08,
+  outputCostUsdPerMillionTokens: 0.18,
+};
+
+describe('createOpenRouterCostTracker', () => {
+  it('accumulates provider-reported cost across streamed model calls', () => {
+    const tracker = createOpenRouterCostTracker(RATES);
+    const first = tracker.metadataExtractor.createStreamExtractor();
+    first.processChunk({choices: [{delta: {content: 'Hello'}}]});
+    first.processChunk({usage: {cost: 0.012}});
+    expect(first.buildMetadata()).toEqual({
+      openrouter: {costUsd: 0.012},
+    });
+
+    const second = tracker.metadataExtractor.createStreamExtractor();
+    second.processChunk({usage: {cost: 0.003}});
+    second.buildMetadata();
+
+    expect(
+      tracker.resolveCost({inputTokens: 1_000_000, outputTokens: 1_000_000}),
+    ).toEqual({costUsd: 0.015, source: 'provider-reported'});
+  });
+
+  it('uses pinned model rates when OpenRouter omits billed cost', () => {
+    const tracker = createOpenRouterCostTracker(RATES);
+
+    expect(
+      tracker.resolveCost({inputTokens: 2_000_000, outputTokens: 500_000}),
+    ).toEqual({costUsd: 0.25, source: 'estimated'});
+  });
+
+  it('preserves a provider-reported zero cost', async () => {
+    const tracker = createOpenRouterCostTracker(RATES);
+
+    expect(
+      await tracker.metadataExtractor.extractMetadata({
+        parsedBody: {usage: {cost: 0}},
+      }),
+    ).toEqual({openrouter: {costUsd: 0}});
+    expect(tracker.resolveCost({inputTokens: 10_000})).toEqual({
+      costUsd: 0,
+      source: 'provider-reported',
+    });
+  });
+
+  it('falls back when one streamed response has usage but no cost', () => {
+    const tracker = createOpenRouterCostTracker(RATES);
+    const reported = tracker.metadataExtractor.createStreamExtractor();
+    reported.processChunk({usage: {cost: 0.012}});
+    reported.buildMetadata();
+    const omitted = tracker.metadataExtractor.createStreamExtractor();
+    omitted.processChunk({usage: {total_tokens: 100}});
+    omitted.buildMetadata();
+
+    expect(
+      tracker.resolveCost({inputTokens: 1_000_000, outputTokens: 1_000_000}),
+    ).toEqual({costUsd: 0.26, source: 'estimated'});
+  });
+});

--- a/apps/sqlrooms-cli-ui/src/evals/__tests__/openRouterCost.test.ts
+++ b/apps/sqlrooms-cli-ui/src/evals/__tests__/openRouterCost.test.ts
@@ -50,14 +50,25 @@ describe('createOpenRouterCostTracker', () => {
   it('falls back when one streamed response has usage but no cost', () => {
     const tracker = createOpenRouterCostTracker(RATES);
     const reported = tracker.metadataExtractor.createStreamExtractor();
-    reported.processChunk({usage: {cost: 0.012}});
+    reported.processChunk({
+      usage: {
+        cost: 0.012,
+        prompt_tokens: 1_000_000,
+        completion_tokens: 500_000,
+      },
+    });
     reported.buildMetadata();
     const omitted = tracker.metadataExtractor.createStreamExtractor();
-    omitted.processChunk({usage: {total_tokens: 100}});
+    omitted.processChunk({
+      usage: {
+        prompt_tokens: 500_000,
+        completion_tokens: 1_000_000,
+      },
+    });
     omitted.buildMetadata();
 
     expect(
-      tracker.resolveCost({inputTokens: 1_000_000, outputTokens: 1_000_000}),
-    ).toEqual({costUsd: 0.26, source: 'estimated'});
+      tracker.resolveCost({inputTokens: 10_000, outputTokens: 10_000}),
+    ).toEqual({costUsd: 0.39, source: 'estimated'});
   });
 });

--- a/apps/sqlrooms-cli-ui/src/evals/loadLocalEvalEnvironment.ts
+++ b/apps/sqlrooms-cli-ui/src/evals/loadLocalEvalEnvironment.ts
@@ -1,0 +1,17 @@
+import {loadEnvFile} from 'node:process';
+
+type EnvFileLoader = (path: string) => void;
+
+/** Loads local eval credentials without overriding an existing environment. */
+export function loadLocalEvalEnvironment(
+  environment: NodeJS.ProcessEnv = process.env,
+  load: EnvFileLoader = loadEnvFile,
+): void {
+  if (environment.OPENROUTER_API_KEY) return;
+
+  try {
+    load('.env.local');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+}

--- a/apps/sqlrooms-cli-ui/src/evals/openRouterCost.ts
+++ b/apps/sqlrooms-cli-ui/src/evals/openRouterCost.ts
@@ -1,0 +1,104 @@
+import type {MetadataExtractor} from '@ai-sdk/openai-compatible';
+
+type TokenUsage = {
+  inputTokens?: number;
+  outputTokens?: number;
+};
+
+export type OpenRouterCost = {
+  costUsd: number;
+  source: 'provider-reported' | 'estimated';
+};
+
+export type OpenRouterCostTrackerOptions = {
+  inputCostUsdPerMillionTokens: number;
+  outputCostUsdPerMillionTokens: number;
+};
+
+function reportedCostUsd(value: unknown): number | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const usage = (value as {usage?: unknown}).usage;
+  if (!usage || typeof usage !== 'object') return undefined;
+  const cost = (usage as {cost?: unknown}).cost;
+  return typeof cost === 'number' && Number.isFinite(cost) && cost >= 0
+    ? cost
+    : undefined;
+}
+
+function estimatedCostUsd(
+  usage: TokenUsage | undefined,
+  options: OpenRouterCostTrackerOptions,
+): number | undefined {
+  if (!usage) return undefined;
+  return (
+    ((usage.inputTokens ?? 0) * options.inputCostUsdPerMillionTokens) /
+      1_000_000 +
+    ((usage.outputTokens ?? 0) * options.outputCostUsdPerMillionTokens) /
+      1_000_000
+  );
+}
+
+/** Collects OpenRouter's billed cost from AI SDK response metadata. */
+export function createOpenRouterCostTracker(
+  options: OpenRouterCostTrackerOptions,
+): {
+  metadataExtractor: MetadataExtractor;
+  resolveCost(usage: TokenUsage | undefined): OpenRouterCost | undefined;
+} {
+  let totalReportedCostUsd: number | undefined;
+  let usageWithoutReportedCost = false;
+
+  const record = (costUsd: number | undefined) => {
+    if (costUsd === undefined) return;
+    totalReportedCostUsd = (totalReportedCostUsd ?? 0) + costUsd;
+  };
+
+  return {
+    metadataExtractor: {
+      async extractMetadata({parsedBody}) {
+        const costUsd = reportedCostUsd(parsedBody);
+        if (
+          costUsd === undefined &&
+          parsedBody &&
+          typeof parsedBody === 'object' &&
+          (parsedBody as {usage?: unknown}).usage
+        ) {
+          usageWithoutReportedCost = true;
+        }
+        record(costUsd);
+        return costUsd === undefined ? undefined : {openrouter: {costUsd}};
+      },
+      createStreamExtractor() {
+        let costUsd: number | undefined;
+        let sawUsage = false;
+        return {
+          processChunk(parsedChunk) {
+            sawUsage ||= Boolean(
+              parsedChunk &&
+              typeof parsedChunk === 'object' &&
+              (parsedChunk as {usage?: unknown}).usage,
+            );
+            costUsd = reportedCostUsd(parsedChunk) ?? costUsd;
+          },
+          buildMetadata() {
+            if (sawUsage && costUsd === undefined) {
+              usageWithoutReportedCost = true;
+            }
+            record(costUsd);
+            return costUsd === undefined ? undefined : {openrouter: {costUsd}};
+          },
+        };
+      },
+    },
+    resolveCost(usage) {
+      if (totalReportedCostUsd !== undefined && !usageWithoutReportedCost) {
+        return {
+          costUsd: totalReportedCostUsd,
+          source: 'provider-reported',
+        };
+      }
+      const costUsd = estimatedCostUsd(usage, options);
+      return costUsd === undefined ? undefined : {costUsd, source: 'estimated'};
+    },
+  };
+}

--- a/apps/sqlrooms-cli-ui/src/evals/openRouterCost.ts
+++ b/apps/sqlrooms-cli-ui/src/evals/openRouterCost.ts
@@ -25,6 +25,32 @@ function reportedCostUsd(value: unknown): number | undefined {
     : undefined;
 }
 
+function reportedTokenUsage(value: unknown): TokenUsage | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const usage = (value as {usage?: unknown}).usage;
+  if (!usage || typeof usage !== 'object') return undefined;
+  const {prompt_tokens: inputTokens, completion_tokens: outputTokens} =
+    usage as {
+      prompt_tokens?: unknown;
+      completion_tokens?: unknown;
+    };
+  const validInputTokens =
+    typeof inputTokens === 'number' &&
+    Number.isFinite(inputTokens) &&
+    inputTokens >= 0
+      ? inputTokens
+      : undefined;
+  const validOutputTokens =
+    typeof outputTokens === 'number' &&
+    Number.isFinite(outputTokens) &&
+    outputTokens >= 0
+      ? outputTokens
+      : undefined;
+  return validInputTokens === undefined && validOutputTokens === undefined
+    ? undefined
+    : {inputTokens: validInputTokens, outputTokens: validOutputTokens};
+}
+
 function estimatedCostUsd(
   usage: TokenUsage | undefined,
   options: OpenRouterCostTrackerOptions,
@@ -46,17 +72,31 @@ export function createOpenRouterCostTracker(
   resolveCost(usage: TokenUsage | undefined): OpenRouterCost | undefined;
 } {
   let totalReportedCostUsd: number | undefined;
+  let totalReportedUsage: TokenUsage | undefined;
   let usageWithoutReportedCost = false;
 
-  const record = (costUsd: number | undefined) => {
-    if (costUsd === undefined) return;
-    totalReportedCostUsd = (totalReportedCostUsd ?? 0) + costUsd;
+  const record = (
+    costUsd: number | undefined,
+    usage: TokenUsage | undefined,
+  ) => {
+    if (costUsd !== undefined) {
+      totalReportedCostUsd = (totalReportedCostUsd ?? 0) + costUsd;
+    }
+    if (usage) {
+      totalReportedUsage = {
+        inputTokens:
+          (totalReportedUsage?.inputTokens ?? 0) + (usage.inputTokens ?? 0),
+        outputTokens:
+          (totalReportedUsage?.outputTokens ?? 0) + (usage.outputTokens ?? 0),
+      };
+    }
   };
 
   return {
     metadataExtractor: {
       async extractMetadata({parsedBody}) {
         const costUsd = reportedCostUsd(parsedBody);
+        const usage = reportedTokenUsage(parsedBody);
         if (
           costUsd === undefined &&
           parsedBody &&
@@ -65,11 +105,12 @@ export function createOpenRouterCostTracker(
         ) {
           usageWithoutReportedCost = true;
         }
-        record(costUsd);
+        record(costUsd, usage);
         return costUsd === undefined ? undefined : {openrouter: {costUsd}};
       },
       createStreamExtractor() {
         let costUsd: number | undefined;
+        let usage: TokenUsage | undefined;
         let sawUsage = false;
         return {
           processChunk(parsedChunk) {
@@ -79,12 +120,13 @@ export function createOpenRouterCostTracker(
               (parsedChunk as {usage?: unknown}).usage,
             );
             costUsd = reportedCostUsd(parsedChunk) ?? costUsd;
+            usage = reportedTokenUsage(parsedChunk) ?? usage;
           },
           buildMetadata() {
             if (sawUsage && costUsd === undefined) {
               usageWithoutReportedCost = true;
             }
-            record(costUsd);
+            record(costUsd, usage);
             return costUsd === undefined ? undefined : {openrouter: {costUsd}};
           },
         };
@@ -97,7 +139,7 @@ export function createOpenRouterCostTracker(
           source: 'provider-reported',
         };
       }
-      const costUsd = estimatedCostUsd(usage, options);
+      const costUsd = estimatedCostUsd(totalReportedUsage ?? usage, options);
       return costUsd === undefined ? undefined : {costUsd, source: 'estimated'};
     },
   };

--- a/apps/sqlrooms-cli-ui/src/evals/promptfooProvider.ts
+++ b/apps/sqlrooms-cli-ui/src/evals/promptfooProvider.ts
@@ -1,13 +1,19 @@
-import {createOpenAICompatible} from '@ai-sdk/openai-compatible';
+import {
+  createOpenAICompatible,
+  type MetadataExtractor,
+} from '@ai-sdk/openai-compatible';
 import {
   toPromptfooAssertionResult,
   toPromptfooProviderResponse,
 } from '@sqlrooms/evals/promptfoo';
 import type {LanguageModel} from 'ai';
 import {createCliEvalTarget} from './createCliEvalTarget';
+import {createOpenRouterCostTracker} from './openRouterCost';
 import {CLI_BEHAVIORAL_SCENARIOS, createCliScenarioOracles} from './scenarios';
 
 const MODEL_ID = 'deepseek/deepseek-v4-flash-0731';
+const MODEL_INPUT_COST_USD_PER_MILLION_TOKENS = 0.08;
+const MODEL_OUTPUT_COST_USD_PER_MILLION_TOKENS = 0.18;
 const MAX_STEPS = 24;
 const TEMPERATURE = 0;
 
@@ -38,7 +44,9 @@ function requiredEnvironment(name: string): string {
   return value;
 }
 
-function createPinnedOpenRouterModel(): LanguageModel {
+function createPinnedOpenRouterModel(
+  metadataExtractor: MetadataExtractor,
+): LanguageModel {
   const provider = createOpenAICompatible({
     name: 'openrouter',
     apiKey: requiredEnvironment('OPENROUTER_API_KEY'),
@@ -47,6 +55,7 @@ function createPinnedOpenRouterModel(): LanguageModel {
       'HTTP-Referer': 'https://github.com/sqlrooms/sqlrooms',
       'X-Title': 'SQLRooms behavioral evals',
     },
+    metadataExtractor,
   });
   return provider.languageModel(MODEL_ID, {
     transformRequestBody: (body) => ({...body, temperature: TEMPERATURE}),
@@ -100,8 +109,12 @@ export default class SqlroomsCliEvalProvider {
     }
 
     const repeatIndex = context?.repeatIndex ?? 0;
+    const costTracker = createOpenRouterCostTracker({
+      inputCostUsdPerMillionTokens: MODEL_INPUT_COST_USD_PER_MILLION_TOKENS,
+      outputCostUsdPerMillionTokens: MODEL_OUTPUT_COST_USD_PER_MILLION_TOKENS,
+    });
     const target = createCliEvalTarget({
-      model: createPinnedOpenRouterModel(),
+      model: createPinnedOpenRouterModel(costTracker.metadataExtractor),
       modelProvider: 'openrouter',
       modelId: MODEL_ID,
       configuredRevision: MODEL_ID,
@@ -113,11 +126,22 @@ export default class SqlroomsCliEvalProvider {
     });
 
     try {
-      const evidence = await target.run({
+      const runEvidence = await target.run({
         scenario,
         oracles: createCliScenarioOracles(scenario),
         repetition: repeatIndex,
       });
+      const cost = costTracker.resolveCost(runEvidence.usage);
+      const evidence = cost
+        ? {
+            ...runEvidence,
+            usage: {...runEvidence.usage, costUsd: cost.costUsd},
+            metadata: {
+              ...runEvidence.metadata,
+              cost: {source: cost.source},
+            },
+          }
+        : runEvidence;
       const response = toPromptfooProviderResponse(evidence);
       const assertion = toPromptfooAssertionResult(evidence.oracleResults);
       return {

--- a/apps/sqlrooms-cli-ui/src/evals/promptfooProvider.ts
+++ b/apps/sqlrooms-cli-ui/src/evals/promptfooProvider.ts
@@ -58,6 +58,7 @@ function createPinnedOpenRouterModel(
       'HTTP-Referer': 'https://github.com/sqlrooms/sqlrooms',
       'X-Title': 'SQLRooms behavioral evals',
     },
+    includeUsage: true,
     metadataExtractor,
   });
   return provider.languageModel(MODEL_ID, {

--- a/apps/sqlrooms-cli-ui/src/evals/promptfooProvider.ts
+++ b/apps/sqlrooms-cli-ui/src/evals/promptfooProvider.ts
@@ -8,8 +8,11 @@ import {
 } from '@sqlrooms/evals/promptfoo';
 import type {LanguageModel} from 'ai';
 import {createCliEvalTarget} from './createCliEvalTarget';
+import {loadLocalEvalEnvironment} from './loadLocalEvalEnvironment';
 import {createOpenRouterCostTracker} from './openRouterCost';
 import {CLI_BEHAVIORAL_SCENARIOS, createCliScenarioOracles} from './scenarios';
+
+loadLocalEvalEnvironment();
 
 const MODEL_ID = 'deepseek/deepseek-v4-flash-0731';
 const MODEL_INPUT_COST_USD_PER_MILLION_TOKENS = 0.08;


### PR DESCRIPTION
## Summary

- collect exact billed cost from OpenRouter response metadata across model calls
- fall back to pinned input/output token rates when billed cost is unavailable
- pass run cost through evidence and Promptfoo so nightly summaries and the observatory report it automatically
- load OPENROUTER_API_KEY from ignored .env.local for local runs while preserving externally supplied CI secrets
- provide a committed .env.example and local setup documentation

## Validation

- pnpm evals:test
- pnpm evals:provider:build
- pnpm --filter sqlrooms-cli-app typecheck
- pnpm --filter sqlrooms-cli-app lint
- live 10-token OpenRouter smoke test reported provider-billed cost
- repository pre-push checks: knip, workspace typecheck, circular dependency scan, full test suite

## Stack

- stacked on #865