### PR TITLE
fix(ci): extend npm verification retry window

### DIFF
--- a/scripts/verify-published-packages.mjs
+++ b/scripts/verify-published-packages.mjs
@@ -6,7 +6,8 @@ import {promisify} from 'node:util';
 const execFileAsync = promisify(execFile);
 const requestedVersion = process.argv[2];
 const registry = 'https://registry.npmjs.org/';
-const attempts = 8;
+// Budget 3.5 minutes of retry delays for npm registry propagation.
+const attempts = 15;
 const batchSize = 8;
 
 async function readJson(filePath) {


### PR DESCRIPTION
## Summary

- increase npm publication verification from 8 to 15 attempts
- expand the retry-delay budget from 56 seconds to 3.5 minutes
- document the propagation-delay allowance next to the policy

This prevents the false failure seen in https://github.com/sqlrooms/sqlrooms/actions/runs/33174330675, where npm accepted the package but exposed its registry metadata after the verifier timed out.

## Verification

- node --check scripts/verify-published-packages.mjs
- Prettier check
- verified all 47 packages at 0.29.0-rc.12 against npm
- pnpm build
- Knip, workspace typecheck, and circular-dependency check via pre-push hook
- sqlrooms-server tests: 28 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended package publication verification retries to better accommodate registry propagation delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->