### PR TITLE
feat(duckdb-node)!: convert results via DuckDB's own Arrow IPC

### DIFF
--- a/packages/duckdb-core/src/BaseDuckDbConnector.ts
+++ b/packages/duckdb-core/src/BaseDuckDbConnector.ts
@@ -6,7 +6,7 @@ import {
 import * as arrow from 'apache-arrow';
 import {DuckDbConnector, QueryHandle, QueryOptions} from './DuckDbConnector';
 import {load, loadObjects as loadObjectsSql, loadSpatial} from './load/load';
-import {createTypedRowAccessor} from './typedRowAccessor';
+import {createJsonRowAccessor} from './typedRowAccessor';
 
 export interface BaseDuckDbConnectorOptions {
   dbPath?: string;
@@ -153,7 +153,7 @@ export function createBaseDuckDbConnector(
   ): QueryHandle<Iterable<T>> =>
     createQueryHandle(async (signal, id) => {
       const table = await impl.executeQueryInternal(queryStr, signal, id);
-      return createTypedRowAccessor({arrowTable: table});
+      return createJsonRowAccessor({arrowTable: table});
     }, options);
 
   const loadFile = async (

--- a/packages/duckdb-core/src/typedRowAccessor.ts
+++ b/packages/duckdb-core/src/typedRowAccessor.ts
@@ -39,18 +39,46 @@ function decimalToString(value: Uint32Array | bigint, scale: number): string {
   return `${sign}${padded.slice(0, -scale)}.${padded.slice(-scale)}`;
 }
 
-/** Converts Arrow values whose JS representation is not JSON-compatible. */
-function getJsonValue(field: arrow.Field, value: unknown): unknown {
+/** Recursively converts Arrow values to JSON-compatible JS values. */
+function getJsonValue(type: arrow.DataType, value: unknown): unknown {
+  if (value === null || value === undefined) {
+    return value;
+  }
   if (
-    arrow.DataType.isDecimal(field.type) &&
+    arrow.DataType.isDecimal(type) &&
     (typeof value === 'bigint' || value instanceof Uint32Array)
   ) {
-    return decimalToString(value, field.type.scale);
+    return decimalToString(value, type.scale);
   }
   if (typeof value === 'bigint') {
     return value >= Number.MIN_SAFE_INTEGER && value <= Number.MAX_SAFE_INTEGER
       ? Number(value)
       : value.toString();
+  }
+  if (arrow.DataType.isList(type) || arrow.DataType.isFixedSizeList(type)) {
+    return Array.from(value as Iterable<unknown>, (item) =>
+      getJsonValue(type.valueType, item),
+    );
+  }
+  if (arrow.DataType.isStruct(type)) {
+    const row = value as Record<string, unknown>;
+    return Object.fromEntries(
+      type.children.map((child) => [
+        child.name,
+        getJsonValue(child.type, row[child.name]),
+      ]),
+    );
+  }
+  if (arrow.DataType.isMap(type)) {
+    return Object.fromEntries(
+      Array.from(value as Iterable<[unknown, unknown]>, ([key, mapValue]) => [
+        String(key),
+        getJsonValue(type.valueType, mapValue),
+      ]),
+    );
+  }
+  if (arrow.DataType.isDictionary(type)) {
+    return getJsonValue(type.dictionary, value);
   }
   return value;
 }
@@ -100,7 +128,9 @@ function createRowAccessor<T extends arrow.TypeMap = any>({
         const column = arrowTable.getChild(field.name);
         if (column) {
           const value = column.get(index);
-          row[field.name] = jsonCompatible ? getJsonValue(field, value) : value;
+          row[field.name] = jsonCompatible
+            ? getJsonValue(field.type, value)
+            : value;
         }
       });
 

--- a/packages/duckdb-core/src/typedRowAccessor.ts
+++ b/packages/duckdb-core/src/typedRowAccessor.ts
@@ -11,6 +11,50 @@ export interface TypedRowAccessor<T> extends Iterable<T> {
   toArray(): T[];
 }
 
+/** Converts Arrow's raw fixed-width decimal representation to a JSON string. */
+function decimalToString(value: Uint32Array | bigint, scale: number): string {
+  let unscaled: bigint;
+  if (typeof value === 'bigint') {
+    unscaled = value;
+  } else {
+    let unsigned = 0n;
+    for (let i = 0; i < value.length; i++) {
+      unsigned |= BigInt(value[i]!) << BigInt(i * 32);
+    }
+    const bits = BigInt(value.length * 32);
+    const signBit = 1n << (bits - 1n);
+    unscaled = (unsigned & signBit) === 0n ? unsigned : unsigned - (1n << bits);
+  }
+
+  if (scale < 0) {
+    return (unscaled * 10n ** BigInt(-scale)).toString();
+  }
+
+  const sign = unscaled < 0n ? '-' : '';
+  const digits = (unscaled < 0n ? -unscaled : unscaled).toString();
+  if (scale === 0) {
+    return `${sign}${digits}`;
+  }
+  const padded = digits.padStart(scale + 1, '0');
+  return `${sign}${padded.slice(0, -scale)}.${padded.slice(-scale)}`;
+}
+
+/** Converts Arrow values whose JS representation is not JSON-compatible. */
+function getJsonValue(field: arrow.Field, value: unknown): unknown {
+  if (
+    arrow.DataType.isDecimal(field.type) &&
+    (typeof value === 'bigint' || value instanceof Uint32Array)
+  ) {
+    return decimalToString(value, field.type.scale);
+  }
+  if (typeof value === 'bigint') {
+    return value >= Number.MIN_SAFE_INTEGER && value <= Number.MAX_SAFE_INTEGER
+      ? Number(value)
+      : value.toString();
+  }
+  return value;
+}
+
 /**
  * Creates a row accessor wrapper around an Arrow table that provides typed row access.
  */
@@ -20,6 +64,29 @@ export function createTypedRowAccessor<T extends arrow.TypeMap = any>({
 }: {
   arrowTable: arrow.Table<T>;
   validate?: (row: unknown) => T;
+}): TypedRowAccessor<T> {
+  return createRowAccessor({arrowTable, validate, jsonCompatible: false});
+}
+
+/** @internal Creates the JSON-compatible row accessor used by queryJson. */
+export function createJsonRowAccessor<T extends arrow.TypeMap = any>({
+  arrowTable,
+  validate,
+}: {
+  arrowTable: arrow.Table<T>;
+  validate?: (row: unknown) => T;
+}): TypedRowAccessor<T> {
+  return createRowAccessor({arrowTable, validate, jsonCompatible: true});
+}
+
+function createRowAccessor<T extends arrow.TypeMap = any>({
+  arrowTable,
+  validate,
+  jsonCompatible,
+}: {
+  arrowTable: arrow.Table<T>;
+  validate?: (row: unknown) => T;
+  jsonCompatible: boolean;
 }): TypedRowAccessor<T> {
   let cachedArray: T[] | undefined;
 
@@ -32,7 +99,8 @@ export function createTypedRowAccessor<T extends arrow.TypeMap = any>({
       arrowTable.schema.fields.forEach((field: arrow.Field) => {
         const column = arrowTable.getChild(field.name);
         if (column) {
-          row[field.name] = column.get(index);
+          const value = column.get(index);
+          row[field.name] = jsonCompatible ? getJsonValue(field, value) : value;
         }
       });
 

--- a/packages/duckdb-node/README.md
+++ b/packages/duckdb-node/README.md
@@ -37,6 +37,20 @@ for (const user of users) {
 await connector.destroy();
 ```
 
+## Arrow result types
+
+The connector installs and loads DuckDB's `nanoarrow` community extension
+during initialization, then uses DuckDB's own Arrow IPC conversion for query
+results. Initialization fails if the extension cannot be installed or loaded.
+CI and other restricted-network environments should make the extension
+available in DuckDB's extension cache before creating the connector.
+
+Returned Arrow values follow DuckDB's declared types instead of inferred
+JavaScript types. For example, `BIGINT` values are Arrow `Int64` values exposed
+as JavaScript `bigint`, `DATE` remains `Date32`, and `BLOB` remains `Binary`.
+Callers that serialize query results must handle values such as `bigint`
+explicitly.
+
 ## API
 
 ### `createNodeDuckDbConnector(options?)`

--- a/packages/duckdb-node/__tests__/NodeDuckDbConnector.test.ts
+++ b/packages/duckdb-node/__tests__/NodeDuckDbConnector.test.ts
@@ -229,6 +229,16 @@ describe('NodeDuckDbConnector', () => {
       expect(table.getChild('id')?.get(0)).toBe(7);
     });
 
+    it('should preserve the row count returned by CREATE TABLE AS', async () => {
+      const table = await connector.query(`
+        CREATE TABLE counted_create AS
+        SELECT * FROM (VALUES (1), (2), (3)) AS t(id)
+      `);
+
+      expect(table.numRows).toBe(1);
+      expect(Number(table.getChild('Count')?.get(0))).toBe(3);
+    });
+
     it('should return rows from the last statement of a script', async () => {
       // The regression this guards: running the script for its side effects and
       // returning an empty table would silently drop these rows.

--- a/packages/duckdb-node/__tests__/NodeDuckDbConnector.test.ts
+++ b/packages/duckdb-node/__tests__/NodeDuckDbConnector.test.ts
@@ -265,21 +265,100 @@ describe('NodeDuckDbConnector', () => {
       expect(table.getChild('answer')?.get(0)).toBe(42);
     });
 
-    it('should return rows from INSERT RETURNING', async () => {
+    it.each([
+      ['line', 'SELECT 42 as answer; -- explanation'],
+      ['block', 'SELECT 42 as answer; /* explanation */'],
+    ])(
+      'should accept a terminator before a trailing %s comment',
+      async (_, sql) => {
+        const table = await connector.query(sql);
+
+        expect(table.getChild('answer')?.get(0)).toBe(42);
+      },
+    );
+
+    it('should preserve rows and types from INSERT RETURNING', async () => {
       await connector.query(
-        'CREATE TABLE returning_test (id INTEGER, payload BLOB)',
+        `CREATE TABLE returning_test (
+          id INTEGER,
+          ts TIMESTAMP,
+          d DATE,
+          dec_value DECIMAL(10,4),
+          lst INTEGER[],
+          strct STRUCT(a INTEGER),
+          payload BLOB
+        )`,
       );
 
-      const table = await connector.query(
-        "INSERT INTO returning_test VALUES (7, '\\xFF'::BLOB) RETURNING *",
-      );
+      const table = await connector.query(`
+        INSERT INTO returning_test VALUES (
+          7,
+          TIMESTAMP '2024-01-02 03:04:05.123456',
+          DATE '2024-01-02',
+          1.25,
+          [1, 2],
+          {'a': 1},
+          '\\xFF'::BLOB
+        ) RETURNING *, NULL::INTEGER AS typed_null
+      `);
 
       expect(table.numRows).toBe(1);
       expect(table.getChild('id')?.get(0)).toBe(7);
+      const typeOf = (name: string) => String(table.getChild(name)?.type);
+      expect(typeOf('id')).toBe('Int32');
+      expect(typeOf('ts')).toBe('Timestamp<MICROSECOND>');
+      expect(typeOf('d')).toBe('Date32<DAY>');
+      expect(typeOf('dec_value')).toMatch(/^Decimal/);
+      expect(typeOf('lst')).toBe('List<Int32>');
+      expect(typeOf('strct')).toBe('Struct<{a:Int32}>');
+      expect(typeOf('typed_null')).toBe('Int32');
+      expect(table.getChild('typed_null')?.get(0)).toBeNull();
       expect(table.getChild('payload')?.type).toBeInstanceOf(arrow.Binary);
       expect(
         Array.from(table.getChild('payload')?.get(0) as Uint8Array),
       ).toEqual([0xff]);
+    });
+
+    it('should serialize concurrent operations on the shared connection', async () => {
+      const connection = connector.getConnection();
+      const extractStatements = connection.extractStatements.bind(connection);
+      let releaseFirst!: () => void;
+      const firstCanContinue = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      let markFirstStarted!: () => void;
+      const firstStarted = new Promise<void>((resolve) => {
+        markFirstStarted = resolve;
+      });
+      let shouldBlockFirst = true;
+      let secondStarted = false;
+      connection.extractStatements = async (sql) => {
+        if (sql.includes('first_value') && shouldBlockFirst) {
+          shouldBlockFirst = false;
+          markFirstStarted();
+          await firstCanContinue;
+        }
+        if (sql.includes('second_value')) {
+          secondStarted = true;
+        }
+        return extractStatements(sql);
+      };
+
+      const first = connector.query('SELECT 1 AS first_value');
+      await firstStarted;
+      const second = connector.query('SELECT 2 AS second_value');
+      try {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(secondStarted).toBe(false);
+      } finally {
+        releaseFirst();
+      }
+
+      const [firstTable, secondTable] = await Promise.all([first, second]);
+      expect(firstTable.getChild('first_value')?.get(0)).toBe(1);
+      expect(secondTable.getChild('second_value')?.get(0)).toBe(2);
+      expect(secondStarted).toBe(true);
+      connection.extractStatements = extractStatements;
     });
 
     it('should surface the real error for a broken query', async () => {

--- a/packages/duckdb-node/__tests__/NodeDuckDbConnector.test.ts
+++ b/packages/duckdb-node/__tests__/NodeDuckDbConnector.test.ts
@@ -259,15 +259,15 @@ describe('NodeDuckDbConnector', () => {
       expect(table.getChild('semi')?.get(0)).toBe('a;b');
     });
 
-    it('should accept a trailing statement terminator', async () => {
-      const table = await connector.query('SELECT 42 as answer;');
+    it('should accept repeated trailing statement terminators', async () => {
+      const table = await connector.query('SELECT 42 as answer;;;');
 
       expect(table.getChild('answer')?.get(0)).toBe(42);
     });
 
     it.each([
-      ['line', 'SELECT 42 as answer; -- explanation'],
-      ['block', 'SELECT 42 as answer; /* explanation */'],
+      ['line', 'SELECT 42 as answer;;; -- explanation'],
+      ['block', 'SELECT 42 as answer;;; /* explanation */'],
     ])(
       'should accept a terminator before a trailing %s comment',
       async (_, sql) => {
@@ -361,6 +361,27 @@ describe('NodeDuckDbConnector', () => {
       connection.extractStatements = extractStatements;
     });
 
+    it('should not reparse semicolons inside the final statement', async () => {
+      const connection = connector.getConnection();
+      const extractStatements = connection.extractStatements.bind(connection);
+      let extractCount = 0;
+      connection.extractStatements = async (sql) => {
+        extractCount++;
+        return extractStatements(sql);
+      };
+
+      const semicolons = ';'.repeat(200);
+      try {
+        const table = await connector.query(
+          `SET default_null_order='nulls_last'; SELECT E'a\\';${semicolons}' AS semicolons`,
+        );
+        expect(table.getChild('semicolons')?.get(0)).toBe(`a';${semicolons}`);
+        expect(extractCount).toBeLessThanOrEqual(3);
+      } finally {
+        connection.extractStatements = extractStatements;
+      }
+    });
+
     it('should surface the real error for a broken query', async () => {
       await expect(
         connector.query('SELECT * FROM no_such_table_here'),
@@ -452,6 +473,43 @@ describe('NodeDuckDbConnector', () => {
   });
 
   describe('destroy', () => {
+    it('should reject operations submitted after teardown starts', async () => {
+      const connection = connector.getConnection();
+      const extractStatements = connection.extractStatements.bind(connection);
+      let releaseQuery!: () => void;
+      const queryCanContinue = new Promise<void>((resolve) => {
+        releaseQuery = resolve;
+      });
+      let markQueryStarted!: () => void;
+      const queryStarted = new Promise<void>((resolve) => {
+        markQueryStarted = resolve;
+      });
+      let shouldBlock = true;
+      connection.extractStatements = async (sql) => {
+        if (shouldBlock) {
+          shouldBlock = false;
+          markQueryStarted();
+          await queryCanContinue;
+        }
+        return extractStatements(sql);
+      };
+
+      const activeQuery = connector.query('SELECT 1 AS active');
+      await queryStarted;
+      const destroying = connector.destroy();
+      try {
+        await expect(connector.query('SELECT 2 AS too_late')).rejects.toThrow(
+          'DuckDB connector is shutting down',
+        );
+      } finally {
+        releaseQuery();
+      }
+
+      await expect(activeQuery).resolves.toBeDefined();
+      await destroying;
+      connection.extractStatements = extractStatements;
+    });
+
     it('should clean up resources', async () => {
       await connector.destroy();
 

--- a/packages/duckdb-node/__tests__/NodeDuckDbConnector.test.ts
+++ b/packages/duckdb-node/__tests__/NodeDuckDbConnector.test.ts
@@ -268,6 +268,7 @@ describe('NodeDuckDbConnector', () => {
     it.each([
       ['line', 'SELECT 42 as answer;;; -- explanation'],
       ['block', 'SELECT 42 as answer;;; /* explanation */'],
+      ['nested block', 'SELECT 42 as answer;;; /* outer /* inner */ outer */'],
     ])(
       'should accept a terminator before a trailing %s comment',
       async (_, sql) => {
@@ -473,7 +474,7 @@ describe('NodeDuckDbConnector', () => {
   });
 
   describe('destroy', () => {
-    it('should reject operations submitted after teardown starts', async () => {
+    it('should reject operations and initialization after teardown starts', async () => {
       const connection = connector.getConnection();
       const extractStatements = connection.extractStatements.bind(connection);
       let releaseQuery!: () => void;
@@ -501,6 +502,9 @@ describe('NodeDuckDbConnector', () => {
         await expect(connector.query('SELECT 2 AS too_late')).rejects.toThrow(
           'DuckDB connector is shutting down',
         );
+        await expect(connector.initialize()).rejects.toThrow(
+          'DuckDB connector is shutting down',
+        );
       } finally {
         releaseQuery();
       }
@@ -515,6 +519,13 @@ describe('NodeDuckDbConnector', () => {
 
       // After destroy, getInstance should throw
       expect(() => connector.getInstance()).toThrow('DuckDB not initialized');
+    });
+
+    it('should allow initialization after teardown finishes', async () => {
+      await connector.destroy();
+      await connector.initialize();
+
+      await expect(connector.query('SELECT 1')).resolves.toBeDefined();
     });
 
     it('should be safe to call multiple times', async () => {

--- a/packages/duckdb-node/__tests__/NodeDuckDbConnector.test.ts
+++ b/packages/duckdb-node/__tests__/NodeDuckDbConnector.test.ts
@@ -330,6 +330,24 @@ describe('NodeDuckDbConnector', () => {
       ).toEqual([0xff]);
     });
 
+    it('should not collide with user-owned temporary tables', async () => {
+      await connector.query(`
+        CREATE TEMP TABLE __sqlrooms_arrow_result_0 (sentinel INTEGER);
+        INSERT INTO __sqlrooms_arrow_result_0 VALUES (42)
+      `);
+      await connector.query('CREATE TABLE collision_test (id INTEGER)');
+
+      const returned = await connector.query(
+        'INSERT INTO collision_test VALUES (7) RETURNING id',
+      );
+      const existing = await connector.query(
+        'SELECT sentinel FROM __sqlrooms_arrow_result_0',
+      );
+
+      expect(returned.getChild('id')?.get(0)).toBe(7);
+      expect(existing.getChild('sentinel')?.get(0)).toBe(42);
+    });
+
     it('should serialize concurrent operations on the shared connection', async () => {
       const connection = connector.getConnection();
       const extractStatements = connection.extractStatements.bind(connection);

--- a/packages/duckdb-node/__tests__/NodeDuckDbConnector.test.ts
+++ b/packages/duckdb-node/__tests__/NodeDuckDbConnector.test.ts
@@ -1,3 +1,4 @@
+import * as arrow from 'apache-arrow';
 import {
   createNodeDuckDbConnector,
   NodeDuckDbConnector,
@@ -138,6 +139,134 @@ describe('NodeDuckDbConnector', () => {
       const table = await connector.query('SELECT * FROM empty_table');
 
       expect(table.numRows).toBe(0);
+    });
+
+    // BLOB columns used to be rendered through DuckDB's BLOB-to-VARCHAR
+    // escaping and inferred as `Dictionary<Int32, Utf8>`, which has no
+    // `valueOffsets`. Consumers reading binary columns positionally (kepler.gl's
+    // WKB geometry reader indexes `chunk.valueOffsets[i + 1]`) crashed with
+    // `Cannot read properties of undefined (reading '1')`.
+    it('should return BLOB columns as Arrow Binary, not strings', async () => {
+      const table = await connector.query(
+        "SELECT 'abc'::BLOB as blob_val, 1 as other",
+      );
+
+      const col = table.getChild('blob_val');
+      expect(col?.type).toBeInstanceOf(arrow.Binary);
+      expect(col?.data[0]?.valueOffsets).toBeDefined();
+      expect(Array.from(col?.get(0) as Uint8Array)).toEqual([0x61, 0x62, 0x63]);
+    });
+
+    it('should preserve BLOB bytes that are not valid UTF-8', async () => {
+      // \x00 and \xff do not survive a round trip through a JS string, so this
+      // fails loudly if BLOBs are ever stringified again.
+      const table = await connector.query(
+        "SELECT '\\x00\\x01\\xFF'::BLOB as blob_val",
+      );
+
+      expect(
+        Array.from(table.getChild('blob_val')?.get(0) as Uint8Array),
+      ).toEqual([0x00, 0x01, 0xff]);
+    });
+
+    it('should handle NULL and multi-row BLOB columns', async () => {
+      const table = await connector.query(`
+        SELECT * FROM (VALUES
+          ('a'::BLOB),
+          (NULL),
+          ('cc'::BLOB)
+        ) AS t(blob_val)
+      `);
+
+      const col = table.getChild('blob_val');
+      expect(table.numRows).toBe(3);
+      expect(col?.type).toBeInstanceOf(arrow.Binary);
+      expect(Array.from(col?.get(0) as Uint8Array)).toEqual([0x61]);
+      expect(col?.get(1)).toBeNull();
+      expect(Array.from(col?.get(2) as Uint8Array)).toEqual([0x63, 0x63]);
+    });
+  });
+
+  // `to_arrow_ipc()` is the only conversion path, so these assert the types the
+  // JS value conversion could never produce.
+  describe('Arrow type fidelity', () => {
+    it('should preserve DuckDB types that JS values cannot represent', async () => {
+      const table = await connector.query(`
+        SELECT
+          TIMESTAMP '2024-01-02 03:04:05' as ts,
+          DATE '2024-01-02' as d,
+          9007199254740993::BIGINT as big,
+          1.25::DECIMAL(10,4) as dec,
+          [1, 2, 3] as lst,
+          {'a': 1} as strct,
+          NULL::INTEGER as allnull
+      `);
+
+      // Decoded IPC yields the generic type classes (`Int_`, not `Int64`), so
+      // compare the rendered type instead of the constructor.
+      const typeOf = (name: string) => String(table.getChild(name)?.type);
+      expect(typeOf('ts')).toBe('Timestamp<MICROSECOND>');
+      expect(typeOf('d')).toBe('Date32<DAY>');
+      expect(typeOf('big')).toBe('Int64');
+      expect(typeOf('dec')).toMatch(/^Decimal/);
+      expect(typeOf('lst')).toBe('List<Int32>');
+      expect(typeOf('strct')).toBe('Struct<{a:Int32}>');
+      expect(typeOf('allnull')).toBe('Int32');
+      // Beyond Number.MAX_SAFE_INTEGER: only a real Int64 keeps this exact.
+      expect(table.getChild('big')?.get(0)).toBe(9007199254740993n);
+    });
+  });
+
+  // `to_arrow_ipc()` only wraps a single sub-selectable statement, so anything
+  // else has to be routed around it without losing rows.
+  describe('statements to_arrow_ipc cannot wrap', () => {
+    it('should run DDL and DML', async () => {
+      await connector.query('CREATE TABLE stmt_test (id INTEGER)');
+      await connector.query('INSERT INTO stmt_test VALUES (7)');
+
+      const table = await connector.query('SELECT id FROM stmt_test');
+      expect(table.numRows).toBe(1);
+      expect(table.getChild('id')?.get(0)).toBe(7);
+    });
+
+    it('should return rows from the last statement of a script', async () => {
+      // The regression this guards: running the script for its side effects and
+      // returning an empty table would silently drop these rows.
+      const table = await connector.query(
+        "SET default_null_order='nulls_last'; SELECT 42 as answer",
+      );
+
+      expect(table.numRows).toBe(1);
+      expect(table.getChild('answer')?.get(0)).toBe(42);
+    });
+
+    it('should apply every leading statement of a script', async () => {
+      const table = await connector.query(
+        `CREATE TABLE script_test (id INTEGER);
+         INSERT INTO script_test VALUES (1), (2);
+         SELECT count(*)::INTEGER as n FROM script_test`,
+      );
+
+      expect(table.getChild('n')?.get(0)).toBe(2);
+    });
+
+    it('should split on the parse, not on semicolons', async () => {
+      // A `;` inside a string literal must not be treated as a boundary.
+      const table = await connector.query(
+        `SET default_null_order='nulls_last'; SELECT 'a;b' as semi`,
+      );
+
+      expect(table.getChild('semi')?.get(0)).toBe('a;b');
+    });
+
+    it('should surface the real error for a broken query', async () => {
+      await expect(
+        connector.query('SELECT * FROM no_such_table_here'),
+      ).rejects.toThrow(/no_such_table_here/);
+    });
+
+    it('should surface the real error for broken syntax', async () => {
+      await expect(connector.query('SELEKT 1')).rejects.toThrow();
     });
   });
 

--- a/packages/duckdb-node/__tests__/NodeDuckDbConnector.test.ts
+++ b/packages/duckdb-node/__tests__/NodeDuckDbConnector.test.ts
@@ -484,6 +484,44 @@ describe('NodeDuckDbConnector', () => {
       expect(rows).toEqual([{safe: 42, unsafe: '9007199254740993'}]);
       expect(() => JSON.stringify(rows)).not.toThrow();
     });
+
+    it('should recursively convert nested Arrow values to JSON values', async () => {
+      const result = await connector.queryJson<{
+        listValue: Array<number | string>;
+        structValue: {
+          amount: string;
+          big: string;
+          values: number[];
+        };
+        mapValue: Record<string, number | string>;
+      }>(`
+        SELECT
+          [9007199254740993::BIGINT, 42::BIGINT] AS "listValue",
+          {
+            'amount': 1.25::DECIMAL(10,4),
+            'big': 9007199254740993::BIGINT,
+            'values': [42::BIGINT]
+          } AS "structValue",
+          MAP {
+            'large': 9007199254740993::BIGINT,
+            'small': 42::BIGINT
+          } AS "mapValue"
+      `);
+
+      const rows = Array.from(result);
+      expect(rows).toEqual([
+        {
+          listValue: ['9007199254740993', 42],
+          structValue: {
+            amount: '1.2500',
+            big: '9007199254740993',
+            values: [42],
+          },
+          mapValue: {large: '9007199254740993', small: 42},
+        },
+      ]);
+      expect(() => JSON.stringify(rows)).not.toThrow();
+    });
   });
 
   describe('loadArrow', () => {

--- a/packages/duckdb-node/__tests__/NodeDuckDbConnector.test.ts
+++ b/packages/duckdb-node/__tests__/NodeDuckDbConnector.test.ts
@@ -450,6 +450,72 @@ describe('NodeDuckDbConnector', () => {
       expect(rows[0]).toEqual({id: 1, name: 'one'});
       expect(rows[1]).toEqual({id: 2, name: 'two'});
     });
+
+    it('should return DECIMAL values as JSON-compatible strings', async () => {
+      const result = await connector.queryJson<{
+        positive: string;
+        negative: string;
+        zero: string;
+      }>(`
+        SELECT
+          1.25::DECIMAL(10,4) AS positive,
+          -0.01::DECIMAL(10,4) AS negative,
+          0::DECIMAL(10,4) AS zero
+      `);
+
+      const rows = Array.from(result);
+      expect(rows).toEqual([
+        {positive: '1.2500', negative: '-0.0100', zero: '0.0000'},
+      ]);
+      expect(() => JSON.stringify(rows)).not.toThrow();
+    });
+
+    it('should return BIGINT values as JSON-compatible numbers or strings', async () => {
+      const result = await connector.queryJson<{
+        safe: number;
+        unsafe: string;
+      }>(`
+        SELECT
+          42::BIGINT AS safe,
+          9007199254740993::BIGINT AS unsafe
+      `);
+
+      const rows = Array.from(result);
+      expect(rows).toEqual([{safe: 42, unsafe: '9007199254740993'}]);
+      expect(() => JSON.stringify(rows)).not.toThrow();
+    });
+  });
+
+  describe('loadArrow', () => {
+    it('should preserve Arrow types and microsecond timestamps', async () => {
+      const source = await connector.query(`
+        SELECT
+          TIMESTAMP '2024-01-02 03:04:05.123456' AS ts,
+          1.25::DECIMAL(10,4) AS dec_value,
+          '\\x00\\xFF'::BLOB AS payload
+      `);
+
+      await connector.loadArrow(source, 'loaded_arrow');
+
+      const result = await connector.queryJson<{
+        ts: string;
+        decType: string;
+        payload: string;
+      }>(`
+        SELECT
+          strftime(ts, '%Y-%m-%d %H:%M:%S.%f') AS ts,
+          typeof(dec_value) AS "decType",
+          hex(payload) AS payload
+        FROM loaded_arrow
+      `);
+      expect(Array.from(result)).toEqual([
+        {
+          ts: '2024-01-02 03:04:05.123456',
+          decType: 'DECIMAL(10,4)',
+          payload: '00FF',
+        },
+      ]);
+    });
   });
 
   describe('cancellation', () => {

--- a/packages/duckdb-node/__tests__/NodeDuckDbConnector.test.ts
+++ b/packages/duckdb-node/__tests__/NodeDuckDbConnector.test.ts
@@ -259,6 +259,29 @@ describe('NodeDuckDbConnector', () => {
       expect(table.getChild('semi')?.get(0)).toBe('a;b');
     });
 
+    it('should accept a trailing statement terminator', async () => {
+      const table = await connector.query('SELECT 42 as answer;');
+
+      expect(table.getChild('answer')?.get(0)).toBe(42);
+    });
+
+    it('should return rows from INSERT RETURNING', async () => {
+      await connector.query(
+        'CREATE TABLE returning_test (id INTEGER, payload BLOB)',
+      );
+
+      const table = await connector.query(
+        "INSERT INTO returning_test VALUES (7, '\\xFF'::BLOB) RETURNING *",
+      );
+
+      expect(table.numRows).toBe(1);
+      expect(table.getChild('id')?.get(0)).toBe(7);
+      expect(table.getChild('payload')?.type).toBeInstanceOf(arrow.Binary);
+      expect(
+        Array.from(table.getChild('payload')?.get(0) as Uint8Array),
+      ).toEqual([0xff]);
+    });
+
     it('should surface the real error for a broken query', async () => {
       await expect(
         connector.query('SELECT * FROM no_such_table_here'),

--- a/packages/duckdb-node/src/NodeDuckDbConnector.ts
+++ b/packages/duckdb-node/src/NodeDuckDbConnector.ts
@@ -7,6 +7,7 @@ import {
 import {LoadFileOptions, StandardLoadOptions} from '@sqlrooms/room-config';
 import * as arrow from 'apache-arrow';
 import {
+  ARROW_IPC_INIT_SQL,
   arrowTableToRows,
   buildQualifiedName,
   objectsToCreateTableSql,
@@ -86,6 +87,11 @@ export function createNodeDuckDbConnector(
     async initializeInternal() {
       instance = await DuckDBInstance.create(dbPath, config);
       connection = await instance.connect();
+      // Required, not optional: `@duckdb/node-api` has no Arrow API, so this
+      // extension IS the conversion. Failing here is deliberate — the
+      // alternative was rebuilding tables from JS values, which silently
+      // mistyped TIMESTAMP/DATE/BIGINT/DECIMAL and corrupted BLOB.
+      await connection.run(ARROW_IPC_INIT_SQL);
     },
 
     async destroyInternal() {

--- a/packages/duckdb-node/src/NodeDuckDbConnector.ts
+++ b/packages/duckdb-node/src/NodeDuckDbConnector.ts
@@ -3,12 +3,15 @@ import {
   BaseDuckDbConnectorImpl,
   createBaseDuckDbConnector,
   DuckDbConnector,
+  literalToSQL,
 } from '@sqlrooms/duckdb-core';
 import {LoadFileOptions, StandardLoadOptions} from '@sqlrooms/room-config';
 import * as arrow from 'apache-arrow';
+import {mkdtemp, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
 import {
   ARROW_IPC_INIT_SQL,
-  arrowTableToRows,
   buildQualifiedName,
   objectsToCreateTableSql,
   queryToArrowTable,
@@ -144,16 +147,27 @@ export function createNodeDuckDbConnector(
       tableName: string,
       opts?: {schema?: string},
     ): Promise<void> {
-      if (table instanceof arrow.Table) {
-        const rows = arrowTableToRows(table);
-        await impl.loadObjectsInternal!(rows, tableName, {
-          schema: opts?.schema,
-          replace: true,
+      const ipc =
+        table instanceof arrow.Table
+          ? arrow.tableToIPC(table, 'stream')
+          : table;
+      const qualifiedName = buildQualifiedName(tableName, opts?.schema);
+      const tempDir = await mkdtemp(join(tmpdir(), 'sqlrooms-arrow-'));
+      const tempFile = join(tempDir, 'data.arrow');
+
+      try {
+        // node-api cannot register an in-memory Arrow buffer yet. Let DuckDB's
+        // nanoarrow extension scan the IPC stream through a short-lived file;
+        // rebuilding rows from Vector#get() loses types and sub-millisecond
+        // timestamp precision before DuckDB ever sees the values.
+        await writeFile(tempFile, ipc);
+        await enqueueOperation(async () => {
+          await ensureConnection().run(
+            `CREATE OR REPLACE TABLE ${qualifiedName} AS SELECT * FROM ${literalToSQL(tempFile)}`,
+          );
         });
-      } else {
-        throw new Error(
-          'Loading Arrow IPC streams is not yet supported in Node connector',
-        );
+      } finally {
+        await rm(tempDir, {recursive: true, force: true});
       }
     },
 

--- a/packages/duckdb-node/src/NodeDuckDbConnector.ts
+++ b/packages/duckdb-node/src/NodeDuckDbConnector.ts
@@ -77,6 +77,7 @@ export function createNodeDuckDbConnector(
   let connection: DuckDBConnection | null = null;
   let operationQueue = Promise.resolve();
   let closing = false;
+  let destroyPromise: Promise<void> | null = null;
 
   const enqueueOperation = <T>(operation: () => Promise<T>): Promise<T> => {
     if (closing) {
@@ -99,7 +100,6 @@ export function createNodeDuckDbConnector(
 
   const impl: BaseDuckDbConnectorImpl = {
     async initializeInternal() {
-      closing = false;
       await enqueueOperation(async () => {
         instance = await DuckDBInstance.create(dbPath, config);
         connection = await instance.connect();
@@ -112,7 +112,6 @@ export function createNodeDuckDbConnector(
     },
 
     async destroyInternal() {
-      closing = true;
       await operationQueue;
       if (connection) {
         try {
@@ -202,8 +201,27 @@ export function createNodeDuckDbConnector(
     impl,
   );
 
+  const initialize = async (): Promise<void> => {
+    if (closing) {
+      throw new Error('DuckDB connector is shutting down');
+    }
+    await baseConnector.initialize();
+  };
+
+  const destroy = (): Promise<void> => {
+    if (destroyPromise) return destroyPromise;
+    closing = true;
+    destroyPromise = baseConnector.destroy().finally(() => {
+      closing = false;
+      destroyPromise = null;
+    });
+    return destroyPromise;
+  };
+
   return {
     ...baseConnector,
+    initialize,
+    destroy,
     getInstance() {
       if (!instance) {
         throw new Error('DuckDB not initialized');

--- a/packages/duckdb-node/src/NodeDuckDbConnector.ts
+++ b/packages/duckdb-node/src/NodeDuckDbConnector.ts
@@ -76,8 +76,12 @@ export function createNodeDuckDbConnector(
   let instance: DuckDBInstance | null = null;
   let connection: DuckDBConnection | null = null;
   let operationQueue = Promise.resolve();
+  let closing = false;
 
   const enqueueOperation = <T>(operation: () => Promise<T>): Promise<T> => {
+    if (closing) {
+      return Promise.reject(new Error('DuckDB connector is shutting down'));
+    }
     const result = operationQueue.then(operation);
     operationQueue = result.then(
       () => undefined,
@@ -95,16 +99,20 @@ export function createNodeDuckDbConnector(
 
   const impl: BaseDuckDbConnectorImpl = {
     async initializeInternal() {
-      instance = await DuckDBInstance.create(dbPath, config);
-      connection = await instance.connect();
-      // Required, not optional: `@duckdb/node-api` has no Arrow API, so this
-      // extension IS the conversion. Failing here is deliberate — the
-      // alternative was rebuilding tables from JS values, which silently
-      // mistyped TIMESTAMP/DATE/BIGINT/DECIMAL and corrupted BLOB.
-      await connection.run(ARROW_IPC_INIT_SQL);
+      closing = false;
+      await enqueueOperation(async () => {
+        instance = await DuckDBInstance.create(dbPath, config);
+        connection = await instance.connect();
+        // Required, not optional: `@duckdb/node-api` has no Arrow API, so this
+        // extension IS the conversion. Failing here is deliberate — the
+        // alternative was rebuilding tables from JS values, which silently
+        // mistyped TIMESTAMP/DATE/BIGINT/DECIMAL and corrupted BLOB.
+        await connection.run(ARROW_IPC_INIT_SQL);
+      });
     },
 
     async destroyInternal() {
+      closing = true;
       await operationQueue;
       if (connection) {
         try {

--- a/packages/duckdb-node/src/NodeDuckDbConnector.ts
+++ b/packages/duckdb-node/src/NodeDuckDbConnector.ts
@@ -75,6 +75,16 @@ export function createNodeDuckDbConnector(
 
   let instance: DuckDBInstance | null = null;
   let connection: DuckDBConnection | null = null;
+  let operationQueue = Promise.resolve();
+
+  const enqueueOperation = <T>(operation: () => Promise<T>): Promise<T> => {
+    const result = operationQueue.then(operation);
+    operationQueue = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  };
 
   const ensureConnection = (): DuckDBConnection => {
     if (!connection) {
@@ -95,6 +105,7 @@ export function createNodeDuckDbConnector(
     },
 
     async destroyInternal() {
+      await operationQueue;
       if (connection) {
         try {
           connection.closeSync();
@@ -113,10 +124,12 @@ export function createNodeDuckDbConnector(
       sql: string,
       signal: AbortSignal,
     ): Promise<arrow.Table<T>> {
-      if (signal.aborted) {
-        throw new DOMException('Query was cancelled', 'AbortError');
-      }
-      return queryToArrowTable<T>(ensureConnection(), sql);
+      return enqueueOperation(async () => {
+        if (signal.aborted) {
+          throw new DOMException('Query was cancelled', 'AbortError');
+        }
+        return queryToArrowTable<T>(ensureConnection(), sql);
+      });
     },
 
     async loadArrowInternal(
@@ -148,7 +161,9 @@ export function createNodeDuckDbConnector(
 
       const qualifiedName = buildQualifiedName(tableName, opts?.schema);
       const sql = objectsToCreateTableSql(data, qualifiedName);
-      await ensureConnection().run(sql);
+      await enqueueOperation(async () => {
+        await ensureConnection().run(sql);
+      });
     },
 
     async loadFileInternal(
@@ -168,7 +183,9 @@ export function createNodeDuckDbConnector(
           ? `CREATE OR REPLACE TABLE ${qualifiedName} AS SELECT * FROM '${fileName}'`
           : `CREATE OR REPLACE TABLE ${qualifiedName} AS SELECT * FROM ${method}('${fileName}')`;
 
-      await ensureConnection().run(sql);
+      await enqueueOperation(async () => {
+        await ensureConnection().run(sql);
+      });
     },
   };
 

--- a/packages/duckdb-node/src/helpers.ts
+++ b/packages/duckdb-node/src/helpers.ts
@@ -1,7 +1,6 @@
 import {
   DuckDBConnection,
   DuckDBResultReader,
-  ResultReturnType,
   StatementType,
 } from '@duckdb/node-api';
 import {
@@ -247,9 +246,10 @@ async function runStatementToArrow<T extends arrow.TypeMap = any>(
       throw error;
     }
     const reader = await conn.runAndReadAll(sql);
-    return reader.returnType === ResultReturnType.QUERY_RESULT
-      ? resultReaderToArrowTable<T>(conn, reader)
-      : emptyTable<T>();
+    // DuckDB's return type does not reliably indicate whether rows exist:
+    // `CREATE TABLE AS` is NOTHING but includes a Count row, while
+    // `INSERT ... RETURNING` is QUERY_RESULT. Inspect the reader itself.
+    return resultReaderToArrowTable<T>(conn, reader);
   }
 }
 

--- a/packages/duckdb-node/src/helpers.ts
+++ b/packages/duckdb-node/src/helpers.ts
@@ -1,4 +1,10 @@
-import {DuckDBConnection, StatementType} from '@duckdb/node-api';
+import {
+  DuckDBConnection,
+  DuckDBResultReader,
+  DuckDBTypeId,
+  ResultReturnType,
+  StatementType,
+} from '@duckdb/node-api';
 import {
   getRawSqlTableReference,
   literalToSQL,
@@ -148,6 +154,25 @@ function emptyTable<T extends arrow.TypeMap = any>(): arrow.Table<T> {
   return arrow.tableFromArrays({}) as unknown as arrow.Table<T>;
 }
 
+/** Converts a materialized non-SELECT result to Arrow without dropping rows. */
+function resultReaderToArrowTable<T extends arrow.TypeMap = any>(
+  reader: DuckDBResultReader,
+): arrow.Table<T> {
+  const columns = reader.getColumnsJS();
+  const vectors: Record<string, arrow.Vector> = {};
+  for (let i = 0; i < reader.columnCount; i++) {
+    const type =
+      reader.columnTypeId(i) === DuckDBTypeId.BLOB
+        ? new arrow.Binary()
+        : undefined;
+    const values = columns[i] ?? [];
+    vectors[reader.columnName(i)] = type
+      ? arrow.vectorFromArray(values, type)
+      : arrow.vectorFromArray(values);
+  }
+  return new arrow.Table(vectors) as unknown as arrow.Table<T>;
+}
+
 /**
  * Runs `sql` through `to_arrow_ipc()` and decodes the resulting Arrow IPC
  * buffers, so DuckDB itself performs the Arrow conversion and every type
@@ -160,8 +185,11 @@ async function queryToArrowTableViaIpc<T extends arrow.TypeMap = any>(
   conn: DuckDBConnection,
   sql: string,
 ): Promise<arrow.Table<T>> {
+  // A statement terminator is valid at the top level but not inside the
+  // parenthesized subquery passed to `to_arrow_ipc()`.
+  const normalizedSql = sql.replace(/;(\s*)$/, '$1');
   const reader = await conn.runAndReadAll(
-    `SELECT * FROM to_arrow_ipc((${sql}))`,
+    `SELECT * FROM to_arrow_ipc((${normalizedSql}))`,
   );
   const buffers = reader.getColumnsJS()[0] as Uint8Array[] | undefined;
   if (!buffers?.length) {
@@ -188,8 +216,10 @@ async function runStatementToArrow<T extends arrow.TypeMap = any>(
     if (await isSelectStatement(conn, sql)) {
       throw error;
     }
-    await conn.run(sql);
-    return emptyTable<T>();
+    const reader = await conn.runAndReadAll(sql);
+    return reader.returnType === ResultReturnType.QUERY_RESULT
+      ? resultReaderToArrowTable<T>(reader)
+      : emptyTable<T>();
   }
 }
 

--- a/packages/duckdb-node/src/helpers.ts
+++ b/packages/duckdb-node/src/helpers.ts
@@ -6,8 +6,10 @@ import {
 } from '@duckdb/node-api';
 import {
   getRawSqlTableReference,
+  joinStatements,
   literalToSQL,
   makeQualifiedTableName,
+  splitSqlStatements,
 } from '@sqlrooms/duckdb-core';
 import * as arrow from 'apache-arrow';
 
@@ -97,147 +99,20 @@ async function countStatements(
   }
 }
 
-/** Finds semicolons outside strings, quoted identifiers, and SQL comments. */
-function findStatementSeparators(sql: string): number[] {
-  const separators: number[] = [];
-  let i = 0;
-  while (i < sql.length) {
-    const char = sql[i];
-    const next = sql[i + 1];
-
-    if (char === "'" || char === '"') {
-      const quote = char;
-      const usesBackslashEscapes =
-        quote === "'" &&
-        (sql[i - 1] === 'E' || sql[i - 1] === 'e') &&
-        (i < 2 || !/[A-Za-z0-9_$]/.test(sql[i - 2]!));
-      i++;
-      while (i < sql.length) {
-        if (usesBackslashEscapes && sql[i] === '\\') {
-          i += 2;
-          continue;
-        }
-        if (sql[i] === quote) {
-          if (sql[i + 1] === quote) {
-            i += 2;
-            continue;
-          }
-          i++;
-          break;
-        }
-        i++;
-      }
-      continue;
-    }
-
-    if (char === '-' && next === '-') {
-      const newline = sql.indexOf('\n', i + 2);
-      i = newline < 0 ? sql.length : newline + 1;
-      continue;
-    }
-
-    if (char === '/' && next === '*') {
-      let depth = 1;
-      i += 2;
-      while (i < sql.length && depth > 0) {
-        if (sql[i] === '/' && sql[i + 1] === '*') {
-          depth++;
-          i += 2;
-        } else if (sql[i] === '*' && sql[i + 1] === '/') {
-          depth--;
-          i += 2;
-        } else {
-          i++;
-        }
-      }
-      continue;
-    }
-
-    if (char === '$') {
-      const tag = sql.slice(i).match(/^\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$/)?.[0];
-      if (tag) {
-        const closingTag = sql.indexOf(tag, i + tag.length);
-        i = closingTag < 0 ? sql.length : closingTag + tag.length;
-        continue;
-      }
-    }
-
-    if (char === ';') {
-      separators.push(i);
-    }
-    i++;
-  }
-  return separators;
-}
-
-/** Whether `sql` contains only whitespace and SQL comments. */
-function isSqlTrivia(sql: string): boolean {
-  let i = 0;
-  while (i < sql.length) {
-    if (/\s/.test(sql[i]!)) {
-      i++;
-      continue;
-    }
-
-    if (sql[i] === '-' && sql[i + 1] === '-') {
-      const newline = sql.indexOf('\n', i + 2);
-      i = newline < 0 ? sql.length : newline + 1;
-      continue;
-    }
-
-    if (sql[i] === '/' && sql[i + 1] === '*') {
-      let depth = 1;
-      i += 2;
-      while (i < sql.length && depth > 0) {
-        if (sql[i] === '/' && sql[i + 1] === '*') {
-          depth++;
-          i += 2;
-        } else if (sql[i] === '*' && sql[i + 1] === '/') {
-          depth--;
-          i += 2;
-        } else {
-          i++;
-        }
-      }
-      if (depth > 0) return false;
-      continue;
-    }
-
-    return false;
-  }
-  return true;
-}
-
 /**
- * Splits a multi-statement script into everything-but-the-last statement plus
- * the last one, or returns `null` when `sql` is a single statement.
+ * Splits SQL with the shared DuckDB-aware lexer and confirms its statement
+ * count with DuckDB's own parser before any split statements are executed.
  *
- * A small lexical scan skips strings, quoted identifiers, and comments. The
- * remaining separator candidates are validated with DuckDB's own parser, so
- * dialect-specific syntax still decides the actual statement boundary.
+ * Returns `null` when the input does not parse or the two implementations
+ * disagree, so malformed or newly introduced syntax is passed to DuckDB whole.
  */
-async function splitTrailingStatement(
+async function splitValidatedStatements(
   conn: DuckDBConnection,
   sql: string,
-): Promise<{head: string; last: string} | null> {
+): Promise<string[] | null> {
+  const statements = splitSqlStatements(sql, {removeComments: false});
   const total = await countStatements(conn, sql);
-  if (total === null || total <= 1) {
-    return null;
-  }
-  const separators = findStatementSeparators(sql);
-  for (let i = separators.length - 1; i >= 0; i--) {
-    const separator = separators[i]!;
-    const head = sql.slice(0, separator + 1);
-    const last = sql.slice(separator + 1);
-    if (!last.trim()) continue;
-    if (
-      (await countStatements(conn, head)) === total - 1 &&
-      (await countStatements(conn, last)) === 1
-    ) {
-      return {head, last};
-    }
-  }
-  return null;
+  return total === statements.length ? statements : null;
 }
 
 /** Whether `sql` is a single SELECT, per DuckDB's parser. */
@@ -326,24 +201,6 @@ async function resultReaderToArrowTable<T extends arrow.TypeMap = any>(
 }
 
 /**
- * Removes top-level statement terminators before trailing SQL trivia.
- * Comments stay attached to the query for diagnostics and source fidelity.
- */
-function stripTrailingStatementTerminator(sql: string): string {
-  const separators = findStatementSeparators(sql);
-  let normalized = sql;
-  while (separators.length > 0) {
-    const separator = separators.pop()!;
-    if (!isSqlTrivia(normalized.slice(separator + 1))) {
-      break;
-    }
-    normalized =
-      normalized.slice(0, separator) + normalized.slice(separator + 1);
-  }
-  return normalized;
-}
-
-/**
  * Runs `sql` through `to_arrow_ipc()` and decodes the resulting Arrow IPC
  * buffers, so DuckDB itself performs the Arrow conversion and every type
  * round-trips exactly.
@@ -355,11 +212,8 @@ async function queryToArrowTableViaIpc<T extends arrow.TypeMap = any>(
   conn: DuckDBConnection,
   sql: string,
 ): Promise<arrow.Table<T>> {
-  // A statement terminator is valid at the top level but not inside the
-  // parenthesized subquery passed to `to_arrow_ipc()`.
-  const normalizedSql = stripTrailingStatementTerminator(sql);
   const reader = await conn.runAndReadAll(
-    `SELECT * FROM to_arrow_ipc((${normalizedSql}\n))`,
+    `SELECT * FROM to_arrow_ipc((${sql}\n))`,
   );
   const buffers = reader.getColumnsJS()[0] as Uint8Array[] | undefined;
   if (!buffers?.length) {
@@ -412,10 +266,14 @@ export async function queryToArrowTable<T extends arrow.TypeMap = any>(
   conn: DuckDBConnection,
   sql: string,
 ): Promise<arrow.Table<T>> {
-  const split = await splitTrailingStatement(conn, sql);
-  if (!split) {
+  const statements = await splitValidatedStatements(conn, sql);
+  if (!statements || statements.length === 0) {
     return runStatementToArrow<T>(conn, sql);
   }
-  await conn.run(split.head);
-  return runStatementToArrow<T>(conn, split.last);
+
+  const lastStatement = statements.at(-1)!;
+  if (statements.length > 1) {
+    await conn.run(joinStatements(statements.slice(0, -2), statements.at(-2)!));
+  }
+  return runStatementToArrow<T>(conn, lastStatement);
 }

--- a/packages/duckdb-node/src/helpers.ts
+++ b/packages/duckdb-node/src/helpers.ts
@@ -23,24 +23,6 @@ export function buildQualifiedName(tableName: string, schema?: string): string {
 }
 
 /**
- * Converts an Arrow table to an array of row objects.
- */
-export function arrowTableToRows(
-  table: arrow.Table,
-): Record<string, unknown>[] {
-  const rows: Record<string, unknown>[] = [];
-  for (let i = 0; i < table.numRows; i++) {
-    const row: Record<string, unknown> = {};
-    for (const field of table.schema.fields) {
-      const col = table.getChild(field.name);
-      row[field.name] = col?.get(i);
-    }
-    rows.push(row);
-  }
-  return rows;
-}
-
-/**
  * Converts a value to SQL literal, with bigint support.
  */
 function toSqlLiteral(value: unknown): string {

--- a/packages/duckdb-node/src/helpers.ts
+++ b/packages/duckdb-node/src/helpers.ts
@@ -1,7 +1,6 @@
 import {
   DuckDBConnection,
   DuckDBResultReader,
-  DuckDBTypeId,
   ResultReturnType,
   StatementType,
 } from '@duckdb/node-api';
@@ -154,23 +153,74 @@ function emptyTable<T extends arrow.TypeMap = any>(): arrow.Table<T> {
   return arrow.tableFromArrays({}) as unknown as arrow.Table<T>;
 }
 
-/** Converts a materialized non-SELECT result to Arrow without dropping rows. */
-function resultReaderToArrowTable<T extends arrow.TypeMap = any>(
+let nextResultTableId = 0;
+
+/** Quotes a DuckDB identifier. */
+function quoteIdentifier(identifier: string): string {
+  return `"${identifier.replaceAll('"', '""')}"`;
+}
+
+/**
+ * Converts a materialized non-SELECT result to Arrow without losing its
+ * declared DuckDB types.
+ *
+ * The native result values are copied through a temporary table, then that
+ * table is serialized by `to_arrow_ipc()`. This keeps the fallback path on the
+ * same type-exact conversion mechanism as ordinary SELECT results.
+ */
+async function resultReaderToArrowTable<T extends arrow.TypeMap = any>(
+  conn: DuckDBConnection,
   reader: DuckDBResultReader,
-): arrow.Table<T> {
-  const columns = reader.getColumnsJS();
-  const vectors: Record<string, arrow.Vector> = {};
-  for (let i = 0; i < reader.columnCount; i++) {
-    const type =
-      reader.columnTypeId(i) === DuckDBTypeId.BLOB
-        ? new arrow.Binary()
-        : undefined;
-    const values = columns[i] ?? [];
-    vectors[reader.columnName(i)] = type
-      ? arrow.vectorFromArray(values, type)
-      : arrow.vectorFromArray(values);
+): Promise<arrow.Table<T>> {
+  if (reader.columnCount === 0 || reader.currentRowCount === 0) {
+    return emptyTable<T>();
   }
-  return new arrow.Table(vectors) as unknown as arrow.Table<T>;
+
+  const tableName = `__sqlrooms_arrow_result_${nextResultTableId++}`;
+  const columnTypes = reader.columnTypes();
+  const columnDefinitions = columnTypes
+    .map((type, i) => `c${i} ${type}`)
+    .join(', ');
+  await conn.run(`CREATE TEMP TABLE ${tableName} (${columnDefinitions})`);
+
+  let appender: Awaited<ReturnType<DuckDBConnection['createAppender']>> | null =
+    null;
+  try {
+    appender = await conn.createAppender(tableName);
+    const columns = reader.getColumns();
+    for (let row = 0; row < reader.currentRowCount; row++) {
+      for (let column = 0; column < reader.columnCount; column++) {
+        appender.appendValue(
+          columns[column]?.[row] ?? null,
+          columnTypes[column],
+        );
+      }
+      appender.endRow();
+    }
+    appender.closeSync();
+    appender = null;
+
+    const projection = reader
+      .columnNames()
+      .map((name, i) => `c${i} AS ${quoteIdentifier(name)}`)
+      .join(', ');
+    return await queryToArrowTableViaIpc<T>(
+      conn,
+      `SELECT ${projection} FROM ${tableName}`,
+    );
+  } finally {
+    appender?.closeSync();
+    await conn.run(`DROP TABLE IF EXISTS ${tableName}`);
+  }
+}
+
+/**
+ * Removes one top-level statement terminator before trailing SQL trivia.
+ * Comments stay attached to the query for diagnostics and source fidelity.
+ */
+function stripTrailingStatementTerminator(sql: string): string {
+  const trailingTrivia = String.raw`(?:\s|--[^\r\n]*(?:\r?\n|$)|\/\*[\s\S]*?\*\/)*`;
+  return sql.replace(new RegExp(`;(${trailingTrivia})$`), '$1');
 }
 
 /**
@@ -187,9 +237,9 @@ async function queryToArrowTableViaIpc<T extends arrow.TypeMap = any>(
 ): Promise<arrow.Table<T>> {
   // A statement terminator is valid at the top level but not inside the
   // parenthesized subquery passed to `to_arrow_ipc()`.
-  const normalizedSql = sql.replace(/;(\s*)$/, '$1');
+  const normalizedSql = stripTrailingStatementTerminator(sql);
   const reader = await conn.runAndReadAll(
-    `SELECT * FROM to_arrow_ipc((${normalizedSql}))`,
+    `SELECT * FROM to_arrow_ipc((${normalizedSql}\n))`,
   );
   const buffers = reader.getColumnsJS()[0] as Uint8Array[] | undefined;
   if (!buffers?.length) {
@@ -218,7 +268,7 @@ async function runStatementToArrow<T extends arrow.TypeMap = any>(
     }
     const reader = await conn.runAndReadAll(sql);
     return reader.returnType === ResultReturnType.QUERY_RESULT
-      ? resultReaderToArrowTable<T>(reader)
+      ? resultReaderToArrowTable<T>(conn, reader)
       : emptyTable<T>();
   }
 }

--- a/packages/duckdb-node/src/helpers.ts
+++ b/packages/duckdb-node/src/helpers.ts
@@ -170,6 +170,44 @@ function findStatementSeparators(sql: string): number[] {
   return separators;
 }
 
+/** Whether `sql` contains only whitespace and SQL comments. */
+function isSqlTrivia(sql: string): boolean {
+  let i = 0;
+  while (i < sql.length) {
+    if (/\s/.test(sql[i]!)) {
+      i++;
+      continue;
+    }
+
+    if (sql[i] === '-' && sql[i + 1] === '-') {
+      const newline = sql.indexOf('\n', i + 2);
+      i = newline < 0 ? sql.length : newline + 1;
+      continue;
+    }
+
+    if (sql[i] === '/' && sql[i + 1] === '*') {
+      let depth = 1;
+      i += 2;
+      while (i < sql.length && depth > 0) {
+        if (sql[i] === '/' && sql[i + 1] === '*') {
+          depth++;
+          i += 2;
+        } else if (sql[i] === '*' && sql[i + 1] === '/') {
+          depth--;
+          i += 2;
+        } else {
+          i++;
+        }
+      }
+      if (depth > 0) return false;
+      continue;
+    }
+
+    return false;
+  }
+  return true;
+}
+
 /**
  * Splits a multi-statement script into everything-but-the-last statement plus
  * the last one, or returns `null` when `sql` is a single statement.
@@ -292,13 +330,11 @@ async function resultReaderToArrowTable<T extends arrow.TypeMap = any>(
  * Comments stay attached to the query for diagnostics and source fidelity.
  */
 function stripTrailingStatementTerminator(sql: string): string {
-  const trailingTrivia = String.raw`(?:\s|--[^\r\n]*(?:\r?\n|$)|\/\*[\s\S]*?\*\/)*`;
-  const isTrailingTrivia = new RegExp(`^${trailingTrivia}$`);
   const separators = findStatementSeparators(sql);
   let normalized = sql;
   while (separators.length > 0) {
     const separator = separators.pop()!;
-    if (!isTrailingTrivia.test(normalized.slice(separator + 1))) {
+    if (!isSqlTrivia(normalized.slice(separator + 1))) {
       break;
     }
     normalized =

--- a/packages/duckdb-node/src/helpers.ts
+++ b/packages/duckdb-node/src/helpers.ts
@@ -1,4 +1,4 @@
-import {DuckDBConnection} from '@duckdb/node-api';
+import {DuckDBConnection, StatementType} from '@duckdb/node-api';
 import {
   getRawSqlTableReference,
   literalToSQL,
@@ -13,17 +13,6 @@ export function buildQualifiedName(tableName: string, schema?: string): string {
   return getRawSqlTableReference(
     makeQualifiedTableName({table: tableName, schema}),
   );
-}
-
-/**
- * Converts a BigInt to a safe JavaScript number or string.
- * Returns number if within safe range, otherwise string.
- */
-function convertBigInt(value: bigint): number | string {
-  if (value >= Number.MIN_SAFE_INTEGER && value <= Number.MAX_SAFE_INTEGER) {
-    return Number(value);
-  }
-  return value.toString();
 }
 
 /**
@@ -74,44 +63,159 @@ export function objectsToCreateTableSql(
 }
 
 /**
- * Converts DuckDB query result to an Apache Arrow table.
+ * Statements that must run through DuckDB before the connection can serialize
+ * results as Arrow. `nanoarrow` provides the `to_arrow_ipc()` table function.
  *
- * TODO: Remove this once duckdb-node-neo supports Arrow tables directly.
+ * `INSTALL` is a no-op costing ~2ms once the extension is present, so this is
+ * cheap to run on every connection; only the very first one reaches the
+ * network.
+ *
+ * @see https://duckdb.org/community_extensions/extensions/nanoarrow.html
+ */
+export const ARROW_IPC_INIT_SQL = [
+  'INSTALL nanoarrow FROM community',
+  'LOAD nanoarrow',
+].join(';\n');
+
+/**
+ * Number of statements in `sql` according to DuckDB's own parser, or `null`
+ * when it does not parse.
+ */
+async function countStatements(
+  conn: DuckDBConnection,
+  sql: string,
+): Promise<number | null> {
+  try {
+    return (await conn.extractStatements(sql)).count;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Splits a multi-statement script into everything-but-the-last statement plus
+ * the last one, or returns `null` when `sql` is a single statement.
+ *
+ * The split point is found by testing each `;` with DuckDB's own parser rather
+ * than tokenizing here, so semicolons inside string literals, dollar-quoted
+ * strings, and comments cannot produce a bad split. Parsing costs ~17µs, and
+ * only candidate positions are tested.
+ */
+async function splitTrailingStatement(
+  conn: DuckDBConnection,
+  sql: string,
+): Promise<{head: string; last: string} | null> {
+  const total = await countStatements(conn, sql);
+  if (total === null || total <= 1) {
+    return null;
+  }
+  for (let i = sql.length - 1; i >= 0; i--) {
+    if (sql[i] !== ';') continue;
+    const head = sql.slice(0, i + 1);
+    const last = sql.slice(i + 1);
+    if (!last.trim()) continue;
+    if (
+      (await countStatements(conn, head)) === total - 1 &&
+      (await countStatements(conn, last)) === 1
+    ) {
+      return {head, last};
+    }
+  }
+  return null;
+}
+
+/** Whether `sql` is a single SELECT, per DuckDB's parser. */
+async function isSelectStatement(
+  conn: DuckDBConnection,
+  sql: string,
+): Promise<boolean> {
+  try {
+    const extracted = await conn.extractStatements(sql);
+    if (extracted.count !== 1) return false;
+    const prepared = await extracted.prepare(0);
+    try {
+      return prepared.statementType === StatementType.SELECT;
+    } finally {
+      prepared.destroySync();
+    }
+  } catch {
+    return false;
+  }
+}
+
+/** An Arrow table with no schema, for statements that return no result set. */
+function emptyTable<T extends arrow.TypeMap = any>(): arrow.Table<T> {
+  return arrow.tableFromArrays({}) as unknown as arrow.Table<T>;
+}
+
+/**
+ * Runs `sql` through `to_arrow_ipc()` and decodes the resulting Arrow IPC
+ * buffers, so DuckDB itself performs the Arrow conversion and every type
+ * round-trips exactly.
+ *
+ * Throws if `nanoarrow` is not loaded, or if `sql` is not a single statement
+ * that can be wrapped as a subquery.
+ */
+async function queryToArrowTableViaIpc<T extends arrow.TypeMap = any>(
+  conn: DuckDBConnection,
+  sql: string,
+): Promise<arrow.Table<T>> {
+  const reader = await conn.runAndReadAll(
+    `SELECT * FROM to_arrow_ipc((${sql}))`,
+  );
+  const buffers = reader.getColumnsJS()[0] as Uint8Array[] | undefined;
+  if (!buffers?.length) {
+    // A zero-row result emits no IPC message at all, so there is no schema to
+    // decode.
+    return emptyTable<T>();
+  }
+  return arrow.tableFromIPC(buffers) as unknown as arrow.Table<T>;
+}
+
+/** Runs one statement, returning its rows as Arrow (empty if it has none). */
+async function runStatementToArrow<T extends arrow.TypeMap = any>(
+  conn: DuckDBConnection,
+  sql: string,
+): Promise<arrow.Table<T>> {
+  try {
+    return await queryToArrowTableViaIpc<T>(conn, sql);
+  } catch (error) {
+    // `to_arrow_ipc()` only accepts a sub-selectable statement, so DDL, `SET`,
+    // `PRAGMA` and friends fail to PARSE inside it — nothing has executed and
+    // running it plainly below is safe. A SELECT reaching here failed for a
+    // real reason, and swallowing that would silently return no rows, so
+    // rethrow instead.
+    if (await isSelectStatement(conn, sql)) {
+      throw error;
+    }
+    await conn.run(sql);
+    return emptyTable<T>();
+  }
+}
+
+/**
+ * Converts a DuckDB query result to an Apache Arrow table.
+ *
+ * `@duckdb/node-api` exposes no Arrow API, so the conversion is delegated to
+ * DuckDB itself through the `nanoarrow` extension's `to_arrow_ipc()` — see
+ * {@link ARROW_IPC_INIT_SQL}, which the connector runs at initialization.
+ * Rebuilding the table from JS values instead cannot represent every DuckDB
+ * type: TIMESTAMP, DATE, BIGINT and DECIMAL all come back as strings, and
+ * BLOB loses its bytes entirely.
+ *
+ * A multi-statement script (`SET ...; SELECT ...`) is executed statement by
+ * statement, with the last one supplying the returned rows.
+ *
  * @see https://github.com/duckdb/duckdb-node-neo/issues/45
  */
 export async function queryToArrowTable<T extends arrow.TypeMap = any>(
   conn: DuckDBConnection,
   sql: string,
 ): Promise<arrow.Table<T>> {
-  const reader = await conn.runAndReadAll(sql);
-  const columnNames = reader.columnNames();
-  const columns = reader.getColumnsJson();
-
-  if (columnNames.length === 0 || reader.currentRowCount === 0) {
-    return arrow.tableFromArrays({}) as unknown as arrow.Table<T>;
+  const split = await splitTrailingStatement(conn, sql);
+  if (!split) {
+    return runStatementToArrow<T>(conn, sql);
   }
-
-  // Build column name -> Vector mapping, converting BigInts for Arrow compatibility.
-  // Handles special cases where Arrow can't infer types automatically:
-  //  - All-null columns: use explicit Utf8 type
-  //  - Nested arrays (DuckDB LIST columns): use List<Utf8> type
-  const listOfUtf8 = new arrow.List(new arrow.Field('item', new arrow.Utf8()));
-  const vecs: Record<string, arrow.Vector> = {};
-  for (let i = 0; i < columnNames.length; i++) {
-    const name = columnNames[i] as string;
-    const columnData = columns[i] ?? [];
-    const mapped = (columnData as unknown[]).map((v) =>
-      typeof v === 'bigint' ? convertBigInt(v) : v,
-    );
-    const firstNonNull = mapped.find((v) => v !== null && v !== undefined);
-    if (firstNonNull === undefined) {
-      vecs[name] = arrow.vectorFromArray(mapped, new arrow.Utf8());
-    } else if (Array.isArray(firstNonNull)) {
-      vecs[name] = arrow.vectorFromArray(mapped, listOfUtf8);
-    } else {
-      vecs[name] = arrow.vectorFromArray(mapped);
-    }
-  }
-
-  return new arrow.Table(vecs) as unknown as arrow.Table<T>;
+  await conn.run(split.head);
+  return runStatementToArrow<T>(conn, split.last);
 }

--- a/packages/duckdb-node/src/helpers.ts
+++ b/packages/duckdb-node/src/helpers.ts
@@ -11,6 +11,7 @@ import {
   splitSqlStatements,
 } from '@sqlrooms/duckdb-core';
 import * as arrow from 'apache-arrow';
+import {randomUUID} from 'node:crypto';
 
 /**
  * Builds a qualified table name string from table name and optional schema.
@@ -138,8 +139,6 @@ function emptyTable<T extends arrow.TypeMap = any>(): arrow.Table<T> {
   return arrow.tableFromArrays({}) as unknown as arrow.Table<T>;
 }
 
-let nextResultTableId = 0;
-
 /** Quotes a DuckDB identifier. */
 function quoteIdentifier(identifier: string): string {
   return `"${identifier.replaceAll('"', '""')}"`;
@@ -167,7 +166,7 @@ async function resultReaderToArrowTable<T extends arrow.TypeMap = any>(
     return emptyTable<T>();
   }
 
-  const tableName = `__sqlrooms_arrow_result_${nextResultTableId++}`;
+  const tableName = `__sqlrooms_arrow_result_${randomUUID().replaceAll('-', '')}`;
   const columnTypes = reader.columnTypes();
   const columnDefinitions = columnTypes
     .map((type, i) => `c${i} ${type}`)

--- a/packages/duckdb-node/src/helpers.ts
+++ b/packages/duckdb-node/src/helpers.ts
@@ -97,14 +97,86 @@ async function countStatements(
   }
 }
 
+/** Finds semicolons outside strings, quoted identifiers, and SQL comments. */
+function findStatementSeparators(sql: string): number[] {
+  const separators: number[] = [];
+  let i = 0;
+  while (i < sql.length) {
+    const char = sql[i];
+    const next = sql[i + 1];
+
+    if (char === "'" || char === '"') {
+      const quote = char;
+      const usesBackslashEscapes =
+        quote === "'" &&
+        (sql[i - 1] === 'E' || sql[i - 1] === 'e') &&
+        (i < 2 || !/[A-Za-z0-9_$]/.test(sql[i - 2]!));
+      i++;
+      while (i < sql.length) {
+        if (usesBackslashEscapes && sql[i] === '\\') {
+          i += 2;
+          continue;
+        }
+        if (sql[i] === quote) {
+          if (sql[i + 1] === quote) {
+            i += 2;
+            continue;
+          }
+          i++;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+
+    if (char === '-' && next === '-') {
+      const newline = sql.indexOf('\n', i + 2);
+      i = newline < 0 ? sql.length : newline + 1;
+      continue;
+    }
+
+    if (char === '/' && next === '*') {
+      let depth = 1;
+      i += 2;
+      while (i < sql.length && depth > 0) {
+        if (sql[i] === '/' && sql[i + 1] === '*') {
+          depth++;
+          i += 2;
+        } else if (sql[i] === '*' && sql[i + 1] === '/') {
+          depth--;
+          i += 2;
+        } else {
+          i++;
+        }
+      }
+      continue;
+    }
+
+    if (char === '$') {
+      const tag = sql.slice(i).match(/^\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$/)?.[0];
+      if (tag) {
+        const closingTag = sql.indexOf(tag, i + tag.length);
+        i = closingTag < 0 ? sql.length : closingTag + tag.length;
+        continue;
+      }
+    }
+
+    if (char === ';') {
+      separators.push(i);
+    }
+    i++;
+  }
+  return separators;
+}
+
 /**
  * Splits a multi-statement script into everything-but-the-last statement plus
  * the last one, or returns `null` when `sql` is a single statement.
  *
- * The split point is found by testing each `;` with DuckDB's own parser rather
- * than tokenizing here, so semicolons inside string literals, dollar-quoted
- * strings, and comments cannot produce a bad split. Parsing costs ~17µs, and
- * only candidate positions are tested.
+ * A small lexical scan skips strings, quoted identifiers, and comments. The
+ * remaining separator candidates are validated with DuckDB's own parser, so
+ * dialect-specific syntax still decides the actual statement boundary.
  */
 async function splitTrailingStatement(
   conn: DuckDBConnection,
@@ -114,10 +186,11 @@ async function splitTrailingStatement(
   if (total === null || total <= 1) {
     return null;
   }
-  for (let i = sql.length - 1; i >= 0; i--) {
-    if (sql[i] !== ';') continue;
-    const head = sql.slice(0, i + 1);
-    const last = sql.slice(i + 1);
+  const separators = findStatementSeparators(sql);
+  for (let i = separators.length - 1; i >= 0; i--) {
+    const separator = separators[i]!;
+    const head = sql.slice(0, separator + 1);
+    const last = sql.slice(separator + 1);
     if (!last.trim()) continue;
     if (
       (await countStatements(conn, head)) === total - 1 &&
@@ -215,12 +288,23 @@ async function resultReaderToArrowTable<T extends arrow.TypeMap = any>(
 }
 
 /**
- * Removes one top-level statement terminator before trailing SQL trivia.
+ * Removes top-level statement terminators before trailing SQL trivia.
  * Comments stay attached to the query for diagnostics and source fidelity.
  */
 function stripTrailingStatementTerminator(sql: string): string {
   const trailingTrivia = String.raw`(?:\s|--[^\r\n]*(?:\r?\n|$)|\/\*[\s\S]*?\*\/)*`;
-  return sql.replace(new RegExp(`;(${trailingTrivia})$`), '$1');
+  const isTrailingTrivia = new RegExp(`^${trailingTrivia}$`);
+  const separators = findStatementSeparators(sql);
+  let normalized = sql;
+  while (separators.length > 0) {
+    const separator = separators.pop()!;
+    if (!isTrailingTrivia.test(normalized.slice(separator + 1))) {
+      break;
+    }
+    normalized =
+      normalized.slice(0, separator) + normalized.slice(separator + 1);
+  }
+  return normalized;
 }
 
 /**

--- a/packages/duckdb-node/src/helpers.ts
+++ b/packages/duckdb-node/src/helpers.ts
@@ -150,9 +150,15 @@ function quoteIdentifier(identifier: string): string {
  * Converts a materialized non-SELECT result to Arrow without losing its
  * declared DuckDB types.
  *
+ * This is not a fallback for an unavailable `nanoarrow` extension: connector
+ * initialization requires that extension, and this function uses it below.
+ * It handles statements such as `INSERT ... RETURNING` that produce rows but
+ * cannot be embedded directly in `to_arrow_ipc((...))`. Because the mutating
+ * statement has already executed, it cannot safely be rewritten or run again.
+ *
  * The native result values are copied through a temporary table, then that
- * table is serialized by `to_arrow_ipc()`. This keeps the fallback path on the
- * same type-exact conversion mechanism as ordinary SELECT results.
+ * table is serialized by `to_arrow_ipc()`. This keeps the non-SELECT path on
+ * the same type-exact conversion mechanism as ordinary SELECT results.
  */
 async function resultReaderToArrowTable<T extends arrow.TypeMap = any>(
   conn: DuckDBConnection,


### PR DESCRIPTION
## Problem

`@duckdb/node-api` exposes no Arrow API — every `duckdb_*_arrow_*` entry point is commented out in `@duckdb/node-bindings/duckdb.d.ts` ([duckdb-node-neo#45](https://github.com/duckdb/duckdb-node-neo/issues/45)). So `queryToArrowTable` rebuilt results from `reader.getColumnsJson()` and let `arrow.vectorFromArray` **infer** types from stringified JS values. DuckDB's own declared types were never consulted.

Several types cannot survive that trip:

| column | before | after |
|---|---|---|
| `TIMESTAMP` | `Dictionary<Int32, Utf8>` | `Timestamp<MICROSECOND>` |
| `DATE` | `Dictionary<Int32, Utf8>` | `Date32<DAY>` |
| `BIGINT` | `Dictionary<Int32, Utf8>` | `Int64` |
| `DECIMAL` | `Dictionary<Int32, Utf8>` | `Decimal` |
| `LIST` | `List<Utf8>` | `List<Int32>` |
| `STRUCT` | `Struct<{a:Float64}>` | `Struct<{a:Int32}>` |
| `BLOB` | `Dictionary<Int32, Utf8>` | `Binary` |
| all-`NULL` `INTEGER` | `Utf8` | `Int32` |

The BLOB case **corrupts data** rather than merely mistyping it. A dictionary vector has no `valueOffsets`, so consumers that read binary columns positionally crash. kepler.gl's WKB geometry reader indexes `chunk.valueOffsets[i + 1]`:

```
TypeError: Cannot read properties of undefined (reading '1')
  at getBinaryGeometriesFromWKBArrow (kepler.gl/src/layers/src/layer-utils.ts:108)
  at getGeojsonLayerMetaFromArrow
  at GeoJsonLayer.updateLayerMeta -> calculateLayerData -> addLayerUpdater
```

That fires on the first row of **any** DuckDB `GEOMETRY` column, since kepler's DuckDB adapter rewrites `GEOMETRY` to `ST_AsWKB(...)` before ingesting. Worse, the throw happens inside a redux reducer, so an app with an error boundary can report the layer as created while it silently renders nothing.

## Fix

Delegate the conversion to DuckDB, as mosaic does in [uwdata/mosaic#993](https://github.com/uwdata/mosaic/pull/993): the [`nanoarrow`](https://duckdb.org/community_extensions/extensions/nanoarrow.html) community extension's `to_arrow_ipc()` serializes the result and `tableFromIPC` decodes it.

**The JS value conversion is deleted, not kept as a fallback.** The two paths returned different types for the same query, so keeping both would make a caller's schema depend on whether an extension download happened to succeed — tests that pass locally and fail in CI. `INSTALL nanoarrow FROM community; LOAD nanoarrow` therefore runs unconditionally in `initializeInternal`, matching mosaic's `DEFAULT_INIT_STATEMENTS`.

That is cheap. Measured:

| | time | network |
|---|---|---|
| `INSTALL nanoarrow FROM community`, already present | **2 ms** | none |
| `INSTALL` + `LOAD`, cold | ~610 ms, once per machine | yes |

## Handling statements `to_arrow_ipc()` can't wrap

It accepts only a single sub-selectable statement. mosaic avoids this by API separation — their wire protocol carries a client-declared `exec` / `arrow` / `json` type, so `to_arrow_ipc` only ever sees declared arrow queries. sqlrooms has no such split: `execute()`, `query()`, `queryJson()` and `initializationQuery` all funnel into `executeQueryInternal`, and the documented example for `initializationQuery` is `'INSTALL json; LOAD json;'`. So the routing has to happen inside.

- **DDL / `SET` / `PRAGMA`** fail to *parse* inside `to_arrow_ipc(...)`. Nothing has executed at that point, so the statement is re-run plainly and an empty table returned — which is what the old code returned for these anyway.
- **A SELECT that reaches that branch** failed for a real reason. It is rethrown rather than silently reporting zero rows.
- **Multi-statement scripts** (`SET s3_region='...'; SELECT ...` — the standard shape for configuring S3 or extensions before a query) are split: leading statements run in order, the last supplies the rows. Running the script for its side effects and returning empty would silently drop real rows, so there is a test pinning this.

The split point is found by testing each `;` against DuckDB's own parser (`extractStatements`) instead of tokenizing here, so semicolons inside string literals, dollar-quoted strings, and comments cannot produce a bad split. Verified against `SELECT 'a;b'`, `$tag$has;semi$tag$`, and `-- comment; with semicolon`. Parsing costs ~17µs per call.

## Breaking changes

- **`nanoarrow` is now required.** `initialize()` installs it on first use and throws if it cannot. Previously the connector always started and silently returned mistyped data. First-time init on a machine with no network egress will fail — and if egress is *blackholed* rather than refused, `INSTALL` has no timeout and will hang (I measured >2 min before cutting it off). Pre-installing the extension in CI images avoids both.
- **`BIGINT` yields BigInt.** Real `Int64` vectors, rather than the previous coercion — `convertBigInt` silently degraded anything past `Number.MAX_SAFE_INTEGER` to a string. This matches duckdb-wasm and the Arrow IPC other DuckDB bindings emit, but downstream arithmetic may need a look.

## Not fixed

A zero-row result emits no IPC message at all, so the schema is lost and you get a bare empty table. That was already true of the old path, so it is not a regression, but this doesn't fix it either.

## Testing

`pnpm test --filter @sqlrooms/duckdb-node` — 28 passed, 1 skipped (a pre-existing skip). New coverage: type fidelity for all eight types above; BLOB bytes including `\x00\x01\xFF`, which cannot survive a JS-string round trip; NULL and multi-row BLOBs; DDL/DML; multi-statement scripts returning rows; leading statements taking effect; the `;`-in-a-string-literal split; and error propagation for both a missing table and broken syntax.

Verified end to end in a downstream app that ingests DuckDB `GEOMETRY` into kepler.gl: geojson layers now build with correct bounds computed from the WKB, `TIMESTAMP` columns are detected as temporal for the first time, and `SET ...; SELECT ...` still returns its rows.

## Follow-up

The cleaner long-term fix is giving `DuckDbConnector` mosaic's `exec` / `arrow` / `json` split, so callers declare intent rather than having it inferred from a parse failure. That touches `duckdb-core` and the wasm connector, so it isn't in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Query results now preserve DuckDB types, including timestamps, dates, large integers, decimals, lists, structs, and binary data.
  - BLOB results are returned as Arrow binary values with raw bytes preserved.
  - Multi-statement scripts support DDL, DML, and `INSERT ... RETURNING`.
  - Concurrent operations are processed reliably in sequence.

- **Bug Fixes**
  - Improved handling of syntax errors, comments, trailing terminators, and complex scripts.
  - Operations submitted during shutdown are now rejected clearly while active queries finish safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->