### PR TITLE
fix: CLI DuckDB WebSocket startup

### DIFF
--- a/apps/sqlrooms-cli-ui/README.md
+++ b/apps/sqlrooms-cli-ui/README.md
@@ -139,7 +139,7 @@ pnpm dev cli
 This starts:
 
 - the Python API server on `http://127.0.0.1:4273` with `--experimental` and without serving static UI, or the next free port
-- the Vite UI on `http://localhost:3100`, or the next free port, proxying `/api` and `/config.json` to the selected Python API port
+- the Vite UI on `http://localhost:3100`, or the next free port, proxying `/api`, `/config.json`, and `/ws` to the selected Python API port
 - a per-session dev database named after the selected UI port, for example `sqlrooms-3100.db`
 
 If you want fixed ports, pass them to the Python server:

--- a/apps/sqlrooms-cli-ui/cliDevProxy.d.mts
+++ b/apps/sqlrooms-cli-ui/cliDevProxy.d.mts
@@ -1,0 +1,5 @@
+import type {ProxyOptions} from 'vite';
+
+export declare function createCliDevProxy(
+  apiProxyTarget: string,
+): Record<string, string | ProxyOptions>;

--- a/apps/sqlrooms-cli-ui/cliDevProxy.mjs
+++ b/apps/sqlrooms-cli-ui/cliDevProxy.mjs
@@ -1,0 +1,11 @@
+/** Create the Vite routes that proxy CLI API and WebSocket traffic. */
+export function createCliDevProxy(apiProxyTarget) {
+  return {
+    '/api': apiProxyTarget,
+    '/config.json': apiProxyTarget,
+    '/ws': {
+      target: apiProxyTarget,
+      ws: true,
+    },
+  };
+}

--- a/apps/sqlrooms-cli-ui/cliDevProxy.test.mjs
+++ b/apps/sqlrooms-cli-ui/cliDevProxy.test.mjs
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import {createHash} from 'node:crypto';
+import {createServer as createHttpServer} from 'node:http';
+import {once} from 'node:events';
+import test from 'node:test';
+import {createServer as createViteServer} from 'vite';
+
+import {createCliDevProxy} from './cliDevProxy.mjs';
+
+test('the CLI WebSocket proxy forwards upgrade requests', async (t) => {
+  let upgradePath;
+  const upstreamSockets = new Set();
+  const upstream = createHttpServer();
+  upstream.on('upgrade', (request, socket) => {
+    upgradePath = request.url;
+    upstreamSockets.add(socket);
+    socket.on('close', () => upstreamSockets.delete(socket));
+    const accept = createHash('sha1')
+      .update(
+        `${request.headers['sec-websocket-key']}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`,
+      )
+      .digest('base64');
+    socket.write(
+      'HTTP/1.1 101 Switching Protocols\r\n' +
+        'Upgrade: websocket\r\n' +
+        'Connection: Upgrade\r\n' +
+        `Sec-WebSocket-Accept: ${accept}\r\n\r\n`,
+    );
+  });
+  upstream.listen(0, '127.0.0.1');
+  await once(upstream, 'listening');
+  const upstreamAddress = upstream.address();
+  assert.notEqual(upstreamAddress, null);
+  assert.equal(typeof upstreamAddress, 'object');
+
+  const vite = await createViteServer({
+    configFile: false,
+    logLevel: 'silent',
+    server: {
+      host: '127.0.0.1',
+      port: 0,
+      proxy: createCliDevProxy(`http://127.0.0.1:${upstreamAddress.port}`),
+    },
+  });
+  await vite.listen();
+  const viteAddress = vite.httpServer?.address();
+  assert.notEqual(viteAddress, null);
+  assert.equal(typeof viteAddress, 'object');
+
+  t.after(async () => {
+    for (const socket of upstreamSockets) socket.destroy();
+    await vite.close();
+    await new Promise((resolve, reject) => {
+      upstream.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+
+  const socket = new WebSocket(`ws://127.0.0.1:${viteAddress.port}/ws/duckdb`);
+  await new Promise((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error('WebSocket proxy timed out')),
+      5_000,
+    );
+    socket.addEventListener(
+      'open',
+      () => {
+        clearTimeout(timeout);
+        resolve();
+      },
+      {once: true},
+    );
+    socket.addEventListener(
+      'error',
+      () => {
+        clearTimeout(timeout);
+        reject(new Error('WebSocket proxy failed'));
+      },
+      {once: true},
+    );
+  });
+
+  assert.equal(upgradePath, '/ws/duckdb');
+  socket.close();
+});

--- a/apps/sqlrooms-cli-ui/package.json
+++ b/apps/sqlrooms-cli-ui/package.json
@@ -9,7 +9,7 @@
     "evals:provider:build": "vite build -c evals/vite.config.ts",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest && node --test ../../scripts/cli-dev-args.test.mjs cliDevProxy.test.mjs",
+    "test": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest && node --test ../../scripts/cli-dev-args.test.mjs ../../scripts/cli-dev-readiness.test.mjs cliDevProxy.test.mjs",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/sqlrooms-cli-ui/package.json
+++ b/apps/sqlrooms-cli-ui/package.json
@@ -9,7 +9,7 @@
     "evals:provider:build": "vite build -c evals/vite.config.ts",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest",
+    "test": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest && node --test ../../scripts/cli-dev-args.test.mjs cliDevProxy.test.mjs",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/sqlrooms-cli-ui/src/__tests__/runtimeConfig.test.ts
+++ b/apps/sqlrooms-cli-ui/src/__tests__/runtimeConfig.test.ts
@@ -16,6 +16,7 @@ describe('resolveCliDevProxyConfig', () => {
           },
         },
         'http://192.0.2.10:3100/workspace',
+        {proxyWebSockets: true},
       ),
     ).toMatchObject({
       wsUrl: 'ws://192.0.2.10:3100/ws/duckdb',
@@ -30,7 +31,9 @@ describe('resolveCliDevProxyConfig', () => {
 
   test('uses secure WebSockets for an HTTPS development page', () => {
     expect(
-      resolveCliDevProxyConfig({}, 'https://dev.example.test:3100'),
+      resolveCliDevProxyConfig({}, 'https://dev.example.test:3100', {
+        proxyWebSockets: true,
+      }),
     ).toMatchObject({
       wsUrl: 'wss://dev.example.test:3100/ws/duckdb',
       crdtWsUrl: 'wss://dev.example.test:3100/ws/duckdb',
@@ -56,9 +59,7 @@ describe('resolveCliDevProxyConfig', () => {
     };
 
     expect(
-      resolveCliDevProxyConfig(config, 'http://localhost:3100', {
-        proxyWebSockets: false,
-      }),
+      resolveCliDevProxyConfig(config, 'http://localhost:3100'),
     ).toMatchObject(config);
   });
 });

--- a/apps/sqlrooms-cli-ui/src/__tests__/runtimeConfig.test.ts
+++ b/apps/sqlrooms-cli-ui/src/__tests__/runtimeConfig.test.ts
@@ -47,4 +47,18 @@ describe('resolveCliDevProxyConfig', () => {
       config,
     );
   });
+
+  test('preserves an explicit external WebSocket URL', () => {
+    const config = {
+      apiBaseUrl: '',
+      wsUrl: 'wss://tunnel.example.test/ws/duckdb',
+      crdtWsUrl: 'wss://tunnel.example.test/ws/duckdb',
+    };
+
+    expect(
+      resolveCliDevProxyConfig(config, 'http://localhost:3100', {
+        proxyWebSockets: false,
+      }),
+    ).toMatchObject(config);
+  });
 });

--- a/apps/sqlrooms-cli-ui/src/__tests__/runtimeConfig.test.ts
+++ b/apps/sqlrooms-cli-ui/src/__tests__/runtimeConfig.test.ts
@@ -1,0 +1,50 @@
+import {describe, expect, test} from '@jest/globals';
+import {resolveCliDevProxyConfig} from '../runtimeConfig';
+
+describe('resolveCliDevProxyConfig', () => {
+  test('uses the browser origin for wildcard-host development proxies', () => {
+    expect(
+      resolveCliDevProxyConfig(
+        {
+          wsUrl: 'ws://localhost:4273/ws/duckdb',
+          crdtWsUrl: 'ws://localhost:4273/ws/duckdb',
+          apiBaseUrl: '',
+          mcp: {
+            enabled: true,
+            url: 'http://127.0.0.1:42100/mcp',
+            bridgeUrl: 'ws://localhost:4273/ws/mcp-bridge',
+          },
+        },
+        'http://192.0.2.10:3100/workspace',
+      ),
+    ).toMatchObject({
+      wsUrl: 'ws://192.0.2.10:3100/ws/duckdb',
+      crdtWsUrl: 'ws://192.0.2.10:3100/ws/duckdb',
+      apiBaseUrl: '',
+      mcp: {
+        url: 'http://127.0.0.1:42100/mcp',
+        bridgeUrl: 'ws://192.0.2.10:3100/ws/mcp-bridge',
+      },
+    });
+  });
+
+  test('uses secure WebSockets for an HTTPS development page', () => {
+    expect(
+      resolveCliDevProxyConfig({}, 'https://dev.example.test:3100'),
+    ).toMatchObject({
+      wsUrl: 'wss://dev.example.test:3100/ws/duckdb',
+      crdtWsUrl: 'wss://dev.example.test:3100/ws/duckdb',
+    });
+  });
+
+  test('preserves explicitly configured external URLs', () => {
+    const config = {
+      apiBaseUrl: 'https://tunnel.example.test',
+      wsUrl: 'wss://tunnel.example.test/ws/duckdb',
+    };
+
+    expect(resolveCliDevProxyConfig(config, 'http://localhost:3100')).toBe(
+      config,
+    );
+  });
+});

--- a/apps/sqlrooms-cli-ui/src/runtimeConfig.ts
+++ b/apps/sqlrooms-cli-ui/src/runtimeConfig.ts
@@ -127,7 +127,7 @@ function webSocketUrl(pageUrl: string, pathname: string): string {
 export function resolveCliDevProxyConfig(
   config: RuntimeConfig,
   pageUrl: string,
-  {proxyWebSockets = true}: {proxyWebSockets?: boolean} = {},
+  {proxyWebSockets = false}: {proxyWebSockets?: boolean} = {},
 ): RuntimeConfig {
   if (config.apiBaseUrl) return config;
 

--- a/apps/sqlrooms-cli-ui/src/runtimeConfig.ts
+++ b/apps/sqlrooms-cli-ui/src/runtimeConfig.ts
@@ -114,6 +114,37 @@ export type RuntimeConfig = {
   };
 };
 
+function webSocketUrl(pageUrl: string, pathname: string): string {
+  const url = new URL(pathname, pageUrl);
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+  return url.toString();
+}
+
+/**
+ * Route development connections through Vite using the page's actual origin.
+ * Explicit external URLs are preserved for tunnels and other custom setups.
+ */
+export function resolveCliDevProxyConfig(
+  config: RuntimeConfig,
+  pageUrl: string,
+): RuntimeConfig {
+  if (config.apiBaseUrl) return config;
+
+  const wsUrl = webSocketUrl(pageUrl, '/ws/duckdb');
+  return {
+    ...config,
+    apiBaseUrl: '',
+    wsUrl,
+    crdtWsUrl: wsUrl,
+    mcp: config.mcp
+      ? {
+          ...config.mcp,
+          bridgeUrl: webSocketUrl(pageUrl, '/ws/mcp-bridge'),
+        }
+      : undefined,
+  };
+}
+
 const RUNTIME_CONFIG_TIMEOUT_MS = 20_000;
 const RUNTIME_CONFIG_RETRY_DELAY_MS = 250;
 

--- a/apps/sqlrooms-cli-ui/src/runtimeConfig.ts
+++ b/apps/sqlrooms-cli-ui/src/runtimeConfig.ts
@@ -127,6 +127,7 @@ function webSocketUrl(pageUrl: string, pathname: string): string {
 export function resolveCliDevProxyConfig(
   config: RuntimeConfig,
   pageUrl: string,
+  {proxyWebSockets = true}: {proxyWebSockets?: boolean} = {},
 ): RuntimeConfig {
   if (config.apiBaseUrl) return config;
 
@@ -134,8 +135,7 @@ export function resolveCliDevProxyConfig(
   return {
     ...config,
     apiBaseUrl: '',
-    wsUrl,
-    crdtWsUrl: wsUrl,
+    ...(proxyWebSockets ? {wsUrl, crdtWsUrl: wsUrl} : {}),
     mcp: config.mcp
       ? {
           ...config.mcp,

--- a/apps/sqlrooms-cli-ui/src/runtimeEnvironment.ts
+++ b/apps/sqlrooms-cli-ui/src/runtimeEnvironment.ts
@@ -5,7 +5,10 @@ const fetchedRuntimeConfig = await fetchRuntimeConfig();
 
 /** Runtime configuration loaded once during CLI UI startup. */
 export const runtimeConfig = import.meta.env.DEV
-  ? resolveCliDevProxyConfig(fetchedRuntimeConfig, globalThis.location.href)
+  ? resolveCliDevProxyConfig(fetchedRuntimeConfig, globalThis.location.href, {
+      proxyWebSockets:
+        import.meta.env.VITE_SQLROOMS_CLI_PROXY_WEBSOCKETS !== 'false',
+    })
   : fetchedRuntimeConfig;
 
 /** Whether AI development tools are enabled for this runtime. */

--- a/apps/sqlrooms-cli-ui/src/runtimeEnvironment.ts
+++ b/apps/sqlrooms-cli-ui/src/runtimeEnvironment.ts
@@ -7,7 +7,7 @@ const fetchedRuntimeConfig = await fetchRuntimeConfig();
 export const runtimeConfig = import.meta.env.DEV
   ? resolveCliDevProxyConfig(fetchedRuntimeConfig, globalThis.location.href, {
       proxyWebSockets:
-        import.meta.env.VITE_SQLROOMS_CLI_PROXY_WEBSOCKETS !== 'false',
+        import.meta.env.VITE_SQLROOMS_CLI_PROXY_WEBSOCKETS === 'true',
     })
   : fetchedRuntimeConfig;
 

--- a/apps/sqlrooms-cli-ui/src/runtimeEnvironment.ts
+++ b/apps/sqlrooms-cli-ui/src/runtimeEnvironment.ts
@@ -1,8 +1,12 @@
-import {fetchRuntimeConfig} from './runtimeConfig';
+import {fetchRuntimeConfig, resolveCliDevProxyConfig} from './runtimeConfig';
 import {resolveCliCapabilityProfile} from './profiles';
 
+const fetchedRuntimeConfig = await fetchRuntimeConfig();
+
 /** Runtime configuration loaded once during CLI UI startup. */
-export const runtimeConfig = await fetchRuntimeConfig();
+export const runtimeConfig = import.meta.env.DEV
+  ? resolveCliDevProxyConfig(fetchedRuntimeConfig, globalThis.location.href)
+  : fetchedRuntimeConfig;
 
 /** Whether AI development tools are enabled for this runtime. */
 export const aiDevtoolsEnabled =

--- a/apps/sqlrooms-cli-ui/vite.config.ts
+++ b/apps/sqlrooms-cli-ui/vite.config.ts
@@ -6,6 +6,7 @@ import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import topLevelAwait from 'vite-plugin-top-level-await';
 import wasm from 'vite-plugin-wasm';
+import {createCliDevProxy} from './cliDevProxy.mjs';
 import scaffoldsPlugin from './plugins/scaffolds.ts';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -90,14 +91,7 @@ export default defineConfig({
       'Cross-Origin-Embedder-Policy': 'require-corp',
       'Cross-Origin-Resource-Policy': 'cross-origin',
     },
-    proxy: {
-      '/api': apiProxyTarget,
-      '/config.json': apiProxyTarget,
-      '/ws': {
-        target: apiProxyTarget,
-        ws: true,
-      },
-    },
+    proxy: createCliDevProxy(apiProxyTarget),
   },
   preview: {
     port: 3101,

--- a/apps/sqlrooms-cli-ui/vite.config.ts
+++ b/apps/sqlrooms-cli-ui/vite.config.ts
@@ -93,6 +93,10 @@ export default defineConfig({
     proxy: {
       '/api': apiProxyTarget,
       '/config.json': apiProxyTarget,
+      '/ws': {
+        target: apiProxyTarget,
+        ws: true,
+      },
     },
   },
   preview: {

--- a/python/sqlrooms/package.json
+++ b/python/sqlrooms/package.json
@@ -11,7 +11,7 @@
     "format": "uv run ruff format",
     "prerelease": "pnpm run build && uv run pytest && uv run ruff check && uv run ruff format --check",
     "release": "pnpm run build && uvx twine upload --skip-existing ../dist/sqlrooms-*",
-    "test": "uv run pytest -s --log-cli-level=DEBUG",
+    "test": "uv run pytest -s --log-cli-level=DEBUG && node --test scripts/dev.test.mjs",
     "verify:wheel": "python scripts/verify_wheel.py"
   },
   "dependencies": {

--- a/python/sqlrooms/scripts/dev.mjs
+++ b/python/sqlrooms/scripts/dev.mjs
@@ -11,7 +11,7 @@ function getForwardedArgs() {
 
   try {
     const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? unwrapForwardedArgs(parsed.map(String)) : [];
+    return Array.isArray(parsed) ? parsed.map(String) : [];
   } catch {
     return [];
   }

--- a/python/sqlrooms/scripts/dev.test.mjs
+++ b/python/sqlrooms/scripts/dev.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {spawnSync} from 'node:child_process';
+import test from 'node:test';
+
+test(
+  'the root CLI separator reaches uv with a dash-prefixed database path',
+  {skip: process.platform === 'win32'},
+  (t) => {
+    const testDir = mkdtempSync(path.join(tmpdir(), 'sqlrooms-dev-test-'));
+    const capturePath = path.join(testDir, 'args.json');
+    const fakeUvPath = path.join(testDir, 'uv');
+    t.after(() => rmSync(testDir, {force: true, recursive: true}));
+
+    writeFileSync(
+      fakeUvPath,
+      "#!/usr/bin/env node\nrequire('node:fs').writeFileSync(process.env.SQLROOMS_TEST_CAPTURE_PATH, JSON.stringify(process.argv.slice(2)));\n",
+    );
+    chmodSync(fakeUvPath, 0o755);
+
+    const result = spawnSync(process.execPath, ['scripts/dev.mjs'], {
+      cwd: path.resolve(import.meta.dirname, '..'),
+      env: {
+        ...process.env,
+        PATH: `${testDir}${path.delimiter}${process.env.PATH ?? ''}`,
+        SQLROOMS_CLI_DEV_ARGS: JSON.stringify(['--', '-dev.db']),
+        SQLROOMS_TEST_CAPTURE_PATH: capturePath,
+      },
+      encoding: 'utf8',
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const uvArgs = JSON.parse(readFileSync(capturePath, 'utf8'));
+    const separatorIndex = uvArgs.lastIndexOf('--');
+    assert.notEqual(separatorIndex, -1);
+    assert.deepEqual(uvArgs.slice(separatorIndex), ['--', '-dev.db']);
+  },
+);

--- a/python/sqlrooms/sqlrooms/web/launcher.py
+++ b/python/sqlrooms/sqlrooms/web/launcher.py
@@ -61,6 +61,47 @@ async def _write_upload_to_path(file: UploadFile, target: Path) -> int:
     return bytes_written
 
 
+async def _relay_duckdb_websockets(client_ws: WebSocket, upstream_ws: Any) -> None:
+    async def client_to_upstream() -> None:
+        while True:
+            message = await client_ws.receive()
+            if message["type"] == "websocket.disconnect":
+                await upstream_ws.close()
+                return
+            if message.get("bytes") is not None:
+                await upstream_ws.send(message["bytes"])
+            elif message.get("text") is not None:
+                await upstream_ws.send(message["text"])
+
+    async def upstream_to_client() -> None:
+        async for message in upstream_ws:
+            if isinstance(message, bytes):
+                await client_ws.send_bytes(message)
+            else:
+                await client_ws.send_text(message)
+
+    relay_tasks = {
+        asyncio.create_task(client_to_upstream()),
+        asyncio.create_task(upstream_to_client()),
+    }
+    try:
+        done, _ = await asyncio.wait(
+            relay_tasks,
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        for task in done:
+            task.result()
+    except asyncio.CancelledError:
+        # The dev supervisor cancels active ASGI connections during Ctrl+C.
+        # Treat that as a normal WebSocket shutdown rather than an app error.
+        return
+    finally:
+        for task in relay_tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*relay_tasks, return_exceptions=True)
+
+
 def _normalize_config_string(value: Any) -> str | None:
     if isinstance(value, (int, float)):
         return str(value)
@@ -1011,36 +1052,7 @@ class SqlroomsHttpServer:
                     upstream_url,
                     max_size=None,
                 ) as upstream_ws:
-
-                    async def client_to_upstream() -> None:
-                        while True:
-                            message = await client_ws.receive()
-                            if message["type"] == "websocket.disconnect":
-                                await upstream_ws.close()
-                                return
-                            if message.get("bytes") is not None:
-                                await upstream_ws.send(message["bytes"])
-                            elif message.get("text") is not None:
-                                await upstream_ws.send(message["text"])
-
-                    async def upstream_to_client() -> None:
-                        async for message in upstream_ws:
-                            if isinstance(message, bytes):
-                                await client_ws.send_bytes(message)
-                            else:
-                                await client_ws.send_text(message)
-
-                    done, pending = await asyncio.wait(
-                        {
-                            asyncio.create_task(client_to_upstream()),
-                            asyncio.create_task(upstream_to_client()),
-                        },
-                        return_when=asyncio.FIRST_COMPLETED,
-                    )
-                    for task in pending:
-                        task.cancel()
-                    for task in done:
-                        task.result()
+                    await _relay_duckdb_websockets(client_ws, upstream_ws)
             except WebSocketDisconnect:
                 return
             except OSError as exc:

--- a/python/sqlrooms/sqlrooms/web/mcp_bridge.py
+++ b/python/sqlrooms/sqlrooms/web/mcp_bridge.py
@@ -59,6 +59,8 @@ class McpBridgeBroker:
         await websocket.accept()
         try:
             authenticated = await asyncio.wait_for(websocket.receive_json(), timeout=5)
+        except WebSocketDisconnect:
+            return
         except Exception:
             await websocket.close(code=4401, reason="authentication required")
             return

--- a/python/sqlrooms/tests/test_launcher.py
+++ b/python/sqlrooms/tests/test_launcher.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import socket
 
@@ -11,6 +12,7 @@ from sqlrooms.web.db_bridge import PostgresConnectorSettings, SnowflakeConnector
 from sqlrooms.web.launcher import SqlroomsHttpServer
 from sqlrooms.web.launcher import _can_bind_port
 from sqlrooms.web.launcher import _pick_free_port
+from sqlrooms.web.launcher import _relay_duckdb_websockets
 from sqlrooms.web.launcher import _write_ai_settings_to_toml
 from sqlrooms.web.launcher import _write_db_connectors_to_toml
 from sqlrooms.web.launcher import _write_upload_to_path
@@ -185,6 +187,50 @@ def test_duckdb_websocket_proxy_accepts_first_message_auth(server, caplog):
     assert exc_info.value.code == 1013
     assert "DuckDB websocket backend unavailable" in caplog.text
     assert "DuckDB websocket proxy failed" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_duckdb_websocket_relay_cleans_up_on_cancellation():
+    class BlockingClientWebSocket:
+        def __init__(self):
+            self.started = asyncio.Event()
+            self.cancelled = False
+
+        async def receive(self):
+            self.started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                self.cancelled = True
+                raise
+
+    class BlockingUpstreamWebSocket:
+        def __init__(self):
+            self.started = asyncio.Event()
+            self.cancelled = False
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            self.started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                self.cancelled = True
+                raise
+
+    client_ws = BlockingClientWebSocket()
+    upstream_ws = BlockingUpstreamWebSocket()
+    relay = asyncio.create_task(_relay_duckdb_websockets(client_ws, upstream_ws))
+    await asyncio.gather(client_ws.started.wait(), upstream_ws.started.wait())
+
+    relay.cancel()
+    await relay
+
+    assert relay.cancelled() is False
+    assert client_ws.cancelled is True
+    assert upstream_ws.cancelled is True
 
 
 def test_mcp_browser_bridge_requires_auth(server):

--- a/python/sqlrooms/tests/test_mcp.py
+++ b/python/sqlrooms/tests/test_mcp.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 import mcp.types as types
 import pytest
 from mcp import Client
+from starlette.websockets import WebSocketDisconnect
 
 from sqlrooms.web.mcp import SqlroomsMcpService
 from sqlrooms.web.mcp_bridge import McpBridgeBroker, McpBridgeError
@@ -47,6 +48,30 @@ def test_mcp_bridge_status_reports_expired_lease_as_waiting(monkeypatch):
     monotonic_time = 16.0
 
     assert broker.status()["status"] == "waiting"
+
+
+@pytest.mark.asyncio
+async def test_mcp_bridge_ignores_disconnect_before_authentication():
+    class DisconnectedWebSocket:
+        accepted = False
+        close_called = False
+
+        async def accept(self):
+            self.accepted = True
+
+        async def receive_json(self):
+            raise WebSocketDisconnect(code=1006)
+
+        async def close(self, **_kwargs):
+            self.close_called = True
+
+    websocket = DisconnectedWebSocket()
+    broker = McpBridgeBroker("token")
+
+    await broker.handle_websocket(websocket)
+
+    assert websocket.accepted is True
+    assert websocket.close_called is False
 
 
 @pytest.mark.asyncio

--- a/scripts/cli-dev-args.mjs
+++ b/scripts/cli-dev-args.mjs
@@ -22,25 +22,17 @@ export function publicHost(host) {
   return host === '0.0.0.0' || host === '::' ? 'localhost' : host;
 }
 
-/** Choose the browser-visible host used by the documented Vite development URL. */
-export function browserHost(host) {
-  return ['0.0.0.0', '::', '127.0.0.1', '::1'].includes(host)
-    ? 'localhost'
-    : host;
-}
-
 /** Format a host for use in a URL, including IPv6 brackets when needed. */
 export function hostForUrl(host) {
   return host.includes(':') && !host.startsWith('[') ? `[${host}]` : host;
 }
 
-/** Resolve bind, backend-proxy, and browser-visible hosts for CLI development. */
+/** Resolve bind and backend-proxy hosts for CLI development. */
 export function getCliDevHosts(args) {
   const host = readOptionValue(args, '--host') ?? '127.0.0.1';
   return {
     host,
     proxyHost: hostForUrl(publicHost(host)),
-    externalHost: hostForUrl(browserHost(host)),
   };
 }
 
@@ -84,24 +76,14 @@ export function hasDbPathArg(args) {
 }
 
 /** Build the Python CLI arguments used by the combined CLI development flow. */
-export function getPythonCliDevArgs(
-  args,
-  apiPort,
-  uiPort,
-  externalHost,
-  {externalUrl = process.env.SQLROOMS_EXTERNAL_URL} = {},
-) {
+export function getPythonCliDevArgs(args, apiPort, uiPort) {
   const hasDbPath = hasDbPathArg(args);
   const apiPortArgs = hasOption(args, '--port')
     ? args
     : ['--port', String(apiPort), ...args];
-  const externalUrlArgs =
-    hasOption(args, '--external-url') || externalUrl
-      ? apiPortArgs
-      : ['--external-url', `http://${externalHost}:${uiPort}`, ...apiPortArgs];
-  const experimentalArgs = externalUrlArgs.includes('--experimental')
-    ? externalUrlArgs
-    : ['--experimental', ...externalUrlArgs];
+  const experimentalArgs = apiPortArgs.includes('--experimental')
+    ? apiPortArgs
+    : ['--experimental', ...apiPortArgs];
   return hasDbPath
     ? experimentalArgs
     : [

--- a/scripts/cli-dev-args.mjs
+++ b/scripts/cli-dev-args.mjs
@@ -1,11 +1,11 @@
 import {tmpdir} from 'node:os';
 import path from 'node:path';
 
-/** Preserve the end-of-options marker when forwarding CLI arguments. */
-export function getForwardedCliArgs(args) {
+/** Remove a package manager's separator while preserving a user-supplied one. */
+export function getForwardedCliArgs(args, {stripScriptSeparator = false} = {}) {
   const separatorIndex = args.indexOf('--');
   if (separatorIndex === -1) return args;
-  return args.slice(separatorIndex);
+  return args.slice(separatorIndex + (stripScriptSeparator ? 1 : 0));
 }
 
 /** Read a separate or equals-form CLI option value. */

--- a/scripts/cli-dev-args.mjs
+++ b/scripts/cli-dev-args.mjs
@@ -1,6 +1,13 @@
 import {tmpdir} from 'node:os';
 import path from 'node:path';
 
+/** Preserve the end-of-options marker when forwarding CLI arguments. */
+export function getForwardedCliArgs(args) {
+  const separatorIndex = args.indexOf('--');
+  if (separatorIndex === -1) return args;
+  return args.slice(separatorIndex);
+}
+
 /** Read a separate or equals-form CLI option value. */
 export function readOptionValue(args, name) {
   const prefix = `${name}=`;

--- a/scripts/cli-dev-args.mjs
+++ b/scripts/cli-dev-args.mjs
@@ -6,6 +6,7 @@ export function readOptionValue(args, name) {
   const prefix = `${name}=`;
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
+    if (arg === '--') return null;
     if (arg === name) return args[index + 1] ?? null;
     if (arg.startsWith(prefix)) return arg.slice(prefix.length);
   }

--- a/scripts/cli-dev-args.mjs
+++ b/scripts/cli-dev-args.mjs
@@ -1,0 +1,95 @@
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+
+/** Read a separate or equals-form CLI option value. */
+export function readOptionValue(args, name) {
+  const prefix = `${name}=`;
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === name) return args[index + 1] ?? null;
+    if (arg.startsWith(prefix)) return arg.slice(prefix.length);
+  }
+  return null;
+}
+
+/** Return whether a value-taking CLI option is present with a value. */
+export function hasOption(args, name) {
+  return readOptionValue(args, name) !== null;
+}
+
+/** Convert a wildcard bind host into a host clients can connect to. */
+export function publicHost(host) {
+  return host === '0.0.0.0' || host === '::' ? 'localhost' : host;
+}
+
+/** Format a host for use in a URL, including IPv6 brackets when needed. */
+export function hostForUrl(host) {
+  return host.includes(':') && !host.startsWith('[') ? `[${host}]` : host;
+}
+
+/** Determine whether CLI arguments include a positional or option database path. */
+export function hasDbPathArg(args) {
+  if (
+    readOptionValue(args, '--db-path') !== null ||
+    readOptionValue(args, '-d') !== null
+  ) {
+    return true;
+  }
+
+  const optionsWithValue = new Set([
+    '--config',
+    '--db-path',
+    '--external-url',
+    '--external-ws-url',
+    '--host',
+    '--meta-db',
+    '--meta-namespace',
+    '--port',
+    '--ui',
+    '--ws-port',
+    '-d',
+  ]);
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--') {
+      return args.slice(index + 1).some((value) => !value.startsWith('-'));
+    }
+    if (arg.startsWith('--') && arg.includes('=')) continue;
+    if (optionsWithValue.has(arg)) {
+      index += 1;
+      continue;
+    }
+    if (!arg.startsWith('-')) return true;
+  }
+
+  return false;
+}
+
+/** Build the Python CLI arguments used by the combined CLI development flow. */
+export function getPythonCliDevArgs(
+  args,
+  apiPort,
+  uiPort,
+  externalHost,
+  {externalUrl = process.env.SQLROOMS_EXTERNAL_URL} = {},
+) {
+  const hasDbPath = hasDbPathArg(args);
+  const apiPortArgs = hasOption(args, '--port')
+    ? args
+    : ['--port', String(apiPort), ...args];
+  const externalUrlArgs =
+    hasOption(args, '--external-url') || externalUrl
+      ? apiPortArgs
+      : ['--external-url', `http://${externalHost}:${uiPort}`, ...apiPortArgs];
+  const experimentalArgs = externalUrlArgs.includes('--experimental')
+    ? externalUrlArgs
+    : ['--experimental', ...externalUrlArgs];
+  return hasDbPath
+    ? experimentalArgs
+    : [
+        '--db-path',
+        path.join(tmpdir(), `sqlrooms-${uiPort}.db`),
+        ...experimentalArgs,
+      ];
+}

--- a/scripts/cli-dev-args.mjs
+++ b/scripts/cli-dev-args.mjs
@@ -17,6 +17,14 @@ export function hasOption(args, name) {
   return readOptionValue(args, name) !== null;
 }
 
+/** Return whether Vite should proxy CLI WebSocket connections. */
+export function shouldProxyCliDevWebSockets(
+  args,
+  {externalWsUrl = process.env.SQLROOMS_EXTERNAL_WS_URL} = {},
+) {
+  return !hasOption(args, '--external-ws-url') && !externalWsUrl;
+}
+
 /** Convert a wildcard bind host into a host clients can connect to. */
 export function publicHost(host) {
   return host === '0.0.0.0' || host === '::' ? 'localhost' : host;

--- a/scripts/cli-dev-args.mjs
+++ b/scripts/cli-dev-args.mjs
@@ -53,7 +53,7 @@ export function hasDbPathArg(args) {
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
     if (arg === '--') {
-      return args.slice(index + 1).some((value) => !value.startsWith('-'));
+      return index + 1 < args.length;
     }
     if (arg.startsWith('--') && arg.includes('=')) continue;
     if (optionsWithValue.has(arg)) {

--- a/scripts/cli-dev-args.mjs
+++ b/scripts/cli-dev-args.mjs
@@ -22,9 +22,26 @@ export function publicHost(host) {
   return host === '0.0.0.0' || host === '::' ? 'localhost' : host;
 }
 
+/** Choose the browser-visible host used by the documented Vite development URL. */
+export function browserHost(host) {
+  return ['0.0.0.0', '::', '127.0.0.1', '::1'].includes(host)
+    ? 'localhost'
+    : host;
+}
+
 /** Format a host for use in a URL, including IPv6 brackets when needed. */
 export function hostForUrl(host) {
   return host.includes(':') && !host.startsWith('[') ? `[${host}]` : host;
+}
+
+/** Resolve bind, backend-proxy, and browser-visible hosts for CLI development. */
+export function getCliDevHosts(args) {
+  const host = readOptionValue(args, '--host') ?? '127.0.0.1';
+  return {
+    host,
+    proxyHost: hostForUrl(publicHost(host)),
+    externalHost: hostForUrl(browserHost(host)),
+  };
 }
 
 /** Determine whether CLI arguments include a positional or option database path. */

--- a/scripts/cli-dev-args.test.mjs
+++ b/scripts/cli-dev-args.test.mjs
@@ -5,8 +5,36 @@ import {
   getCliDevHosts,
   getPythonCliDevArgs,
   hasDbPathArg,
+  readOptionValue,
   shouldProxyCliDevWebSockets,
 } from './cli-dev-args.mjs';
+
+test('option parsing stops at the end-of-options marker', () => {
+  assert.equal(
+    readOptionValue(
+      ['--port', '4273', '--', '--port', 'database.db'],
+      '--port',
+    ),
+    '4273',
+  );
+  assert.equal(
+    readOptionValue(['--', '--port', 'database.db'], '--port'),
+    null,
+  );
+  assert.equal(
+    readOptionValue(
+      ['--', '--external-ws-url=wss://example.test/ws/duckdb'],
+      '--external-ws-url',
+    ),
+    null,
+  );
+  assert.equal(
+    shouldProxyCliDevWebSockets(['--', '--external-ws-url', 'database.db'], {
+      externalWsUrl: null,
+    }),
+    true,
+  );
+});
 
 test('external URL option values are not treated as database paths', () => {
   for (const args of [

--- a/scripts/cli-dev-args.test.mjs
+++ b/scripts/cli-dev-args.test.mjs
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import {getPythonCliDevArgs, hasDbPathArg} from './cli-dev-args.mjs';
+import {
+  getCliDevHosts,
+  getPythonCliDevArgs,
+  hasDbPathArg,
+} from './cli-dev-args.mjs';
 
 test('external URL option values are not treated as database paths', () => {
   for (const args of [
@@ -48,4 +52,20 @@ test('the default external URL preserves the selected public host', () => {
   const externalUrlIndex = result.indexOf('--external-url');
 
   assert.equal(result[externalUrlIndex + 1], 'http://192.0.2.10:3100');
+});
+
+test('the default loopback API host uses the documented localhost UI origin', () => {
+  assert.deepEqual(getCliDevHosts([]), {
+    host: '127.0.0.1',
+    proxyHost: '127.0.0.1',
+    externalHost: 'localhost',
+  });
+});
+
+test('an explicit network host remains browser-visible', () => {
+  assert.deepEqual(getCliDevHosts(['--host', '192.0.2.10']), {
+    host: '192.0.2.10',
+    proxyHost: '192.0.2.10',
+    externalHost: '192.0.2.10',
+  });
 });

--- a/scripts/cli-dev-args.test.mjs
+++ b/scripts/cli-dev-args.test.mjs
@@ -2,12 +2,20 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  getForwardedCliArgs,
   getCliDevHosts,
   getPythonCliDevArgs,
   hasDbPathArg,
   readOptionValue,
   shouldProxyCliDevWebSockets,
 } from './cli-dev-args.mjs';
+
+test('the root launcher preserves the end-of-options marker', () => {
+  assert.deepEqual(getForwardedCliArgs(['--dry', '--', '-dev.db']), [
+    '--',
+    '-dev.db',
+  ]);
+});
 
 test('option parsing stops at the end-of-options marker', () => {
   assert.equal(

--- a/scripts/cli-dev-args.test.mjs
+++ b/scripts/cli-dev-args.test.mjs
@@ -23,49 +23,37 @@ test('explicit external URLs still receive a development database path', () => {
     ['--external-url', 'https://example.test'],
     ['--external-url=https://example.test'],
   ]) {
-    const result = getPythonCliDevArgs(args, 4273, 3100, 'localhost', {
-      externalUrl: undefined,
-    });
+    const result = getPythonCliDevArgs(args, 4273, 3100);
     assert.notEqual(result.indexOf('--db-path'), -1, args.join(' '));
   }
 });
 
 test('a dash-prefixed database path after -- is preserved', () => {
   const args = ['--', '-dev.db'];
-  const result = getPythonCliDevArgs(args, 4273, 3100, 'localhost', {
-    externalUrl: null,
-  });
+  const result = getPythonCliDevArgs(args, 4273, 3100);
 
   assert.equal(hasDbPathArg(args), true);
   assert.equal(result.includes('--db-path'), false);
   assert.deepEqual(result.slice(-2), args);
 });
 
-test('the default external URL preserves the selected public host', () => {
-  const result = getPythonCliDevArgs(
-    ['--host', '192.0.2.10'],
-    4273,
-    3100,
-    '192.0.2.10',
-    {externalUrl: null},
-  );
-  const externalUrlIndex = result.indexOf('--external-url');
-
-  assert.equal(result[externalUrlIndex + 1], 'http://192.0.2.10:3100');
-});
-
-test('the default loopback API host uses the documented localhost UI origin', () => {
+test('the default loopback API host remains available to the Vite proxy', () => {
   assert.deepEqual(getCliDevHosts([]), {
     host: '127.0.0.1',
     proxyHost: '127.0.0.1',
-    externalHost: 'localhost',
   });
 });
 
-test('an explicit network host remains browser-visible', () => {
+test('an explicit network host is used by the local backend proxy', () => {
   assert.deepEqual(getCliDevHosts(['--host', '192.0.2.10']), {
     host: '192.0.2.10',
     proxyHost: '192.0.2.10',
-    externalHost: '192.0.2.10',
+  });
+});
+
+test('wildcard binds use loopback only for the local backend proxy', () => {
+  assert.deepEqual(getCliDevHosts(['--host', '0.0.0.0']), {
+    host: '0.0.0.0',
+    proxyHost: 'localhost',
   });
 });

--- a/scripts/cli-dev-args.test.mjs
+++ b/scripts/cli-dev-args.test.mjs
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {getPythonCliDevArgs, hasDbPathArg} from './cli-dev-args.mjs';
+
+test('external URL option values are not treated as database paths', () => {
+  for (const args of [
+    ['--external-url', 'https://example.test'],
+    ['--external-url=https://example.test'],
+    ['--external-ws-url', 'wss://example.test/ws/duckdb'],
+    ['--external-ws-url=wss://example.test/ws/duckdb'],
+  ]) {
+    assert.equal(hasDbPathArg(args), false, args.join(' '));
+  }
+});
+
+test('explicit external URLs still receive a development database path', () => {
+  for (const args of [
+    ['--external-url', 'https://example.test'],
+    ['--external-url=https://example.test'],
+  ]) {
+    const result = getPythonCliDevArgs(args, 4273, 3100, 'localhost', {
+      externalUrl: undefined,
+    });
+    assert.notEqual(result.indexOf('--db-path'), -1, args.join(' '));
+  }
+});
+
+test('the default external URL preserves the selected public host', () => {
+  const result = getPythonCliDevArgs(
+    ['--host', '192.0.2.10'],
+    4273,
+    3100,
+    '192.0.2.10',
+    {externalUrl: undefined},
+  );
+  const externalUrlIndex = result.indexOf('--external-url');
+
+  assert.equal(result[externalUrlIndex + 1], 'http://192.0.2.10:3100');
+});

--- a/scripts/cli-dev-args.test.mjs
+++ b/scripts/cli-dev-args.test.mjs
@@ -26,13 +26,24 @@ test('explicit external URLs still receive a development database path', () => {
   }
 });
 
+test('a dash-prefixed database path after -- is preserved', () => {
+  const args = ['--', '-dev.db'];
+  const result = getPythonCliDevArgs(args, 4273, 3100, 'localhost', {
+    externalUrl: null,
+  });
+
+  assert.equal(hasDbPathArg(args), true);
+  assert.equal(result.includes('--db-path'), false);
+  assert.deepEqual(result.slice(-2), args);
+});
+
 test('the default external URL preserves the selected public host', () => {
   const result = getPythonCliDevArgs(
     ['--host', '192.0.2.10'],
     4273,
     3100,
     '192.0.2.10',
-    {externalUrl: undefined},
+    {externalUrl: null},
   );
   const externalUrlIndex = result.indexOf('--external-url');
 

--- a/scripts/cli-dev-args.test.mjs
+++ b/scripts/cli-dev-args.test.mjs
@@ -10,11 +10,26 @@ import {
   shouldProxyCliDevWebSockets,
 } from './cli-dev-args.mjs';
 
-test('the root launcher preserves the end-of-options marker', () => {
+test('the direct root launcher preserves the end-of-options marker', () => {
   assert.deepEqual(getForwardedCliArgs(['--dry', '--', '-dev.db']), [
     '--',
     '-dev.db',
   ]);
+});
+
+test('the package script drops its separator and preserves the user marker', () => {
+  assert.deepEqual(
+    getForwardedCliArgs(['--dry', '--', '--port', '4274'], {
+      stripScriptSeparator: true,
+    }),
+    ['--port', '4274'],
+  );
+  assert.deepEqual(
+    getForwardedCliArgs(['--dry', '--', '--', '-dev.db'], {
+      stripScriptSeparator: true,
+    }),
+    ['--', '-dev.db'],
+  );
 });
 
 test('option parsing stops at the end-of-options marker', () => {

--- a/scripts/cli-dev-args.test.mjs
+++ b/scripts/cli-dev-args.test.mjs
@@ -5,6 +5,7 @@ import {
   getCliDevHosts,
   getPythonCliDevArgs,
   hasDbPathArg,
+  shouldProxyCliDevWebSockets,
 } from './cli-dev-args.mjs';
 
 test('external URL option values are not treated as database paths', () => {
@@ -26,6 +27,27 @@ test('explicit external URLs still receive a development database path', () => {
     const result = getPythonCliDevArgs(args, 4273, 3100);
     assert.notEqual(result.indexOf('--db-path'), -1, args.join(' '));
   }
+});
+
+test('explicit WebSocket URLs bypass the Vite WebSocket proxy', () => {
+  for (const args of [
+    ['--external-ws-url', 'wss://example.test/ws/duckdb'],
+    ['--external-ws-url=wss://example.test/ws/duckdb'],
+  ]) {
+    assert.equal(
+      shouldProxyCliDevWebSockets(args, {externalWsUrl: null}),
+      false,
+      args.join(' '),
+    );
+  }
+
+  assert.equal(
+    shouldProxyCliDevWebSockets([], {
+      externalWsUrl: 'wss://example.test/ws/duckdb',
+    }),
+    false,
+  );
+  assert.equal(shouldProxyCliDevWebSockets([], {externalWsUrl: null}), true);
 });
 
 test('a dash-prefixed database path after -- is preserved', () => {

--- a/scripts/cli-dev-readiness.mjs
+++ b/scripts/cli-dev-readiness.mjs
@@ -1,0 +1,44 @@
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_ATTEMPT_TIMEOUT_MS = 1_000;
+const DEFAULT_RETRY_DELAY_MS = 100;
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Wait until the CLI API accepts requests or the startup deadline expires. */
+export async function waitForCliApi(
+  url,
+  {
+    attemptTimeoutMs = DEFAULT_ATTEMPT_TIMEOUT_MS,
+    fetchImpl = globalThis.fetch,
+    retryDelayMs = DEFAULT_RETRY_DELAY_MS,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+  } = {},
+) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError;
+
+  do {
+    const remainingMs = Math.max(1, deadline - Date.now());
+    try {
+      const response = await fetchImpl(url, {
+        signal: AbortSignal.timeout(
+          Math.max(1, Math.min(attemptTimeoutMs, remainingMs)),
+        ),
+      });
+      if (response.ok) return;
+      lastError = new Error(`CLI API returned HTTP ${response.status}.`);
+    } catch (error) {
+      lastError = error;
+    }
+
+    const retryRemainingMs = deadline - Date.now();
+    if (retryRemainingMs <= 0) break;
+    await delay(Math.min(retryDelayMs, retryRemainingMs));
+  } while (Date.now() <= deadline);
+
+  throw new Error(`Timed out waiting for SQLRooms CLI API at ${url}.`, {
+    cause: lastError,
+  });
+}

--- a/scripts/cli-dev-readiness.mjs
+++ b/scripts/cli-dev-readiness.mjs
@@ -13,6 +13,7 @@ export async function waitForCliApi(
     attemptTimeoutMs = DEFAULT_ATTEMPT_TIMEOUT_MS,
     fetchImpl = globalThis.fetch,
     retryDelayMs = DEFAULT_RETRY_DELAY_MS,
+    signal,
     timeoutMs = DEFAULT_TIMEOUT_MS,
   } = {},
 ) {
@@ -20,16 +21,25 @@ export async function waitForCliApi(
   let lastError;
 
   do {
+    signal?.throwIfAborted();
     const remainingMs = Math.max(1, deadline - Date.now());
     try {
+      const attemptSignal = AbortSignal.any(
+        [
+          signal,
+          AbortSignal.timeout(
+            Math.max(1, Math.min(attemptTimeoutMs, remainingMs)),
+          ),
+        ].filter(Boolean),
+      );
       const response = await fetchImpl(url, {
-        signal: AbortSignal.timeout(
-          Math.max(1, Math.min(attemptTimeoutMs, remainingMs)),
-        ),
+        signal: attemptSignal,
       });
+      signal?.throwIfAborted();
       if (response.ok) return;
       lastError = new Error(`CLI API returned HTTP ${response.status}.`);
     } catch (error) {
+      signal?.throwIfAborted();
       lastError = error;
     }
 

--- a/scripts/cli-dev-readiness.test.mjs
+++ b/scripts/cli-dev-readiness.test.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {waitForCliApi} from './cli-dev-readiness.mjs';
+
+test('CLI API readiness retries until the server responds', async () => {
+  let attempts = 0;
+  await waitForCliApi('http://127.0.0.1:4273/api/status', {
+    fetchImpl: async () => {
+      attempts += 1;
+      if (attempts < 3) throw new Error('connect ECONNREFUSED');
+      return {ok: true, status: 200};
+    },
+    retryDelayMs: 0,
+    timeoutMs: 1_000,
+  });
+
+  assert.equal(attempts, 3);
+});
+
+test('CLI API readiness retries non-success responses', async () => {
+  let attempts = 0;
+  await waitForCliApi('http://127.0.0.1:4273/api/status', {
+    fetchImpl: async () => {
+      attempts += 1;
+      return {ok: attempts > 1, status: attempts > 1 ? 200 : 503};
+    },
+    retryDelayMs: 0,
+    timeoutMs: 1_000,
+  });
+
+  assert.equal(attempts, 2);
+});

--- a/scripts/cli-dev-readiness.test.mjs
+++ b/scripts/cli-dev-readiness.test.mjs
@@ -31,3 +31,22 @@ test('CLI API readiness retries non-success responses', async () => {
 
   assert.equal(attempts, 2);
 });
+
+test('CLI API readiness stays aborted when an in-flight request succeeds', async () => {
+  const controller = new AbortController();
+  let attemptSignal;
+  const readiness = waitForCliApi('http://127.0.0.1:4273/api/status', {
+    fetchImpl: async (_url, options) => {
+      attemptSignal = options.signal;
+      await new Promise((resolve) => setImmediate(resolve));
+      return {ok: true, status: 200};
+    },
+    signal: controller.signal,
+    timeoutMs: 1_000,
+  });
+
+  controller.abort(new Error('shutdown requested'));
+
+  await assert.rejects(readiness, /shutdown requested/);
+  assert.equal(attemptSignal.aborted, true);
+});

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -56,7 +56,9 @@ const controlArgs = getControlArgs(restArgs);
 const forwardedCliArgs =
   restArgs.indexOf('--') === -1
     ? controlArgs.filter((arg) => arg !== '--dry' && !arg.startsWith('--dry='))
-    : getForwardedCliArgs(restArgs);
+    : getForwardedCliArgs(restArgs, {
+        stripScriptSeparator: Boolean(process.env.npm_execpath),
+      });
 const cliArgs = target === 'cli' ? forwardedCliArgs : [];
 const proxyCliDevWebSockets = shouldProxyCliDevWebSockets(cliArgs);
 const turboArgsForTarget = target === 'cli' ? [] : restArgs;

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -2,6 +2,7 @@ import {spawn, spawnSync} from 'node:child_process';
 import net from 'node:net';
 import path from 'node:path';
 import {
+  getForwardedCliArgs,
   getCliDevHosts,
   getPythonCliDevArgs,
   hasOption,
@@ -45,12 +46,6 @@ const targetConfig =
 const resolvedTarget = targetConfig?.packageName ?? null;
 const filter = resolvedTarget ? `${resolvedTarget}...` : '@sqlrooms/*';
 
-function unwrapForwardedArgs(args) {
-  const separatorIndex = args.indexOf('--');
-  if (separatorIndex === -1) return args;
-  return args.slice(separatorIndex + 1);
-}
-
 function getControlArgs(args) {
   const separatorIndex = args.indexOf('--');
   if (separatorIndex === -1) return args;
@@ -61,7 +56,7 @@ const controlArgs = getControlArgs(restArgs);
 const forwardedCliArgs =
   restArgs.indexOf('--') === -1
     ? controlArgs.filter((arg) => arg !== '--dry' && !arg.startsWith('--dry='))
-    : unwrapForwardedArgs(restArgs);
+    : getForwardedCliArgs(restArgs);
 const cliArgs = target === 'cli' ? forwardedCliArgs : [];
 const proxyCliDevWebSockets = shouldProxyCliDevWebSockets(cliArgs);
 const turboArgsForTarget = target === 'cli' ? [] : restArgs;

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -155,7 +155,7 @@ function parsePortOption(args, name) {
 }
 
 async function getCliDevPorts(args) {
-  const {externalHost, host, proxyHost} = getCliDevHosts(args);
+  const {host, proxyHost} = getCliDevHosts(args);
   const explicitApiPort = parsePortOption(args, '--port');
   const explicitWsPort = parsePortOption(args, '--ws-port');
   const reservedPorts = new Set(
@@ -174,7 +174,7 @@ async function getCliDevPorts(args) {
     '0.0.0.0',
     uiReservedPorts,
   );
-  return {apiPort, externalHost, proxyHost, uiPort};
+  return {apiPort, proxyHost, uiPort};
 }
 
 function turboRunArgs(task, filters, extraArgs = []) {
@@ -262,14 +262,8 @@ if (target !== 'cli') {
     process.exit(1);
   }
 } else if (isDryRun) {
-  const {apiPort, externalHost, proxyHost, uiPort} =
-    await getCliDevPorts(cliArgs);
-  const pythonCliArgs = getPythonCliDevArgs(
-    cliArgs,
-    apiPort,
-    uiPort,
-    externalHost,
-  );
+  const {apiPort, proxyHost, uiPort} = await getCliDevPorts(cliArgs);
+  const pythonCliArgs = getPythonCliDevArgs(cliArgs, apiPort, uiPort);
   console.log(
     `(cd apps/sqlrooms-cli-ui && SQLROOMS_CLI_API_PROXY_TARGET=http://${proxyHost}:${apiPort} ./node_modules/.bin/vite --host --port ${uiPort})`,
   );
@@ -363,14 +357,8 @@ process.on('SIGTERM', () => {
 });
 
 if (target === 'cli') {
-  const {apiPort, externalHost, proxyHost, uiPort} =
-    await getCliDevPorts(cliArgs);
-  const pythonCliArgs = getPythonCliDevArgs(
-    cliArgs,
-    apiPort,
-    uiPort,
-    externalHost,
-  );
+  const {apiPort, proxyHost, uiPort} = await getCliDevPorts(cliArgs);
+  const pythonCliArgs = getPythonCliDevArgs(cliArgs, apiPort, uiPort);
   startProcess(
     'sqlrooms CLI UI dev server',
     ['--host', '--port', String(uiPort)],

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -277,6 +277,7 @@ if (target !== 'cli') {
 }
 
 const children = new Set();
+const cliStartupController = new AbortController();
 let exiting = false;
 
 function stopChildren(signal = 'SIGTERM') {
@@ -347,12 +348,14 @@ function startProcess(
 
 process.on('SIGINT', () => {
   exiting = true;
+  cliStartupController.abort();
   stopChildren('SIGINT');
   setTimeout(() => process.exit(130), 1000).unref();
 });
 
 process.on('SIGTERM', () => {
   exiting = true;
+  cliStartupController.abort();
   stopChildren('SIGTERM');
   setTimeout(() => process.exit(143), 1000).unref();
 });
@@ -369,25 +372,29 @@ if (target === 'cli') {
   });
   const apiStatusUrl = `http://${proxyHost}:${apiPort}/api/status`;
   try {
-    await waitForCliApi(apiStatusUrl);
+    await waitForCliApi(apiStatusUrl, {signal: cliStartupController.signal});
   } catch (error) {
-    exiting = true;
-    stopChildren();
-    console.error('SQLRooms CLI API failed to become ready.', error);
-    process.exit(1);
+    if (!exiting) {
+      exiting = true;
+      stopChildren();
+      console.error('SQLRooms CLI API failed to become ready.', error);
+      process.exit(1);
+    }
   }
-  startProcess(
-    'sqlrooms CLI UI dev server',
-    ['--host', '--port', String(uiPort)],
-    {
-      command: path.resolve('apps/sqlrooms-cli-ui', 'node_modules/.bin/vite'),
-      cwd: path.resolve('apps/sqlrooms-cli-ui'),
-      env: {
-        SQLROOMS_CLI_API_PROXY_TARGET: `http://${proxyHost}:${apiPort}`,
-        VITE_SQLROOMS_CLI_PROXY_WEBSOCKETS: String(proxyCliDevWebSockets),
+  if (!exiting) {
+    startProcess(
+      'sqlrooms CLI UI dev server',
+      ['--host', '--port', String(uiPort)],
+      {
+        command: path.resolve('apps/sqlrooms-cli-ui', 'node_modules/.bin/vite'),
+        cwd: path.resolve('apps/sqlrooms-cli-ui'),
+        env: {
+          SQLROOMS_CLI_API_PROXY_TARGET: `http://${proxyHost}:${apiPort}`,
+          VITE_SQLROOMS_CLI_PROXY_WEBSOCKETS: String(proxyCliDevWebSockets),
+        },
       },
-    },
-  );
+    );
+  }
 } else {
   startProcess(
     'turbo dependency dev watchers',

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -8,6 +8,7 @@ import {
   readOptionValue,
   shouldProxyCliDevWebSockets,
 } from './cli-dev-args.mjs';
+import {waitForCliApi} from './cli-dev-readiness.mjs';
 
 /**
  * Dev entrypoint for this monorepo.
@@ -267,12 +268,13 @@ if (target !== 'cli') {
   const {apiPort, proxyHost, uiPort} = await getCliDevPorts(cliArgs);
   const pythonCliArgs = getPythonCliDevArgs(cliArgs, apiPort, uiPort);
   console.log(
-    `(cd apps/sqlrooms-cli-ui && SQLROOMS_CLI_API_PROXY_TARGET=http://${proxyHost}:${apiPort} VITE_SQLROOMS_CLI_PROXY_WEBSOCKETS=${proxyCliDevWebSockets} ./node_modules/.bin/vite --host --port ${uiPort})`,
-  );
-  console.log(
     `(cd python/sqlrooms && SQLROOMS_CLI_DEV_ARGS=${JSON.stringify(
       pythonCliArgs,
     )} node scripts/dev.mjs)`,
+  );
+  console.log(`(wait for http://${proxyHost}:${apiPort}/api/status)`);
+  console.log(
+    `(cd apps/sqlrooms-cli-ui && SQLROOMS_CLI_API_PROXY_TARGET=http://${proxyHost}:${apiPort} VITE_SQLROOMS_CLI_PROXY_WEBSOCKETS=${proxyCliDevWebSockets} ./node_modules/.bin/vite --host --port ${uiPort})`,
   );
   process.exit(0);
 }
@@ -361,6 +363,22 @@ process.on('SIGTERM', () => {
 if (target === 'cli') {
   const {apiPort, proxyHost, uiPort} = await getCliDevPorts(cliArgs);
   const pythonCliArgs = getPythonCliDevArgs(cliArgs, apiPort, uiPort);
+  startProcess('sqlrooms Python CLI dev server', ['scripts/dev.mjs'], {
+    command: process.execPath,
+    cwd: path.resolve('python/sqlrooms'),
+    env: {
+      SQLROOMS_CLI_DEV_ARGS: JSON.stringify(pythonCliArgs),
+    },
+  });
+  const apiStatusUrl = `http://${proxyHost}:${apiPort}/api/status`;
+  try {
+    await waitForCliApi(apiStatusUrl);
+  } catch (error) {
+    exiting = true;
+    stopChildren();
+    console.error('SQLRooms CLI API failed to become ready.', error);
+    process.exit(1);
+  }
   startProcess(
     'sqlrooms CLI UI dev server',
     ['--host', '--port', String(uiPort)],
@@ -373,13 +391,6 @@ if (target === 'cli') {
       },
     },
   );
-  startProcess('sqlrooms Python CLI dev server', ['scripts/dev.mjs'], {
-    command: process.execPath,
-    cwd: path.resolve('python/sqlrooms'),
-    env: {
-      SQLROOMS_CLI_DEV_ARGS: JSON.stringify(pythonCliArgs),
-    },
-  });
 } else {
   startProcess(
     'turbo dependency dev watchers',

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -2,10 +2,9 @@ import {spawn, spawnSync} from 'node:child_process';
 import net from 'node:net';
 import path from 'node:path';
 import {
+  getCliDevHosts,
   getPythonCliDevArgs,
   hasOption,
-  hostForUrl,
-  publicHost,
   readOptionValue,
 } from './cli-dev-args.mjs';
 
@@ -156,8 +155,7 @@ function parsePortOption(args, name) {
 }
 
 async function getCliDevPorts(args) {
-  const host = readOptionValue(args, '--host') ?? '127.0.0.1';
-  const proxyHost = hostForUrl(publicHost(host));
+  const {externalHost, host, proxyHost} = getCliDevHosts(args);
   const explicitApiPort = parsePortOption(args, '--port');
   const explicitWsPort = parsePortOption(args, '--ws-port');
   const reservedPorts = new Set(
@@ -176,7 +174,7 @@ async function getCliDevPorts(args) {
     '0.0.0.0',
     uiReservedPorts,
   );
-  return {apiPort, proxyHost, uiPort};
+  return {apiPort, externalHost, proxyHost, uiPort};
 }
 
 function turboRunArgs(task, filters, extraArgs = []) {
@@ -264,12 +262,13 @@ if (target !== 'cli') {
     process.exit(1);
   }
 } else if (isDryRun) {
-  const {apiPort, proxyHost, uiPort} = await getCliDevPorts(cliArgs);
+  const {apiPort, externalHost, proxyHost, uiPort} =
+    await getCliDevPorts(cliArgs);
   const pythonCliArgs = getPythonCliDevArgs(
     cliArgs,
     apiPort,
     uiPort,
-    proxyHost,
+    externalHost,
   );
   console.log(
     `(cd apps/sqlrooms-cli-ui && SQLROOMS_CLI_API_PROXY_TARGET=http://${proxyHost}:${apiPort} ./node_modules/.bin/vite --host --port ${uiPort})`,
@@ -364,12 +363,13 @@ process.on('SIGTERM', () => {
 });
 
 if (target === 'cli') {
-  const {apiPort, proxyHost, uiPort} = await getCliDevPorts(cliArgs);
+  const {apiPort, externalHost, proxyHost, uiPort} =
+    await getCliDevPorts(cliArgs);
   const pythonCliArgs = getPythonCliDevArgs(
     cliArgs,
     apiPort,
     uiPort,
-    proxyHost,
+    externalHost,
   );
   startProcess(
     'sqlrooms CLI UI dev server',

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -232,13 +232,18 @@ async function getCliDevPorts(args) {
 }
 
 function getPythonCliDevArgs(args, apiPort, uiPort) {
+  const hasDbPath = hasDbPathArg(args);
   const apiPortArgs = hasOption(args, '--port')
     ? args
     : ['--port', String(apiPort), ...args];
-  const experimentalArgs = apiPortArgs.includes('--experimental')
-    ? apiPortArgs
-    : ['--experimental', ...apiPortArgs];
-  return hasDbPathArg(experimentalArgs)
+  const externalUrlArgs =
+    hasOption(args, '--external-url') || process.env.SQLROOMS_EXTERNAL_URL
+      ? apiPortArgs
+      : ['--external-url', `http://localhost:${uiPort}`, ...apiPortArgs];
+  const experimentalArgs = externalUrlArgs.includes('--experimental')
+    ? externalUrlArgs
+    : ['--experimental', ...externalUrlArgs];
+  return hasDbPath
     ? experimentalArgs
     : [
         '--db-path',

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -6,6 +6,7 @@ import {
   getPythonCliDevArgs,
   hasOption,
   readOptionValue,
+  shouldProxyCliDevWebSockets,
 } from './cli-dev-args.mjs';
 
 /**
@@ -61,6 +62,7 @@ const forwardedCliArgs =
     ? controlArgs.filter((arg) => arg !== '--dry' && !arg.startsWith('--dry='))
     : unwrapForwardedArgs(restArgs);
 const cliArgs = target === 'cli' ? forwardedCliArgs : [];
+const proxyCliDevWebSockets = shouldProxyCliDevWebSockets(cliArgs);
 const turboArgsForTarget = target === 'cli' ? [] : restArgs;
 const isDryRun = controlArgs.some(
   (arg) => arg === '--dry' || arg.startsWith('--dry='),
@@ -265,7 +267,7 @@ if (target !== 'cli') {
   const {apiPort, proxyHost, uiPort} = await getCliDevPorts(cliArgs);
   const pythonCliArgs = getPythonCliDevArgs(cliArgs, apiPort, uiPort);
   console.log(
-    `(cd apps/sqlrooms-cli-ui && SQLROOMS_CLI_API_PROXY_TARGET=http://${proxyHost}:${apiPort} ./node_modules/.bin/vite --host --port ${uiPort})`,
+    `(cd apps/sqlrooms-cli-ui && SQLROOMS_CLI_API_PROXY_TARGET=http://${proxyHost}:${apiPort} VITE_SQLROOMS_CLI_PROXY_WEBSOCKETS=${proxyCliDevWebSockets} ./node_modules/.bin/vite --host --port ${uiPort})`,
   );
   console.log(
     `(cd python/sqlrooms && SQLROOMS_CLI_DEV_ARGS=${JSON.stringify(
@@ -367,6 +369,7 @@ if (target === 'cli') {
       cwd: path.resolve('apps/sqlrooms-cli-ui'),
       env: {
         SQLROOMS_CLI_API_PROXY_TARGET: `http://${proxyHost}:${apiPort}`,
+        VITE_SQLROOMS_CLI_PROXY_WEBSOCKETS: String(proxyCliDevWebSockets),
       },
     },
   );

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,7 +1,13 @@
 import {spawn, spawnSync} from 'node:child_process';
 import net from 'node:net';
-import {tmpdir} from 'node:os';
 import path from 'node:path';
+import {
+  getPythonCliDevArgs,
+  hasOption,
+  hostForUrl,
+  publicHost,
+  readOptionValue,
+} from './cli-dev-args.mjs';
 
 /**
  * Dev entrypoint for this monorepo.
@@ -86,28 +92,6 @@ const childEnv = {
 const CLI_DEV_API_DEFAULT_PORT = 4273;
 const CLI_DEV_UI_DEFAULT_PORT = 3100;
 
-function readOptionValue(args, name) {
-  const prefix = `${name}=`;
-  for (let index = 0; index < args.length; index += 1) {
-    const arg = args[index];
-    if (arg === name) return args[index + 1] ?? null;
-    if (arg.startsWith(prefix)) return arg.slice(prefix.length);
-  }
-  return null;
-}
-
-function hasOption(args, name) {
-  return readOptionValue(args, name) !== null;
-}
-
-function publicHost(host) {
-  return host === '0.0.0.0' || host === '::' ? 'localhost' : host;
-}
-
-function hostForUrl(host) {
-  return host.includes(':') && !host.startsWith('[') ? `[${host}]` : host;
-}
-
 function portProbeHosts(host) {
   return host === 'localhost' ? ['127.0.0.1', '::1'] : [host];
 }
@@ -171,42 +155,6 @@ function parsePortOption(args, name) {
   return Number.isFinite(port) ? port : null;
 }
 
-function hasDbPathArg(args) {
-  if (
-    readOptionValue(args, '--db-path') !== null ||
-    readOptionValue(args, '-d') !== null
-  ) {
-    return true;
-  }
-
-  const optionsWithValue = new Set([
-    '--config',
-    '--db-path',
-    '--host',
-    '--meta-db',
-    '--meta-namespace',
-    '--port',
-    '--ui',
-    '--ws-port',
-    '-d',
-  ]);
-
-  for (let index = 0; index < args.length; index += 1) {
-    const arg = args[index];
-    if (arg === '--') {
-      return args.slice(index + 1).some((value) => !value.startsWith('-'));
-    }
-    if (arg.startsWith('--') && arg.includes('=')) continue;
-    if (optionsWithValue.has(arg)) {
-      index += 1;
-      continue;
-    }
-    if (!arg.startsWith('-')) return true;
-  }
-
-  return false;
-}
-
 async function getCliDevPorts(args) {
   const host = readOptionValue(args, '--host') ?? '127.0.0.1';
   const proxyHost = hostForUrl(publicHost(host));
@@ -229,27 +177,6 @@ async function getCliDevPorts(args) {
     uiReservedPorts,
   );
   return {apiPort, proxyHost, uiPort};
-}
-
-function getPythonCliDevArgs(args, apiPort, uiPort) {
-  const hasDbPath = hasDbPathArg(args);
-  const apiPortArgs = hasOption(args, '--port')
-    ? args
-    : ['--port', String(apiPort), ...args];
-  const externalUrlArgs =
-    hasOption(args, '--external-url') || process.env.SQLROOMS_EXTERNAL_URL
-      ? apiPortArgs
-      : ['--external-url', `http://localhost:${uiPort}`, ...apiPortArgs];
-  const experimentalArgs = externalUrlArgs.includes('--experimental')
-    ? externalUrlArgs
-    : ['--experimental', ...externalUrlArgs];
-  return hasDbPath
-    ? experimentalArgs
-    : [
-        '--db-path',
-        path.join(tmpdir(), `sqlrooms-${uiPort}.db`),
-        ...experimentalArgs,
-      ];
 }
 
 function turboRunArgs(task, filters, extraArgs = []) {
@@ -338,7 +265,12 @@ if (target !== 'cli') {
   }
 } else if (isDryRun) {
   const {apiPort, proxyHost, uiPort} = await getCliDevPorts(cliArgs);
-  const pythonCliArgs = getPythonCliDevArgs(cliArgs, apiPort, uiPort);
+  const pythonCliArgs = getPythonCliDevArgs(
+    cliArgs,
+    apiPort,
+    uiPort,
+    proxyHost,
+  );
   console.log(
     `(cd apps/sqlrooms-cli-ui && SQLROOMS_CLI_API_PROXY_TARGET=http://${proxyHost}:${apiPort} ./node_modules/.bin/vite --host --port ${uiPort})`,
   );
@@ -433,7 +365,12 @@ process.on('SIGTERM', () => {
 
 if (target === 'cli') {
   const {apiPort, proxyHost, uiPort} = await getCliDevPorts(cliArgs);
-  const pythonCliArgs = getPythonCliDevArgs(cliArgs, apiPort, uiPort);
+  const pythonCliArgs = getPythonCliDevArgs(
+    cliArgs,
+    apiPort,
+    uiPort,
+    proxyHost,
+  );
   startProcess(
     'sqlrooms CLI UI dev server',
     ['--host', '--port', String(uiPort)],


### PR DESCRIPTION
## Summary

- Proxy `/ws` through the CLI UI Vite dev server
- Set the Python API external URL to the selected UI port by default
- Preserve explicit external URL and database path arguments
- Update CLI development documentation

## Testing

Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Combined CLI development mode now supports WebSocket connections through `/ws`, including collaboration and MCP features.
  * Automatically configures local UI and API connectivity when no external URL is provided.
  * Uses secure WebSockets when running over HTTPS and preserves explicitly configured external URLs.

* **Bug Fixes**
  * Improved handling of database paths, host settings, and forwarded CLI arguments during development.
  * Improved connectivity between the UI and Python API, including WebSocket-based features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->