### PR TITLE
feat(ai): add chat file attachments

### DIFF
--- a/apps/sqlrooms-cli-ui/src/components/AssistantChatContainer.tsx
+++ b/apps/sqlrooms-cli-ui/src/components/AssistantChatContainer.tsx
@@ -214,6 +214,7 @@ export const AssistantChatContainer: React.FC<AssistantChatContainerProps> = ({
                 }}
               />
               <AssistantContextSelector />
+              <Chat.Composer.Attachments />
               <div className="flex min-w-0 items-center justify-end">
                 <Chat.ModelSelector />
               </div>

--- a/packages/ai-core/README.md
+++ b/packages/ai-core/README.md
@@ -107,9 +107,10 @@ supported categories and opens a type-specific file picker for each one.
 Pending files render in the composer footer and are sent as AI SDK file parts.
 Posted files remain part of the user message: images open at full size in a
 dialog, while text and Markdown open in a scrollable text or rendered-Markdown
-dialog. The default limits are four files, 2 MiB per image, 128 KiB per text
-file, and 128 KiB across all pending text files; the component props can
-override those limits. A file can be sent without adding prompt text.
+dialog. The default limits are four files, 1 MiB per image and across all
+pending images, 128 KiB per text file, and 128 KiB across all pending text
+files; the component props can override those limits. A file can be sent
+without adding prompt text.
 
 > `<InlineApiKeyInput>` assumes session mode: it calls `useStoreWithAi`
 > unconditionally, so passing it as a `Chat.Composer` child under

--- a/packages/ai-core/README.md
+++ b/packages/ai-core/README.md
@@ -86,7 +86,9 @@ export function AiPanel() {
       <Chat.Composer
         placeholder="Ask a question"
         topActions={<Chat.PromptSuggestions.VisibilityToggle />}
-      />
+      >
+        <Chat.Composer.Attachments />
+      </Chat.Composer>
     </Chat>
   );
 }
@@ -98,6 +100,14 @@ and the first `ai.createSession()` transfers it to the new session.
 
 Use `Chat.Composer`'s `topActions` slot for compact controls that should sit in
 the prompt's top row, right-aligned beside context selectors.
+
+Attachments are opt-in. Add `<Chat.Composer.Attachments />` as a composer child
+to accept images and plain-text or Markdown files. Pending files render in the
+composer footer and are sent as AI SDK file parts. Posted files remain part of
+the user message: images open at full size in a dialog, while text and Markdown
+open in a scrollable text or rendered-Markdown dialog. The default limits are
+eight files, 10 MB per image, and 1 MB per text file; the component props can
+override those limits.
 
 > `<InlineApiKeyInput>` assumes session mode: it calls `useStoreWithAi`
 > unconditionally, so passing it as a `Chat.Composer` child under
@@ -180,6 +190,11 @@ Composer primitives (imported from `@sqlrooms/ai-core`, or via
   plain one it renders but never fires `onDrop`, because drops are accepted
   only for collisions carrying the `pointerWithin` marker that
   `RoomDndProvider`'s collision detector adds.
+
+The styled **`Chat.Composer.Attachments`** recipe is intentionally separate
+from those unstyled primitives: mounting it enables the file input and footer
+previews for that chat root. For a custom attachment UI, use
+`useChatAttachments()` under the same composer state boundary.
 
 ### Pre-send policy: `useRegisterBeforeSend`
 
@@ -305,7 +320,7 @@ order, what is hoistable / running / completed), then asks the nearest
 | --------------- | ------------------------------------------------------------- |
 | `ActiveStatus`  | Current in-flight run status and elapsed-time presentation    |
 | `Turn`          | Full turn layout recipe — composes pre-wired semantic regions |
-| `Prompt`        | User prompt chrome for the turn                               |
+| `Prompt`        | User prompt and attachment chrome for the turn                |
 | `Activity`      | Collapsible / status chrome around in-progress work           |
 | `Reasoning`     | Model thinking / reasoning disclosure                         |
 | `ToolActivity`  | One tool (or nested agent) line inside Activity               |

--- a/packages/ai-core/README.md
+++ b/packages/ai-core/README.md
@@ -106,8 +106,9 @@ to accept images and plain-text or Markdown files. Pending files render in the
 composer footer and are sent as AI SDK file parts. Posted files remain part of
 the user message: images open at full size in a dialog, while text and Markdown
 open in a scrollable text or rendered-Markdown dialog. The default limits are
-four files, 2 MiB per image, and 1 MiB per text file; the component props can
-override those limits.
+four files, 2 MiB per image, 128 KiB per text file, and 128 KiB across all
+pending text files; the component props can override those limits. A file can
+be sent without adding prompt text.
 
 > `<InlineApiKeyInput>` assumes session mode: it calls `useStoreWithAi`
 > unconditionally, so passing it as a `Chat.Composer` child under

--- a/packages/ai-core/README.md
+++ b/packages/ai-core/README.md
@@ -196,7 +196,15 @@ Composer primitives (imported from `@sqlrooms/ai-core`, or via
 The styled **`Chat.Composer.Attachments`** recipe is intentionally separate
 from those unstyled primitives: mounting it enables the file input and footer
 previews for that chat root. For a custom attachment UI, use
-`useChatAttachments()` under the same composer state boundary.
+`useChatAttachments()` under the same composer state boundary. Pass
+asynchronous file preparation to `appendAsync` so a file that finishes reading
+after the user switches sessions is discarded:
+
+```tsx
+const {appendAsync} = useChatAttachments();
+
+await appendAsync(async () => [await fileToChatAttachmentPart(file)]);
+```
 
 ### Pre-send policy: `useRegisterBeforeSend`
 

--- a/packages/ai-core/README.md
+++ b/packages/ai-core/README.md
@@ -106,7 +106,7 @@ to accept images and plain-text or Markdown files. Pending files render in the
 composer footer and are sent as AI SDK file parts. Posted files remain part of
 the user message: images open at full size in a dialog, while text and Markdown
 open in a scrollable text or rendered-Markdown dialog. The default limits are
-four files, 2 MB per image, and 1 MB per text file; the component props can
+four files, 2 MiB per image, and 1 MiB per text file; the component props can
 override those limits.
 
 > `<InlineApiKeyInput>` assumes session mode: it calls `useStoreWithAi`

--- a/packages/ai-core/README.md
+++ b/packages/ai-core/README.md
@@ -106,7 +106,7 @@ to accept images and plain-text or Markdown files. Pending files render in the
 composer footer and are sent as AI SDK file parts. Posted files remain part of
 the user message: images open at full size in a dialog, while text and Markdown
 open in a scrollable text or rendered-Markdown dialog. The default limits are
-eight files, 10 MB per image, and 1 MB per text file; the component props can
+four files, 2 MB per image, and 1 MB per text file; the component props can
 override those limits.
 
 > `<InlineApiKeyInput>` assumes session mode: it calls `useStoreWithAi`

--- a/packages/ai-core/README.md
+++ b/packages/ai-core/README.md
@@ -102,13 +102,14 @@ Use `Chat.Composer`'s `topActions` slot for compact controls that should sit in
 the prompt's top row, right-aligned beside context selectors.
 
 Attachments are opt-in. Add `<Chat.Composer.Attachments />` as a composer child
-to accept images and plain-text or Markdown files. Pending files render in the
-composer footer and are sent as AI SDK file parts. Posted files remain part of
-the user message: images open at full size in a dialog, while text and Markdown
-open in a scrollable text or rendered-Markdown dialog. The default limits are
-four files, 2 MiB per image, 128 KiB per text file, and 128 KiB across all
-pending text files; the component props can override those limits. A file can
-be sent without adding prompt text.
+to accept images and plain-text or Markdown files. Its paperclip menu shows the
+supported categories and opens a type-specific file picker for each one.
+Pending files render in the composer footer and are sent as AI SDK file parts.
+Posted files remain part of the user message: images open at full size in a
+dialog, while text and Markdown open in a scrollable text or rendered-Markdown
+dialog. The default limits are four files, 2 MiB per image, 128 KiB per text
+file, and 128 KiB across all pending text files; the component props can
+override those limits. A file can be sent without adding prompt text.
 
 > `<InlineApiKeyInput>` assumes session mode: it calls `useStoreWithAi`
 > unconditionally, so passing it as a `Chat.Composer` child under

--- a/packages/ai-core/__tests__/AiSlice.startAnalysisWhenReady.test.ts
+++ b/packages/ai-core/__tests__/AiSlice.startAnalysisWhenReady.test.ts
@@ -58,6 +58,27 @@ describe('startAnalysisWhenReady', () => {
     expect(sendMessage).toHaveBeenCalledWith({text: 'hello world'});
   });
 
+  it('starts an attachment-only session message', async () => {
+    const store = createTestStore();
+    store.getState().ai.setPrompt('session-1', '');
+    const chat = store.getState().ai.getSessionChat('session-1')!;
+    const sendMessage = jest
+      .spyOn(chat, 'sendMessage')
+      .mockResolvedValue(undefined);
+    const attachment = {
+      type: 'file' as const,
+      filename: 'chart.png',
+      mediaType: 'image/png',
+      url: 'data:image/png;base64,aW1hZ2U=',
+    };
+
+    await store.getState().ai.startAnalysis('session-1', [attachment]);
+
+    expect(sendMessage).toHaveBeenCalledWith({
+      files: [attachment],
+    });
+  });
+
   it('returns false for an unknown session', async () => {
     const store = createTestStore();
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});

--- a/packages/ai-core/__tests__/ChatComposerAttachments.test.tsx
+++ b/packages/ai-core/__tests__/ChatComposerAttachments.test.tsx
@@ -66,7 +66,66 @@ async function selectAttachment(
   await waitForText(container, file.name);
 }
 
+function attachmentInput(
+  container: HTMLElement,
+  kind: 'image' | 'text' = 'text',
+): HTMLInputElement {
+  const label =
+    kind === 'image' ? 'Attach image files' : 'Attach text or Markdown files';
+  return container.querySelector<HTMLInputElement>(
+    `input[type=file][aria-label="${label}"]`,
+  )!;
+}
+
 describe('Chat composer attachments', () => {
+  it('shows separate supported-file choices with matching picker filters', async () => {
+    setMockRuntime();
+    const {container, root} = await renderTree(
+      <LocalAgentChatComposerProvider>
+        <QueryControls>
+          <Attachments />
+        </QueryControls>
+      </LocalAgentChatComposerProvider>,
+    );
+    const imageInput = attachmentInput(container, 'image');
+    const textInput = attachmentInput(container);
+    const imagePicker = jest.spyOn(imageInput, 'click').mockImplementation();
+    const textPicker = jest.spyOn(textInput, 'click').mockImplementation();
+
+    expect(imageInput.accept).toBe('image/*');
+    expect(textInput.accept).toBe(
+      '.txt,.md,.markdown,.mdown,.mkd,text/plain,text/markdown',
+    );
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('button[aria-label="Attach files"]')!
+        .dispatchEvent(
+          new MouseEvent('pointerdown', {bubbles: true, button: 0}),
+        );
+    });
+    await waitForCondition(
+      () => document.body.textContent?.includes('Supported files') ?? false,
+      'attachment menu to open',
+    );
+
+    expect(document.body.textContent).toContain('Image');
+    expect(document.body.textContent).toContain('Any image format');
+    expect(document.body.textContent).toContain('Text or Markdown');
+    expect(document.body.textContent).toContain(
+      '.txt, .md, .markdown, .mdown, .mkd',
+    );
+
+    const menuItems = Array.from(
+      document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+    );
+    await act(async () => menuItems[0]!.click());
+    expect(imagePicker).toHaveBeenCalledTimes(1);
+    expect(textPicker).not.toHaveBeenCalled();
+
+    await cleanup(container, root);
+  });
+
   it('sends an attachment without prompt text and clears it', async () => {
     const runtime = setMockRuntime({prompt: ''});
     const {container, root} = await renderTree(
@@ -76,8 +135,7 @@ describe('Chat composer attachments', () => {
         </QueryControls>
       </LocalAgentChatComposerProvider>,
     );
-    const input =
-      container.querySelector<HTMLInputElement>('input[type=file]')!;
+    const input = attachmentInput(container);
     const file = new File(['# Report\n\nRevenue grew.'], 'report.md', {
       type: 'application/octet-stream',
     });
@@ -121,8 +179,7 @@ describe('Chat composer attachments', () => {
         </RoomStateProvider>
       </TooltipProvider>,
     );
-    const input =
-      container.querySelector<HTMLInputElement>('input[type=file]')!;
+    const input = attachmentInput(container);
 
     await selectAttachment(
       input,
@@ -163,8 +220,7 @@ describe('Chat composer attachments', () => {
         </RoomStateProvider>
       </TooltipProvider>,
     );
-    const input =
-      container.querySelector<HTMLInputElement>('input[type=file]')!;
+    const input = attachmentInput(container);
 
     await selectAttachment(
       input,
@@ -221,8 +277,7 @@ describe('Chat composer attachments', () => {
     );
 
     try {
-      const input =
-        container.querySelector<HTMLInputElement>('input[type=file]')!;
+      const input = attachmentInput(container);
       await act(async () => {
         Object.defineProperty(input, 'files', {
           configurable: true,
@@ -244,7 +299,7 @@ describe('Chat composer attachments', () => {
         () =>
           !container
             .querySelector<HTMLButtonElement>(
-              'button[aria-label="Attach images or text files"]',
+              'button[aria-label="Attach files"]',
             )
             ?.hasAttribute('disabled'),
         'file read to finish',
@@ -269,8 +324,7 @@ describe('Chat composer attachments', () => {
         </QueryControls>
       </LocalAgentChatComposerProvider>,
     );
-    const input =
-      container.querySelector<HTMLInputElement>('input[type=file]')!;
+    const input = attachmentInput(container, 'image');
 
     await act(async () => {
       Object.defineProperty(input, 'files', {
@@ -302,8 +356,7 @@ describe('Chat composer attachments', () => {
         </QueryControls>
       </LocalAgentChatComposerProvider>,
     );
-    const input =
-      container.querySelector<HTMLInputElement>('input[type=file]')!;
+    const input = attachmentInput(container);
 
     await selectAttachment(
       input,

--- a/packages/ai-core/__tests__/ChatComposerAttachments.test.tsx
+++ b/packages/ai-core/__tests__/ChatComposerAttachments.test.tsx
@@ -1,0 +1,167 @@
+/** @jest-environment jsdom */
+import {jest} from '@jest/globals';
+import {RoomStateProvider} from '@sqlrooms/room-store';
+import React, {act} from 'react';
+import {
+  cleanup,
+  createSessionTestStore,
+  fireKeyDown,
+  mockChatRuntimeModule,
+  renderTree,
+  setMockRuntime,
+  setMockSessionRuntime,
+  stubAnalysisActions,
+  textarea,
+  typeInto,
+} from './support';
+
+jest.unstable_mockModule(
+  '../src/components/ChatRuntimeContext',
+  mockChatRuntimeModule,
+);
+
+const {LocalAgentChatComposerProvider} =
+  await import('../src/components/composer');
+const {Attachments} = await import('../src/components/composer/attachments');
+const {QueryControls} = await import('../src/components/QueryControls');
+const {ChatAttachmentPreview} =
+  await import('../src/components/ChatAttachmentPreview');
+const {TooltipProvider} = await import('@sqlrooms/ui');
+
+describe('Chat composer attachments', () => {
+  it('opts in through a composer child, sends the file part, and clears it', async () => {
+    const runtime = setMockRuntime({prompt: 'Summarize this file'});
+    const {container, root} = await renderTree(
+      <LocalAgentChatComposerProvider>
+        <QueryControls>
+          <Attachments />
+        </QueryControls>
+      </LocalAgentChatComposerProvider>,
+    );
+    const input =
+      container.querySelector<HTMLInputElement>('input[type=file]')!;
+    const file = new File(['# Report\n\nRevenue grew.'], 'report.md', {
+      type: 'application/octet-stream',
+    });
+
+    await act(async () => {
+      Object.defineProperty(input, 'files', {
+        configurable: true,
+        value: [file],
+      });
+      input.dispatchEvent(new Event('change', {bubbles: true}));
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+
+    expect(container.textContent).toContain('report.md');
+
+    await act(async () => {
+      fireKeyDown(textarea(container)!);
+    });
+
+    expect(runtime.sendPrompt).toHaveBeenCalledTimes(1);
+    const [text, attachments] = (
+      runtime.sendPrompt as jest.MockedFunction<typeof runtime.sendPrompt>
+    ).mock.calls[0]!;
+    expect(text).toBeUndefined();
+    expect(attachments).toEqual([
+      expect.objectContaining({
+        type: 'file',
+        filename: 'report.md',
+        mediaType: 'text/markdown',
+        url: expect.stringMatching(/^data:application\/octet-stream;base64,/),
+      }),
+    ]);
+    expect(container.textContent).not.toContain('report.md');
+
+    await cleanup(container, root);
+  });
+
+  it('forwards attachments through session-mode analysis', async () => {
+    setMockSessionRuntime();
+    const store = createSessionTestStore();
+    const {startAnalysisWhenReady} = stubAnalysisActions(store);
+    const {container, root} = await renderTree(
+      <TooltipProvider>
+        <RoomStateProvider roomStore={store}>
+          <QueryControls>
+            <Attachments />
+          </QueryControls>
+        </RoomStateProvider>
+      </TooltipProvider>,
+    );
+    const input =
+      container.querySelector<HTMLInputElement>('input[type=file]')!;
+
+    await act(async () => {
+      Object.defineProperty(input, 'files', {
+        configurable: true,
+        value: [new File(['plain text'], 'notes.txt', {type: 'text/plain'})],
+      });
+      input.dispatchEvent(new Event('change', {bubbles: true}));
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      typeInto(textarea(container)!, 'Read the notes');
+    });
+
+    await act(async () => {
+      fireKeyDown(textarea(container)!);
+    });
+
+    const sessionId = store.getState().ai.getCurrentSession()?.id;
+    expect(startAnalysisWhenReady).toHaveBeenCalledWith(
+      sessionId,
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'file',
+          filename: 'notes.txt',
+          mediaType: 'text/plain',
+        }),
+      ]),
+    );
+
+    await cleanup(container, root);
+  });
+
+  it('opens text and image attachments in dialogs', async () => {
+    const textAttachment = {
+      type: 'file' as const,
+      filename: 'notes.md',
+      mediaType: 'text/markdown',
+      url: `data:text/markdown;base64,${btoa('# Heading\n\nBody')}`,
+    };
+    const {container, root} = await renderTree(
+      <ChatAttachmentPreview attachment={textAttachment} />,
+    );
+
+    await act(async () => {
+      container.querySelector('button')!.click();
+    });
+
+    expect(document.body.textContent).toContain('Attached text file preview');
+    expect(document.body.textContent).toContain('Heading');
+    expect(document.body.textContent).toContain('Body');
+
+    await cleanup(container, root);
+
+    const imageAttachment = {
+      type: 'file' as const,
+      filename: 'chart.png',
+      mediaType: 'image/png',
+      url: 'data:image/png;base64,aW1hZ2U=',
+    };
+    const imageTree = await renderTree(
+      <ChatAttachmentPreview attachment={imageAttachment} />,
+    );
+
+    await act(async () => {
+      imageTree.container.querySelector('button')!.click();
+    });
+
+    expect(document.body.textContent).toContain('Attached image preview');
+    expect(document.body.querySelectorAll('img[alt="chart.png"]')).toHaveLength(
+      2,
+    );
+
+    await cleanup(imageTree.container, imageTree.root);
+  });
+});

--- a/packages/ai-core/__tests__/ChatComposerAttachments.test.tsx
+++ b/packages/ai-core/__tests__/ChatComposerAttachments.test.tsx
@@ -12,7 +12,6 @@ import {
   setMockSessionRuntime,
   stubAnalysisActions,
   textarea,
-  typeInto,
 } from './support';
 
 jest.unstable_mockModule(
@@ -68,8 +67,8 @@ async function selectAttachment(
 }
 
 describe('Chat composer attachments', () => {
-  it('opts in through a composer child, sends the file part, and clears it', async () => {
-    const runtime = setMockRuntime({prompt: 'Summarize this file'});
+  it('sends an attachment without prompt text and clears it', async () => {
+    const runtime = setMockRuntime({prompt: ''});
     const {container, root} = await renderTree(
       <LocalAgentChatComposerProvider>
         <QueryControls>
@@ -109,7 +108,7 @@ describe('Chat composer attachments', () => {
     await cleanup(container, root);
   });
 
-  it('forwards attachments through session-mode analysis', async () => {
+  it('forwards an attachment-only send through session-mode analysis', async () => {
     setMockSessionRuntime();
     const store = createSessionTestStore();
     const {startAnalysisWhenReady} = stubAnalysisActions(store);
@@ -130,10 +129,6 @@ describe('Chat composer attachments', () => {
       new File(['plain text'], 'notes.txt', {type: 'text/plain'}),
       container,
     );
-    await act(async () => {
-      typeInto(textarea(container)!, 'Read the notes');
-    });
-
     await act(async () => {
       fireKeyDown(textarea(container)!);
     });
@@ -294,6 +289,42 @@ describe('Chat composer attachments', () => {
       fireKeyDown(textarea(container)!);
     });
     expect(runtime.sendPrompt).toHaveBeenCalledWith();
+
+    await cleanup(container, root);
+  });
+
+  it('enforces a combined text attachment size limit', async () => {
+    setMockRuntime();
+    const {container, root} = await renderTree(
+      <LocalAgentChatComposerProvider>
+        <QueryControls>
+          <Attachments maxTextFileSize={10} maxTotalTextFileSize={12} />
+        </QueryControls>
+      </LocalAgentChatComposerProvider>,
+    );
+    const input =
+      container.querySelector<HTMLInputElement>('input[type=file]')!;
+
+    await selectAttachment(
+      input,
+      new File(['12345678'], 'first.txt', {type: 'text/plain'}),
+      container,
+    );
+    await act(async () => {
+      Object.defineProperty(input, 'files', {
+        configurable: true,
+        value: [new File(['abcdefgh'], 'second.txt', {type: 'text/plain'})],
+      });
+      input.dispatchEvent(new Event('change', {bubbles: true}));
+    });
+
+    expect(container.textContent).toContain('first.txt');
+    expect(
+      container.querySelector('button[aria-label="Open second.txt"]'),
+    ).toBeNull();
+    expect(container.textContent).toContain(
+      'second.txt exceeds the combined text attachment limit.',
+    );
 
     await cleanup(container, root);
   });

--- a/packages/ai-core/__tests__/ChatComposerAttachments.test.tsx
+++ b/packages/ai-core/__tests__/ChatComposerAttachments.test.tsx
@@ -2,6 +2,8 @@
 import {jest} from '@jest/globals';
 import {RoomStateProvider} from '@sqlrooms/room-store';
 import React, {act} from 'react';
+import type {FileUIPart} from 'ai';
+import type {ChatAttachmentsState} from '../src/components/composer';
 import {
   cleanup,
   createSessionTestStore,
@@ -21,7 +23,8 @@ jest.unstable_mockModule(
 
 const {LocalAgentChatComposerProvider} =
   await import('../src/components/composer');
-const {Attachments} = await import('../src/components/composer/attachments');
+const {Attachments, useChatAttachments} =
+  await import('../src/components/composer/attachments');
 const {QueryControls} = await import('../src/components/QueryControls');
 const {ChatAttachmentPreview} =
   await import('../src/components/ChatAttachmentPreview');
@@ -75,6 +78,27 @@ function attachmentInput(
   return container.querySelector<HTMLInputElement>(
     `input[type=file][aria-label="${label}"]`,
   )!;
+}
+
+let customAttachmentState: ChatAttachmentsState | undefined;
+
+function CustomAttachmentHarness() {
+  const attachmentState = useChatAttachments();
+  React.useEffect(() => {
+    customAttachmentState = attachmentState;
+    return () => {
+      if (customAttachmentState === attachmentState) {
+        customAttachmentState = undefined;
+      }
+    };
+  }, [attachmentState]);
+  return (
+    <span>
+      {attachmentState.attachments
+        .map((attachment) => attachment.filename)
+        .join(',')}
+    </span>
+  );
 }
 
 describe('Chat composer attachments', () => {
@@ -313,6 +337,53 @@ describe('Chat composer attachments', () => {
       });
       await cleanup(container, root);
     }
+  });
+
+  it('protects custom asynchronous appends across session changes', async () => {
+    customAttachmentState = undefined;
+    setMockSessionRuntime();
+    const store = createSessionTestStore();
+    const firstSessionId = store.getState().ai.createSession('First');
+    const secondSessionId = store.getState().ai.createSession('Second');
+    store.getState().ai.switchSession(firstSessionId);
+    const {container, root} = await renderTree(
+      <TooltipProvider>
+        <RoomStateProvider roomStore={store}>
+          <QueryControls>
+            <CustomAttachmentHarness />
+          </QueryControls>
+        </RoomStateProvider>
+      </TooltipProvider>,
+    );
+
+    let finishPreparation: ((attachments: FileUIPart[]) => void) | undefined;
+    const preparation = new Promise<FileUIPart[]>((resolve) => {
+      finishPreparation = resolve;
+    });
+    let appendResult: Promise<boolean> | undefined;
+    act(() => {
+      appendResult = customAttachmentState?.appendAsync(() => preparation);
+    });
+
+    await act(async () => {
+      store.getState().ai.switchSession(secondSessionId);
+    });
+    await act(async () => {
+      finishPreparation?.([
+        {
+          type: 'file',
+          filename: 'first-session.txt',
+          mediaType: 'text/plain',
+          url: 'data:text/plain;base64,cHJpdmF0ZSBub3Rlcw==',
+        },
+      ]);
+      await appendResult;
+    });
+
+    expect(await appendResult).toBe(false);
+    expect(container.textContent).not.toContain('first-session.txt');
+
+    await cleanup(container, root);
   });
 
   it('rejects images larger than the constrained default', async () => {

--- a/packages/ai-core/__tests__/ChatComposerAttachments.test.tsx
+++ b/packages/ai-core/__tests__/ChatComposerAttachments.test.tsx
@@ -35,7 +35,11 @@ async function waitForText(
   text: string,
 ): Promise<void> {
   await waitForCondition(
-    () => Boolean(container.textContent?.includes(text)),
+    () =>
+      Boolean(container.textContent?.includes(text)) ||
+      Array.from(container.querySelectorAll('button')).some(
+        (button) => button.getAttribute('aria-label') === `Open ${text}`,
+      ),
     text,
   );
 }
@@ -401,7 +405,7 @@ describe('Chat composer attachments', () => {
       Object.defineProperty(input, 'files', {
         configurable: true,
         value: [
-          new File([new Uint8Array(2 * 1024 * 1024 + 1)], 'large.png', {
+          new File([new Uint8Array(1024 * 1024 + 1)], 'large.png', {
             type: 'image/png',
           }),
         ],
@@ -414,6 +418,47 @@ describe('Chat composer attachments', () => {
       fireKeyDown(textarea(container)!);
     });
     expect(runtime.sendPrompt).toHaveBeenCalledWith();
+
+    await cleanup(container, root);
+  });
+
+  it('enforces the default combined image attachment size limit', async () => {
+    setMockRuntime();
+    const {container, root} = await renderTree(
+      <LocalAgentChatComposerProvider>
+        <QueryControls>
+          <Attachments />
+        </QueryControls>
+      </LocalAgentChatComposerProvider>,
+    );
+    const input = attachmentInput(container, 'image');
+
+    await selectAttachment(
+      input,
+      new File([new Uint8Array(600 * 1024)], 'first.png', {type: 'image/png'}),
+      container,
+    );
+    await act(async () => {
+      Object.defineProperty(input, 'files', {
+        configurable: true,
+        value: [
+          new File([new Uint8Array(600 * 1024)], 'second.png', {
+            type: 'image/png',
+          }),
+        ],
+      });
+      input.dispatchEvent(new Event('change', {bubbles: true}));
+    });
+
+    expect(
+      container.querySelector('button[aria-label="Open first.png"]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('button[aria-label="Open second.png"]'),
+    ).toBeNull();
+    expect(container.textContent).toContain(
+      'second.png exceeds the combined image attachment limit.',
+    );
 
     await cleanup(container, root);
   });

--- a/packages/ai-core/__tests__/ChatComposerAttachments.test.tsx
+++ b/packages/ai-core/__tests__/ChatComposerAttachments.test.tsx
@@ -28,6 +28,45 @@ const {ChatAttachmentPreview} =
   await import('../src/components/ChatAttachmentPreview');
 const {TooltipProvider} = await import('@sqlrooms/ui');
 
+async function waitForText(
+  container: HTMLElement,
+  text: string,
+): Promise<void> {
+  await waitForCondition(
+    () => Boolean(container.textContent?.includes(text)),
+    text,
+  );
+}
+
+async function waitForCondition(
+  condition: () => boolean,
+  description: string,
+): Promise<void> {
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    if (condition()) return;
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+  throw new Error(`Timed out waiting for ${description}`);
+}
+
+async function selectAttachment(
+  input: HTMLInputElement,
+  file: File,
+  container: HTMLElement,
+): Promise<void> {
+  await act(async () => {
+    Object.defineProperty(input, 'files', {
+      configurable: true,
+      value: [file],
+    });
+    input.dispatchEvent(new Event('change', {bubbles: true}));
+  });
+  await waitForText(container, file.name);
+}
+
 describe('Chat composer attachments', () => {
   it('opts in through a composer child, sends the file part, and clears it', async () => {
     const runtime = setMockRuntime({prompt: 'Summarize this file'});
@@ -44,14 +83,7 @@ describe('Chat composer attachments', () => {
       type: 'application/octet-stream',
     });
 
-    await act(async () => {
-      Object.defineProperty(input, 'files', {
-        configurable: true,
-        value: [file],
-      });
-      input.dispatchEvent(new Event('change', {bubbles: true}));
-      await new Promise((resolve) => setTimeout(resolve, 20));
-    });
+    await selectAttachment(input, file, container);
 
     expect(container.textContent).toContain('report.md');
 
@@ -93,13 +125,12 @@ describe('Chat composer attachments', () => {
     const input =
       container.querySelector<HTMLInputElement>('input[type=file]')!;
 
+    await selectAttachment(
+      input,
+      new File(['plain text'], 'notes.txt', {type: 'text/plain'}),
+      container,
+    );
     await act(async () => {
-      Object.defineProperty(input, 'files', {
-        configurable: true,
-        value: [new File(['plain text'], 'notes.txt', {type: 'text/plain'})],
-      });
-      input.dispatchEvent(new Event('change', {bubbles: true}));
-      await new Promise((resolve) => setTimeout(resolve, 20));
       typeInto(textarea(container)!, 'Read the notes');
     });
 
@@ -118,6 +149,151 @@ describe('Chat composer attachments', () => {
         }),
       ]),
     );
+
+    await cleanup(container, root);
+  });
+
+  it('clears pending attachments when the active session changes', async () => {
+    setMockSessionRuntime();
+    const store = createSessionTestStore();
+    const firstSessionId = store.getState().ai.createSession('First');
+    const secondSessionId = store.getState().ai.createSession('Second');
+    store.getState().ai.switchSession(firstSessionId);
+    const {container, root} = await renderTree(
+      <TooltipProvider>
+        <RoomStateProvider roomStore={store}>
+          <QueryControls>
+            <Attachments />
+          </QueryControls>
+        </RoomStateProvider>
+      </TooltipProvider>,
+    );
+    const input =
+      container.querySelector<HTMLInputElement>('input[type=file]')!;
+
+    await selectAttachment(
+      input,
+      new File(['private notes'], 'first-session.txt', {type: 'text/plain'}),
+      container,
+    );
+    expect(container.textContent).toContain('first-session.txt');
+
+    await act(async () => {
+      store.getState().ai.switchSession(secondSessionId);
+    });
+
+    expect(container.textContent).not.toContain('first-session.txt');
+    await cleanup(container, root);
+  });
+
+  it('does not append a file that finishes reading after a session change', async () => {
+    const OriginalFileReader = globalThis.FileReader;
+    let finishRead: (() => void) | undefined;
+    class DeferredFileReader {
+      result: string | ArrayBuffer | null = null;
+      error: DOMException | null = null;
+      onload: FileReader['onload'] = null;
+      onerror: FileReader['onerror'] = null;
+
+      readAsDataURL() {
+        finishRead = () => {
+          this.result = 'data:text/plain;base64,cHJpdmF0ZSBub3Rlcw==';
+          this.onload?.call(
+            this as unknown as FileReader,
+            new ProgressEvent('load') as ProgressEvent<FileReader>,
+          );
+        };
+      }
+    }
+    Object.defineProperty(globalThis, 'FileReader', {
+      configurable: true,
+      value: DeferredFileReader,
+    });
+
+    const store = createSessionTestStore();
+    const firstSessionId = store.getState().ai.createSession('First');
+    const secondSessionId = store.getState().ai.createSession('Second');
+    store.getState().ai.switchSession(firstSessionId);
+    setMockSessionRuntime();
+    const {container, root} = await renderTree(
+      <TooltipProvider>
+        <RoomStateProvider roomStore={store}>
+          <QueryControls>
+            <Attachments />
+          </QueryControls>
+        </RoomStateProvider>
+      </TooltipProvider>,
+    );
+
+    try {
+      const input =
+        container.querySelector<HTMLInputElement>('input[type=file]')!;
+      await act(async () => {
+        Object.defineProperty(input, 'files', {
+          configurable: true,
+          value: [
+            new File(['private notes'], 'first-session.txt', {
+              type: 'text/plain',
+            }),
+          ],
+        });
+        input.dispatchEvent(new Event('change', {bubbles: true}));
+      });
+      expect(finishRead).toBeDefined();
+
+      await act(async () => {
+        store.getState().ai.switchSession(secondSessionId);
+      });
+      await act(async () => finishRead?.());
+      await waitForCondition(
+        () =>
+          !container
+            .querySelector<HTMLButtonElement>(
+              'button[aria-label="Attach images or text files"]',
+            )
+            ?.hasAttribute('disabled'),
+        'file read to finish',
+      );
+
+      expect(container.textContent).not.toContain('first-session.txt');
+    } finally {
+      Object.defineProperty(globalThis, 'FileReader', {
+        configurable: true,
+        value: OriginalFileReader,
+      });
+      await cleanup(container, root);
+    }
+  });
+
+  it('rejects images larger than the constrained default', async () => {
+    const runtime = setMockRuntime({prompt: 'Inspect this image'});
+    const {container, root} = await renderTree(
+      <LocalAgentChatComposerProvider>
+        <QueryControls>
+          <Attachments />
+        </QueryControls>
+      </LocalAgentChatComposerProvider>,
+    );
+    const input =
+      container.querySelector<HTMLInputElement>('input[type=file]')!;
+
+    await act(async () => {
+      Object.defineProperty(input, 'files', {
+        configurable: true,
+        value: [
+          new File([new Uint8Array(2 * 1024 * 1024 + 1)], 'large.png', {
+            type: 'image/png',
+          }),
+        ],
+      });
+      input.dispatchEvent(new Event('change', {bubbles: true}));
+    });
+
+    expect(container.textContent).toContain('large.png is too large.');
+    await act(async () => {
+      fireKeyDown(textarea(container)!);
+    });
+    expect(runtime.sendPrompt).toHaveBeenCalledWith();
 
     await cleanup(container, root);
   });

--- a/packages/ai-core/__tests__/ChatSearch.test.tsx
+++ b/packages/ai-core/__tests__/ChatSearch.test.tsx
@@ -27,6 +27,8 @@ const {
 } = await import('../src/components/ChatSearch');
 const {ChatAttachmentPreview} =
   await import('../src/components/ChatAttachmentPreview');
+const {getChatAttachmentSearchText} =
+  await import('../src/components/ChatTurnView');
 
 const blocks: ChatSearchBlock[] = [
   {
@@ -170,6 +172,22 @@ describe('chat search helpers', () => {
     expect(findChatSearchMatches(blocks, '   ')).toEqual([]);
   });
 
+  it('normalizes Markdown attachments to their rendered search offsets', () => {
+    const text = getChatAttachmentSearchText({
+      type: 'file',
+      filename: 'report.md',
+      mediaType: 'text/markdown',
+      url: 'data:text/markdown;base64,IyBSZXBvcnQKClJldmVudWUgZ3Jldy4=',
+    });
+    const [match] = findChatSearchMatches(
+      [{id: 'attachment', resultId: 'result', text: text ?? ''}],
+      'Revenue',
+    );
+
+    expect(text).toBe('Report\nRevenue grew.');
+    expect(match?.start).toBe(7);
+  });
+
   it('uses lightweight tool labels instead of large payload text', () => {
     const matches = findChatSearchMatches(blocks, 'payload');
 
@@ -272,6 +290,78 @@ describe('Chat.Search', () => {
     }
     expect(document.body.textContent).toContain('Attached text file preview');
     expect(document.getElementById(activeMatchId!)).not.toBeNull();
+
+    cleanup(container, root);
+  });
+
+  it('reopens a closed attachment when the query changes at the same offset', async () => {
+    latestSearchRef.current = undefined;
+    const attachmentBlock: ChatSearchBlock = {
+      id: 'session-1:result-1:attachment:0',
+      resultId: 'result-1',
+      text: 'foobar content',
+    };
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const store = createTestStore();
+
+    await act(async () => {
+      root.render(
+        <RoomStateProvider roomStore={store}>
+          <ChatSearchProvider>
+            <BlockRegistrar blocks={[attachmentBlock]} />
+            <SearchController />
+            <ChatAttachmentPreview
+              attachment={{
+                type: 'file',
+                filename: 'report.txt',
+                mediaType: 'text/plain',
+                url: 'data:text/plain;base64,Zm9vYmFyIGNvbnRlbnQ=',
+              }}
+              searchBlockId={attachmentBlock.id}
+            />
+          </ChatSearchProvider>
+        </RoomStateProvider>,
+      );
+    });
+
+    await act(async () => {
+      latestSearchRef.current?.setQuery('foo');
+    });
+
+    const firstMatchId = latestSearchRef.current?.activeMatchId;
+    for (let attempts = 0; attempts < 20; attempts += 1) {
+      if (document.getElementById(firstMatchId!)) break;
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+
+    const closeButton = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>('button'),
+    ).find((button) => button.textContent?.trim() === 'Close');
+    expect(closeButton).toBeDefined();
+    act(() => closeButton?.click());
+    expect(document.body.textContent).not.toContain(
+      'Attached text file preview',
+    );
+
+    await act(async () => {
+      latestSearchRef.current?.setQuery('foobar');
+    });
+    expect(latestSearchRef.current?.activeMatchId).toBe(firstMatchId);
+
+    for (let attempts = 0; attempts < 20; attempts += 1) {
+      if (document.body.textContent?.includes('Attached text file preview')) {
+        break;
+      }
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+    expect(document.body.textContent).toContain('Attached text file preview');
+    expect(document.getElementById(firstMatchId!)).not.toBeNull();
 
     cleanup(container, root);
   });

--- a/packages/ai-core/__tests__/ChatSearch.test.tsx
+++ b/packages/ai-core/__tests__/ChatSearch.test.tsx
@@ -7,11 +7,13 @@ import {createRoot, type Root} from 'react-dom/client';
 import {createStore} from 'zustand';
 import {RoomStateProvider} from '@sqlrooms/room-store';
 import {TransformStream} from 'node:stream/web';
+import {TextDecoder} from 'node:util';
 import type {ChatSearchBlock} from '../src/components/ChatSearch';
 import type {AiSliceState} from '../src/AiSlice';
 
 Object.assign(globalThis, {
   TransformStream,
+  TextDecoder,
   IS_REACT_ACT_ENVIRONMENT: true,
 });
 
@@ -23,6 +25,8 @@ const {
   useChatSearch,
   useRegisterChatSearchBlocks,
 } = await import('../src/components/ChatSearch');
+const {ChatAttachmentPreview} =
+  await import('../src/components/ChatAttachmentPreview');
 
 const blocks: ChatSearchBlock[] = [
   {
@@ -222,6 +226,56 @@ describe('chat search helpers', () => {
 });
 
 describe('Chat.Search', () => {
+  it('opens and highlights an active text-attachment match', async () => {
+    latestSearchRef.current = undefined;
+    const attachmentBlock: ChatSearchBlock = {
+      id: 'session-1:result-1:attachment:0',
+      resultId: 'result-1',
+      text: 'Revenue grew this quarter.',
+    };
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const store = createTestStore();
+
+    await act(async () => {
+      root.render(
+        <RoomStateProvider roomStore={store}>
+          <ChatSearchProvider>
+            <BlockRegistrar blocks={[attachmentBlock]} />
+            <SearchController />
+            <ChatAttachmentPreview
+              attachment={{
+                type: 'file',
+                filename: 'report.txt',
+                mediaType: 'text/plain',
+                url: 'data:text/plain;base64,UmV2ZW51ZSBncmV3IHRoaXMgcXVhcnRlci4=',
+              }}
+              searchBlockId={attachmentBlock.id}
+            />
+          </ChatSearchProvider>
+        </RoomStateProvider>,
+      );
+    });
+
+    await act(async () => {
+      latestSearchRef.current?.setQuery('Revenue');
+    });
+
+    const activeMatchId = latestSearchRef.current?.activeMatchId;
+    expect(activeMatchId).toBeDefined();
+    for (let attempts = 0; attempts < 20; attempts += 1) {
+      if (document.getElementById(activeMatchId!)) break;
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+    expect(document.body.textContent).toContain('Attached text file preview');
+    expect(document.getElementById(activeMatchId!)).not.toBeNull();
+
+    cleanup(container, root);
+  });
+
   it('reports matches when blocks are registered after the query is entered', () => {
     latestSearchRef.current = undefined;
     const container = document.createElement('div');

--- a/packages/ai-core/__tests__/ChatSearch.test.tsx
+++ b/packages/ai-core/__tests__/ChatSearch.test.tsx
@@ -133,6 +133,20 @@ function cleanup(container: HTMLElement, root: Root) {
   container.remove();
 }
 
+async function waitForCondition(
+  condition: () => boolean,
+  description: string,
+): Promise<void> {
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    if (condition()) return;
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+  throw new Error(`Timed out waiting for ${description}`);
+}
+
 function setDesignQuery() {
   act(() => {
     if (!latestSearchRef.current) {
@@ -362,6 +376,84 @@ describe('Chat.Search', () => {
     }
     expect(document.body.textContent).toContain('Attached text file preview');
     expect(document.getElementById(firstMatchId!)).not.toBeNull();
+
+    cleanup(container, root);
+  });
+
+  it('closes the previous attachment preview during search navigation', async () => {
+    latestSearchRef.current = undefined;
+    const attachmentBlocks: ChatSearchBlock[] = [
+      {
+        id: 'session-1:result-1:attachment:0',
+        resultId: 'result-1',
+        text: 'needle in first',
+      },
+      {
+        id: 'session-1:result-1:attachment:1',
+        resultId: 'result-1',
+        text: 'needle in second',
+      },
+    ];
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const store = createTestStore();
+
+    await act(async () => {
+      root.render(
+        <RoomStateProvider roomStore={store}>
+          <ChatSearchProvider>
+            <BlockRegistrar blocks={attachmentBlocks} />
+            <SearchController />
+            <ChatAttachmentPreview
+              attachment={{
+                type: 'file',
+                filename: 'first.txt',
+                mediaType: 'text/plain',
+                url: 'data:text/plain;base64,bmVlZGxlIGluIGZpcnN0',
+              }}
+              searchBlockId={attachmentBlocks[0]!.id}
+            />
+            <ChatAttachmentPreview
+              attachment={{
+                type: 'file',
+                filename: 'second.txt',
+                mediaType: 'text/plain',
+                url: 'data:text/plain;base64,bmVlZGxlIGluIHNlY29uZA==',
+              }}
+              searchBlockId={attachmentBlocks[1]!.id}
+            />
+          </ChatSearchProvider>
+        </RoomStateProvider>,
+      );
+    });
+
+    await act(async () => {
+      latestSearchRef.current?.setQuery('needle');
+    });
+    await waitForCondition(
+      () => document.body.querySelectorAll('[role="dialog"]').length === 1,
+      'first attachment preview to open',
+    );
+    expect(
+      document.body.querySelector('[role="dialog"]')?.textContent,
+    ).toContain('first.txt');
+
+    await act(async () => {
+      latestSearchRef.current?.goToNextMatch();
+    });
+    await waitForCondition(() => {
+      const dialogs = document.body.querySelectorAll('[role="dialog"]');
+      return (
+        dialogs.length === 1 &&
+        dialogs[0]?.textContent?.includes('second.txt') === true
+      );
+    }, 'second attachment preview to replace the first');
+
+    expect(document.body.querySelectorAll('[role="dialog"]')).toHaveLength(1);
+    expect(
+      document.body.querySelector('[role="dialog"]')?.textContent,
+    ).not.toContain('first.txt');
 
     cleanup(container, root);
   });

--- a/packages/ai-core/__tests__/ContextUsageIndicator.test.ts
+++ b/packages/ai-core/__tests__/ContextUsageIndicator.test.ts
@@ -1,0 +1,25 @@
+import type {UIMessage} from 'ai';
+import {estimateMessageTokens} from '../src/components/ContextUsageIndicator';
+
+describe('ContextUsageIndicator fallback estimates', () => {
+  it('counts text attachment content as labeled model input', () => {
+    const message: UIMessage = {
+      id: 'user-1',
+      role: 'user',
+      parts: [
+        {
+          type: 'file',
+          filename: 'report.md',
+          mediaType: 'text/markdown',
+          url: `data:text/markdown;base64,${Buffer.from(
+            'Revenue grew 18%.',
+          ).toString('base64')}`,
+        },
+      ],
+    };
+
+    // Four message-overhead tokens plus eleven estimated content tokens for
+    // "Attached file: report.md\n\nRevenue grew 18%.".
+    expect(estimateMessageTokens(message)).toBe(15);
+  });
+});

--- a/packages/ai-core/__tests__/ContextUsageIndicator.test.ts
+++ b/packages/ai-core/__tests__/ContextUsageIndicator.test.ts
@@ -1,5 +1,8 @@
 import type {UIMessage} from 'ai';
-import {estimateMessageTokens} from '../src/components/ContextUsageIndicator';
+import {
+  createConversationContinuationSeed,
+  estimateMessageTokens,
+} from '../src/components/ContextUsageIndicator';
 
 describe('ContextUsageIndicator fallback estimates', () => {
   it('counts text attachment content as labeled model input', () => {
@@ -38,5 +41,38 @@ describe('ContextUsageIndicator fallback estimates', () => {
     };
 
     expect(estimateMessageTokens(message)).toBe(4_100);
+  });
+
+  it('carries image attachments into a summarized continuation', () => {
+    const image = {
+      type: 'file' as const,
+      filename: 'chart.png',
+      mediaType: 'image/png',
+      url: 'data:image/png;base64,aW1hZ2U=',
+    };
+    const messages: UIMessage[] = [
+      {
+        id: 'user-1',
+        role: 'user',
+        parts: [
+          {type: 'text', text: 'What does this show?'},
+          image,
+          {
+            type: 'file',
+            filename: 'notes.txt',
+            mediaType: 'text/plain',
+            url: 'data:text/plain;base64,bm90ZXM=',
+          },
+        ],
+      },
+    ];
+
+    expect(
+      createConversationContinuationSeed('A rising trend.', messages),
+    ).toEqual({
+      prompt:
+        'Please use the following context from a previous session and only respond "Got it" to this message:\n\nA rising trend.',
+      attachments: [image],
+    });
   });
 });

--- a/packages/ai-core/__tests__/ContextUsageIndicator.test.ts
+++ b/packages/ai-core/__tests__/ContextUsageIndicator.test.ts
@@ -22,4 +22,21 @@ describe('ContextUsageIndicator fallback estimates', () => {
     // "Attached file: report.md\n\nRevenue grew 18%.".
     expect(estimateMessageTokens(message)).toBe(15);
   });
+
+  it('reserves a conservative fallback budget for image attachments', () => {
+    const message: UIMessage = {
+      id: 'user-1',
+      role: 'user',
+      parts: [
+        {
+          type: 'file',
+          filename: 'chart.png',
+          mediaType: 'image/png',
+          url: 'data:image/png;base64,aW1hZ2U=',
+        },
+      ],
+    };
+
+    expect(estimateMessageTokens(message)).toBe(4_100);
+  });
 });

--- a/packages/ai-core/__tests__/chatAttachments.test.ts
+++ b/packages/ai-core/__tests__/chatAttachments.test.ts
@@ -1,0 +1,72 @@
+import type {FileUIPart, UIMessage} from 'ai';
+import {
+  getChatAttachmentText,
+  getChatMessageAttachments,
+  isMarkdownAttachment,
+  textAttachmentToModelText,
+} from '../src/chatAttachments';
+import {sanitizeMessagesForLLM} from '../src/utils';
+
+function textAttachment(text: string, filename = 'notes.md'): FileUIPart {
+  return {
+    type: 'file',
+    filename,
+    mediaType: filename.endsWith('.md') ? 'text/markdown' : 'text/plain',
+    url: `data:text/plain;base64,${Buffer.from(text).toString('base64')}`,
+  };
+}
+
+describe('chat attachments', () => {
+  it('decodes UTF-8 text and identifies Markdown', () => {
+    const attachment = textAttachment('# Zürich\n\nHello 👋');
+
+    expect(getChatAttachmentText(attachment)).toBe('# Zürich\n\nHello 👋');
+    expect(isMarkdownAttachment(attachment)).toBe(true);
+    expect(textAttachmentToModelText(attachment)).toBe(
+      'Attached file: notes.md\n\n# Zürich\n\nHello 👋',
+    );
+  });
+
+  it('keeps file parts on the UI message', () => {
+    const attachment = textAttachment('hello', 'notes.txt');
+    const message: UIMessage = {
+      id: 'user-1',
+      role: 'user',
+      parts: [{type: 'text', text: 'Read this'}, attachment],
+    };
+
+    expect(getChatMessageAttachments(message)).toEqual([attachment]);
+    expect(message.parts[1]).toBe(attachment);
+  });
+
+  it('converts text files to labeled model text but preserves images', () => {
+    const text = textAttachment('alpha\nbeta', 'data.txt');
+    const image: FileUIPart = {
+      type: 'file',
+      filename: 'plot.png',
+      mediaType: 'image/png',
+      url: 'data:image/png;base64,aW1hZ2U=',
+    };
+    const message: UIMessage = {
+      id: 'user-1',
+      role: 'user',
+      parts: [{type: 'text', text: 'Compare these'}, text, image],
+    };
+
+    expect(sanitizeMessagesForLLM([message])).toEqual([
+      {
+        ...message,
+        parts: [
+          {type: 'text', text: 'Compare these'},
+          {type: 'text', text: 'Attached file: data.txt\n\nalpha\nbeta'},
+          image,
+        ],
+      },
+    ]);
+    expect(message.parts).toEqual([
+      {type: 'text', text: 'Compare these'},
+      text,
+      image,
+    ]);
+  });
+});

--- a/packages/ai-core/__tests__/chatAttachments.test.ts
+++ b/packages/ai-core/__tests__/chatAttachments.test.ts
@@ -1,11 +1,13 @@
 import type {FileUIPart, UIMessage} from 'ai';
+import type {ChatSessionSchema} from '@sqlrooms/ai-config';
 import {
   getChatAttachmentText,
   getChatMessageAttachments,
   isMarkdownAttachment,
   textAttachmentToModelText,
 } from '../src/chatAttachments';
-import {sanitizeMessagesForLLM} from '../src/utils';
+import {getSessionUserMessageText} from '../src/hooks/useGenerateSessionTitle';
+import {buildConversationText, sanitizeMessagesForLLM} from '../src/utils';
 
 function textAttachment(text: string, filename = 'notes.md'): FileUIPart {
   return {
@@ -68,5 +70,48 @@ describe('chat attachments', () => {
       text,
       image,
     ]);
+  });
+
+  it('uses attachment filenames for attachment-only session titles', () => {
+    const session: ChatSessionSchema = {
+      id: 'session-1',
+      name: 'Chat',
+      modelProvider: 'openai',
+      model: 'gpt-4.1',
+      uiMessages: [
+        {
+          id: 'user-1',
+          role: 'user',
+          parts: [textAttachment('quarterly results', 'report.md')],
+        },
+      ],
+      messagesRevision: 0,
+      prompt: '',
+      isRunning: false,
+    };
+
+    expect(getSessionUserMessageText(session)).toEqual([
+      'Attached file: report.md',
+    ]);
+  });
+
+  it('includes text attachment contents in conversation summaries', () => {
+    const attachment = textAttachment('Revenue grew 18%.', 'report.md');
+    const messages: UIMessage[] = [
+      {
+        id: 'user-1',
+        role: 'user',
+        parts: [{type: 'text', text: 'Summarize this'}, attachment],
+      },
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        parts: [{type: 'text', text: 'I found the main trend.'}],
+      },
+    ];
+
+    expect(buildConversationText(messages)).toBe(
+      'User: Summarize this\n\nAttached file: report.md\n\nRevenue grew 18%.\n\nAssistant: I found the main trend.',
+    );
   });
 });

--- a/packages/ai-core/__tests__/support/localAgentRuntime.tsx
+++ b/packages/ai-core/__tests__/support/localAgentRuntime.tsx
@@ -6,6 +6,7 @@ import {jest} from '@jest/globals';
 // Type-only: importing the real module here would load it before the test
 // file's `jest.unstable_mockModule` call has a chance to replace it.
 import type {LocalAgentChatRuntime} from '../../src/components/ChatRuntimeContext';
+import type {FileUIPart} from 'ai';
 
 /** A fully stubbed local-agent runtime, with every action a spy. */
 export function createMockLocalAgentRuntime(
@@ -18,7 +19,7 @@ export function createMockLocalAgentRuntime(
     isStreaming: false,
     prompt: '',
     setPrompt: jest.fn<(value: string) => void>(),
-    sendPrompt: jest.fn<(value?: string) => void>(),
+    sendPrompt: jest.fn<(value?: string, attachments?: FileUIPart[]) => void>(),
     stop: jest.fn<() => Promise<void>>(async () => {}),
     initialSuggestions: [],
     suggestionsVisible: true,

--- a/packages/ai-core/__tests__/support/sessionStore.tsx
+++ b/packages/ai-core/__tests__/support/sessionStore.tsx
@@ -6,6 +6,7 @@
  * the real runtime context in ahead of the mock.
  */
 import {jest} from '@jest/globals';
+import type {FileUIPart} from 'ai';
 import {createStore} from 'zustand';
 import {
   createBaseRoomSlice,
@@ -45,11 +46,11 @@ export type SessionTestStore = ReturnType<typeof createSessionTestStore>;
  * the real model/transport pipeline.
  */
 export function stubAnalysisActions(store: SessionTestStore) {
-  const startAnalysis = jest.fn<(sessionId: string) => Promise<void>>(
-    async () => {},
-  );
+  const startAnalysis = jest.fn<
+    (sessionId: string, attachments?: FileUIPart[]) => Promise<void>
+  >(async () => {});
   const startAnalysisWhenReady = jest.fn<
-    (sessionId: string) => Promise<boolean>
+    (sessionId: string, attachments?: FileUIPart[]) => Promise<boolean>
   >(async () => true);
   store.setState((state) => ({
     ai: {...state.ai, startAnalysis, startAnalysisWhenReady},

--- a/packages/ai-core/__tests__/useLocalAgentChatTransport.test.ts
+++ b/packages/ai-core/__tests__/useLocalAgentChatTransport.test.ts
@@ -17,6 +17,45 @@ describe('parseLocalAgentUiMessages', () => {
     ).toEqual(messages);
   });
 
+  it('converts text file parts before forwarding them to a local agent', () => {
+    const messages: UIMessage[] = [
+      {
+        id: 'message-1',
+        role: 'user',
+        parts: [
+          {type: 'text', text: 'Summarize this'},
+          {
+            type: 'file',
+            filename: 'notes.txt',
+            mediaType: 'text/plain',
+            url: 'data:text/plain;base64,aGVsbG8=',
+          },
+          {
+            type: 'file',
+            filename: 'chart.png',
+            mediaType: 'image/png',
+            url: 'data:image/png;base64,aW1hZ2U=',
+          },
+        ],
+      },
+    ];
+
+    expect(parseLocalAgentUiMessages(JSON.stringify({messages}))).toEqual([
+      {
+        id: 'message-1',
+        role: 'user',
+        parts: [
+          {type: 'text', text: 'Summarize this'},
+          {type: 'text', text: 'Attached file: notes.txt\n\nhello'},
+          expect.objectContaining({
+            type: 'file',
+            filename: 'chart.png',
+          }),
+        ],
+      },
+    ]);
+  });
+
   it('returns an empty list for malformed or unexpected bodies', () => {
     const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
 

--- a/packages/ai-core/src/AiSlice.ts
+++ b/packages/ai-core/src/AiSlice.ts
@@ -1923,10 +1923,16 @@ export function createAiSlice<TTools extends ToolSet = ToolSet>(
               }
             }),
           );
-          void chat.sendMessage({
-            text: promptText,
-            ...(attachments.length > 0 ? {files: attachments} : {}),
-          });
+          void chat.sendMessage(
+            promptText
+              ? {
+                  text: promptText,
+                  ...(attachments.length > 0 ? {files: attachments} : {}),
+                }
+              : attachments.length > 0
+                ? {files: attachments}
+                : {text: promptText},
+          );
         },
 
         startAnalysisWhenReady: async (

--- a/packages/ai-core/src/AiSlice.ts
+++ b/packages/ai-core/src/AiSlice.ts
@@ -23,6 +23,7 @@ import {
   UIMessage,
   DefaultChatTransport,
   LanguageModel,
+  FileUIPart,
   generateText,
   lastAssistantMessageIsCompleteWithApprovalResponses,
   lastAssistantMessageIsCompleteWithToolCalls,
@@ -185,9 +186,15 @@ export type AiSliceState = {
         sessionId?: string;
       },
     ) => Promise<string>;
-    startAnalysis: (sessionId: string) => Promise<void>;
+    startAnalysis: (
+      sessionId: string,
+      attachments?: FileUIPart[],
+    ) => Promise<void>;
     /** Compatibility entry point; session controllers are ready synchronously. */
-    startAnalysisWhenReady: (sessionId: string) => Promise<boolean>;
+    startAnalysisWhenReady: (
+      sessionId: string,
+      attachments?: FileUIPart[],
+    ) => Promise<boolean>;
     startNewSession: (name: string, prompt: string) => Promise<void>;
     cancelAnalysis: (sessionId: string) => void;
     setAiModel: (modelProvider: string, model: string) => void;
@@ -1842,7 +1849,10 @@ export function createAiSlice<TTools extends ToolSet = ToolSet>(
         /**
          * Start the analysis for a specific session
          */
-        startAnalysis: async (sessionId: string) => {
+        startAnalysis: async (
+          sessionId: string,
+          attachments: FileUIPart[] = [],
+        ) => {
           const state = get();
           const session = state.ai.config.sessions.find(
             (s: ChatSessionSchema) => s.id === sessionId,
@@ -1913,15 +1923,21 @@ export function createAiSlice<TTools extends ToolSet = ToolSet>(
               }
             }),
           );
-          void chat.sendMessage({text: promptText});
+          void chat.sendMessage({
+            text: promptText,
+            ...(attachments.length > 0 ? {files: attachments} : {}),
+          });
         },
 
-        startAnalysisWhenReady: async (sessionId: string) => {
+        startAnalysisWhenReady: async (
+          sessionId: string,
+          attachments: FileUIPart[] = [],
+        ) => {
           if (!get().ai.getSessionChat(sessionId)) {
             console.error('Session not found:', sessionId);
             return false;
           }
-          await get().ai.startAnalysis(sessionId);
+          await get().ai.startAnalysis(sessionId, attachments);
           return true;
         },
 

--- a/packages/ai-core/src/chatAttachments.ts
+++ b/packages/ai-core/src/chatAttachments.ts
@@ -1,0 +1,125 @@
+import type {FileUIPart, UIMessage} from 'ai';
+
+const MARKDOWN_EXTENSIONS = ['.md', '.markdown', '.mdown', '.mkd'];
+const TEXT_EXTENSIONS = ['.txt', ...MARKDOWN_EXTENSIONS];
+
+/** File part accepted and rendered by SQLRooms chat attachment surfaces. */
+export type ChatAttachmentPart = FileUIPart;
+
+/** Whether a media type represents plain text or Markdown. */
+export function isTextAttachmentMediaType(mediaType: string): boolean {
+  return (
+    mediaType === 'text/plain' ||
+    mediaType === 'text/markdown' ||
+    mediaType === 'text/x-markdown'
+  );
+}
+
+/** Whether a filename has a supported plain-text or Markdown extension. */
+export function isTextAttachmentFilename(filename: string): boolean {
+  const lower = filename.toLowerCase();
+  return TEXT_EXTENSIONS.some((extension) => lower.endsWith(extension));
+}
+
+/** Whether an attachment should be rendered as Markdown. */
+export function isMarkdownAttachment(attachment: ChatAttachmentPart): boolean {
+  const filename = attachment.filename?.toLowerCase() ?? '';
+  return (
+    attachment.mediaType === 'text/markdown' ||
+    attachment.mediaType === 'text/x-markdown' ||
+    MARKDOWN_EXTENSIONS.some((extension) => filename.endsWith(extension))
+  );
+}
+
+/** Whether a browser file is supported by the default attachment picker. */
+export function isSupportedChatAttachment(file: File): boolean {
+  return (
+    file.type.startsWith('image/') ||
+    isTextAttachmentMediaType(file.type) ||
+    isTextAttachmentFilename(file.name)
+  );
+}
+
+/** Supplies a useful media type when a browser leaves `File.type` empty. */
+export function getChatAttachmentMediaType(file: File): string {
+  const lower = file.name.toLowerCase();
+  if (MARKDOWN_EXTENSIONS.some((extension) => lower.endsWith(extension))) {
+    return 'text/markdown';
+  }
+  if (lower.endsWith('.txt')) return 'text/plain';
+  if (file.type) return file.type;
+  return 'application/octet-stream';
+}
+
+/** Reads a browser file into the serializable AI SDK file-part shape. */
+export async function fileToChatAttachmentPart(
+  file: File,
+): Promise<ChatAttachmentPart> {
+  const url = await new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === 'string') resolve(reader.result);
+      else reject(new Error(`Could not read ${file.name}`));
+    };
+    reader.onerror = () =>
+      reject(reader.error ?? new Error(`Could not read ${file.name}`));
+    reader.readAsDataURL(file);
+  });
+
+  return {
+    type: 'file',
+    mediaType: getChatAttachmentMediaType(file),
+    filename: file.name,
+    url,
+  };
+}
+
+/** Decodes the text payload from a base64 or percent-encoded data URL. */
+export function getChatAttachmentText(
+  attachment: ChatAttachmentPart,
+): string | undefined {
+  if (!isTextAttachmentMediaType(attachment.mediaType)) return undefined;
+  const commaIndex = attachment.url.indexOf(',');
+  if (commaIndex < 0) return undefined;
+
+  const header = attachment.url.slice(0, commaIndex);
+  const data = attachment.url.slice(commaIndex + 1);
+
+  try {
+    if (!header.includes(';base64')) return decodeURIComponent(data);
+    const binary = globalThis.atob(data);
+    const bytes = Uint8Array.from(binary, (character) =>
+      character.charCodeAt(0),
+    );
+    return new TextDecoder().decode(bytes);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Returns the file parts attached to a UI message. */
+export function getChatMessageAttachments(
+  message: UIMessage | undefined,
+): ChatAttachmentPart[] {
+  if (!message) return [];
+  return message.parts.filter(
+    (part): part is ChatAttachmentPart =>
+      part.type === 'file' && typeof part.url === 'string',
+  );
+}
+
+/**
+ * Turns a text attachment into a labeled text part for provider-independent
+ * model input while leaving the persisted UI message untouched.
+ */
+export function textAttachmentToModelText(
+  attachment: ChatAttachmentPart,
+): string | undefined {
+  const text = getChatAttachmentText(attachment);
+  if (text === undefined) return undefined;
+  const filename = (attachment.filename ?? 'attachment.txt').replace(
+    /[\r\n]+/g,
+    ' ',
+  );
+  return `Attached file: ${filename}\n\n${text}`;
+}

--- a/packages/ai-core/src/components/Chat.tsx
+++ b/packages/ai-core/src/components/Chat.tsx
@@ -8,6 +8,7 @@ import {
 } from './ChatRuntimeContext';
 import {
   DropTarget as ComposerDropTarget,
+  Attachments as ComposerAttachments,
   Input as ComposerInput,
   LocalAgentChatComposerProvider,
   Send as ComposerSend,
@@ -55,6 +56,7 @@ type ChatComponent = FC<RootProps> & {
     Send: typeof ComposerSend;
     Stop: typeof ComposerStop;
     DropTarget: typeof ComposerDropTarget;
+    Attachments: typeof ComposerAttachments;
   };
   InlineApiKeyInput: typeof InlineApiKeyInput;
   PromptSuggestions: typeof PromptSuggestions;
@@ -109,6 +111,7 @@ const Composer = Object.assign(QueryControls, {
   Send: ComposerSend,
   Stop: ComposerStop,
   DropTarget: ComposerDropTarget,
+  Attachments: ComposerAttachments,
 });
 
 export const Chat: ChatComponent = Object.assign(Root, {

--- a/packages/ai-core/src/components/ChatAttachmentPreview.tsx
+++ b/packages/ai-core/src/components/ChatAttachmentPreview.tsx
@@ -7,10 +7,11 @@ import {
   cn,
 } from '@sqlrooms/ui';
 import {FileTextIcon} from 'lucide-react';
-import {useMemo, useState, type FC} from 'react';
+import {useEffect, useMemo, useState, type FC} from 'react';
 import type {ChatAttachmentPart} from '../chatAttachments';
 import {getChatAttachmentText, isMarkdownAttachment} from '../chatAttachments';
 import {MessageContent} from './MessageContent';
+import {HighlightedChatSearchText, useOptionalChatSearch} from './ChatSearch';
 
 /** Props for a clickable image or text/Markdown attachment preview. */
 export type ChatAttachmentPreviewProps = {
@@ -18,17 +19,46 @@ export type ChatAttachmentPreviewProps = {
   attachment: ChatAttachmentPart;
   /** Use the smaller composer-chip presentation. */
   compact?: boolean;
+  /** Registered chat-search block for this attachment's text content. */
+  searchBlockId?: string;
 };
 
 /** Clickable attachment preview with an image or text/Markdown dialog. */
 export const ChatAttachmentPreview: FC<ChatAttachmentPreviewProps> = ({
   attachment,
   compact = false,
+  searchBlockId,
 }) => {
   const [open, setOpen] = useState(false);
+  const search = useOptionalChatSearch();
   const isImage = attachment.mediaType.startsWith('image/');
   const text = useMemo(() => getChatAttachmentText(attachment), [attachment]);
   const filename = attachment.filename ?? (isImage ? 'Image' : 'Text file');
+  const activeMatchId = search?.activeMatchId;
+  const hasActiveAttachmentMatch = Boolean(
+    searchBlockId &&
+    activeMatchId &&
+    search
+      ?.getMatchesForBlock(searchBlockId)
+      .some((match) => match.id === activeMatchId),
+  );
+
+  useEffect(() => {
+    if (!hasActiveAttachmentMatch || !activeMatchId) return;
+    let scrollTimeoutId: ReturnType<typeof setTimeout> | undefined;
+    const openTimeoutId = setTimeout(() => {
+      setOpen(true);
+      scrollTimeoutId = setTimeout(() => {
+        document.getElementById(activeMatchId)?.scrollIntoView?.({
+          block: 'center',
+        });
+      }, 0);
+    }, 0);
+    return () => {
+      clearTimeout(openTimeoutId);
+      if (scrollTimeoutId !== undefined) clearTimeout(scrollTimeoutId);
+    };
+  }, [activeMatchId, hasActiveAttachmentMatch]);
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -85,11 +115,19 @@ export const ChatAttachmentPreview: FC<ChatAttachmentPreviewProps> = ({
           </p>
         ) : isMarkdownAttachment(attachment) ? (
           <div className="min-h-0 overflow-auto rounded-md border p-4">
-            <MessageContent content={text} isAnswer />
+            <MessageContent
+              content={text}
+              isAnswer
+              searchBlockId={searchBlockId}
+            />
           </div>
         ) : (
           <pre className="bg-muted min-h-0 overflow-auto rounded-md border p-4 text-sm whitespace-pre-wrap">
-            {text}
+            {searchBlockId ? (
+              <HighlightedChatSearchText blockId={searchBlockId} text={text} />
+            ) : (
+              text
+            )}
           </pre>
         )}
       </DialogContent>

--- a/packages/ai-core/src/components/ChatAttachmentPreview.tsx
+++ b/packages/ai-core/src/components/ChatAttachmentPreview.tsx
@@ -12,7 +12,9 @@ import type {ChatAttachmentPart} from '../chatAttachments';
 import {getChatAttachmentText, isMarkdownAttachment} from '../chatAttachments';
 import {MessageContent} from './MessageContent';
 
+/** Props for a clickable image or text/Markdown attachment preview. */
 export type ChatAttachmentPreviewProps = {
+  /** Serialized attachment displayed by the preview and its dialog. */
   attachment: ChatAttachmentPart;
   /** Use the smaller composer-chip presentation. */
   compact?: boolean;

--- a/packages/ai-core/src/components/ChatAttachmentPreview.tsx
+++ b/packages/ai-core/src/components/ChatAttachmentPreview.tsx
@@ -1,0 +1,96 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  cn,
+} from '@sqlrooms/ui';
+import {FileTextIcon} from 'lucide-react';
+import {useMemo, useState, type FC} from 'react';
+import type {ChatAttachmentPart} from '../chatAttachments';
+import {getChatAttachmentText, isMarkdownAttachment} from '../chatAttachments';
+import {MessageContent} from './MessageContent';
+
+export type ChatAttachmentPreviewProps = {
+  attachment: ChatAttachmentPart;
+  /** Use the smaller composer-chip presentation. */
+  compact?: boolean;
+};
+
+/** Clickable attachment preview with an image or text/Markdown dialog. */
+export const ChatAttachmentPreview: FC<ChatAttachmentPreviewProps> = ({
+  attachment,
+  compact = false,
+}) => {
+  const [open, setOpen] = useState(false);
+  const isImage = attachment.mediaType.startsWith('image/');
+  const text = useMemo(() => getChatAttachmentText(attachment), [attachment]);
+  const filename = attachment.filename ?? (isImage ? 'Image' : 'Text file');
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <button
+        type="button"
+        className={cn(
+          'hover:bg-muted/70 focus-visible:ring-ring flex overflow-hidden rounded-md text-left outline-none focus-visible:ring-2',
+          compact ? 'h-9 max-w-44 items-center gap-2 pr-2' : 'max-w-56',
+        )}
+        aria-label={`Open ${filename}`}
+        onClick={() => setOpen(true)}
+      >
+        {isImage ? (
+          <img
+            src={attachment.url}
+            alt={filename}
+            className={cn(
+              'bg-muted object-cover',
+              compact ? 'h-9 w-9' : 'h-24 w-32',
+            )}
+          />
+        ) : (
+          <>
+            <span
+              className={cn(
+                'bg-muted flex shrink-0 items-center justify-center',
+                compact ? 'h-9 w-9' : 'h-24 w-16',
+              )}
+            >
+              <FileTextIcon className="text-muted-foreground h-5 w-5" />
+            </span>
+            <span className="min-w-0 truncate text-xs">{filename}</span>
+          </>
+        )}
+      </button>
+      <DialogContent className="max-h-[90vh] max-w-4xl overflow-hidden">
+        <DialogHeader>
+          <DialogTitle className="truncate">{filename}</DialogTitle>
+          <DialogDescription>
+            {isImage ? 'Attached image preview' : 'Attached text file preview'}
+          </DialogDescription>
+        </DialogHeader>
+        {isImage ? (
+          <div className="flex min-h-0 items-center justify-center overflow-auto">
+            <img
+              src={attachment.url}
+              alt={filename}
+              className="max-h-[75vh] max-w-full object-contain"
+            />
+          </div>
+        ) : text === undefined ? (
+          <p className="text-muted-foreground text-sm">
+            This text attachment could not be decoded.
+          </p>
+        ) : isMarkdownAttachment(attachment) ? (
+          <div className="min-h-0 overflow-auto rounded-md border p-4">
+            <MessageContent content={text} isAnswer />
+          </div>
+        ) : (
+          <pre className="bg-muted min-h-0 overflow-auto rounded-md border p-4 text-sm whitespace-pre-wrap">
+            {text}
+          </pre>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/packages/ai-core/src/components/ChatAttachmentPreview.tsx
+++ b/packages/ai-core/src/components/ChatAttachmentPreview.tsx
@@ -35,6 +35,7 @@ export const ChatAttachmentPreview: FC<ChatAttachmentPreviewProps> = ({
   const text = useMemo(() => getChatAttachmentText(attachment), [attachment]);
   const filename = attachment.filename ?? (isImage ? 'Image' : 'Text file');
   const activeMatchId = search?.activeMatchId;
+  const searchQuery = search?.query;
   const hasActiveAttachmentMatch = Boolean(
     searchBlockId &&
     activeMatchId &&
@@ -58,7 +59,7 @@ export const ChatAttachmentPreview: FC<ChatAttachmentPreviewProps> = ({
       clearTimeout(openTimeoutId);
       if (scrollTimeoutId !== undefined) clearTimeout(scrollTimeoutId);
     };
-  }, [activeMatchId, hasActiveAttachmentMatch]);
+  }, [activeMatchId, hasActiveAttachmentMatch, searchQuery]);
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>

--- a/packages/ai-core/src/components/ChatAttachmentPreview.tsx
+++ b/packages/ai-core/src/components/ChatAttachmentPreview.tsx
@@ -7,7 +7,7 @@ import {
   cn,
 } from '@sqlrooms/ui';
 import {FileTextIcon} from 'lucide-react';
-import {useEffect, useMemo, useState, type FC} from 'react';
+import {useEffect, useMemo, useRef, useState, type FC} from 'react';
 import type {ChatAttachmentPart} from '../chatAttachments';
 import {getChatAttachmentText, isMarkdownAttachment} from '../chatAttachments';
 import {MessageContent} from './MessageContent';
@@ -30,6 +30,7 @@ export const ChatAttachmentPreview: FC<ChatAttachmentPreviewProps> = ({
   searchBlockId,
 }) => {
   const [open, setOpen] = useState(false);
+  const openedBySearchRef = useRef(false);
   const search = useOptionalChatSearch();
   const isImage = attachment.mediaType.startsWith('image/');
   const text = useMemo(() => getChatAttachmentText(attachment), [attachment]);
@@ -45,9 +46,16 @@ export const ChatAttachmentPreview: FC<ChatAttachmentPreviewProps> = ({
   );
 
   useEffect(() => {
-    if (!hasActiveAttachmentMatch || !activeMatchId) return;
+    if (!hasActiveAttachmentMatch || !activeMatchId) {
+      if (openedBySearchRef.current) {
+        openedBySearchRef.current = false;
+        setOpen(false);
+      }
+      return;
+    }
     let scrollTimeoutId: ReturnType<typeof setTimeout> | undefined;
     const openTimeoutId = setTimeout(() => {
+      openedBySearchRef.current = true;
       setOpen(true);
       scrollTimeoutId = setTimeout(() => {
         document.getElementById(activeMatchId)?.scrollIntoView?.({
@@ -61,8 +69,13 @@ export const ChatAttachmentPreview: FC<ChatAttachmentPreviewProps> = ({
     };
   }, [activeMatchId, hasActiveAttachmentMatch, searchQuery]);
 
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) openedBySearchRef.current = false;
+    setOpen(nextOpen);
+  };
+
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <button
         type="button"
         className={cn(

--- a/packages/ai-core/src/components/ChatRenderingTypes.ts
+++ b/packages/ai-core/src/components/ChatRenderingTypes.ts
@@ -6,6 +6,7 @@ import type {
 } from 'react';
 import type {Components} from 'react-markdown';
 import type {AgentToolCall} from '../types';
+import type {ChatAttachmentPart} from '../chatAttachments';
 import type {ToolPartWithId} from './buildChatTurnModel';
 import type {HoistableToolCall} from './collectHoistableRenderers';
 
@@ -33,6 +34,7 @@ export type ChatActiveStatusProps = {
 /** Props for the user-prompt presentation slot. */
 export type ChatPromptProps = {
   prompt: string;
+  attachments: readonly ChatAttachmentPart[];
   searchBlockId: string;
 };
 
@@ -117,6 +119,7 @@ export type ChatToolState = AgentToolCall['state'];
 /** Prompt semantics plus its pre-wired rendering component. */
 export type ChatPromptRegion = {
   text: string;
+  attachments: readonly ChatAttachmentPart[];
   Content: ChatComponentType;
 };
 

--- a/packages/ai-core/src/components/ChatRenderingTypes.ts
+++ b/packages/ai-core/src/components/ChatRenderingTypes.ts
@@ -35,6 +35,8 @@ export type ChatActiveStatusProps = {
 export type ChatPromptProps = {
   prompt: string;
   attachments: readonly ChatAttachmentPart[];
+  /** Search block IDs corresponding by index to {@link attachments}. */
+  attachmentSearchBlockIds: readonly string[];
   searchBlockId: string;
 };
 

--- a/packages/ai-core/src/components/ChatRuntimeContext.tsx
+++ b/packages/ai-core/src/components/ChatRuntimeContext.tsx
@@ -80,11 +80,15 @@ export const LocalAgentChatRuntimeProvider: FC<LocalAgentChatRootProps> = ({
   const sendPrompt = useCallback(
     (value?: string, attachments: FileUIPart[] = []) => {
       const text = (value ?? prompt).trim();
-      if (!text || isStreaming) return;
-      void sendMessage({
-        text,
-        ...(attachments.length > 0 ? {files: attachments} : {}),
-      });
+      if ((!text && attachments.length === 0) || isStreaming) return;
+      void sendMessage(
+        text
+          ? {
+              text,
+              ...(attachments.length > 0 ? {files: attachments} : {}),
+            }
+          : {files: attachments},
+      );
       setPrompt('');
     },
     [isStreaming, prompt, sendMessage],

--- a/packages/ai-core/src/components/ChatRuntimeContext.tsx
+++ b/packages/ai-core/src/components/ChatRuntimeContext.tsx
@@ -1,5 +1,11 @@
 import {useChat} from '@ai-sdk/react';
-import type {AbstractChat, ChatStatus, ToolLoopAgent, UIMessage} from 'ai';
+import type {
+  AbstractChat,
+  ChatStatus,
+  FileUIPart,
+  ToolLoopAgent,
+  UIMessage,
+} from 'ai';
 import {
   createContext,
   useCallback,
@@ -24,7 +30,7 @@ export type LocalAgentChatRuntime = {
   isStreaming: boolean;
   prompt: string;
   setPrompt: (value: string) => void;
-  sendPrompt: (value?: string) => void;
+  sendPrompt: (value?: string, attachments?: FileUIPart[]) => void;
   stop: AbstractChat<UIMessage>['stop'];
   initialSuggestions: readonly string[];
   suggestionsVisible: boolean;
@@ -72,10 +78,13 @@ export const LocalAgentChatRuntimeProvider: FC<LocalAgentChatRootProps> = ({
   useMessagesObserver(messages, onMessagesChange);
 
   const sendPrompt = useCallback(
-    (value?: string) => {
+    (value?: string, attachments: FileUIPart[] = []) => {
       const text = (value ?? prompt).trim();
       if (!text || isStreaming) return;
-      void sendMessage({text});
+      void sendMessage({
+        text,
+        ...(attachments.length > 0 ? {files: attachments} : {}),
+      });
       setPrompt('');
     },
     [isStreaming, prompt, sendMessage],

--- a/packages/ai-core/src/components/ChatSearch.tsx
+++ b/packages/ai-core/src/components/ChatSearch.tsx
@@ -181,7 +181,7 @@ export const ChatSearchProvider: React.FC<PropsWithChildren> = ({children}) => {
   useEffect(() => {
     if (!activeMatchId) return;
     const scrollToActiveMatch = () => {
-      document.getElementById(activeMatchId)?.scrollIntoView({
+      document.getElementById(activeMatchId)?.scrollIntoView?.({
         block: 'center',
         inline: 'nearest',
       });
@@ -238,8 +238,7 @@ export const ChatSearchProvider: React.FC<PropsWithChildren> = ({children}) => {
   }, [matches]);
 
   const getMatchesForBlock = useCallback(
-    (blockId: string) =>
-      matchesByBlock.get(blockId) ?? EMPTY_SEARCH_MATCHES,
+    (blockId: string) => matchesByBlock.get(blockId) ?? EMPTY_SEARCH_MATCHES,
     [matchesByBlock],
   );
 

--- a/packages/ai-core/src/components/ChatTurnView.tsx
+++ b/packages/ai-core/src/components/ChatTurnView.tsx
@@ -35,6 +35,10 @@ import {HoistedRenderersProvider} from './HoistedRenderersContext';
 import {processMessageContent} from './MessageContent';
 import {createChatTurnPresentation} from './defaultChatRendering';
 import {useChatTurnContentBinder} from './useChatTurnContentBinder';
+import {
+  getChatAttachmentText,
+  getChatMessageAttachments,
+} from '../chatAttachments';
 
 export type ChatTurnViewProps = {
   /** @deprecated Prefer `chatTurn`; this accepts the legacy derived result shape. */
@@ -88,6 +92,10 @@ export const ChatTurnView: React.FC<ChatTurnViewProps> = ({
   );
   const turnId = chatTurn?.id ?? analysisResult?.id ?? '';
   const prompt = chatTurn?.prompt ?? analysisResult?.prompt ?? '';
+  const promptAttachments = useMemo(
+    () => getChatMessageAttachments(chatTurn?.userMessage),
+    [chatTurn?.userMessage],
+  );
   const isCompleted =
     chatTurn?.isCompleted ?? analysisResult?.isCompleted ?? true;
   const errorMessage = chatTurn?.errorMessage ?? analysisResult?.errorMessage;
@@ -153,6 +161,16 @@ export const ChatTurnView: React.FC<ChatTurnViewProps> = ({
       },
     ];
 
+    promptAttachments.forEach((attachment, index) => {
+      const text = getChatAttachmentText(attachment);
+      if (!text) return;
+      blocks.push({
+        id: `${searchBlockPrefix}:attachment:${index}`,
+        resultId: turnId,
+        text,
+      });
+    });
+
     uiMessageParts.forEach((part, index) => {
       if (isTextPart(part)) {
         const isSuppressed = !model.textItems.some(
@@ -192,6 +210,7 @@ export const ChatTurnView: React.FC<ChatTurnViewProps> = ({
     searchBlockPrefix,
     uiMessageParts,
     model.textItems,
+    promptAttachments,
   ]);
 
   useRegisterChatSearchBlocks(searchBlockPrefix, searchBlocks);
@@ -251,6 +270,7 @@ export const ChatTurnView: React.FC<ChatTurnViewProps> = ({
         turnId,
         model,
         prompt,
+        promptAttachments,
         isCompleted,
         searchBlockPrefix,
         customMarkdownComponents,
@@ -274,6 +294,7 @@ export const ChatTurnView: React.FC<ChatTurnViewProps> = ({
       turnId,
       model,
       prompt,
+      promptAttachments,
       isCompleted,
       searchBlockPrefix,
       customMarkdownComponents,

--- a/packages/ai-core/src/components/ChatTurnView.tsx
+++ b/packages/ai-core/src/components/ChatTurnView.tsx
@@ -9,6 +9,12 @@ import {useAssistantMessageParts} from '../hooks/useAssistantMessageParts';
 import {useToolTimingRecorder} from '../hooks/useToolTimingRecorder';
 import type {AgentToolCall} from '../types';
 import {
+  getChatAttachmentText,
+  getChatMessageAttachments,
+  isMarkdownAttachment,
+  type ChatAttachmentPart,
+} from '../chatAttachments';
+import {
   isDynamicToolPart,
   isReasoningPart,
   isTextPart,
@@ -35,10 +41,6 @@ import {HoistedRenderersProvider} from './HoistedRenderersContext';
 import {processMessageContent} from './MessageContent';
 import {createChatTurnPresentation} from './defaultChatRendering';
 import {useChatTurnContentBinder} from './useChatTurnContentBinder';
-import {
-  getChatAttachmentText,
-  getChatMessageAttachments,
-} from '../chatAttachments';
 
 export type ChatTurnViewProps = {
   /** @deprecated Prefer `chatTurn`; this accepts the legacy derived result shape. */
@@ -57,6 +59,15 @@ const ToolTimingRecorder: React.FC<{
   useToolTimingRecorder(toolCallId, isComplete);
   return null;
 };
+
+/** Returns attachment text normalized to match its rendered search offsets. */
+export function getChatAttachmentSearchText(
+  attachment: ChatAttachmentPart,
+): string | undefined {
+  const text = getChatAttachmentText(attachment);
+  if (!text || !isMarkdownAttachment(attachment)) return text;
+  return markdownToPlainText(processMessageContent(text).processedContent);
+}
 
 export const ChatTurnView: React.FC<ChatTurnViewProps> = ({
   analysisResult,
@@ -162,7 +173,7 @@ export const ChatTurnView: React.FC<ChatTurnViewProps> = ({
     ];
 
     promptAttachments.forEach((attachment, index) => {
-      const text = getChatAttachmentText(attachment);
+      const text = getChatAttachmentSearchText(attachment);
       if (!text) return;
       blocks.push({
         id: `${searchBlockPrefix}:attachment:${index}`,

--- a/packages/ai-core/src/components/ContextUsageIndicator.tsx
+++ b/packages/ai-core/src/components/ContextUsageIndicator.tsx
@@ -8,6 +8,8 @@ import type {AssistantMessageMetadata} from '../types';
 import {buildConversationText} from '../utils';
 
 const DEFAULT_CONTEXT_WINDOW = 200_000;
+// Cross-provider fallback when image dimensions and tokenizer usage are absent.
+const FALLBACK_IMAGE_TOKEN_ESTIMATE = 4_096;
 const USAGE_WARNING_THRESHOLD = 60;
 const USAGE_CRITICAL_THRESHOLD = 80;
 
@@ -106,6 +108,8 @@ export function estimateMessageTokens(msg: UIMessage): number {
       const attachmentText = textAttachmentToModelText(part as FileUIPart);
       if (attachmentText !== undefined) {
         tokens += estimateTokenCount(attachmentText);
+      } else if ((part as FileUIPart).mediaType.startsWith('image/')) {
+        tokens += FALLBACK_IMAGE_TOKEN_ESTIMATE;
       }
     } else if (
       typeof part.type === 'string' &&

--- a/packages/ai-core/src/components/ContextUsageIndicator.tsx
+++ b/packages/ai-core/src/components/ContextUsageIndicator.tsx
@@ -1,8 +1,9 @@
 import {type BaseRoomStoreState, useRoomStoreApi} from '@sqlrooms/room-store';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@sqlrooms/ui';
-import type {UIMessage} from 'ai';
+import type {FileUIPart, UIMessage} from 'ai';
 import {useCallback, useMemo, useRef} from 'react';
 import {type AiSliceState, useStoreWithAi} from '../AiSlice';
+import {textAttachmentToModelText} from '../chatAttachments';
 import type {AssistantMessageMetadata} from '../types';
 import {buildConversationText} from '../utils';
 
@@ -93,13 +94,19 @@ function computeTokenUsage(
   return {contextTokens, cumulativeTokens};
 }
 
-function estimateMessageTokens(msg: UIMessage): number {
+/** Estimates one persisted message when provider-reported usage is absent. */
+export function estimateMessageTokens(msg: UIMessage): number {
   let tokens = 4; // per-message overhead
   for (const part of msg.parts) {
     if (part.type === 'text') {
       tokens += estimateTokenCount((part as {text: string}).text);
     } else if (part.type === 'reasoning') {
       tokens += estimateTokenCount((part as {text?: string}).text ?? '');
+    } else if (part.type === 'file') {
+      const attachmentText = textAttachmentToModelText(part as FileUIPart);
+      if (attachmentText !== undefined) {
+        tokens += estimateTokenCount(attachmentText);
+      }
     } else if (
       typeof part.type === 'string' &&
       (part.type.startsWith('tool-') || part.type === 'dynamic-tool')

--- a/packages/ai-core/src/components/ContextUsageIndicator.tsx
+++ b/packages/ai-core/src/components/ContextUsageIndicator.tsx
@@ -127,6 +127,23 @@ type ContextUsageIndicatorProps = {
   modelName?: string;
 };
 
+/** Summary prompt and visual evidence used to seed a continuation session. */
+export function createConversationContinuationSeed(
+  summary: string,
+  messages: UIMessage[],
+): {prompt: string; attachments: FileUIPart[]} {
+  const attachments = messages.flatMap((message) =>
+    message.parts.filter(
+      (part): part is FileUIPart =>
+        part.type === 'file' && part.mediaType.startsWith('image/'),
+    ),
+  );
+  return {
+    prompt: `Please use the following context from a previous session and only respond "Got it" to this message:\n\n${summary}`,
+    attachments,
+  };
+}
+
 export const ContextUsageIndicator: React.FC<ContextUsageIndicatorProps> = ({
   contextWindow = DEFAULT_CONTEXT_WINDOW,
   modelProvider,
@@ -180,10 +197,15 @@ export const ContextUsageIndicator: React.FC<ContextUsageIndicatorProps> = ({
       const newSessionId = state.ai.config.currentSessionId;
       if (!newSessionId) return;
 
-      const contextMessage = `Please use the following context from a previous session and only respond "Got it" to this message:\n\n${summary}`;
-      state.ai.setPrompt(newSessionId, contextMessage);
+      const continuation = createConversationContinuationSeed(
+        summary,
+        uiMessages,
+      );
+      state.ai.setPrompt(newSessionId, continuation.prompt);
 
-      await storeApi.getState().ai.startAnalysisWhenReady(newSessionId);
+      await storeApi
+        .getState()
+        .ai.startAnalysisWhenReady(newSessionId, continuation.attachments);
     } catch (error) {
       console.error('Failed to summarize conversation:', error);
     } finally {

--- a/packages/ai-core/src/components/ContextUsageIndicator.tsx
+++ b/packages/ai-core/src/components/ContextUsageIndicator.tsx
@@ -4,6 +4,7 @@ import type {UIMessage} from 'ai';
 import {useCallback, useMemo, useRef} from 'react';
 import {type AiSliceState, useStoreWithAi} from '../AiSlice';
 import type {AssistantMessageMetadata} from '../types';
+import {buildConversationText} from '../utils';
 
 const DEFAULT_CONTEXT_WINDOW = 200_000;
 const USAGE_WARNING_THRESHOLD = 60;
@@ -23,20 +24,6 @@ function estimateTokenCount(text: string): number {
   const normalized = text.trim();
   if (!normalized) return 0;
   return Math.ceil(normalized.length / 4);
-}
-
-function buildConversationText(messages: UIMessage[]): string {
-  return messages
-    .map((msg) => {
-      const role = msg.role === 'user' ? 'User' : 'Assistant';
-      const text = msg.parts
-        .filter((p) => p.type === 'text')
-        .map((p) => (p as {text: string}).text)
-        .join('');
-      return `${role}: ${text}`;
-    })
-    .filter((line) => line.length > 6)
-    .join('\n\n');
 }
 
 function getStrokeColor(percentage: number): string {

--- a/packages/ai-core/src/components/LocalAgentChatMessages.tsx
+++ b/packages/ai-core/src/components/LocalAgentChatMessages.tsx
@@ -11,6 +11,8 @@ import {getChatActiveStatus} from './ChatActiveStatus';
 import {useChatRenderingComponents} from './ChatRenderingContext';
 import {useToolRenderBehavior} from './FlatAgentRenderer';
 import {useChatRuntime} from './ChatRuntimeContext';
+import {ChatAttachmentPreview} from './ChatAttachmentPreview';
+import type {ChatAttachmentPart} from '../chatAttachments';
 
 export type LocalAgentChatMessagesProps = {
   className?: string;
@@ -100,6 +102,13 @@ const LocalAgentMessagePart: FC<{
   }
   if (type === 'reasoning') {
     return <ReasoningPart text={(part as {text?: string}).text ?? ''} />;
+  }
+  if (type === 'file') {
+    return (
+      <div className="bg-muted max-w-[75%] rounded-md border p-2">
+        <ChatAttachmentPreview attachment={part as ChatAttachmentPart} />
+      </div>
+    );
   }
   if (type === 'dynamic-tool' || type.startsWith('tool-')) {
     return <LocalAgentToolActivityLine part={part} />;

--- a/packages/ai-core/src/components/composer/ChatComposerContext.tsx
+++ b/packages/ai-core/src/components/composer/ChatComposerContext.tsx
@@ -11,6 +11,10 @@ import {
   useSendsBlocked,
   useVetoableSend,
 } from './beforeSend';
+import {
+  ChatComposerAttachmentsProvider,
+  useChatAttachments,
+} from './attachments';
 
 export type {ChatComposerMode};
 
@@ -81,6 +85,7 @@ export interface ChatComposerState {
  * otherwise.
  */
 function useSessionComposerState(): ChatComposerState {
+  const {attachments, clear: clearAttachments} = useChatAttachments();
   // Select the id, not the session: the session object is replaced as messages
   // stream in, which would re-render every composer on each token.
   const sessionId = useStoreWithAi((s) => s.ai.getCurrentSession()?.id);
@@ -152,15 +157,24 @@ function useSessionComposerState(): ChatComposerState {
         activeSessionId = createSession();
         setPromptAction(activeSessionId, value);
         setDraftPrompt('');
-        void runAnalysisWhenReady(activeSessionId);
+        if (attachments.length > 0) {
+          void runAnalysisWhenReady(activeSessionId, attachments);
+        } else {
+          void runAnalysisWhenReady(activeSessionId);
+        }
       } else {
         // With no override the session's stored prompt is already `value`, so
         // only write it back when a caller supplies different text.
         if (text !== undefined) {
           setPromptAction(activeSessionId, value);
         }
-        runAnalysis(activeSessionId);
+        if (attachments.length > 0) {
+          void runAnalysis(activeSessionId, attachments);
+        } else {
+          void runAnalysis(activeSessionId);
+        }
       }
+      clearAttachments();
     },
     [
       prompt,
@@ -171,6 +185,8 @@ function useSessionComposerState(): ChatComposerState {
       setDraftPrompt,
       runAnalysisWhenReady,
       runAnalysis,
+      attachments,
+      clearAttachments,
     ],
   );
 
@@ -219,6 +235,7 @@ function useLocalAgentComposerState(
   runtime: LocalAgentChatRuntime,
 ): ChatComposerState {
   const {prompt, setPrompt, sendPrompt, stop, isStreaming} = runtime;
+  const {attachments, clear: clearAttachments} = useChatAttachments();
 
   const sendBlocked = useSendsBlocked();
   // Shared by `canSend` and the pre-send wrapper's guard, so a handler cannot
@@ -232,7 +249,16 @@ function useLocalAgentComposerState(
   // `sendPrompt` already matches `send`'s signature and applies the same
   // guards, so only the veto wrapper is added. `stop` returns a promise, so it
   // is wrapped to match `cancel`'s `void` contract.
-  const send = useVetoableSend(sendPrompt, prompt, canSendText);
+  const rawSend = useCallback(
+    (text?: string) => {
+      if (attachments.length > 0) sendPrompt(text, attachments);
+      else if (text === undefined) sendPrompt();
+      else sendPrompt(text);
+      clearAttachments();
+    },
+    [sendPrompt, attachments, clearAttachments],
+  );
+  const send = useVetoableSend(rawSend, prompt, canSendText);
 
   const cancel = useCallback(() => {
     void stop();
@@ -263,17 +289,27 @@ const composerContext = createDualModeChatContext<ChatComposerState>({
   useLocalAgentState: useLocalAgentComposerState,
 });
 
-/** Mounts the veto registry above a state provider, since `send` reads it. */
-const withBeforeSend = (
+/** Mounts composer infrastructure above a state provider, since `send` reads it. */
+const withComposerInfrastructure = (
   Provider: FC<PropsWithChildren>,
   displayName: string,
-): FC<PropsWithChildren> =>
-  withProvider(ChatComposerBeforeSendProvider, Provider, displayName);
+): FC<PropsWithChildren> => {
+  const WithBeforeSend = withProvider(
+    ChatComposerBeforeSendProvider,
+    Provider,
+    `${displayName}BeforeSend`,
+  );
+  return withProvider(
+    ChatComposerAttachmentsProvider,
+    WithBeforeSend,
+    displayName,
+  );
+};
 
 /**
  * Publishes normalized session-mode composer state. Rendered by `Chat.Root`.
  */
-export const SessionChatComposerProvider = withBeforeSend(
+export const SessionChatComposerProvider = withComposerInfrastructure(
   composerContext.SessionProvider,
   'SessionChatComposerProvider',
 );
@@ -282,7 +318,7 @@ export const SessionChatComposerProvider = withBeforeSend(
  * Publishes normalized local-agent-mode composer state. Rendered by
  * `Chat.LocalAgentRoot`, inside its `LocalAgentChatRuntimeProvider`.
  */
-export const LocalAgentChatComposerProvider = withBeforeSend(
+export const LocalAgentChatComposerProvider = withComposerInfrastructure(
   composerContext.LocalAgentProvider,
   'LocalAgentChatComposerProvider',
 );
@@ -295,7 +331,7 @@ export const LocalAgentChatComposerProvider = withBeforeSend(
  * session-mode provider is rendered around them, so a composer used without a
  * `<Chat>` ancestor still works.
  */
-export const ChatComposerStateBoundary = withBeforeSend(
+export const ChatComposerStateBoundary = withComposerInfrastructure(
   composerContext.StateBoundary,
   'ChatComposerStateBoundary',
 );

--- a/packages/ai-core/src/components/composer/ChatComposerContext.tsx
+++ b/packages/ai-core/src/components/composer/ChatComposerContext.tsx
@@ -1,4 +1,11 @@
-import {useCallback, useMemo, type FC, type PropsWithChildren} from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  type FC,
+  type PropsWithChildren,
+} from 'react';
 import {useStoreWithAi} from '../../AiSlice';
 import type {LocalAgentChatRuntime} from '../ChatRuntimeContext';
 import {
@@ -89,6 +96,14 @@ function useSessionComposerState(): ChatComposerState {
   // Select the id, not the session: the session object is replaced as messages
   // stream in, which would re-render every composer on each token.
   const sessionId = useStoreWithAi((s) => s.ai.getCurrentSession()?.id);
+  const previousSessionIdRef = useRef(sessionId);
+
+  useEffect(() => {
+    if (previousSessionIdRef.current !== sessionId) {
+      clearAttachments();
+      previousSessionIdRef.current = sessionId;
+    }
+  }, [sessionId, clearAttachments]);
 
   // Short-circuits: `requiresApiKey()` invokes the host's factory, and this
   // selector re-runs once per streamed token.

--- a/packages/ai-core/src/components/composer/ChatComposerContext.tsx
+++ b/packages/ai-core/src/components/composer/ChatComposerContext.tsx
@@ -59,8 +59,8 @@ export interface ChatComposerState {
   cancel: () => void;
   /**
    * True when {@link send} would currently do something: a model is
-   * resolvable, the prompt is non-empty once trimmed, and nothing is already
-   * running or summarizing.
+   * resolvable, the prompt is non-empty once trimmed or an attachment is
+   * pending, and nothing is already running or summarizing.
    */
   canSend: boolean;
   /** True while a response is being generated. */
@@ -150,22 +150,28 @@ function useSessionComposerState(): ChatComposerState {
   // guard (over an optional override), so the two cannot disagree.
   const sendBlocked = useSendsBlocked();
 
-  const canSendText = useCallback(
+  const canSendInput = useCallback(
     (text: string) =>
       hasResolvableModel &&
       !sendBlocked &&
       !isRunning &&
       !isSummarizing &&
-      text.trim().length > 0,
-    [hasResolvableModel, sendBlocked, isRunning, isSummarizing],
+      (text.trim().length > 0 || attachments.length > 0),
+    [
+      hasResolvableModel,
+      sendBlocked,
+      isRunning,
+      isSummarizing,
+      attachments.length,
+    ],
   );
 
-  const canSend = canSendText(prompt);
+  const canSend = canSendInput(prompt);
 
   const rawSend = useCallback(
     (text?: string) => {
       const value = text ?? prompt;
-      if (!canSendText(value)) return;
+      if (!canSendInput(value)) return;
 
       let activeSessionId = sessionId;
       if (!activeSessionId) {
@@ -193,7 +199,7 @@ function useSessionComposerState(): ChatComposerState {
     },
     [
       prompt,
-      canSendText,
+      canSendInput,
       sessionId,
       createSession,
       setPromptAction,
@@ -205,7 +211,7 @@ function useSessionComposerState(): ChatComposerState {
     ],
   );
 
-  const send = useVetoableSend(rawSend, prompt, canSendText);
+  const send = useVetoableSend(rawSend, prompt, canSendInput);
 
   const cancel = useCallback(() => {
     if (!sessionId) return;
@@ -255,11 +261,14 @@ function useLocalAgentComposerState(
   const sendBlocked = useSendsBlocked();
   // Shared by `canSend` and the pre-send wrapper's guard, so a handler cannot
   // fire for text this mode would refuse to send.
-  const canSendText = useCallback(
-    (text: string) => !isStreaming && !sendBlocked && text.trim().length > 0,
-    [isStreaming, sendBlocked],
+  const canSendInput = useCallback(
+    (text: string) =>
+      !isStreaming &&
+      !sendBlocked &&
+      (text.trim().length > 0 || attachments.length > 0),
+    [isStreaming, sendBlocked, attachments.length],
   );
-  const canSend = canSendText(prompt);
+  const canSend = canSendInput(prompt);
 
   // `sendPrompt` already matches `send`'s signature and applies the same
   // guards, so only the veto wrapper is added. `stop` returns a promise, so it
@@ -273,7 +282,7 @@ function useLocalAgentComposerState(
     },
     [sendPrompt, attachments, clearAttachments],
   );
-  const send = useVetoableSend(rawSend, prompt, canSendText);
+  const send = useVetoableSend(rawSend, prompt, canSendInput);
 
   const cancel = useCallback(() => {
     void stop();

--- a/packages/ai-core/src/components/composer/attachments.tsx
+++ b/packages/ai-core/src/components/composer/attachments.tsx
@@ -21,8 +21,8 @@ import {ChatAttachmentPreview} from '../ChatAttachmentPreview';
 import {useBlockSends} from './beforeSend';
 
 const DEFAULT_ACCEPT = 'image/*,.txt,.md,.markdown,text/plain,text/markdown';
-const DEFAULT_MAX_FILES = 8;
-const DEFAULT_MAX_FILE_SIZE = 10 * 1024 * 1024;
+const DEFAULT_MAX_FILES = 4;
+const DEFAULT_MAX_FILE_SIZE = 2 * 1024 * 1024;
 const DEFAULT_MAX_TEXT_FILE_SIZE = 1024 * 1024;
 
 /** Transient files and actions shared by attachment UI under one chat root. */
@@ -37,7 +37,23 @@ export type ChatAttachmentsState = {
   clear: () => void;
 };
 
-const ChatAttachmentsContext = createContext<ChatAttachmentsState | null>(null);
+type ChatAttachmentsContextValue = ChatAttachmentsState & {
+  getRevision: () => number;
+  appendAtRevision: (attachments: FileUIPart[], revision: number) => void;
+};
+
+const ChatAttachmentsContext =
+  createContext<ChatAttachmentsContextValue | null>(null);
+
+function useChatAttachmentsContext(): ChatAttachmentsContextValue {
+  const value = useContext(ChatAttachmentsContext);
+  if (!value) {
+    throw new Error(
+      'useChatAttachments must be used under Chat.Root, Chat.LocalAgentRoot, or ChatComposerStateBoundary.',
+    );
+  }
+  return value;
+}
 
 /** Holds transient attachments for one chat composer tree. */
 export const ChatComposerAttachmentsProvider: FC<PropsWithChildren> = ({
@@ -45,6 +61,7 @@ export const ChatComposerAttachmentsProvider: FC<PropsWithChildren> = ({
 }) => {
   const inherited = useContext(ChatAttachmentsContext);
   const [attachments, setAttachments] = useState<FileUIPart[]>([]);
+  const revisionRef = useRef(0);
 
   const append = useCallback((next: FileUIPart[]) => {
     setAttachments((current) => [...current, ...next]);
@@ -52,10 +69,28 @@ export const ChatComposerAttachmentsProvider: FC<PropsWithChildren> = ({
   const remove = useCallback((attachment: FileUIPart) => {
     setAttachments((current) => current.filter((item) => item !== attachment));
   }, []);
-  const clear = useCallback(() => setAttachments([]), []);
+  const clear = useCallback(() => {
+    revisionRef.current += 1;
+    setAttachments([]);
+  }, []);
+  const getRevision = useCallback(() => revisionRef.current, []);
+  const appendAtRevision = useCallback(
+    (next: FileUIPart[], revision: number) => {
+      if (revisionRef.current !== revision) return;
+      setAttachments((current) => [...current, ...next]);
+    },
+    [],
+  );
   const value = useMemo(
-    () => ({attachments, append, remove, clear}),
-    [attachments, append, remove, clear],
+    () => ({
+      attachments,
+      append,
+      remove,
+      clear,
+      getRevision,
+      appendAtRevision,
+    }),
+    [attachments, append, remove, clear, getRevision, appendAtRevision],
   );
 
   if (inherited) return <>{children}</>;
@@ -68,15 +103,16 @@ export const ChatComposerAttachmentsProvider: FC<PropsWithChildren> = ({
 
 /** Reads and manages the transient attachments for the current composer. */
 export function useChatAttachments(): ChatAttachmentsState {
-  const value = useContext(ChatAttachmentsContext);
-  if (!value) {
-    throw new Error(
-      'useChatAttachments must be used under Chat.Root, Chat.LocalAgentRoot, or ChatComposerStateBoundary.',
-    );
-  }
-  return value;
+  return useChatAttachmentsContext();
 }
 
+/**
+ * Configuration for the opt-in composer attachment picker.
+ *
+ * By default it accepts up to four files, limits images to 2 MiB each, and
+ * limits plain-text or Markdown files to 1 MiB each. Unsupported, oversized,
+ * or excess files are rejected and reported through {@link onError}.
+ */
 export type ChatComposerAttachmentsProps = {
   className?: string;
   /** Native file-input accept value. */
@@ -103,7 +139,8 @@ export const Attachments: FC<ChatComposerAttachmentsProps> = ({
   maxTextFileSize = DEFAULT_MAX_TEXT_FILE_SIZE,
   onError,
 }) => {
-  const {attachments, append, remove} = useChatAttachments();
+  const attachmentState = useChatAttachmentsContext();
+  const {attachments, remove, getRevision, appendAtRevision} = attachmentState;
   const inputRef = useRef<HTMLInputElement>(null);
   const [error, setError] = useState<string>();
   const [isReading, setIsReading] = useState(false);
@@ -146,9 +183,13 @@ export const Attachments: FC<ChatComposerAttachmentsProps> = ({
       }
       if (accepted.length === 0) return;
 
+      const revision = getRevision();
       setIsReading(true);
       try {
-        append(await Promise.all(accepted.map(fileToChatAttachmentPart)));
+        appendAtRevision(
+          await Promise.all(accepted.map(fileToChatAttachmentPart)),
+          revision,
+        );
       } catch (readError) {
         reportError(
           readError instanceof Error
@@ -161,7 +202,8 @@ export const Attachments: FC<ChatComposerAttachmentsProps> = ({
     },
     [
       attachments.length,
-      append,
+      appendAtRevision,
+      getRevision,
       maxFiles,
       maxFileSize,
       maxTextFileSize,

--- a/packages/ai-core/src/components/composer/attachments.tsx
+++ b/packages/ai-core/src/components/composer/attachments.tsx
@@ -1,5 +1,13 @@
-import {Button, cn} from '@sqlrooms/ui';
-import {PaperclipIcon, XIcon} from 'lucide-react';
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+  cn,
+} from '@sqlrooms/ui';
+import {FileTextIcon, ImageIcon, PaperclipIcon, XIcon} from 'lucide-react';
 import {
   createContext,
   useCallback,
@@ -21,7 +29,9 @@ import {
 import {ChatAttachmentPreview} from '../ChatAttachmentPreview';
 import {useBlockSends} from './beforeSend';
 
-const DEFAULT_ACCEPT = 'image/*,.txt,.md,.markdown,text/plain,text/markdown';
+const DEFAULT_IMAGE_ACCEPT = 'image/*';
+const DEFAULT_TEXT_ACCEPT =
+  '.txt,.md,.markdown,.mdown,.mkd,text/plain,text/markdown';
 const DEFAULT_MAX_FILES = 4;
 const DEFAULT_MAX_FILE_SIZE = 2 * 1024 * 1024;
 const DEFAULT_MAX_TEXT_FILE_SIZE = 128 * 1024;
@@ -118,8 +128,10 @@ export function useChatAttachments(): ChatAttachmentsState {
  */
 export type ChatComposerAttachmentsProps = {
   className?: string;
-  /** Native file-input accept value. */
-  accept?: string;
+  /** Native file-input accept value for the image choice. */
+  imageAccept?: string;
+  /** Native file-input accept value for the text or Markdown choice. */
+  textAccept?: string;
   /** Maximum number of files waiting in the composer. */
   maxFiles?: number;
   /** Maximum image size in bytes. */
@@ -138,7 +150,8 @@ export type ChatComposerAttachmentsProps = {
  */
 export const Attachments: FC<ChatComposerAttachmentsProps> = ({
   className,
-  accept = DEFAULT_ACCEPT,
+  imageAccept = DEFAULT_IMAGE_ACCEPT,
+  textAccept = DEFAULT_TEXT_ACCEPT,
   maxFiles = DEFAULT_MAX_FILES,
   maxFileSize = DEFAULT_MAX_FILE_SIZE,
   maxTextFileSize = DEFAULT_MAX_TEXT_FILE_SIZE,
@@ -147,7 +160,8 @@ export const Attachments: FC<ChatComposerAttachmentsProps> = ({
 }) => {
   const attachmentState = useChatAttachmentsContext();
   const {attachments, remove, getRevision, appendAtRevision} = attachmentState;
-  const inputRef = useRef<HTMLInputElement>(null);
+  const imageInputRef = useRef<HTMLInputElement>(null);
+  const textInputRef = useRef<HTMLInputElement>(null);
   const [error, setError] = useState<string>();
   const [isReading, setIsReading] = useState(false);
 
@@ -243,26 +257,67 @@ export const Attachments: FC<ChatComposerAttachmentsProps> = ({
   return (
     <div className={cn('flex items-center gap-2', className)}>
       <input
-        ref={inputRef}
+        ref={imageInputRef}
         type="file"
         className="sr-only"
-        accept={accept}
+        accept={imageAccept}
         multiple
         onChange={handleChange}
-        aria-label="Attach files"
+        aria-label="Attach image files"
       />
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon"
-        className="h-7 w-7 shrink-0"
-        aria-label="Attach images or text files"
-        title="Attach images or text files"
-        disabled={isReading || attachments.length >= maxFiles}
-        onClick={() => inputRef.current?.click()}
-      >
-        <PaperclipIcon className="h-4 w-4" />
-      </Button>
+      <input
+        ref={textInputRef}
+        type="file"
+        className="sr-only"
+        accept={textAccept}
+        multiple
+        onChange={handleChange}
+        aria-label="Attach text or Markdown files"
+      />
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 shrink-0"
+            aria-label="Attach files"
+            title="Attach files"
+            disabled={isReading || attachments.length >= maxFiles}
+          >
+            <PaperclipIcon className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" side="top" className="w-64">
+          <DropdownMenuLabel className="text-muted-foreground text-xs">
+            Supported files
+          </DropdownMenuLabel>
+          <DropdownMenuItem
+            className="items-start gap-2 p-2"
+            onSelect={() => imageInputRef.current?.click()}
+          >
+            <ImageIcon className="mt-0.5" />
+            <span className="grid gap-0.5">
+              <span>Image</span>
+              <span className="text-muted-foreground text-xs font-normal">
+                Any image format
+              </span>
+            </span>
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="items-start gap-2 p-2"
+            onSelect={() => textInputRef.current?.click()}
+          >
+            <FileTextIcon className="mt-0.5" />
+            <span className="grid gap-0.5">
+              <span>Text or Markdown</span>
+              <span className="text-muted-foreground text-xs font-normal">
+                .txt, .md, .markdown, .mdown, .mkd
+              </span>
+            </span>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
       {attachments.map((attachment, index) => (
         <div
           key={`${attachment.filename ?? 'attachment'}-${index}`}

--- a/packages/ai-core/src/components/composer/attachments.tsx
+++ b/packages/ai-core/src/components/composer/attachments.tsx
@@ -41,23 +41,24 @@ const DEFAULT_MAX_TOTAL_TEXT_FILE_SIZE = 128 * 1024;
 export type ChatAttachmentsState = {
   /** Files waiting to be included in the next user message. */
   attachments: FileUIPart[];
-  /** Adds already-serialized AI SDK file parts. */
+  /** Adds already-serialized AI SDK file parts without asynchronous work. */
   append: (attachments: FileUIPart[]) => void;
+  /**
+   * Prepares files asynchronously and appends them only if the composer state
+   * has not been cleared while the work is pending.
+   *
+   * @returns Whether the prepared attachments were still current and appended.
+   */
+  appendAsync: (prepare: () => Promise<FileUIPart[]>) => Promise<boolean>;
   /** Removes one pending file part by identity. */
   remove: (attachment: FileUIPart) => void;
   /** Removes every pending attachment. */
   clear: () => void;
 };
 
-type ChatAttachmentsContextValue = ChatAttachmentsState & {
-  getRevision: () => number;
-  appendAtRevision: (attachments: FileUIPart[], revision: number) => void;
-};
+const ChatAttachmentsContext = createContext<ChatAttachmentsState | null>(null);
 
-const ChatAttachmentsContext =
-  createContext<ChatAttachmentsContextValue | null>(null);
-
-function useChatAttachmentsContext(): ChatAttachmentsContextValue {
+function useChatAttachmentsContext(): ChatAttachmentsState {
   const value = useContext(ChatAttachmentsContext);
   if (!value) {
     throw new Error(
@@ -78,6 +79,18 @@ export const ChatComposerAttachmentsProvider: FC<PropsWithChildren> = ({
   const append = useCallback((next: FileUIPart[]) => {
     setAttachments((current) => [...current, ...next]);
   }, []);
+  const appendAsync = useCallback(
+    async (prepare: () => Promise<FileUIPart[]>): Promise<boolean> => {
+      const revision = revisionRef.current;
+      const next = await prepare();
+      if (revisionRef.current !== revision) return false;
+      if (next.length > 0) {
+        setAttachments((current) => [...current, ...next]);
+      }
+      return true;
+    },
+    [],
+  );
   const remove = useCallback((attachment: FileUIPart) => {
     setAttachments((current) => current.filter((item) => item !== attachment));
   }, []);
@@ -85,24 +98,15 @@ export const ChatComposerAttachmentsProvider: FC<PropsWithChildren> = ({
     revisionRef.current += 1;
     setAttachments([]);
   }, []);
-  const getRevision = useCallback(() => revisionRef.current, []);
-  const appendAtRevision = useCallback(
-    (next: FileUIPart[], revision: number) => {
-      if (revisionRef.current !== revision) return;
-      setAttachments((current) => [...current, ...next]);
-    },
-    [],
-  );
   const value = useMemo(
     () => ({
       attachments,
       append,
+      appendAsync,
       remove,
       clear,
-      getRevision,
-      appendAtRevision,
     }),
-    [attachments, append, remove, clear, getRevision, appendAtRevision],
+    [attachments, append, appendAsync, remove, clear],
   );
 
   if (inherited) return <>{children}</>;
@@ -159,7 +163,7 @@ export const Attachments: FC<ChatComposerAttachmentsProps> = ({
   onError,
 }) => {
   const attachmentState = useChatAttachmentsContext();
-  const {attachments, remove, getRevision, appendAtRevision} = attachmentState;
+  const {attachments, appendAsync, remove} = attachmentState;
   const imageInputRef = useRef<HTMLInputElement>(null);
   const textInputRef = useRef<HTMLInputElement>(null);
   const [error, setError] = useState<string>();
@@ -216,12 +220,10 @@ export const Attachments: FC<ChatComposerAttachmentsProps> = ({
       }
       if (accepted.length === 0) return;
 
-      const revision = getRevision();
       setIsReading(true);
       try {
-        appendAtRevision(
-          await Promise.all(accepted.map(fileToChatAttachmentPart)),
-          revision,
+        await appendAsync(() =>
+          Promise.all(accepted.map(fileToChatAttachmentPart)),
         );
       } catch (readError) {
         reportError(
@@ -235,8 +237,7 @@ export const Attachments: FC<ChatComposerAttachmentsProps> = ({
     },
     [
       attachments,
-      appendAtRevision,
-      getRevision,
+      appendAsync,
       maxFiles,
       maxFileSize,
       maxTextFileSize,

--- a/packages/ai-core/src/components/composer/attachments.tsx
+++ b/packages/ai-core/src/components/composer/attachments.tsx
@@ -33,9 +33,26 @@ const DEFAULT_IMAGE_ACCEPT = 'image/*';
 const DEFAULT_TEXT_ACCEPT =
   '.txt,.md,.markdown,.mdown,.mkd,text/plain,text/markdown';
 const DEFAULT_MAX_FILES = 4;
-const DEFAULT_MAX_FILE_SIZE = 2 * 1024 * 1024;
+const DEFAULT_MAX_FILE_SIZE = 1024 * 1024;
+const DEFAULT_MAX_TOTAL_IMAGE_FILE_SIZE = 1024 * 1024;
 const DEFAULT_MAX_TEXT_FILE_SIZE = 128 * 1024;
 const DEFAULT_MAX_TOTAL_TEXT_FILE_SIZE = 128 * 1024;
+
+function estimateAttachmentPayloadSize(url: string): number {
+  const commaIndex = url.indexOf(',');
+  if (commaIndex < 0) return new TextEncoder().encode(url).byteLength;
+  const header = url.slice(0, commaIndex);
+  const payload = url.slice(commaIndex + 1);
+  if (!header.includes(';base64')) {
+    try {
+      return new TextEncoder().encode(decodeURIComponent(payload)).byteLength;
+    } catch {
+      return new TextEncoder().encode(url).byteLength;
+    }
+  }
+  const padding = payload.endsWith('==') ? 2 : payload.endsWith('=') ? 1 : 0;
+  return Math.max(0, Math.floor((payload.length * 3) / 4) - padding);
+}
 
 /** Transient files and actions shared by attachment UI under one chat root. */
 export type ChatAttachmentsState = {
@@ -125,8 +142,9 @@ export function useChatAttachments(): ChatAttachmentsState {
 /**
  * Configuration for the opt-in composer attachment picker.
  *
- * By default it accepts up to four files, limits images to 2 MiB each, and
- * limits plain-text or Markdown files to 128 KiB each and in aggregate.
+ * By default it accepts up to four files, limits images to 1 MiB each and in
+ * aggregate, and limits plain-text or Markdown files to 128 KiB each and in
+ * aggregate.
  * Unsupported, oversized, or excess files are rejected and reported through
  * {@link onError}.
  */
@@ -140,6 +158,8 @@ export type ChatComposerAttachmentsProps = {
   maxFiles?: number;
   /** Maximum image size in bytes. */
   maxFileSize?: number;
+  /** Maximum combined size of pending image files in bytes. */
+  maxTotalImageFileSize?: number;
   /** Maximum text or Markdown size in bytes. */
   maxTextFileSize?: number;
   /** Maximum combined size of pending text and Markdown files in bytes. */
@@ -158,6 +178,7 @@ export const Attachments: FC<ChatComposerAttachmentsProps> = ({
   textAccept = DEFAULT_TEXT_ACCEPT,
   maxFiles = DEFAULT_MAX_FILES,
   maxFileSize = DEFAULT_MAX_FILE_SIZE,
+  maxTotalImageFileSize = DEFAULT_MAX_TOTAL_IMAGE_FILE_SIZE,
   maxTextFileSize = DEFAULT_MAX_TEXT_FILE_SIZE,
   maxTotalTextFileSize = DEFAULT_MAX_TOTAL_TEXT_FILE_SIZE,
   onError,
@@ -189,6 +210,13 @@ export const Attachments: FC<ChatComposerAttachmentsProps> = ({
       }
 
       const accepted: File[] = [];
+      let totalImageFileSize = attachments.reduce(
+        (total, attachment) =>
+          attachment.mediaType.startsWith('image/')
+            ? total + estimateAttachmentPayloadSize(attachment.url)
+            : total,
+        0,
+      );
       let totalTextFileSize = attachments.reduce((total, attachment) => {
         const text = getChatAttachmentText(attachment);
         return text === undefined
@@ -206,13 +234,23 @@ export const Attachments: FC<ChatComposerAttachmentsProps> = ({
           reportError(`${file.name} is too large.`);
           continue;
         }
+        if (!isText && totalImageFileSize + file.size > maxTotalImageFileSize) {
+          reportError(
+            `${file.name} exceeds the combined image attachment limit.`,
+          );
+          continue;
+        }
         if (isText && totalTextFileSize + file.size > maxTotalTextFileSize) {
           reportError(
             `${file.name} exceeds the combined text attachment limit.`,
           );
           continue;
         }
-        if (isText) totalTextFileSize += file.size;
+        if (isText) {
+          totalTextFileSize += file.size;
+        } else {
+          totalImageFileSize += file.size;
+        }
         accepted.push(file);
       }
       if (files.length > remaining) {
@@ -240,6 +278,7 @@ export const Attachments: FC<ChatComposerAttachmentsProps> = ({
       appendAsync,
       maxFiles,
       maxFileSize,
+      maxTotalImageFileSize,
       maxTextFileSize,
       maxTotalTextFileSize,
       reportError,

--- a/packages/ai-core/src/components/composer/attachments.tsx
+++ b/packages/ai-core/src/components/composer/attachments.tsx
@@ -1,0 +1,232 @@
+import {Button, cn} from '@sqlrooms/ui';
+import {PaperclipIcon, XIcon} from 'lucide-react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type FC,
+  type PropsWithChildren,
+} from 'react';
+import type {FileUIPart} from 'ai';
+import {
+  fileToChatAttachmentPart,
+  getChatAttachmentMediaType,
+  isSupportedChatAttachment,
+} from '../../chatAttachments';
+import {ChatAttachmentPreview} from '../ChatAttachmentPreview';
+import {useBlockSends} from './beforeSend';
+
+const DEFAULT_ACCEPT = 'image/*,.txt,.md,.markdown,text/plain,text/markdown';
+const DEFAULT_MAX_FILES = 8;
+const DEFAULT_MAX_FILE_SIZE = 10 * 1024 * 1024;
+const DEFAULT_MAX_TEXT_FILE_SIZE = 1024 * 1024;
+
+/** Transient files and actions shared by attachment UI under one chat root. */
+export type ChatAttachmentsState = {
+  /** Files waiting to be included in the next user message. */
+  attachments: FileUIPart[];
+  /** Adds already-serialized AI SDK file parts. */
+  append: (attachments: FileUIPart[]) => void;
+  /** Removes one pending file part by identity. */
+  remove: (attachment: FileUIPart) => void;
+  /** Removes every pending attachment. */
+  clear: () => void;
+};
+
+const ChatAttachmentsContext = createContext<ChatAttachmentsState | null>(null);
+
+/** Holds transient attachments for one chat composer tree. */
+export const ChatComposerAttachmentsProvider: FC<PropsWithChildren> = ({
+  children,
+}) => {
+  const inherited = useContext(ChatAttachmentsContext);
+  const [attachments, setAttachments] = useState<FileUIPart[]>([]);
+
+  const append = useCallback((next: FileUIPart[]) => {
+    setAttachments((current) => [...current, ...next]);
+  }, []);
+  const remove = useCallback((attachment: FileUIPart) => {
+    setAttachments((current) => current.filter((item) => item !== attachment));
+  }, []);
+  const clear = useCallback(() => setAttachments([]), []);
+  const value = useMemo(
+    () => ({attachments, append, remove, clear}),
+    [attachments, append, remove, clear],
+  );
+
+  if (inherited) return <>{children}</>;
+  return (
+    <ChatAttachmentsContext.Provider value={value}>
+      {children}
+    </ChatAttachmentsContext.Provider>
+  );
+};
+
+/** Reads and manages the transient attachments for the current composer. */
+export function useChatAttachments(): ChatAttachmentsState {
+  const value = useContext(ChatAttachmentsContext);
+  if (!value) {
+    throw new Error(
+      'useChatAttachments must be used under Chat.Root, Chat.LocalAgentRoot, or ChatComposerStateBoundary.',
+    );
+  }
+  return value;
+}
+
+export type ChatComposerAttachmentsProps = {
+  className?: string;
+  /** Native file-input accept value. */
+  accept?: string;
+  /** Maximum number of files waiting in the composer. */
+  maxFiles?: number;
+  /** Maximum image size in bytes. */
+  maxFileSize?: number;
+  /** Maximum text or Markdown size in bytes. */
+  maxTextFileSize?: number;
+  /** Called when one or more selected files cannot be attached. */
+  onError?: (message: string) => void;
+};
+
+/**
+ * Opt-in attachment controls for {@link QueryControls}. Add as a
+ * `Chat.Composer` child to enable image and text/Markdown attachments.
+ */
+export const Attachments: FC<ChatComposerAttachmentsProps> = ({
+  className,
+  accept = DEFAULT_ACCEPT,
+  maxFiles = DEFAULT_MAX_FILES,
+  maxFileSize = DEFAULT_MAX_FILE_SIZE,
+  maxTextFileSize = DEFAULT_MAX_TEXT_FILE_SIZE,
+  onError,
+}) => {
+  const {attachments, append, remove} = useChatAttachments();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [error, setError] = useState<string>();
+  const [isReading, setIsReading] = useState(false);
+
+  useBlockSends(isReading);
+
+  const reportError = useCallback(
+    (message: string) => {
+      setError(message);
+      onError?.(message);
+    },
+    [onError],
+  );
+
+  const addFiles = useCallback(
+    async (files: File[]) => {
+      setError(undefined);
+      const remaining = Math.max(0, maxFiles - attachments.length);
+      if (remaining === 0) {
+        reportError(`You can attach up to ${maxFiles} files.`);
+        return;
+      }
+
+      const accepted: File[] = [];
+      for (const file of files.slice(0, remaining)) {
+        if (!isSupportedChatAttachment(file)) {
+          reportError(`${file.name} is not a supported image or text file.`);
+          continue;
+        }
+        const isText = !getChatAttachmentMediaType(file).startsWith('image/');
+        const sizeLimit = isText ? maxTextFileSize : maxFileSize;
+        if (file.size > sizeLimit) {
+          reportError(`${file.name} is too large.`);
+          continue;
+        }
+        accepted.push(file);
+      }
+      if (files.length > remaining) {
+        reportError(`You can attach up to ${maxFiles} files.`);
+      }
+      if (accepted.length === 0) return;
+
+      setIsReading(true);
+      try {
+        append(await Promise.all(accepted.map(fileToChatAttachmentPart)));
+      } catch (readError) {
+        reportError(
+          readError instanceof Error
+            ? readError.message
+            : 'Could not read the selected file.',
+        );
+      } finally {
+        setIsReading(false);
+      }
+    },
+    [
+      attachments.length,
+      append,
+      maxFiles,
+      maxFileSize,
+      maxTextFileSize,
+      reportError,
+    ],
+  );
+
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const files = Array.from(event.currentTarget.files ?? []);
+      event.currentTarget.value = '';
+      void addFiles(files);
+    },
+    [addFiles],
+  );
+
+  return (
+    <div className={cn('flex items-center gap-2', className)}>
+      <input
+        ref={inputRef}
+        type="file"
+        className="sr-only"
+        accept={accept}
+        multiple
+        onChange={handleChange}
+        aria-label="Attach files"
+      />
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="h-7 w-7 shrink-0"
+        aria-label="Attach images or text files"
+        title="Attach images or text files"
+        disabled={isReading || attachments.length >= maxFiles}
+        onClick={() => inputRef.current?.click()}
+      >
+        <PaperclipIcon className="h-4 w-4" />
+      </Button>
+      {attachments.map((attachment, index) => (
+        <div
+          key={`${attachment.filename ?? 'attachment'}-${index}`}
+          className="bg-background relative shrink-0 rounded-md border"
+        >
+          <ChatAttachmentPreview attachment={attachment} compact />
+          <Button
+            type="button"
+            variant="secondary"
+            size="icon"
+            className="absolute -top-1.5 -right-1.5 h-5 w-5 rounded-full"
+            aria-label={`Remove ${attachment.filename ?? 'attachment'}`}
+            onClick={() => remove(attachment)}
+          >
+            <XIcon className="h-3 w-3" />
+          </Button>
+        </div>
+      ))}
+      {error ? (
+        <span
+          className="text-destructive max-w-48 truncate text-xs"
+          role="alert"
+        >
+          {error}
+        </span>
+      ) : null}
+    </div>
+  );
+};

--- a/packages/ai-core/src/components/composer/attachments.tsx
+++ b/packages/ai-core/src/components/composer/attachments.tsx
@@ -15,6 +15,7 @@ import type {FileUIPart} from 'ai';
 import {
   fileToChatAttachmentPart,
   getChatAttachmentMediaType,
+  getChatAttachmentText,
   isSupportedChatAttachment,
 } from '../../chatAttachments';
 import {ChatAttachmentPreview} from '../ChatAttachmentPreview';
@@ -23,7 +24,8 @@ import {useBlockSends} from './beforeSend';
 const DEFAULT_ACCEPT = 'image/*,.txt,.md,.markdown,text/plain,text/markdown';
 const DEFAULT_MAX_FILES = 4;
 const DEFAULT_MAX_FILE_SIZE = 2 * 1024 * 1024;
-const DEFAULT_MAX_TEXT_FILE_SIZE = 1024 * 1024;
+const DEFAULT_MAX_TEXT_FILE_SIZE = 128 * 1024;
+const DEFAULT_MAX_TOTAL_TEXT_FILE_SIZE = 128 * 1024;
 
 /** Transient files and actions shared by attachment UI under one chat root. */
 export type ChatAttachmentsState = {
@@ -110,8 +112,9 @@ export function useChatAttachments(): ChatAttachmentsState {
  * Configuration for the opt-in composer attachment picker.
  *
  * By default it accepts up to four files, limits images to 2 MiB each, and
- * limits plain-text or Markdown files to 1 MiB each. Unsupported, oversized,
- * or excess files are rejected and reported through {@link onError}.
+ * limits plain-text or Markdown files to 128 KiB each and in aggregate.
+ * Unsupported, oversized, or excess files are rejected and reported through
+ * {@link onError}.
  */
 export type ChatComposerAttachmentsProps = {
   className?: string;
@@ -123,6 +126,8 @@ export type ChatComposerAttachmentsProps = {
   maxFileSize?: number;
   /** Maximum text or Markdown size in bytes. */
   maxTextFileSize?: number;
+  /** Maximum combined size of pending text and Markdown files in bytes. */
+  maxTotalTextFileSize?: number;
   /** Called when one or more selected files cannot be attached. */
   onError?: (message: string) => void;
 };
@@ -137,6 +142,7 @@ export const Attachments: FC<ChatComposerAttachmentsProps> = ({
   maxFiles = DEFAULT_MAX_FILES,
   maxFileSize = DEFAULT_MAX_FILE_SIZE,
   maxTextFileSize = DEFAULT_MAX_TEXT_FILE_SIZE,
+  maxTotalTextFileSize = DEFAULT_MAX_TOTAL_TEXT_FILE_SIZE,
   onError,
 }) => {
   const attachmentState = useChatAttachmentsContext();
@@ -165,6 +171,12 @@ export const Attachments: FC<ChatComposerAttachmentsProps> = ({
       }
 
       const accepted: File[] = [];
+      let totalTextFileSize = attachments.reduce((total, attachment) => {
+        const text = getChatAttachmentText(attachment);
+        return text === undefined
+          ? total
+          : total + new TextEncoder().encode(text).byteLength;
+      }, 0);
       for (const file of files.slice(0, remaining)) {
         if (!isSupportedChatAttachment(file)) {
           reportError(`${file.name} is not a supported image or text file.`);
@@ -176,6 +188,13 @@ export const Attachments: FC<ChatComposerAttachmentsProps> = ({
           reportError(`${file.name} is too large.`);
           continue;
         }
+        if (isText && totalTextFileSize + file.size > maxTotalTextFileSize) {
+          reportError(
+            `${file.name} exceeds the combined text attachment limit.`,
+          );
+          continue;
+        }
+        if (isText) totalTextFileSize += file.size;
         accepted.push(file);
       }
       if (files.length > remaining) {
@@ -201,12 +220,13 @@ export const Attachments: FC<ChatComposerAttachmentsProps> = ({
       }
     },
     [
-      attachments.length,
+      attachments,
       appendAtRevision,
       getRevision,
       maxFiles,
       maxFileSize,
       maxTextFileSize,
+      maxTotalTextFileSize,
       reportError,
     ],
   );

--- a/packages/ai-core/src/components/composer/beforeSend.tsx
+++ b/packages/ai-core/src/components/composer/beforeSend.tsx
@@ -157,13 +157,13 @@ export function useBlockSends(enabled = true): void {
  *
  * @param send - The mode's raw send action.
  * @param prompt - Used as the veto's argument when `send` gets no text.
- * @param canSendText - The mode's readiness predicate, consulted before any
+ * @param canSend - The mode's readiness predicate, consulted before any
  *   handler runs so a vetoed-or-impossible send triggers no side effects.
  */
 export function useVetoableSend(
   send: (text?: string) => void,
   prompt: string,
-  canSendText: (text: string) => boolean,
+  canSend: (text: string) => boolean,
 ): (text?: string) => void {
   const {run, blocked} = useBeforeSendRegistry();
   return useCallback(
@@ -172,11 +172,11 @@ export function useVetoableSend(
       const text = args[0] ?? prompt;
       // Readiness before vetoes: handlers have side effects, and `send` is
       // documented as a no-op when sending isn't possible.
-      if (blocked || !canSendText(text)) return;
+      if (blocked || !canSend(text)) return;
       if (!run(text)) return;
       send(...args);
     },
-    [run, blocked, canSendText, send, prompt],
+    [run, blocked, canSend, send, prompt],
   );
 }
 

--- a/packages/ai-core/src/components/composer/index.ts
+++ b/packages/ai-core/src/components/composer/index.ts
@@ -23,3 +23,9 @@ export type {ChatComposerStopProps} from './Stop';
 
 export {DropTarget} from './DropTarget';
 export type {ChatComposerDropTargetProps} from './DropTarget';
+
+export {Attachments, useChatAttachments} from './attachments';
+export type {
+  ChatAttachmentsState,
+  ChatComposerAttachmentsProps,
+} from './attachments';

--- a/packages/ai-core/src/components/defaultChatRendering.tsx
+++ b/packages/ai-core/src/components/defaultChatRendering.tsx
@@ -48,14 +48,27 @@ import {
   type ChatTurnTextItem,
 } from './buildChatTurnModel';
 import type {ChatTurnContentBinder} from './useChatTurnContentBinder';
+import type {ChatAttachmentPart} from '../chatAttachments';
+import {ChatAttachmentPreview} from './ChatAttachmentPreview';
 
 /** SQLRooms default user-prompt presentation. */
 export const DefaultChatPrompt: React.FC<ChatPromptProps> = ({
   prompt,
+  attachments,
   searchBlockId,
 }) => (
-  <div className="group/prompt bg-muted relative ml-auto flex w-fit max-w-[85%] items-start rounded-md border p-2 text-sm">
-    <div className="min-w-0 flex-1">
+  <div className="group/prompt bg-muted relative ml-auto flex w-fit max-w-[85%] flex-col gap-2 rounded-md border p-2 text-sm">
+    {attachments.length > 0 ? (
+      <div className="flex max-w-full flex-wrap justify-end gap-2">
+        {attachments.map((attachment, index) => (
+          <ChatAttachmentPreview
+            key={`${attachment.filename ?? 'attachment'}-${index}`}
+            attachment={attachment}
+          />
+        ))}
+      </div>
+    ) : null}
+    <div className="min-w-0">
       <ExpandableContent maxHeight={60} showLabels={false}>
         <div className="break-words">
           <HighlightedChatSearchText blockId={searchBlockId} text={prompt} />
@@ -232,6 +245,7 @@ type CreateChatTurnPresentationOptions = {
   turnId: string;
   model: ChatTurnModel;
   prompt: string;
+  promptAttachments: readonly ChatAttachmentPart[];
   isCompleted: boolean;
   searchBlockPrefix: string;
   customMarkdownComponents?: Partial<Components>;
@@ -258,6 +272,7 @@ export function createChatTurnPresentation({
   turnId,
   model,
   prompt,
+  promptAttachments,
   isCompleted,
   searchBlockPrefix,
   customMarkdownComponents,
@@ -285,7 +300,11 @@ export function createChatTurnPresentation({
     Actions,
   } = components;
   const PromptContent = bindContent('prompt', () => (
-    <Prompt prompt={prompt} searchBlockId={`${searchBlockPrefix}:prompt`} />
+    <Prompt
+      prompt={prompt}
+      attachments={promptAttachments}
+      searchBlockId={`${searchBlockPrefix}:prompt`}
+    />
   ));
 
   const isActivityRunning =
@@ -564,7 +583,11 @@ export function createChatTurnPresentation({
   return {
     id: turnId,
     isCompleted,
-    prompt: {text: prompt, Content: PromptContent},
+    prompt: {
+      text: prompt,
+      attachments: promptAttachments,
+      Content: PromptContent,
+    },
     activity: {
       isRunning: isActivityRunning,
       toolCount: model.leafToolCount,

--- a/packages/ai-core/src/components/defaultChatRendering.tsx
+++ b/packages/ai-core/src/components/defaultChatRendering.tsx
@@ -55,6 +55,7 @@ import {ChatAttachmentPreview} from './ChatAttachmentPreview';
 export const DefaultChatPrompt: React.FC<ChatPromptProps> = ({
   prompt,
   attachments,
+  attachmentSearchBlockIds,
   searchBlockId,
 }) => (
   <div className="group/prompt bg-muted relative ml-auto flex w-fit max-w-[85%] flex-col gap-2 rounded-md border p-2 text-sm">
@@ -64,6 +65,7 @@ export const DefaultChatPrompt: React.FC<ChatPromptProps> = ({
           <ChatAttachmentPreview
             key={`${attachment.filename ?? 'attachment'}-${index}`}
             attachment={attachment}
+            searchBlockId={attachmentSearchBlockIds[index]}
           />
         ))}
       </div>
@@ -303,6 +305,9 @@ export function createChatTurnPresentation({
     <Prompt
       prompt={prompt}
       attachments={promptAttachments}
+      attachmentSearchBlockIds={promptAttachments.map(
+        (_, index) => `${searchBlockPrefix}:attachment:${index}`,
+      )}
       searchBlockId={`${searchBlockPrefix}:prompt`}
     />
   ));

--- a/packages/ai-core/src/hooks/useGenerateSessionTitle.ts
+++ b/packages/ai-core/src/hooks/useGenerateSessionTitle.ts
@@ -5,6 +5,11 @@ import {useStoreWithAi, type AiSliceState} from '../AiSlice';
 type SessionMessagePart =
   ChatSessionSchema['uiMessages'][number]['parts'][number];
 type SessionTextPart = SessionMessagePart & {type: 'text'; text: string};
+type SessionFilePart = SessionMessagePart & {
+  type: 'file';
+  filename?: string;
+  mediaType: string;
+};
 
 export type GenerateSessionTitlePromptOptions = Parameters<
   AiSliceState['ai']['sendPrompt']
@@ -81,13 +86,33 @@ function isTextPart(part: SessionMessagePart): part is SessionTextPart {
   );
 }
 
+function isFilePart(part: SessionMessagePart): part is SessionFilePart {
+  return part.type === 'file' && 'mediaType' in part;
+}
+
+function getFileTitleText(part: SessionFilePart): string {
+  const filename = part.filename?.replace(/[\r\n]+/g, ' ').trim();
+  if (filename) return `Attached file: ${filename}`;
+  return part.mediaType.startsWith('image/')
+    ? 'Attached image'
+    : 'Attached file';
+}
+
+/**
+ * Collects user-authored text for session-title generation. File parts add a
+ * bounded filename or media-type fallback so attachment-only turns can receive
+ * a generated title without sending the attachment payload a second time.
+ */
 export function getSessionUserMessageText(session: ChatSessionSchema) {
   return session.uiMessages
     .filter((message) => message.role === 'user')
     .map((message) =>
       message.parts
-        .filter(isTextPart)
-        .map((part) => part.text)
+        .map((part) => {
+          if (isTextPart(part)) return part.text;
+          if (isFilePart(part)) return getFileTitleText(part);
+          return '';
+        })
         .join(' ')
         .trim(),
     )

--- a/packages/ai-core/src/hooks/useLocalAgentChatTransport.ts
+++ b/packages/ai-core/src/hooks/useLocalAgentChatTransport.ts
@@ -9,7 +9,9 @@ import {sanitizeMessagesForLLM} from '../utils';
 
 /**
  * Build a local `useChat` transport that drives a pre-constructed
- * `ToolLoopAgent` directly instead of calling an HTTP endpoint.
+ * `ToolLoopAgent` directly instead of calling an HTTP endpoint. Before local
+ * dispatch, text and Markdown file parts are converted to model text while
+ * image file parts are retained.
  */
 export function useLocalAgentChatTransport(
   agent: ToolLoopAgent<any, any, any>,
@@ -30,6 +32,10 @@ export function useLocalAgentChatTransport(
   );
 }
 
+/**
+ * Parses and sanitizes a local-agent request body for model dispatch.
+ * Text and Markdown file parts become labeled text; image parts remain files.
+ */
 export function parseLocalAgentUiMessages(
   body: BodyInit | null | undefined,
 ): UIMessage[] {

--- a/packages/ai-core/src/hooks/useLocalAgentChatTransport.ts
+++ b/packages/ai-core/src/hooks/useLocalAgentChatTransport.ts
@@ -5,6 +5,7 @@ import {
   type UIMessage,
 } from 'ai';
 import {useMemo} from 'react';
+import {sanitizeMessagesForLLM} from '../utils';
 
 /**
  * Build a local `useChat` transport that drives a pre-constructed
@@ -17,7 +18,7 @@ export function useLocalAgentChatTransport(
     () =>
       new DefaultChatTransport<UIMessage>({
         fetch: (async (_url: RequestInfo | URL, init?: RequestInit) => {
-          const uiMessages = parseUiMessages(init?.body);
+          const uiMessages = parseLocalAgentUiMessages(init?.body);
           return createAgentUIStreamResponse({
             agent,
             uiMessages,
@@ -32,7 +33,7 @@ export function useLocalAgentChatTransport(
 export function parseLocalAgentUiMessages(
   body: BodyInit | null | undefined,
 ): UIMessage[] {
-  return parseUiMessages(body);
+  return sanitizeMessagesForLLM(parseUiMessages(body));
 }
 
 function parseUiMessages(body: BodyInit | null | undefined): UIMessage[] {

--- a/packages/ai-core/src/index.ts
+++ b/packages/ai-core/src/index.ts
@@ -121,6 +121,8 @@ export {
   Send as ChatComposerSend,
   Stop as ChatComposerStop,
   DropTarget as ChatComposerDropTarget,
+  Attachments as ChatComposerAttachments,
+  useChatAttachments,
 } from './components/composer';
 export type {
   ChatComposerMode,
@@ -130,7 +132,20 @@ export type {
   ChatComposerSendProps,
   ChatComposerStopProps,
   ChatComposerDropTargetProps,
+  ChatComposerAttachmentsProps,
+  ChatAttachmentsState,
 } from './components/composer';
+export {
+  fileToChatAttachmentPart,
+  getChatAttachmentMediaType,
+  getChatAttachmentText,
+  getChatMessageAttachments,
+  isMarkdownAttachment,
+  isSupportedChatAttachment,
+  isTextAttachmentFilename,
+  isTextAttachmentMediaType,
+} from './chatAttachments';
+export type {ChatAttachmentPart} from './chatAttachments';
 export {
   usePromptSuggestions,
   ChatSuggestionsStateBoundary,

--- a/packages/ai-core/src/utils.ts
+++ b/packages/ai-core/src/utils.ts
@@ -461,6 +461,44 @@ export function sanitizeMessagesForLLM(
 }
 
 /**
+ * Formats persisted UI messages for conversation summarization. Consecutive
+ * text parts remain contiguous, while text and Markdown file parts are decoded
+ * into labeled sections so summarize-and-continue does not lose their content.
+ */
+export function buildConversationText(messages: UIMessage[]): string {
+  return messages
+    .map((message) => {
+      const sections: string[] = [];
+      let text = '';
+
+      const flushText = () => {
+        if (text) sections.push(text);
+        text = '';
+      };
+
+      for (const part of message.parts) {
+        if (part.type === 'text') {
+          text += (part as TextUIPart).text;
+          continue;
+        }
+        if (part.type !== 'file') continue;
+
+        const attachmentText = textAttachmentToModelText(part as FileUIPart);
+        if (attachmentText === undefined) continue;
+        flushText();
+        sections.push(attachmentText);
+      }
+      flushText();
+
+      const role = message.role === 'user' ? 'User' : 'Assistant';
+      const content = sections.join('\n\n');
+      return content ? `${role}: ${content}` : '';
+    })
+    .filter((line) => line.length > 0)
+    .join('\n\n');
+}
+
+/**
  * Determines whether the analysis should end based on completed messages.
  *
  * The analysis should continue (return false) when the last assistant message

--- a/packages/ai-core/src/utils.ts
+++ b/packages/ai-core/src/utils.ts
@@ -13,12 +13,14 @@ import {
   UIMessagePart,
 } from '@sqlrooms/ai-config';
 import {
+  type FileUIPart,
   TextUIPart,
   UIMessage,
   lastAssistantMessageIsCompleteWithToolCalls,
 } from 'ai';
 import {ABORT_EVENT, TOOL_CALL_CANCELLED} from './constants';
 import {CHAT_REQUEST_ERROR_PART_TYPE} from './chatTurns';
+import {textAttachmentToModelText} from './chatAttachments';
 
 /**
  * Merge multiple AbortSignals into a single signal.
@@ -420,6 +422,12 @@ export function sanitizeMessagesForLLM(
           return true;
         })
         .map((part) => {
+          if (part.type === 'file') {
+            const text = textAttachmentToModelText(part as FileUIPart);
+            if (text !== undefined) {
+              return {type: 'text' as const, text};
+            }
+          }
           const p = part as Record<string, unknown>;
           if (
             p.state === 'output-available' &&

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -137,8 +137,9 @@ function AiPanel() {
 ```
 
 `Chat.Composer.Attachments` is opt-in. It accepts images plus plain-text and
-Markdown files, shows removable previews before sending, and renders posted
-attachments as clickable previews that open in a larger dialog.
+Markdown files through explicit choices in the paperclip menu, shows removable
+previews before sending, and renders posted attachments as clickable previews
+that open in a larger dialog.
 
 ### Customize chat presentation
 

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -128,12 +128,17 @@ function AiPanel() {
             updateProvider(provider, {apiKey});
           }}
         />
+        <Chat.Composer.Attachments />
         <Chat.ModelSelector />
       </Chat.Composer>
     </Chat>
   );
 }
 ```
+
+`Chat.Composer.Attachments` is opt-in. It accepts images plus plain-text and
+Markdown files, shows removable previews before sending, and renders posted
+attachments as clickable previews that open in a larger dialog.
 
 ### Customize chat presentation
 

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -197,6 +197,21 @@ export {ModelSelector} from '@sqlrooms/ai-core';
 export {SessionControls} from '@sqlrooms/ai-core';
 export {QueryControls} from '@sqlrooms/ai-core';
 export {
+  fileToChatAttachmentPart,
+  getChatAttachmentMediaType,
+  getChatAttachmentText,
+  getChatMessageAttachments,
+  isMarkdownAttachment,
+  isSupportedChatAttachment,
+  isTextAttachmentFilename,
+  isTextAttachmentMediaType,
+} from '@sqlrooms/ai-core';
+export type {
+  ChatAttachmentPart,
+  ChatAttachmentsState,
+  ChatComposerAttachmentsProps,
+} from '@sqlrooms/ai-core';
+export {
   BlockAiPromptPopover,
   type BlockAiPromptPopoverProps,
   createAskAiBlockHeaderAction,

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -205,6 +205,7 @@ export {
   isSupportedChatAttachment,
   isTextAttachmentFilename,
   isTextAttachmentMediaType,
+  useChatAttachments,
 } from '@sqlrooms/ai-core';
 export type {
   ChatAttachmentPart,


### PR DESCRIPTION
## Summary

- add opt-in `<Chat.Composer.Attachments />` support for image, plain-text, and Markdown files
- persist attachments in chat messages and render clickable image/text previews with enlarged dialogs
- convert text attachments to provider-independent model text while preserving image file parts
- enable attachments in the SQLRooms CLI chat and document the public API

## Testing

- `pnpm build`
- `pnpm --filter @sqlrooms/ai-core test --runInBand` (38 suites, 281 tests)
- `pnpm --filter @sqlrooms/ai-core lint`
- `pnpm --filter @sqlrooms/ai typecheck`
- `pnpm --filter sqlrooms-cli-app typecheck`
- pre-push checks: `knip`, workspace typecheck, circular-dependency check, and full workspace tests (34 tasks)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional image, plain-text, and Markdown file attachments to chat messages.
  - Added separate image and text/Markdown pickers, removable previews, and clickable posted-file previews with larger dialogs.
  - Supports attachment-only messages in chat and session analysis workflows.
  - Text attachments are included in chat processing, summaries, token estimates, and search.
  - Added file-type and size validation with clear rejection messages.
  - Pending attachments are safely cleared when switching sessions.
- **Documentation**
  - Documented attachment setup, limits, previews, and custom attachment interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->