### PR TITLE
fix(duckdb-core): handle DuckDB SQL statement syntax

### DIFF
--- a/packages/duckdb-core/README.md
+++ b/packages/duckdb-core/README.md
@@ -22,6 +22,19 @@ A powerful wrapper around DuckDB-WASM that provides React hooks and utilities fo
 - **Data Export**: Export query results to CSV files with pagination for large datasets
 - **Batch Processing**: Handle large datasets efficiently with built-in pagination support
 
+### SQL Statement Utilities
+
+`splitSqlStatements` splits DuckDB SQL without treating semicolons inside quoted
+strings, dollar-quoted strings, or comments as statement boundaries. Comments are
+removed safely by default; preserve them when the original SQL will be rewritten
+or re-executed:
+
+```ts
+import {splitSqlStatements} from '@sqlrooms/duckdb-core';
+
+const statements = splitSqlStatements(sql, {removeComments: false});
+```
+
 ## Installation
 
 ```bash

--- a/packages/duckdb-core/__tests__/splitSqlStatements.test.ts
+++ b/packages/duckdb-core/__tests__/splitSqlStatements.test.ts
@@ -1,4 +1,5 @@
 import {
+  joinStatements,
   makeLimitQuery,
   separateLastStatement,
   splitSqlStatements,
@@ -33,6 +34,13 @@ describe('splitSqlStatements', () => {
       first,
       second,
       'SELECT $1',
+    ]);
+  });
+
+  it('does not treat dollar signs inside unquoted identifiers as quotes', () => {
+    expect(splitSqlStatements('SELECT 1 AS foo$bar$; SELECT 2')).toEqual([
+      'SELECT 1 AS foo$bar$',
+      'SELECT 2',
     ]);
   });
 
@@ -74,6 +82,18 @@ describe('splitSqlStatements', () => {
 
     expect(splitSqlStatements(input)).toEqual([]);
     expect(splitSqlStatements(input, {removeComments: false})).toEqual([]);
+  });
+});
+
+describe('joinStatements', () => {
+  it('keeps separators outside trailing line comments', () => {
+    const {precedingStatements, lastStatement} = separateLastStatement(
+      'CREATE TEMP TABLE t AS SELECT 1 -- setup\n; SELECT * FROM t',
+    );
+
+    expect(joinStatements(precedingStatements, lastStatement)).toBe(
+      'CREATE TEMP TABLE t AS SELECT 1 -- setup\n;\nSELECT * FROM t',
+    );
   });
 });
 

--- a/packages/duckdb-core/__tests__/splitSqlStatements.test.ts
+++ b/packages/duckdb-core/__tests__/splitSqlStatements.test.ts
@@ -1,4 +1,8 @@
-import {separateLastStatement, splitSqlStatements} from '../src/duckdb-utils';
+import {
+  makeLimitQuery,
+  separateLastStatement,
+  splitSqlStatements,
+} from '../src/duckdb-utils';
 
 describe('splitSqlStatements', () => {
   it('ignores semicolons in quoted strings and identifiers', () => {
@@ -83,5 +87,14 @@ describe('separateLastStatement', () => {
       precedingStatements: ['-- setup\nCREATE TEMP TABLE t AS SELECT 1'],
       lastStatement: 'SELECT/* final */ * FROM t',
     });
+  });
+
+  it('preserves dollar-quoted comment text when rewriting the last statement', () => {
+    const query = `SELECT $$one; -- not a comment$$ AS value`;
+    const {lastStatement} = separateLastStatement(query);
+
+    expect(
+      makeLimitQuery(lastStatement, {limit: 10, sanitize: false}),
+    ).toContain(query);
   });
 });

--- a/packages/duckdb-core/__tests__/splitSqlStatements.test.ts
+++ b/packages/duckdb-core/__tests__/splitSqlStatements.test.ts
@@ -1,0 +1,87 @@
+import {separateLastStatement, splitSqlStatements} from '../src/duckdb-utils';
+
+describe('splitSqlStatements', () => {
+  it('ignores semicolons in quoted strings and identifiers', () => {
+    expect(
+      splitSqlStatements(
+        `SELECT 'one;''two' AS value; SELECT "semi;""colon" FROM tbl;`,
+      ),
+    ).toEqual([
+      `SELECT 'one;''two' AS value`,
+      `SELECT "semi;""colon" FROM tbl`,
+    ]);
+  });
+
+  it('ignores semicolons in escape string literals', () => {
+    const escapeString = String.raw`SELECT E'one\';two' AS value`;
+
+    expect(splitSqlStatements(`${escapeString}; SELECT 2`)).toEqual([
+      escapeString,
+      'SELECT 2',
+    ]);
+  });
+
+  it('ignores semicolons in tagged and untagged dollar-quoted strings', () => {
+    const first = `SELECT $$one; -- not a comment$$ AS value`;
+    const second = `SELECT $tag_1$two; $$still quoted$$$tag_1$ AS value`;
+
+    expect(splitSqlStatements(`${first}; ${second}; SELECT $1`)).toEqual([
+      first,
+      second,
+      'SELECT $1',
+    ]);
+  });
+
+  it('handles nested block comments', () => {
+    expect(
+      splitSqlStatements(
+        'SELECT/* outer; /* nested; */ still outer */1; SELECT 2',
+      ),
+    ).toEqual(['SELECT 1', 'SELECT 2']);
+  });
+
+  it('does not join tokens when removing comments', () => {
+    expect(splitSqlStatements('SELECT/* comment */1')).toEqual(['SELECT 1']);
+  });
+
+  it('preserves line breaks when removing comments', () => {
+    expect(splitSqlStatements('SELECT 1-- comment;\r\n+ 2; SELECT 3')).toEqual([
+      'SELECT 1 \r\n+ 2',
+      'SELECT 3',
+    ]);
+  });
+
+  it('can preserve comments and otherwise original statement text', () => {
+    const input = `
+      -- setup;
+      CREATE TEMP TABLE t AS SELECT 1/* value */;
+      -- final;
+      SELECT * FROM t;
+    `;
+
+    expect(splitSqlStatements(input, {removeComments: false})).toEqual([
+      '-- setup;\n      CREATE TEMP TABLE t AS SELECT 1/* value */',
+      '-- final;\n      SELECT * FROM t',
+    ]);
+  });
+
+  it('ignores comment-only and empty segments', () => {
+    const input = '-- comment;\n; /* outer /* nested */ comment */;';
+
+    expect(splitSqlStatements(input)).toEqual([]);
+    expect(splitSqlStatements(input, {removeComments: false})).toEqual([]);
+  });
+});
+
+describe('separateLastStatement', () => {
+  it('preserves comments when separating statements for rewriting', () => {
+    expect(
+      separateLastStatement(
+        '-- setup\nCREATE TEMP TABLE t AS SELECT 1; SELECT/* final */ * FROM t',
+      ),
+    ).toEqual({
+      precedingStatements: ['-- setup\nCREATE TEMP TABLE t AS SELECT 1'],
+      lastStatement: 'SELECT/* final */ * FROM t',
+    });
+  });
+});

--- a/packages/duckdb-core/src/duckdb-utils.ts
+++ b/packages/duckdb-core/src/duckdb-utils.ts
@@ -634,11 +634,16 @@ function isDollarQuoteTagContinuation(char: string | undefined): boolean {
   return isDollarQuoteTagStart(char) || (code >= 48 && code <= 57);
 }
 
+function isUnquotedIdentifierContinuation(char: string | undefined): boolean {
+  return char === '$' || isDollarQuoteTagContinuation(char);
+}
+
 function getDollarQuoteDelimiter(
   input: string,
   start: number,
 ): string | undefined {
   if (input[start] !== '$') return undefined;
+  if (isUnquotedIdentifierContinuation(input[start - 1])) return undefined;
   if (input[start + 1] === '$') return '$$';
   if (!isDollarQuoteTagStart(input[start + 1])) return undefined;
 
@@ -654,7 +659,7 @@ function isEscapeStringPrefix(input: string, quoteStart: number): boolean {
   if (prefix !== 'e' && prefix !== 'E') return false;
 
   const beforePrefix = input[quoteStart - 2];
-  return !beforePrefix || !isDollarQuoteTagContinuation(beforePrefix);
+  return !beforePrefix || !isUnquotedIdentifierContinuation(beforePrefix);
 }
 
 function scanSqlStatementRanges(input: string): SqlStatementRange[] {
@@ -903,6 +908,6 @@ export function joinStatements(
   lastStatement: string,
 ): string {
   return precedingStatements.length > 0
-    ? [...precedingStatements, lastStatement].join(';\n')
+    ? [...precedingStatements, lastStatement].join('\n;\n')
     : lastStatement;
 }

--- a/packages/duckdb-core/src/duckdb-utils.ts
+++ b/packages/duckdb-core/src/duckdb-utils.ts
@@ -606,139 +606,222 @@ export const getSqlErrorWithPointer = (query: string, position: number) => {
   return {line, column, lineText, pointerLine, formatted};
 };
 
-//
-// const queries = splitSqlStatements(`
-//   SELECT * FROM users WHERE name = 'John;Doe';
-//   SELECT * FROM orders -- This comment; won't break;
-//   /*
-//      Multi-line comment;
-//      With semicolons;
-//   */
-//   SELECT "Quoted;identifier" FROM table;
-//`);
+type SqlCommentRange = {
+  start: number;
+  end: number;
+};
 
-// Returns:
-// [
-//   "SELECT * FROM users WHERE name = 'John;Doe'",
-//   "SELECT * FROM orders -- This comment; won't break",
-//   "SELECT \"Quoted;identifier\" FROM table"
-// ]
+type SqlStatementRange = {
+  start: number;
+  end: number;
+  comments: SqlCommentRange[];
+};
+
+function isDollarQuoteTagStart(char: string | undefined): boolean {
+  if (!char) return false;
+  const code = char.charCodeAt(0);
+  return (
+    (code >= 65 && code <= 90) ||
+    (code >= 97 && code <= 122) ||
+    char === '_' ||
+    code >= 0x80
+  );
+}
+
+function isDollarQuoteTagContinuation(char: string | undefined): boolean {
+  if (!char) return false;
+  const code = char.charCodeAt(0);
+  return isDollarQuoteTagStart(char) || (code >= 48 && code <= 57);
+}
+
+function getDollarQuoteDelimiter(
+  input: string,
+  start: number,
+): string | undefined {
+  if (input[start] !== '$') return undefined;
+  if (input[start + 1] === '$') return '$$';
+  if (!isDollarQuoteTagStart(input[start + 1])) return undefined;
+
+  let end = start + 2;
+  while (isDollarQuoteTagContinuation(input[end])) {
+    end++;
+  }
+  return input[end] === '$' ? input.slice(start, end + 1) : undefined;
+}
+
+function isEscapeStringPrefix(input: string, quoteStart: number): boolean {
+  const prefix = input[quoteStart - 1];
+  if (prefix !== 'e' && prefix !== 'E') return false;
+
+  const beforePrefix = input[quoteStart - 2];
+  return !beforePrefix || !isDollarQuoteTagContinuation(beforePrefix);
+}
+
+function scanSqlStatementRanges(input: string): SqlStatementRange[] {
+  const statements: SqlStatementRange[] = [];
+  let statementStart = 0;
+  let comments: SqlCommentRange[] = [];
+  let hasSqlContent = false;
+
+  for (let i = 0; i < input.length; i++) {
+    const char = input[i];
+
+    if (char === '-' && input[i + 1] === '-') {
+      const commentStart = i;
+      i += 2;
+      while (i < input.length && input[i] !== '\n' && input[i] !== '\r') {
+        i++;
+      }
+      comments.push({start: commentStart, end: i});
+      i--;
+      continue;
+    }
+
+    if (char === '/' && input[i + 1] === '*') {
+      const commentStart = i;
+      let depth = 1;
+      i += 2;
+      while (i < input.length && depth > 0) {
+        if (input[i] === '/' && input[i + 1] === '*') {
+          depth++;
+          i += 2;
+        } else if (input[i] === '*' && input[i + 1] === '/') {
+          depth--;
+          i += 2;
+        } else {
+          i++;
+        }
+      }
+      comments.push({start: commentStart, end: i});
+      i--;
+      continue;
+    }
+
+    if (char === "'" || char === '"') {
+      hasSqlContent = true;
+      const escapeBackslashes = char === "'" && isEscapeStringPrefix(input, i);
+      const quote = char;
+      i++;
+      while (i < input.length) {
+        if (escapeBackslashes && input[i] === '\\') {
+          i += 2;
+          continue;
+        }
+        if (input[i] === quote) {
+          if (input[i + 1] === quote) {
+            i += 2;
+            continue;
+          }
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+
+    const dollarQuoteDelimiter = getDollarQuoteDelimiter(input, i);
+    if (dollarQuoteDelimiter) {
+      hasSqlContent = true;
+      const closingDelimiter = input.indexOf(
+        dollarQuoteDelimiter,
+        i + dollarQuoteDelimiter.length,
+      );
+      i =
+        closingDelimiter === -1
+          ? input.length
+          : closingDelimiter + dollarQuoteDelimiter.length - 1;
+      continue;
+    }
+
+    if (char === ';') {
+      if (hasSqlContent) {
+        statements.push({
+          start: statementStart,
+          end: i,
+          comments,
+        });
+      }
+      statementStart = i + 1;
+      comments = [];
+      hasSqlContent = false;
+      continue;
+    }
+
+    if (char && !/\s/.test(char)) {
+      hasSqlContent = true;
+    }
+  }
+
+  if (hasSqlContent) {
+    statements.push({
+      start: statementStart,
+      end: input.length,
+      comments,
+    });
+  }
+
+  return statements;
+}
+
+function removeSqlComments(
+  input: string,
+  statement: SqlStatementRange,
+): string {
+  let result = '';
+  let current = statement.start;
+
+  for (const comment of statement.comments) {
+    result += input.slice(current, comment.start);
+    const lineBreaks = input
+      .slice(comment.start, comment.end)
+      .match(/\r\n|\r|\n/g);
+    result += lineBreaks?.join('') ?? ' ';
+    current = comment.end;
+  }
+
+  return result + input.slice(current, statement.end);
+}
+
+/**
+ * Options for {@link splitSqlStatements}.
+ */
+export type SplitSqlStatementsOptions = {
+  /**
+   * Whether to remove SQL comments from returned statements. Comment removal
+   * preserves line breaks and inserts whitespace where needed to avoid joining
+   * adjacent SQL tokens.
+   *
+   * @default true
+   */
+  removeComments?: boolean;
+};
 
 /**
  * Split a string with potentially multiple SQL queries (separated as usual by ';')
  * into an array of queries.
  * This implementation:
  *  - Handles single and double quoted strings with proper escaping
- *  - Removes all comments: line comments (--) and block comments (/* ... *\/)
+ *  - Handles DuckDB dollar-quoted strings
+ *  - Handles line comments (--) and nested block comments (/* ... *\/)
  *  - Ignores semicolons in quoted strings and comments
  *  - Trims whitespace from queries
  *  - Handles SQL-style escaped quotes ('' inside strings)
  *  - Returns only non-empty queries
  *
  * @param input - The SQL string containing one or more statements
- * @returns An array of SQL statements with all comments removed
+ * @param options - Options controlling the returned SQL
+ * @returns An array of SQL statements, with comments removed by default
  */
-export function splitSqlStatements(input: string): string[] {
-  const queries: string[] = [];
-  let currentQuery = '';
-  let inSingleQuote = false;
-  let inDoubleQuote = false;
-  let inLineComment = false;
-  let inBlockComment = false;
-
-  for (let i = 0; i < input.length; i++) {
-    const char = input[i];
-
-    if (inLineComment) {
-      if (char === '\n') {
-        inLineComment = false;
-        currentQuery += char; // preserve newlines for line numbers
-      }
-      // else: skip comment chars
-      continue;
-    }
-
-    if (inBlockComment) {
-      if (char === '*' && input[i + 1] === '/') {
-        inBlockComment = false;
-        i++; // skip '/'
-      }
-      // else: skip comment chars
-      continue;
-    }
-
-    if (inSingleQuote) {
-      currentQuery += char;
-      if (char === "'") {
-        // Handle escaped single quotes in SQL
-        if (i + 1 < input.length && input[i + 1] === "'") {
-          currentQuery += input[++i];
-        } else {
-          inSingleQuote = false;
-        }
-      }
-      continue;
-    }
-
-    if (inDoubleQuote) {
-      currentQuery += char;
-      if (char === '"') {
-        // Handle escaped double quotes
-        if (i + 1 < input.length && input[i + 1] === '"') {
-          currentQuery += input[++i];
-        } else {
-          inDoubleQuote = false;
-        }
-      }
-      continue;
-    }
-
-    // Check for comment starts
-    if (char === '-' && input[i + 1] === '-') {
-      inLineComment = true;
-      i++; // skip next '-'
-      continue;
-    }
-
-    if (char === '/' && input[i + 1] === '*') {
-      inBlockComment = true;
-      i++; // skip next '*'
-      continue;
-    }
-
-    // Check for quote starts
-    if (char === "'") {
-      inSingleQuote = true;
-      currentQuery += char;
-      continue;
-    }
-
-    if (char === '"') {
-      inDoubleQuote = true;
-      currentQuery += char;
-      continue;
-    }
-
-    // Handle query separator
-    if (char === ';') {
-      const trimmed = currentQuery.trim();
-      if (trimmed.length > 0) {
-        queries.push(trimmed);
-      }
-      currentQuery = '';
-      continue;
-    }
-
-    currentQuery += char;
-  }
-
-  // Add the final query
-  const trimmed = currentQuery.trim();
-  if (trimmed.length > 0) {
-    queries.push(trimmed);
-  }
-
-  return queries;
+export function splitSqlStatements(
+  input: string,
+  {removeComments = true}: SplitSqlStatementsOptions = {},
+): string[] {
+  return scanSqlStatementRanges(input).map((statement) =>
+    (removeComments
+      ? removeSqlComments(input, statement)
+      : input.slice(statement.start, statement.end)
+    ).trim(),
+  );
 }
 
 /**
@@ -799,7 +882,7 @@ export type SeparatedStatements = {
  * @throws Error if the query contains no statements
  */
 export function separateLastStatement(query: string): SeparatedStatements {
-  const statements = splitSqlStatements(query);
+  const statements = splitSqlStatements(query, {removeComments: false});
   if (statements.length === 0) {
     throw new Error('Query must contain at least one statement');
   }

--- a/packages/duckdb-core/src/index.ts
+++ b/packages/duckdb-core/src/index.ts
@@ -57,6 +57,7 @@ export {
   type QualifiedTableName,
   type ResolveTableReferenceResult,
   type SeparatedStatements,
+  type SplitSqlStatementsOptions,
 } from './duckdb-utils';
 
 export {

--- a/packages/duckdb/README.md
+++ b/packages/duckdb/README.md
@@ -22,6 +22,19 @@ A powerful wrapper around DuckDB-WASM that provides React hooks and utilities fo
 - **Data Export**: Export query results to CSV files with pagination for large datasets
 - **Batch Processing**: Handle large datasets efficiently with built-in pagination support
 
+### SQL Statement Utilities
+
+`splitSqlStatements` splits DuckDB SQL without treating semicolons inside quoted
+strings, dollar-quoted strings, or comments as statement boundaries. Comments are
+removed safely by default; preserve them when the original SQL will be rewritten
+or re-executed:
+
+```ts
+import {splitSqlStatements} from '@sqlrooms/duckdb';
+
+const statements = splitSqlStatements(sql, {removeComments: false});
+```
+
 ## Installation
 
 ```bash

--- a/packages/duckdb/src/index.ts
+++ b/packages/duckdb/src/index.ts
@@ -128,6 +128,7 @@ export {
   type DbSchemaNode,
   type DuckDbConnector,
   type FunctionSuggestion,
+  type SplitSqlStatementsOptions,
   type FullTableIdentity,
   type GroupedFunctionSuggestion,
   type NodeObject,

--- a/packages/sql-editor/src/components/SqlQueryPreview.tsx
+++ b/packages/sql-editor/src/components/SqlQueryPreview.tsx
@@ -58,7 +58,7 @@ export const SqlQueryPreview: React.FC<SqlQueryPreviewProps> = ({
     // Apply limit to the query
     const limited = makeLimitQuery(lastStatement, {
       limit,
-      sanitize: true,
+      sanitize: false,
     });
 
     return {limitedQuery: limited, error: null};


### PR DESCRIPTION
## Summary

- replace the ad hoc SQL splitter with a lexical boundary scanner
- support DuckDB dollar-quoted strings, escape strings, and nested block comments
- keep comment removal backward-compatible while preventing comments from joining adjacent tokens
- add an option to preserve comments and use it when statements are rewritten and re-executed
- document the public option and add focused regression coverage

## Testing

- `pnpm --filter @sqlrooms/duckdb-core test`
- `pnpm --filter @sqlrooms/duckdb test`
- `pnpm build`
- pre-push checks: knip, workspace typecheck, circular dependency check, and full workspace test suite


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SQL statement splitting that correctly handles quoted strings, dollar-quoted strings, escape strings, and nested comments.
  * Added an option to preserve SQL comments during statement processing.
  * Exposed the new configuration type through the DuckDB packages.

* **Bug Fixes**
  * Improved query rewriting to preserve original SQL text when applying row limits.
  * Improved statement joining around trailing line comments.

* **Documentation**
  * Documented SQL statement utilities and comment-handling options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->