### PR TITLE
fix(documents): distinguish missing block documents

### DIFF
--- a/packages/documents/README.md
+++ b/packages/documents/README.md
@@ -173,6 +173,10 @@ const tools = {
 };
 ```
 
+The block-listing tool returns the target `blockDocumentId` and a
+`documentExists` flag alongside `blocks`, so agents can distinguish an empty
+document from a missing or incompatible artifact.
+
 `BlockDocumentAiAdapter.addBlock` may return a block ID synchronously or from a
 promise. Hosts that already expose block-document mutations as room commands can
 therefore use `createBlockDocumentCommandAiAdapter` to invoke the canonical

--- a/packages/documents/__tests__/BlockDocumentAi.test.ts
+++ b/packages/documents/__tests__/BlockDocumentAi.test.ts
@@ -166,6 +166,8 @@ describe('block document AI helpers', () => {
 
     expect(result).toEqual({
       success: true,
+      blockDocumentId: 'document-1',
+      documentExists: true,
       blocks: [
         {
           blockId: 'block-1',
@@ -229,6 +231,8 @@ describe('block document AI helpers', () => {
 
     expect(result).toEqual({
       success: true,
+      blockDocumentId: 'document-1',
+      documentExists: true,
       blocks: [
         {
           blockId: 'block-1',
@@ -246,6 +250,38 @@ describe('block document AI helpers', () => {
           ],
         },
       ],
+    });
+  });
+
+  it('distinguishes an empty block document from a missing one', async () => {
+    const blockDocumentAdapter: BlockDocumentAiAdapter = {
+      setCurrentBlockDocument: () => {},
+      ensureBlockDocument: () => {},
+      getBlocks: (blockDocumentId) =>
+        blockDocumentId === 'empty-document' ? [] : undefined,
+      addBlock: (_blockDocumentId, block) => block.id,
+    };
+
+    const emptyDocumentTool = createListBlockDocumentBlocksTool({
+      blockDocumentAdapter,
+      blockDocumentId: 'empty-document',
+    });
+    const missingDocumentTool = createListBlockDocumentBlocksTool({
+      blockDocumentAdapter,
+      blockDocumentId: 'missing-document',
+    });
+
+    await expect((emptyDocumentTool as any).execute({})).resolves.toEqual({
+      success: true,
+      blockDocumentId: 'empty-document',
+      documentExists: true,
+      blocks: [],
+    });
+    await expect((missingDocumentTool as any).execute({})).resolves.toEqual({
+      success: true,
+      blockDocumentId: 'missing-document',
+      documentExists: false,
+      blocks: [],
     });
   });
 

--- a/packages/documents/src/createListBlockDocumentBlocksTool.ts
+++ b/packages/documents/src/createListBlockDocumentBlocksTool.ts
@@ -39,8 +39,8 @@ type BlockDocumentToolOutput<T> =
   | {success: false; errorMessage: string};
 
 type ListBlockDocumentBlocksToolOutput = BlockDocumentToolOutput<{
-  blockDocumentId?: string;
-  documentExists?: boolean;
+  blockDocumentId: string;
+  documentExists: boolean;
   blocks?: BlockDocumentBlockSummary[];
 }>;
 

--- a/packages/documents/src/createListBlockDocumentBlocksTool.ts
+++ b/packages/documents/src/createListBlockDocumentBlocksTool.ts
@@ -39,6 +39,8 @@ type BlockDocumentToolOutput<T> =
   | {success: false; errorMessage: string};
 
 type ListBlockDocumentBlocksToolOutput = BlockDocumentToolOutput<{
+  blockDocumentId?: string;
+  documentExists?: boolean;
   blocks?: BlockDocumentBlockSummary[];
 }>;
 
@@ -130,10 +132,12 @@ export function createListBlockDocumentBlocksTool({
     inputSchema: ListBlockDocumentBlocksToolInput,
     execute: async () => {
       try {
-        const blocks = blockDocumentAdapter.getBlocks(blockDocumentId) ?? [];
+        const nodes = blockDocumentAdapter.getBlocks(blockDocumentId);
         return {
           success: true,
-          blocks: blocks
+          blockDocumentId,
+          documentExists: nodes !== undefined,
+          blocks: (nodes ?? [])
             .map((node, index) =>
               (() => {
                 const block = blockDocumentNodeToBlock(node);


### PR DESCRIPTION
## Summary

- return the target blockDocumentId and documentExists from the block-document listing tool
- preserve the distinction between an empty document and a missing or incompatible artifact
- add populated, empty, and missing-state regression coverage and document the result contract

## Testing

- pnpm build
- pnpm --filter @sqlrooms/documents test --runInBand
- pnpm --filter @sqlrooms/documents typecheck
- pnpm --filter @sqlrooms/documents lint
- pre-push hook under Node 24.19.0: Knip, workspace type-checks, Madge circular-dependency scan, and full Turbo test suite

Closes #884

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Block-listing results now include the requested document ID.
  - Results indicate whether the document exists, distinguishing empty documents from missing ones.
  - Missing documents continue to return an empty block list while being clearly identified.

- **Documentation**
  - Updated documentation to describe the new result fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->