### PR TITLE
fix(deck): generate canonical point map transforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@ docs/.vitepress/cache
 
 .pnpm-store/
 
+# Evaluation outputs
+/artifacts/
+/.promptfoo/
+
 .cursor/plans/
 
 .worktrees/

--- a/apps/sqlrooms-cli-ui/src/__tests__/createCliBlockDocumentCommands.test.ts
+++ b/apps/sqlrooms-cli-ui/src/__tests__/createCliBlockDocumentCommands.test.ts
@@ -1,4 +1,5 @@
 import {jest} from '@jest/globals';
+import {createDeckMapPointTransformSql} from '@sqlrooms/deck';
 import {makeQualifiedTableName} from '@sqlrooms/duckdb';
 import {createCliBlockDocumentCommands} from '../createCliBlockDocumentCommands';
 import {
@@ -232,6 +233,67 @@ describe('createCliBlockDocumentCommands', () => {
         String(id).startsWith('dashboard.'),
       ),
     ).toBe(false);
+  });
+
+  it('generates canonical point geometry from structured provenance', async () => {
+    const {state, mapsById} = setup();
+    const result = await command('block-document.add-map-block').execute(
+      {getState: () => state} as any,
+      {
+        blockDocumentId: 'document-1',
+        title: 'Earthquake Points',
+        tableName: 'earthquakes',
+        pointBinding: {
+          dataset: 'earthquakes',
+          longitudeColumn: 'longitude',
+          latitudeColumn: 'latitude',
+          geometryColumn: 'geom',
+        },
+        config: {
+          datasets: {
+            earthquakes: {
+              source: {
+                tableName: 'earthquakes',
+                transformSql:
+                  'SELECT * EXCLUDE (latitude, longitude), ST_AsWKB(ST_Point(longitude, latitude)) AS geom FROM __sqlrooms_source',
+              },
+            },
+          },
+          spec: {
+            layers: [
+              {
+                '@@type': 'GeoArrowScatterplotLayer',
+                _sqlroomsBinding: {dataset: 'earthquakes'},
+              },
+            ],
+          },
+        },
+      },
+    );
+
+    expect(result).toMatchObject({success: true});
+    const mapId = (result as any).data.mapId as string;
+    const config = mapsById[mapId].config;
+    expect(config.datasets.earthquakes).toMatchObject({
+      geometryColumn: 'geom',
+      geometryEncodingHint: 'wkb',
+      source: {
+        tableName: '"main"."earthquakes"',
+        transformSql: createDeckMapPointTransformSql({
+          longitudeColumn: 'longitude',
+          latitudeColumn: 'latitude',
+          geometryColumn: 'geom',
+        }),
+      },
+    });
+    expect(config.spec.layers[0]._sqlroomsBinding).toEqual({
+      dataset: 'earthquakes',
+      geometryColumn: 'geom',
+    });
+    expect(config.fitToData).toMatchObject({
+      dataset: 'earthquakes',
+      geometryColumn: 'geom',
+    });
   });
 
   it('updates document maps as resources without dashboard commands or panelId', async () => {

--- a/apps/sqlrooms-cli-ui/src/createCliBlockDocumentCommands.ts
+++ b/apps/sqlrooms-cli-ui/src/createCliBlockDocumentCommands.ts
@@ -477,6 +477,7 @@ export function createCliBlockDocumentCommands({
           {
             blockDocumentId: params.blockDocumentId,
             config: params.config,
+            pointBinding: params.pointBinding,
             mapId: params.mapId,
             tableName: params.tableName,
             title: params.title,

--- a/apps/sqlrooms-cli-ui/src/createCliBlockDocumentCommands.ts
+++ b/apps/sqlrooms-cli-ui/src/createCliBlockDocumentCommands.ts
@@ -447,7 +447,10 @@ export function createCliBlockDocumentCommands({
             findTable: (tableName) => {
               const table = state.db.findTable(tableName);
               return table
-                ? {tableIdentity: getTableIdentity(table.table)}
+                ? {
+                    tableIdentity: getTableIdentity(table.table),
+                    columns: table.columns,
+                  }
                 : undefined;
             },
             prepareConfig: ({

--- a/packages/deck/README.md
+++ b/packages/deck/README.md
@@ -367,9 +367,12 @@ exported so hosts can normalize AI-authored configs before calling
 `createOrUpdateDeckMapResource(...)`. Passing structured `pointBinding` to the
 resource helper applies `applyDeckMapPointBinding(...)`: it generates canonical
 WKB point SQL through `createDeckMapPointTransformSql(...)` and aligns the target
-dataset, point layers, and fit binding. This is the preferred path for standard
-table-backed longitude/latitude maps; raw `transformSql` remains available for
-custom spatial transforms. `normalizeDeckMapPointConfig(...)` only adds
+dataset, point layers, brush interaction, and fit binding. The host table lookup
+also supplies source columns so a generated geometry alias that would duplicate
+an existing column is rejected before durable state is written. This is the
+preferred path for standard table-backed longitude/latitude maps; raw
+`transformSql` remains available for custom spatial transforms.
+`normalizeDeckMapPointConfig(...)` only adds
 the standard lon/lat point transform to table-backed datasets that do not
 already declare `geometryColumn`, `source.sqlQuery`, or `source.transformSql`
 and whose resolved table does not expose a native geometry column; native

--- a/packages/deck/README.md
+++ b/packages/deck/README.md
@@ -334,6 +334,11 @@ const result = await createOrUpdateDeckMapResource(
     blockDocumentId,
     mapId,
     config,
+    pointBinding: {
+      dataset: 'places',
+      longitudeColumn: 'longitude',
+      latitudeColumn: 'latitude',
+    },
     tableName,
     title,
     intent,
@@ -355,10 +360,16 @@ title and uses it as the default block caption. Block metadata is written only
 after the map write succeeds.
 
 Map authoring helpers such as `normalizeDeckMapPointConfig(...)`,
-`normalizeDeckMapFillColor(...)`, `regenerateMapConfigForTable(...)`, and
+`applyDeckMapPointBinding(...)`, `normalizeDeckMapFillColor(...)`,
+`regenerateMapConfigForTable(...)`, and
 dataset-source helpers such as `getFirstDatasetSourceTableName(...)` are
 exported so hosts can normalize AI-authored configs before calling
-`createOrUpdateDeckMapResource(...)`. `normalizeDeckMapPointConfig(...)` only adds
+`createOrUpdateDeckMapResource(...)`. Passing structured `pointBinding` to the
+resource helper applies `applyDeckMapPointBinding(...)`: it generates canonical
+WKB point SQL through `createDeckMapPointTransformSql(...)` and aligns the target
+dataset, point layers, and fit binding. This is the preferred path for standard
+table-backed longitude/latitude maps; raw `transformSql` remains available for
+custom spatial transforms. `normalizeDeckMapPointConfig(...)` only adds
 the standard lon/lat point transform to table-backed datasets that do not
 already declare `geometryColumn`, `source.sqlQuery`, or `source.transformSql`
 and whose resolved table does not expose a native geometry column; native

--- a/packages/deck/README.md
+++ b/packages/deck/README.md
@@ -370,9 +370,11 @@ WKB point SQL through `createDeckMapPointTransformSql(...)` and aligns the targe
 dataset, point layers, brush interaction, and fit binding. The host table lookup
 also supplies source columns so missing coordinate columns and a generated
 geometry alias that would duplicate an existing column are rejected before
-durable state is written. This is the preferred path for standard table-backed
-longitude/latitude maps; raw `transformSql` remains available for custom spatial
-transforms.
+durable state is written. For a single table-backed dataset, its canonical table
+identity must also match the selected table because that selection overrides the
+authored dataset source at render time. This is the preferred path for standard
+table-backed longitude/latitude maps; raw `transformSql` remains available for
+custom spatial transforms.
 `normalizeDeckMapPointConfig(...)` only adds
 the standard lon/lat point transform to table-backed datasets that do not
 already declare `geometryColumn`, `source.sqlQuery`, or `source.transformSql`

--- a/packages/deck/README.md
+++ b/packages/deck/README.md
@@ -368,10 +368,11 @@ exported so hosts can normalize AI-authored configs before calling
 resource helper applies `applyDeckMapPointBinding(...)`: it generates canonical
 WKB point SQL through `createDeckMapPointTransformSql(...)` and aligns the target
 dataset, point layers, brush interaction, and fit binding. The host table lookup
-also supplies source columns so a generated geometry alias that would duplicate
-an existing column is rejected before durable state is written. This is the
-preferred path for standard table-backed longitude/latitude maps; raw
-`transformSql` remains available for custom spatial transforms.
+also supplies source columns so missing coordinate columns and a generated
+geometry alias that would duplicate an existing column are rejected before
+durable state is written. This is the preferred path for standard table-backed
+longitude/latitude maps; raw `transformSql` remains available for custom spatial
+transforms.
 `normalizeDeckMapPointConfig(...)` only adds
 the standard lon/lat point transform to table-backed datasets that do not
 already declare `geometryColumn`, `source.sqlQuery`, or `source.transformSql`

--- a/packages/deck/__tests__/createOrUpdateDeckMapResource.test.ts
+++ b/packages/deck/__tests__/createOrUpdateDeckMapResource.test.ts
@@ -26,7 +26,10 @@ function host(overrides: Partial<CreateOrUpdateDeckMapResourceHost> = {}) {
     updateBlockMetadata: jest.fn(),
     ensureMap: jest.fn(),
     writeMap: jest.fn(),
-    findTable: jest.fn(() => ({tableIdentity: 'main.places'})),
+    findTable: jest.fn(() => ({
+      tableIdentity: 'main.places',
+      columns: [{name: 'longitude'}, {name: 'latitude'}],
+    })),
     ...overrides,
   };
   return value;
@@ -143,11 +146,45 @@ describe('createOrUpdateDeckMapResource', () => {
     );
   });
 
+  test('rejects point geometry aliases that collide with source columns', async () => {
+    const h = host({
+      findTable: jest.fn(() => ({
+        tableIdentity: 'main.places',
+        columns: [
+          {name: 'longitude'},
+          {name: 'latitude'},
+          {name: '__sqlrooms_geom'},
+        ],
+      })),
+    });
+
+    await expect(
+      createOrUpdateDeckMapResource(h, {
+        blockDocumentId: 'document-1',
+        config,
+        pointBinding: {
+          dataset: 'places',
+          longitudeColumn: 'longitude',
+          latitudeColumn: 'latitude',
+        },
+        createMapId: () => 'map-1',
+      }),
+    ).rejects.toThrow(
+      'Point binding geometryColumn "__sqlrooms_geom" conflicts with an existing source column.',
+    );
+    expect(h.createMapBlock).not.toHaveBeenCalled();
+    expect(h.ensureMap).not.toHaveBeenCalled();
+    expect(h.writeMap).not.toHaveBeenCalled();
+  });
+
   test('canonicalizes table-backed dataset sources before writing', async () => {
     const h = host({
       findTable: jest.fn((tableName) =>
         tableName === 'analytics.events'
-          ? {tableIdentity: '"analytics"."events"'}
+          ? {
+              tableIdentity: '"analytics"."events"',
+              columns: [{name: 'longitude'}, {name: 'latitude'}],
+            }
           : undefined,
       ),
     });

--- a/packages/deck/__tests__/createOrUpdateDeckMapResource.test.ts
+++ b/packages/deck/__tests__/createOrUpdateDeckMapResource.test.ts
@@ -95,6 +95,54 @@ describe('createOrUpdateDeckMapResource', () => {
     });
   });
 
+  test('normalizes serialized point-layer bindings before writing', async () => {
+    const h = host();
+    const serializedConfig: DeckMapConfig = {
+      spec: JSON.stringify({
+        layers: [
+          {
+            '@@type': 'GeoArrowScatterplotLayer',
+            _sqlroomsBinding: {
+              dataset: 'places',
+              longitudeColumn: 'old_lon',
+              latitudeColumn: 'old_lat',
+            },
+          },
+        ],
+      }),
+      datasets: {places: {source: {tableName: 'places'}}},
+    };
+
+    await createOrUpdateDeckMapResource(h, {
+      blockDocumentId: 'document-1',
+      config: serializedConfig,
+      pointBinding: {
+        dataset: 'places',
+        longitudeColumn: 'longitude',
+        latitudeColumn: 'latitude',
+        geometryColumn: 'geom',
+      },
+      createMapId: () => 'map-1',
+    });
+
+    expect(h.writeMap).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          spec: {
+            layers: [
+              expect.objectContaining({
+                _sqlroomsBinding: {
+                  dataset: 'places',
+                  geometryColumn: 'geom',
+                },
+              }),
+            ],
+          },
+        }),
+      }),
+    );
+  });
+
   test('canonicalizes table-backed dataset sources before writing', async () => {
     const h = host({
       findTable: jest.fn((tableName) =>

--- a/packages/deck/__tests__/createOrUpdateDeckMapResource.test.ts
+++ b/packages/deck/__tests__/createOrUpdateDeckMapResource.test.ts
@@ -199,6 +199,45 @@ describe('createOrUpdateDeckMapResource', () => {
     expect(h.writeMap).not.toHaveBeenCalled();
   });
 
+  test('rejects a selected table that would override the point-bound source', async () => {
+    const h = host({
+      findTable: jest.fn((tableName) => {
+        if (tableName === 'places') {
+          return {
+            tableIdentity: 'main.places',
+            columns: [{name: 'longitude'}, {name: 'latitude'}],
+          };
+        }
+        if (tableName === 'cities') {
+          return {
+            tableIdentity: 'main.cities',
+            columns: [{name: 'longitude'}, {name: 'latitude'}],
+          };
+        }
+        return undefined;
+      }),
+    });
+
+    await expect(
+      createOrUpdateDeckMapResource(h, {
+        blockDocumentId: 'document-1',
+        config,
+        tableName: 'cities',
+        pointBinding: {
+          dataset: 'places',
+          longitudeColumn: 'longitude',
+          latitudeColumn: 'latitude',
+        },
+        createMapId: () => 'map-1',
+      }),
+    ).rejects.toThrow(
+      'Point binding dataset "places" resolves to table "main.places", but selected table "main.cities" would override it.',
+    );
+    expect(h.createMapBlock).not.toHaveBeenCalled();
+    expect(h.ensureMap).not.toHaveBeenCalled();
+    expect(h.writeMap).not.toHaveBeenCalled();
+  });
+
   test('canonicalizes table-backed dataset sources before writing', async () => {
     const h = host({
       findTable: jest.fn((tableName) =>

--- a/packages/deck/__tests__/createOrUpdateDeckMapResource.test.ts
+++ b/packages/deck/__tests__/createOrUpdateDeckMapResource.test.ts
@@ -177,6 +177,28 @@ describe('createOrUpdateDeckMapResource', () => {
     expect(h.writeMap).not.toHaveBeenCalled();
   });
 
+  test('rejects missing point coordinate columns before writing', async () => {
+    const h = host();
+
+    await expect(
+      createOrUpdateDeckMapResource(h, {
+        blockDocumentId: 'document-1',
+        config,
+        pointBinding: {
+          dataset: 'places',
+          longitudeColumn: 'lon',
+          latitudeColumn: 'latitude',
+        },
+        createMapId: () => 'map-1',
+      }),
+    ).rejects.toThrow(
+      'Point binding longitudeColumn "lon" was not found in source columns.',
+    );
+    expect(h.createMapBlock).not.toHaveBeenCalled();
+    expect(h.ensureMap).not.toHaveBeenCalled();
+    expect(h.writeMap).not.toHaveBeenCalled();
+  });
+
   test('canonicalizes table-backed dataset sources before writing', async () => {
     const h = host({
       findTable: jest.fn((tableName) =>

--- a/packages/deck/__tests__/mapAiConfig.test.ts
+++ b/packages/deck/__tests__/mapAiConfig.test.ts
@@ -49,4 +49,35 @@ describe('DeckMapResourceConfigParameter', () => {
     expect(result.data?.replaceLayers).toBe(true);
     expect(result.data?.replaceDatasets).toBe(true);
   });
+
+  test('accepts structured point provenance', () => {
+    const result = DeckMapResourceToolParameters.safeParse({
+      title: 'Places',
+      reasoning: 'Map table coordinates',
+      tableName: 'places',
+      pointBinding: {
+        dataset: 'places',
+        longitudeColumn: 'longitude',
+        latitudeColumn: 'latitude',
+      },
+      config: {
+        spec: {
+          layers: [
+            {
+              '@@type': 'GeoArrowScatterplotLayer',
+              _sqlroomsBinding: {dataset: 'places'},
+            },
+          ],
+        },
+        datasets: {places: {source: {tableName: 'places'}}},
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data?.pointBinding).toEqual({
+      dataset: 'places',
+      longitudeColumn: 'longitude',
+      latitudeColumn: 'latitude',
+    });
+  });
 });

--- a/packages/deck/__tests__/mapResourceAuthoring.test.ts
+++ b/packages/deck/__tests__/mapResourceAuthoring.test.ts
@@ -847,6 +847,8 @@ describe('Deck map resource authoring contract', () => {
     expect(instructions).toContain('omit getWeight');
     expect(instructions).toContain('will not invent centroids');
     expect(instructions).toContain('SELECT *, ST_AsWKB(col) AS col');
+    expect(instructions).toContain('pointBinding');
+    expect(instructions).toContain('Do not author transformSql');
     expect(instructions).toContain('COLOR SCALE FIELD VARIANCE');
     expect(instructions).toContain('min = max');
     expect(instructions).not.toContain('Mosaic');

--- a/packages/deck/__tests__/normalizeDeckMapPointConfig.test.ts
+++ b/packages/deck/__tests__/normalizeDeckMapPointConfig.test.ts
@@ -109,6 +109,41 @@ describe('normalizeDeckMapPointConfig', () => {
     });
   });
 
+  it.each([
+    {
+      bindingName: 'longitudeColumn',
+      longitudeColumn: 'missing_longitude',
+      latitudeColumn: 'latitude',
+    },
+    {
+      bindingName: 'latitudeColumn',
+      longitudeColumn: 'longitude',
+      latitudeColumn: 'missing_latitude',
+    },
+  ])(
+    'rejects a missing $bindingName before generating point SQL',
+    ({bindingName, longitudeColumn, latitudeColumn}) => {
+      expect(() =>
+        applyDeckMapPointBinding({
+          config: {
+            spec: {layers: []},
+            datasets: {places: {source: {tableName: 'places'}}},
+          },
+          pointBinding: {
+            dataset: 'places',
+            longitudeColumn,
+            latitudeColumn,
+          },
+          sourceColumns: placesTable.columns,
+        }),
+      ).toThrow(
+        `Point binding ${bindingName} "${
+          bindingName === 'longitudeColumn' ? longitudeColumn : latitudeColumn
+        }" was not found in source columns.`,
+      );
+    },
+  );
+
   it('injects transformSql and geometry bindings for lon/lat table sources', () => {
     const config = {
       spec: {

--- a/packages/deck/__tests__/normalizeDeckMapPointConfig.test.ts
+++ b/packages/deck/__tests__/normalizeDeckMapPointConfig.test.ts
@@ -47,6 +47,7 @@ describe('normalizeDeckMapPointConfig', () => {
         places: {
           source: {
             tableName: 'places',
+            sqlQuery: 'SELECT * FROM archived_places',
             transformSql:
               'SELECT ST_AsWKB(ST_Point(lon, lat)) AS geom FROM __sqlrooms_source',
           },

--- a/packages/deck/__tests__/normalizeDeckMapPointConfig.test.ts
+++ b/packages/deck/__tests__/normalizeDeckMapPointConfig.test.ts
@@ -1,5 +1,6 @@
 import {makeQualifiedTableName, type DataTable} from '@sqlrooms/duckdb';
 import {
+  applyDeckMapPointBinding,
   createDeckMapPointTransformSql,
   normalizeDeckMapPointConfig,
   regenerateMapConfigForTable,
@@ -25,6 +26,69 @@ describe('normalizeDeckMapPointConfig', () => {
         geometryColumn: '__sqlrooms_geom',
       }),
     ).toContain(DECK_TABLE_DATASET_SOURCE_RELATION);
+  });
+
+  it('applies structured point provenance with canonical SQL and bindings', () => {
+    const config = {
+      spec: {
+        layers: [
+          {
+            '@@type': 'GeoJsonLayer',
+            id: 'places',
+            _sqlroomsBinding: {
+              dataset: 'places',
+              longitudeColumn: 'old_lon',
+              latitudeColumn: 'old_lat',
+            },
+          },
+        ],
+      },
+      datasets: {
+        places: {
+          source: {
+            tableName: 'places',
+            transformSql:
+              'SELECT ST_AsWKB(ST_Point(lon, lat)) AS geom FROM __sqlrooms_source',
+          },
+        },
+      },
+      fitToData: {
+        dataset: 'places',
+        longitudeColumn: 'old_lon',
+        latitudeColumn: 'old_lat',
+      },
+    };
+
+    const next = applyDeckMapPointBinding({
+      config,
+      pointBinding: {
+        dataset: 'places',
+        longitudeColumn: 'longitude',
+        latitudeColumn: 'latitude',
+        geometryColumn: 'geom',
+      },
+    });
+
+    expect(next.datasets.places).toEqual({
+      source: {
+        tableName: 'places',
+        transformSql: createDeckMapPointTransformSql({
+          longitudeColumn: 'longitude',
+          latitudeColumn: 'latitude',
+          geometryColumn: 'geom',
+        }),
+      },
+      geometryColumn: 'geom',
+      geometryEncodingHint: 'wkb',
+    });
+    expect(next.spec.layers[0]._sqlroomsBinding).toEqual({
+      dataset: 'places',
+      geometryColumn: 'geom',
+    });
+    expect(next.fitToData).toEqual({
+      dataset: 'places',
+      geometryColumn: 'geom',
+    });
   });
 
   it('injects transformSql and geometry bindings for lon/lat table sources', () => {

--- a/packages/deck/__tests__/normalizeDeckMapPointConfig.test.ts
+++ b/packages/deck/__tests__/normalizeDeckMapPointConfig.test.ts
@@ -35,6 +35,7 @@ describe('normalizeDeckMapPointConfig', () => {
           {
             '@@type': 'GeoJsonLayer',
             id: 'places',
+            getPosition: '@@=[old_lon, old_lat]',
             _sqlroomsBinding: {
               dataset: 'places',
               longitudeColumn: 'old_lon',
@@ -58,6 +59,13 @@ describe('normalizeDeckMapPointConfig', () => {
         longitudeColumn: 'old_lon',
         latitudeColumn: 'old_lat',
       },
+      interaction: {
+        type: 'point-radius-brush' as const,
+        dataset: 'places',
+        longitudeColumn: 'old_lon',
+        latitudeColumn: 'old_lat',
+        radiusMeters: 1000,
+      },
     };
 
     const next = applyDeckMapPointBinding({
@@ -68,6 +76,7 @@ describe('normalizeDeckMapPointConfig', () => {
         latitudeColumn: 'latitude',
         geometryColumn: 'geom',
       },
+      sourceColumns: placesTable.columns,
     });
 
     expect(next.datasets.places).toEqual({
@@ -86,9 +95,17 @@ describe('normalizeDeckMapPointConfig', () => {
       dataset: 'places',
       geometryColumn: 'geom',
     });
+    expect(next.spec.layers[0]).not.toHaveProperty('getPosition');
     expect(next.fitToData).toEqual({
       dataset: 'places',
       geometryColumn: 'geom',
+    });
+    expect(next.interaction).toEqual({
+      type: 'point-radius-brush',
+      dataset: 'places',
+      longitudeColumn: 'longitude',
+      latitudeColumn: 'latitude',
+      radiusMeters: 1000,
     });
   });
 

--- a/packages/deck/src/createOrUpdateDeckMapResource.ts
+++ b/packages/deck/src/createOrUpdateDeckMapResource.ts
@@ -8,6 +8,7 @@ import {
 import {assertDeckMapResourceConfig} from './mapResourceAuthoring';
 import {
   applyDeckMapPointBinding,
+  type DeckMapConfigColumn,
   type DeckMapPointBinding,
 } from './mapConfigUtils';
 
@@ -44,7 +45,11 @@ export type CreateOrUpdateDeckMapResourceHost = {
     config: DeckMapConfig;
     selectedTable?: string;
   }) => void | Promise<void>;
-  findTable: (tableName: string) => {tableIdentity: string} | undefined;
+  findTable: (
+    tableName: string,
+  ) =>
+    | {tableIdentity: string; columns: readonly DeckMapConfigColumn[]}
+    | undefined;
   prepareConfig?: (options: {
     config: DeckMapConfig;
     existingMapConfig?: DeckMapConfig;
@@ -148,10 +153,19 @@ export async function createOrUpdateDeckMapResource(
         replaceDatasets: params.replaceDatasets,
       })
     : params.config;
+  const pointBindingDataset = params.pointBinding
+    ? preparedConfig.datasets[params.pointBinding.dataset.trim()]
+    : undefined;
+  const pointBindingTable = isDeckMapTableDatasetSource(
+    pointBindingDataset?.source,
+  )
+    ? host.findTable(pointBindingDataset.source.tableName)
+    : undefined;
   const pointBoundConfig = params.pointBinding
     ? applyDeckMapPointBinding({
         config: preparedConfig,
         pointBinding: params.pointBinding,
+        sourceColumns: pointBindingTable?.columns ?? [],
       })
     : preparedConfig;
   const resolvedConfig = resolveTableDatasetSources(host, pointBoundConfig);

--- a/packages/deck/src/createOrUpdateDeckMapResource.ts
+++ b/packages/deck/src/createOrUpdateDeckMapResource.ts
@@ -6,6 +6,10 @@ import {
   hasSqlOnlyDatasetSource,
 } from './datasetSourceUtils';
 import {assertDeckMapResourceConfig} from './mapResourceAuthoring';
+import {
+  applyDeckMapPointBinding,
+  type DeckMapPointBinding,
+} from './mapConfigUtils';
 
 /**
  * Host callbacks used to coordinate a durable Deck map resource with its block
@@ -54,6 +58,8 @@ export type CreateOrUpdateDeckMapResourceHost = {
 export type CreateOrUpdateDeckMapResourceParams = {
   blockDocumentId: string;
   config: DeckMapConfig;
+  /** Generates canonical point geometry from structured lon/lat provenance. */
+  pointBinding?: DeckMapPointBinding;
   mapId?: string;
   tableName?: string;
   title?: string;
@@ -142,7 +148,13 @@ export async function createOrUpdateDeckMapResource(
         replaceDatasets: params.replaceDatasets,
       })
     : params.config;
-  const resolvedConfig = resolveTableDatasetSources(host, preparedConfig);
+  const pointBoundConfig = params.pointBinding
+    ? applyDeckMapPointBinding({
+        config: preparedConfig,
+        pointBinding: params.pointBinding,
+      })
+    : preparedConfig;
+  const resolvedConfig = resolveTableDatasetSources(host, pointBoundConfig);
   assertDeckMapResourceConfig(resolvedConfig);
   const tableName =
     requestedTable ?? getFirstDatasetSourceTableName(resolvedConfig);

--- a/packages/deck/src/createOrUpdateDeckMapResource.ts
+++ b/packages/deck/src/createOrUpdateDeckMapResource.ts
@@ -161,6 +161,15 @@ export async function createOrUpdateDeckMapResource(
   )
     ? host.findTable(pointBindingDataset.source.tableName)
     : undefined;
+  if (
+    params.pointBinding &&
+    isDeckMapTableDatasetSource(pointBindingDataset?.source) &&
+    !pointBindingTable
+  ) {
+    throw new Error(
+      `Dataset "${params.pointBinding.dataset.trim()}" table "${pointBindingDataset.source.tableName}" was not found.`,
+    );
+  }
   const pointBoundConfig = params.pointBinding
     ? applyDeckMapPointBinding({
         config: preparedConfig,

--- a/packages/deck/src/createOrUpdateDeckMapResource.ts
+++ b/packages/deck/src/createOrUpdateDeckMapResource.ts
@@ -194,6 +194,20 @@ export async function createOrUpdateDeckMapResource(
   const table = tableName ? host.findTable(tableName) : undefined;
   if (tableName && !table)
     throw new Error(`Table "${tableName}" was not found.`);
+  const tableDatasetCount = Object.values(resolvedConfig.datasets).filter(
+    (dataset) => isDeckMapTableDatasetSource(dataset.source),
+  ).length;
+  if (
+    params.pointBinding &&
+    tableDatasetCount === 1 &&
+    pointBindingTable &&
+    table &&
+    pointBindingTable.tableIdentity !== table.tableIdentity
+  ) {
+    throw new Error(
+      `Point binding dataset "${params.pointBinding.dataset.trim()}" resolves to table "${pointBindingTable.tableIdentity}", but selected table "${table.tableIdentity}" would override it.`,
+    );
+  }
 
   const caption =
     params.caption?.trim() ||

--- a/packages/deck/src/index.ts
+++ b/packages/deck/src/index.ts
@@ -26,6 +26,7 @@ export {
 } from './mapConfig';
 export {getDeckMapDataPolicy, type DeckMapDataPolicy} from './mapDataPolicy';
 export {
+  applyDeckMapPointBinding,
   createDeckMapDashboardConfigForTable,
   createDeckMapConfigForTable,
   createDeckMapDashboardPanelConfigForTable,
@@ -42,6 +43,7 @@ export {
 export type {
   DeckMapConfigColumn,
   DeckMapFillColor,
+  DeckMapPointBinding,
   DeckMapTableReference,
 } from './mapConfigUtils';
 export {

--- a/packages/deck/src/mapAiConfig.ts
+++ b/packages/deck/src/mapAiConfig.ts
@@ -1,5 +1,6 @@
 import {z} from 'zod';
 import type {DeckMapConfig} from './mapConfig';
+import type {DeckMapPointBinding} from './mapConfigUtils';
 
 const DeckMapDatasetSource = z.union([
   z.looseObject({
@@ -38,6 +39,13 @@ const DeckMapFitToDataConfig = z.looseObject({
   maxZoom: z.number().optional(),
 });
 
+const DeckMapPointBindingParameter = z.object({
+  dataset: z.string().trim().min(1),
+  longitudeColumn: z.string().trim().min(1),
+  latitudeColumn: z.string().trim().min(1),
+  geometryColumn: z.string().trim().min(1).optional(),
+}) satisfies z.ZodType<DeckMapPointBinding>;
+
 /** Validates the portable Deck map config accepted from commands and AI tools. */
 export const DeckMapResourceConfigParameter = z.looseObject({
   spec: z.union([z.string(), z.record(z.string(), z.unknown())]),
@@ -66,6 +74,9 @@ export const DeckMapResourceConfigParameter = z.looseObject({
 export const DeckMapResourceToolParameters = z.object({
   title: z.string().optional().default('Map'),
   config: DeckMapResourceConfigParameter,
+  pointBinding: DeckMapPointBindingParameter.optional().describe(
+    'Structured point provenance for a table-backed dataset. Prefer this over authoring transformSql when longitude and latitude columns should become WKB point geometry.',
+  ),
   tableName: z.string().optional(),
   replaceLayers: z
     .boolean()

--- a/packages/deck/src/mapConfigUtils.ts
+++ b/packages/deck/src/mapConfigUtils.ts
@@ -426,7 +426,7 @@ export function applyDeckMapPointBinding<
       [datasetId]: {
         ...dataset,
         source: {
-          ...dataset.source,
+          tableName: dataset.source.tableName,
           transformSql: createDeckMapPointTransformSql({
             longitudeColumn,
             latitudeColumn,

--- a/packages/deck/src/mapConfigUtils.ts
+++ b/packages/deck/src/mapConfigUtils.ts
@@ -338,9 +338,11 @@ function normalizeDeckMapPointLayers<T extends unknown[]>(options: {
     const geometryBinding = {...binding};
     delete geometryBinding.longitudeColumn;
     delete geometryBinding.latitudeColumn;
+    const pointLayer = {...layer};
+    delete pointLayer.getPosition;
 
     return {
-      ...layer,
+      ...pointLayer,
       _sqlroomsBinding: {
         ...geometryBinding,
         dataset:
@@ -362,7 +364,11 @@ function normalizeDeckMapPointLayers<T extends unknown[]>(options: {
  */
 export function applyDeckMapPointBinding<
   T extends DeckMapDashboardPanelConfig,
->(options: {config: T; pointBinding: DeckMapPointBinding}): T {
+>(options: {
+  config: T;
+  pointBinding: DeckMapPointBinding;
+  sourceColumns: readonly DeckMapConfigColumn[];
+}): T {
   const {config, pointBinding} = options;
   const datasetId = pointBinding.dataset.trim();
   const longitudeColumn = pointBinding.longitudeColumn.trim();
@@ -385,6 +391,15 @@ export function applyDeckMapPointBinding<
 
   const geometryColumn =
     pointBinding.geometryColumn?.trim() || DEFAULT_GEOMETRY_COLUMN;
+  if (
+    options.sourceColumns.some(
+      (column) => column.name.toLowerCase() === geometryColumn.toLowerCase(),
+    )
+  ) {
+    throw new Error(
+      `Point binding geometryColumn "${geometryColumn}" conflicts with an existing source column.`,
+    );
+  }
   const datasetIds = Object.keys(config.datasets);
   let parsedSpec: unknown = config.spec;
   if (typeof parsedSpec === 'string') {
@@ -425,10 +440,16 @@ export function applyDeckMapPointBinding<
       maxZoom: 12,
     };
   }
+  const interaction =
+    config.interaction?.type === 'point-radius-brush' &&
+    config.interaction.dataset === datasetId
+      ? {...config.interaction, longitudeColumn, latitudeColumn}
+      : config.interaction;
 
   return {
     ...config,
     spec,
+    ...(interaction !== config.interaction ? {interaction} : {}),
     datasets: {
       ...config.datasets,
       [datasetId]: {

--- a/packages/deck/src/mapConfigUtils.ts
+++ b/packages/deck/src/mapConfigUtils.ts
@@ -272,7 +272,16 @@ const DECK_MAP_POINT_LAYER_TYPES = new Set([
   'GeoArrowScatterplotLayer',
   'GeoArrowHeatmapLayer',
   'GeoArrowColumnLayer',
+  'GeoJsonLayer',
 ]);
+
+/** Structured provenance for a table-backed longitude/latitude point dataset. */
+export type DeckMapPointBinding = {
+  dataset: string;
+  longitudeColumn: string;
+  latitudeColumn: string;
+  geometryColumn?: string;
+};
 
 function isDeckMapConfigRecord(
   value: unknown,
@@ -326,11 +335,14 @@ function normalizeDeckMapPointLayers<T extends unknown[]>(options: {
     const binding = isDeckMapConfigRecord(layer._sqlroomsBinding)
       ? layer._sqlroomsBinding
       : {};
+    const geometryBinding = {...binding};
+    delete geometryBinding.longitudeColumn;
+    delete geometryBinding.latitudeColumn;
 
     return {
       ...layer,
       _sqlroomsBinding: {
-        ...binding,
+        ...geometryBinding,
         dataset:
           typeof binding.dataset === 'string'
             ? binding.dataset
@@ -341,6 +353,92 @@ function normalizeDeckMapPointLayers<T extends unknown[]>(options: {
   });
 
   return (changed ? layers : options.layers) as T;
+}
+
+/**
+ * Applies a structured longitude/latitude point binding to a native Deck map
+ * config. The generated geometry SQL intentionally comes from the same
+ * canonical helper used by first-party map builders.
+ */
+export function applyDeckMapPointBinding<
+  T extends DeckMapDashboardPanelConfig,
+>(options: {config: T; pointBinding: DeckMapPointBinding}): T {
+  const {config, pointBinding} = options;
+  const datasetId = pointBinding.dataset.trim();
+  const longitudeColumn = pointBinding.longitudeColumn.trim();
+  const latitudeColumn = pointBinding.latitudeColumn.trim();
+  if (!datasetId || !longitudeColumn || !latitudeColumn) {
+    throw new Error(
+      'Point binding requires dataset, longitudeColumn, and latitudeColumn.',
+    );
+  }
+
+  const dataset = config.datasets[datasetId];
+  if (!dataset) {
+    throw new Error(`Point binding references unknown dataset "${datasetId}".`);
+  }
+  if (!isDeckMapTableDatasetSource(dataset.source)) {
+    throw new Error(
+      `Point binding dataset "${datasetId}" must use source.tableName.`,
+    );
+  }
+
+  const geometryColumn =
+    pointBinding.geometryColumn?.trim() || DEFAULT_GEOMETRY_COLUMN;
+  const datasetIds = Object.keys(config.datasets);
+  const spec = isDeckMapConfigRecord(config.spec)
+    ? {
+        ...config.spec,
+        ...(Array.isArray(config.spec.layers)
+          ? {
+              layers: normalizeDeckMapPointLayers({
+                layers: config.spec.layers,
+                datasetId,
+                datasetIds,
+                geometryColumn,
+              }),
+            }
+          : {}),
+      }
+    : config.spec;
+  let fitToData = config.fitToData;
+  if (isDeckMapConfigRecord(fitToData) && fitToData.dataset === datasetId) {
+    const geometryFit = {...fitToData};
+    delete geometryFit.longitudeColumn;
+    delete geometryFit.latitudeColumn;
+    delete geometryFit.geometryColumns;
+    delete geometryFit.h3Column;
+    fitToData = {...geometryFit, geometryColumn};
+  } else if (!fitToData) {
+    fitToData = {
+      dataset: datasetId,
+      geometryColumn,
+      padding: 40,
+      maxZoom: 12,
+    };
+  }
+
+  return {
+    ...config,
+    spec,
+    datasets: {
+      ...config.datasets,
+      [datasetId]: {
+        ...dataset,
+        source: {
+          ...dataset.source,
+          transformSql: createDeckMapPointTransformSql({
+            longitudeColumn,
+            latitudeColumn,
+            geometryColumn,
+          }),
+        },
+        geometryColumn,
+        geometryEncodingHint: 'wkb',
+      },
+    },
+    fitToData,
+  } as T;
 }
 
 /**

--- a/packages/deck/src/mapConfigUtils.ts
+++ b/packages/deck/src/mapConfigUtils.ts
@@ -391,11 +391,20 @@ export function applyDeckMapPointBinding<
 
   const geometryColumn =
     pointBinding.geometryColumn?.trim() || DEFAULT_GEOMETRY_COLUMN;
-  if (
-    options.sourceColumns.some(
-      (column) => column.name.toLowerCase() === geometryColumn.toLowerCase(),
-    )
-  ) {
+  const sourceColumnNames = new Set(
+    options.sourceColumns.map((column) => column.name.toLowerCase()),
+  );
+  for (const [bindingName, columnName] of [
+    ['longitudeColumn', longitudeColumn],
+    ['latitudeColumn', latitudeColumn],
+  ] as const) {
+    if (!sourceColumnNames.has(columnName.toLowerCase())) {
+      throw new Error(
+        `Point binding ${bindingName} "${columnName}" was not found in source columns.`,
+      );
+    }
+  }
+  if (sourceColumnNames.has(geometryColumn.toLowerCase())) {
     throw new Error(
       `Point binding geometryColumn "${geometryColumn}" conflicts with an existing source column.`,
     );

--- a/packages/deck/src/mapConfigUtils.ts
+++ b/packages/deck/src/mapConfigUtils.ts
@@ -386,13 +386,21 @@ export function applyDeckMapPointBinding<
   const geometryColumn =
     pointBinding.geometryColumn?.trim() || DEFAULT_GEOMETRY_COLUMN;
   const datasetIds = Object.keys(config.datasets);
-  const spec = isDeckMapConfigRecord(config.spec)
+  let parsedSpec: unknown = config.spec;
+  if (typeof parsedSpec === 'string') {
+    try {
+      parsedSpec = JSON.parse(parsedSpec);
+    } catch {
+      // Durable resource validation reports the invalid serialized spec.
+    }
+  }
+  const spec = isDeckMapConfigRecord(parsedSpec)
     ? {
-        ...config.spec,
-        ...(Array.isArray(config.spec.layers)
+        ...parsedSpec,
+        ...(Array.isArray(parsedSpec.layers)
           ? {
               layers: normalizeDeckMapPointLayers({
-                layers: config.spec.layers,
+                layers: parsedSpec.layers,
                 datasetId,
                 datasetIds,
                 geometryColumn,
@@ -400,7 +408,7 @@ export function applyDeckMapPointBinding<
             }
           : {}),
       }
-    : config.spec;
+    : parsedSpec;
   let fitToData = config.fitToData;
   if (isDeckMapConfigRecord(fitToData) && fitToData.dataset === datasetId) {
     const geometryFit = {...fitToData};

--- a/packages/deck/src/mapResourceAuthoring.ts
+++ b/packages/deck/src/mapResourceAuthoring.ts
@@ -851,6 +851,7 @@ When authoring a document map config, use the resource-native Deck JSON contract
 - Every dataset must define source.tableName, source.tableName plus source.transformSql, or source.sqlQuery. Never put sql directly on the dataset object.
 - Bind every layer to a dataset with _sqlroomsBinding.dataset. Never use data: "@@#datasetId" or an implicit single-dataset binding as a durable resource binding.
 - Use supported Deck JSON layer classes such as GeoArrowScatterplotLayer, GeoArrowHeatmapLayer, GeoArrowPolygonLayer, GeoArrowPathLayer, GeoArrowTripsLayer, GeoArrowArcLayer, GeoArrowColumnLayer, GeoArrowH3HexagonLayer, or GeoJsonLayer. Prefer typed GeoArrow* layers when geometry type is known; GeoJsonLayer is valid for table-backed WKB/GeoJSON via _sqlroomsBinding.
+- For a standard table-backed longitude/latitude point map, pass the tool's top-level pointBinding with dataset, longitudeColumn, and latitudeColumn. Do not author transformSql, geometryColumn, geometryEncodingHint, or layer geometryColumn for that dataset; the resource writer generates and aligns canonical WKB point geometry. Set geometryColumn in pointBinding only when the default __sqlrooms_geom name is unsuitable.
 ${getDeckMapSharedAiContractRules()}
 - For table-backed datasets, also pass the same table through the tool's top-level tableName field. A selected table does not replace the required dataset source.
 - transformSql must be a single SELECT and must read from __sqlrooms_source. Use source.sqlQuery only for a standalone pinned query.
@@ -862,5 +863,5 @@ ${getDeckMapSharedAiContractRules()}
 - If a map write reports an invalid resource config, repair the reported paths and retry the same direct map operation; do not replace it with a dashboard-backed map.
 
 Minimal table-backed point map shape:
-{"configMode":"basic","datasets":{"places":{"source":{"tableName":"places"},"geometryColumn":"geom","geometryEncodingHint":"wkb"}},"spec":{"layers":[{"@@type":"GeoArrowScatterplotLayer","id":"places","_sqlroomsBinding":{"dataset":"places","geometryColumn":"geom"},"getRadius":4,"radiusUnits":"pixels","pickable":true}]},"fitToData":{"dataset":"places","geometryColumn":"geom"}}`;
+{"tableName":"places","pointBinding":{"dataset":"places","longitudeColumn":"longitude","latitudeColumn":"latitude"},"config":{"configMode":"basic","datasets":{"places":{"source":{"tableName":"places"}}},"spec":{"layers":[{"@@type":"GeoArrowScatterplotLayer","id":"places","_sqlroomsBinding":{"dataset":"places"},"getRadius":4,"radiusUnits":"pixels","pickable":true}]}}}`;
 }


### PR DESCRIPTION
## Why

The nightly behavioral eval run [32804414491](https://github.com/sqlrooms/sqlrooms/actions/runs/32804414491) exposed a contract mismatch between production map authoring and the stricter eval oracle.

The create-document scenario produced correctly bound WKB point maps from `longitude` and `latitude`, but the agent authored harmless SQL variants such as `SELECT * EXCLUDE (...)`. The oracle intentionally compares against `createDeckMapPointTransformSql(...)` instead of growing another regex-based SQL parser, so those variants failed exact canonical validation.

Exact validation is only appropriate when agents have a production primitive that guarantees the same canonical output. Previously, the document map tool exposed raw `transformSql` and the AI instructions encouraged authoring it directly, so that guarantee did not exist.

## What changed

- Add structured `pointBinding` provenance for table-backed point maps: dataset, longitude column, latitude column, and an optional geometry column.
- Generate point geometry through `createDeckMapPointTransformSql(...)` at the shared Deck resource boundary.
- Align the dataset's WKB metadata, point-layer geometry binding, and fit binding with the generated geometry column.
- Remove stale coordinate bindings so rendering cannot prefer them over the generated geometry.
- Teach document map agents to use `pointBinding` for ordinary longitude/latitude maps while retaining raw SQL for genuinely custom spatial transforms.
- Cover schema validation, canonical SQL generation, binding alignment, GeoJSON point layers, and the noncanonical SQL observed in the nightly run.

## Result

Production and the eval now validate the same composable primitive. This avoids both regex-based SQL semantics and false negatives caused by equivalent model-authored SQL.

This change addresses the three `canonical-bindings` false negatives from that nightly. The separate mutation scenario timeout was a genuine stochastic model-behavior failure and is intentionally outside this PR.

## Validation

- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm knip`
- Circular dependency check
- PR build, documentation, and title checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured point-binding support for Deck map creation and updates.
  * Point bindings automatically synchronize dataset geometry, map layers, interactions, and “fit to data” settings.
  * Added canonical WKB point geometry generation.
  * Exposed point-binding functionality for integrations and command-based workflows.

* **Bug Fixes**
  * Added validation for missing coordinate columns, conflicting geometry aliases, and mismatched source tables.

* **Documentation**
  * Updated map authoring guidance and examples to recommend structured point bindings for table-backed maps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->