### PR TITLE
ci(evals): publish nightly run summary

### DIFF
--- a/.github/workflows/evals-nightly.yml
+++ b/.github/workflows/evals-nightly.yml
@@ -49,6 +49,15 @@ jobs:
         if: always()
         run: pnpm evals:export --database "$PROMPTFOO_CONFIG_DIR/promptfoo.db" --output artifacts/summary.json --markdown artifacts/summary.md
 
+      - name: Publish observatory summary
+        if: always()
+        run: |
+          if [ -f artifacts/summary.md ]; then
+            cat artifacts/summary.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo '_No behavioral eval summary was generated._' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Upload retained run history
         if: always()
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
## Summary
- publish the retained behavioral eval Markdown report to the GitHub Actions run summary
- leave an explicit fallback note when the report could not be generated
- keep the existing summary artifact upload unchanged

## Validation
- parsed evals-nightly.yml as YAML
- exercised both the generated-summary and missing-summary shell paths
- ran git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nightly evaluation runs now display their generated Markdown summary directly in the workflow results.
  * A fallback message is shown when the summary is unavailable, ensuring run status information remains visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->