### PR TITLE
fix(duckdb-core): preserve string numeric values

### DIFF
--- a/packages/duckdb-core/__tests__/getColValAsNumber.test.ts
+++ b/packages/duckdb-core/__tests__/getColValAsNumber.test.ts
@@ -1,0 +1,26 @@
+import type * as arrow from 'apache-arrow';
+import {getColValAsNumber} from '../src/duckdb-utils';
+
+function tableWithValue(value: unknown): arrow.Table {
+  return {
+    getChildAt: () => ({get: () => value}),
+    getChild: () => ({get: () => value}),
+  } as unknown as arrow.Table;
+}
+
+describe('getColValAsNumber', () => {
+  it.each([
+    ['multi-digit integer string', '557', 557],
+    ['decimal string', '0.5', 0.5],
+    ['negative decimal string', '-122.42', -122.42],
+    ['number', 557, 557],
+    ['bigint', 557n, 557],
+    ['array-wrapped bigint', [557n], 557],
+  ])('converts a %s', (_description, value, expected) => {
+    expect(getColValAsNumber(tableWithValue(value))).toBe(expected);
+  });
+
+  it.each([null, undefined])('returns NaN for %s', (value) => {
+    expect(getColValAsNumber(tableWithValue(value))).toBeNaN();
+  });
+});

--- a/packages/duckdb-core/src/duckdb-utils.ts
+++ b/packages/duckdb-core/src/duckdb-utils.ts
@@ -570,8 +570,8 @@ export function getColValAsNumber(
   if (v === undefined || v === null) {
     return NaN;
   }
-  // if it's an array (can be returned by duckdb as bigint)
-  return Number(v[0] ?? v);
+  // BigInts can be returned wrapped in an array by DuckDB connectors.
+  return Number(Array.isArray(v) ? v[0] : v);
 }
 
 /**

--- a/packages/duckdb-core/src/duckdb-utils.ts
+++ b/packages/duckdb-core/src/duckdb-utils.ts
@@ -550,12 +550,13 @@ export const isNumericDuckType = (type: string) =>
 
 /**
  * Extracts a numeric value from an Arrow Table at the specified column and row index.
- * Handles both column name and index-based access. Converts BigInt values to numbers.
+ * Converts scalar values to numbers, or unwraps and converts the first element
+ * when the value is an array. Returns NaN for nullish values.
  *
  * @param res - The Arrow Table containing the data
  * @param column - The column name or index (0-based) to read from. Defaults to first column (0)
  * @param index - The row index (0-based) to read from. Defaults to first row (0)
- * @returns The numeric value at the specified position, or NaN if the value is null/undefined
+ * @returns The converted numeric value, or NaN if the value is nullish
  * @example
  * const value = getColValAsNumber(table, "amount", 0)
  */


### PR DESCRIPTION
## Summary

- only unwrap actual arrays before converting DuckDB result values to numbers
- preserve complete multi-digit, decimal, and negative numeric strings
- add regression coverage for strings, numbers, BigInts, array-wrapped BigInts, and nullish values

## Testing

- pnpm --filter @sqlrooms/duckdb-core test --runInBand (72 tests)
- pnpm --filter @sqlrooms/duckdb-core typecheck
- pnpm --filter @sqlrooms/duckdb-core lint
- pnpm build (49 workspace package builds)

Fixes #882

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numeric value handling to correctly process scalar values and array-wrapped results.
  * Preserved support for numeric strings, decimals, negative values, numbers, bigints, and null values.

* **Tests**
  * Added coverage for supported numeric formats, array-wrapped bigints, and null or undefined inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->