### PR TITLE
chore: require Node 24.9 for repository tooling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,10 @@ what actions will and will not be tolerated.
 
 ## Our Development Process
 
+Repository development and testing require Node.js `>=24.9` and the pnpm
+version declared in `package.json`. Published packages may support older Node.js
+versions independently of this repository tooling requirement.
+
 We use example applications to test and validate changes. You can run the examples by following these steps:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -395,6 +395,10 @@ The `useSql` hook automatically re-runs queries when the database state changes 
 
 ## Develop locally
 
+Repository development and testing require Node.js `>=24.9`. This tooling
+requirement does not change the Node.js versions supported by published
+packages.
+
 ```bash
 pnpm install
 pnpm build

--- a/dev-docs/contributing/cursor-cloud.md
+++ b/dev-docs/contributing/cursor-cloud.md
@@ -4,7 +4,7 @@
 
 ## Environment
 
-- Node.js >=22 and pnpm are provided via nvm (pre-installed; see `package.json#engines` and `package.json#packageManager` for exact versions)
+- Node.js >=24.9 and pnpm are provided via nvm (pre-installed; see `package.json#engines` and `package.json#packageManager` for exact versions)
 - The update script runs `pnpm install` and `pnpm build` on startup — all `@sqlrooms/*` packages will be built and ready
 
 ## Running Example Apps

--- a/dev-docs/roadmaps/sqlrooms-cli-first-launch.md
+++ b/dev-docs/roadmaps/sqlrooms-cli-first-launch.md
@@ -114,7 +114,7 @@ not require explaining all of them.
   - `uv tool install sqlrooms`
   - `sqlrooms --help`
 - Confirm `requires-python` should remain `>=3.10` even though the monorepo
-  requires Node `>=22` for development. Users of the published Python tool
+  requires Node `>=24.9` for development. Users of the published Python tool
   should not need Node.
 - Confirm all runtime dependencies are captured transitively. The CLI imports
   `diskcache` via launcher code; today that appears to arrive through

--- a/examples/ai-nextjs/README.md
+++ b/examples/ai-nextjs/README.md
@@ -34,7 +34,7 @@ The client-side code is similar to the `ai-core` example but configured to use a
 
 ### Prerequisites
 
-- Node.js >= 22
+- Node.js >= 24.9
 - OpenAI API key (or other supported AI provider)
 - pnpm package manager
 

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   },
   "packageManager": "pnpm@11.1.2",
   "engines": {
-    "node": ">=22.12"
+    "node": ">=24.9"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ packages:
   - 'packages/kepler.gl/src/*'
   - 'apps/*'
   - 'python/*'
+engineStrict: true
 overrides:
   # First same-major releases that fix provider-utils SSRF (CVE-2026-8768).
   # GHSA-866g-f22w-33x8 remains accepted on 3.x until an upstream backport exists.


### PR DESCRIPTION
## Summary

- require Node.js `>=24.9` for repository development and testing
- document the tooling baseline in contributor, local-development, cloud, roadmap, and repository-run example docs
- keep published package/runtime compatibility independent, including existing Node 22 package engines

## Rationale

Jest's ESM loading path requires Node APIs available from Node 24.9. CI already runs Node 24, but the private root package declared `>=22.12`, so contributors on a nominally supported Node 22 release could silently lose test coverage.

## Validation

- `pnpm typecheck` under Node 26 — 54/54 tasks passed
- affected `ai-core` renderer/context suites under Node 26 — 4/4 suites and 7/7 tests passed
- Prettier check — passed
- package JSON ordering check — 86/86 files passed

Published package engine declarations are intentionally unchanged; this PR only raises the monorepo development and test-runner baseline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated local development and testing requirements to Node.js 24.9 or newer.
  * Clarified the required pnpm version for repository development.
  * Updated setup guidance across contributing documentation, roadmaps, and the Next.js example.
  * Clarified that published packages and tools may retain independent Node.js support.

* **Chores**
  * Enabled strict enforcement of the documented Node.js and pnpm requirements during workspace setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->