### PR TITLE
fix(preset-jest): transform workspace package ESM

### DIFF
--- a/packages/preset-jest/base.js
+++ b/packages/preset-jest/base.js
@@ -29,11 +29,27 @@ export default {
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
+  // Compile SQLRooms package output from both conventional node_modules trees
+  // and pnpm's virtual store while continuing to ignore other dependencies.
+  transformIgnorePatterns: [
+    'node_modules/(?!\\.pnpm(?:/|$)|@sqlrooms/)',
+    'node_modules/\\.pnpm/(?!@sqlrooms\\+[^@/]+@)',
+    '\\.pnp\\.[^\\/]+$',
+  ],
   transform: {
     '^.+\\.tsx?$': [
       'ts-jest',
       {
         useESM: true,
+      },
+    ],
+    '^.+\\.jsx?$': [
+      'ts-jest',
+      {
+        useESM: true,
+        tsconfig: {
+          allowJs: true,
+        },
       },
     ],
   },


### PR DESCRIPTION
## Summary

- transform JavaScript package output with `ts-jest` in ESM mode
- allow `@sqlrooms/*` through Jest's transform ignore rules for conventional and pnpm `node_modules` layouts
- preserve the default Yarn PnP ignore and leave non-SQLRooms dependencies untouched

## Measurement

Measured from clean `origin/main` at `a00bc275` after `pnpm build`, using `npx jest --runInBand` in all 28 packages with a Jest config.

| | Baseline | After | Delta |
| --- | ---: | ---: | ---: |
| Passing suites | 160 | 160 | 0 |
| Failing suites | 12 | 12 | 0 |
| Passing tests | 1,373 | 1,373 | 0 |
| Failing tests | 12 | 12 | 0 |
| Skipped tests | 1 | 1 | 0 |

Current main no longer reproduces the older `@sqlrooms/*/dist` failures in active suites: #866 changed the import paths that produced most of the reported baseline, and the lockfile now uses Jest 30. The preset now explicitly supports transforming workspace package output, with no changed suite or test counts on current main.

I also evaluated mapping bare `@sqlrooms/*` imports to source. That candidate caused `db` and `duckdb` to load the React/TSX `room-store` source entry and killed two suites / 38 tests with `Unexpected token '<'`, so it was rejected.

The 12 remaining failed suites are unchanged from the clean baseline:

- 6 third-party ESM loader failures (`vscode-languageserver-types` or `d3-color`)
- 5 suites using unavailable Jest globals
- 1 network-dependent suite with two failed fetches

No revived assertion failures were patched.

## Verification

- `pnpm build` — 49/49 tasks passed
- per-package `npx jest --runInBand` baseline and after comparison — identical counts across 172 suites / 1,386 tests
- `pnpm typecheck` — 54/54 tasks passed
- pre-push `knip`, typecheck, and circular dependency checks passed
- pre-push `turbo test` stops at the verified pre-existing `@sqlrooms/kepler` third-party ESM failure
