### PR TITLE
feat(ai): add caller-scoped command guard

### DIFF
--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -47,6 +47,26 @@ agent tool policy for future skill runtimes. Hosts with product-specific agent
 tool names can call `createSkillRuntimeToolPolicy()` to substitute names such
 as their own block document agent while keeping the package defaults generic.
 
+Hosts can scope a command tool instance with `commandGuard`. Denied descriptors
+are omitted from `search_commands`, `list_commands`, and `get_command`, and
+`execute_command` refuses them before validation, confirmation, or invocation.
+The refusal uses `command-not-available-to-caller` unless the guard supplies a
+custom code; a custom message can direct the model to an owning agent tool.
+Direct `store.commands.invokeCommand` calls are unaffected.
+
+```tsx
+const commandTools = createCommandTools(store, {
+  commandGuard: (descriptor) =>
+    descriptor.id.startsWith('block-document.') && !descriptor.readOnly
+      ? {
+          allowed: false,
+          code: 'use-document-agent',
+          message: 'Use the document agent tool for document edits.',
+        }
+      : {allowed: true},
+});
+```
+
 ## Installation
 
 ```bash

--- a/packages/ai/__tests__/commandTools.test.ts
+++ b/packages/ai/__tests__/commandTools.test.ts
@@ -200,6 +200,157 @@ describe('command tools', () => {
     });
   });
 
+  it('omits denied commands from search, list, and command details', async () => {
+    const guardedDescriptors = [
+      commandDescriptors[0],
+      {
+        ...commandDescriptors[1],
+        id: 'block-document.hidden-mutation',
+        visible: false,
+      },
+      commandDescriptors[2],
+    ] as const;
+    const commandGuard = jest.fn((descriptor: {id: string}) => ({
+      allowed: descriptor.id === 'artifact.rename',
+    }));
+    const tools = createCommandState(jest.fn(), guardedDescriptors, {
+      commandGuard,
+    });
+
+    const searchResult = await (tools.search_commands as any).execute({
+      query: '',
+      includeHidden: true,
+      includeDisabled: true,
+      limit: 50,
+    });
+    const listResult = await (tools.list_commands as any).execute({
+      includeInvisible: true,
+      includeDisabled: true,
+      includeInputSchema: true,
+    });
+    const hiddenGetResult = await (tools.get_command as any).execute({
+      commandId: 'block-document.hidden-mutation',
+      includeHidden: true,
+      includeDisabled: true,
+    });
+    const disabledGetResult = await (tools.get_command as any).execute({
+      commandId: 'artifact.delete',
+      includeHidden: true,
+      includeDisabled: true,
+    });
+
+    expect(searchResult.commands.map((command: any) => command.id)).toEqual([
+      'artifact.rename',
+    ]);
+    expect(listResult.commands.map((command: any) => command.id)).toEqual([
+      'artifact.rename',
+    ]);
+    expect(hiddenGetResult).toEqual({
+      success: false,
+      errorMessage: 'Unknown command ID "block-document.hidden-mutation".',
+    });
+    expect(disabledGetResult).toEqual({
+      success: false,
+      errorMessage: 'Unknown command ID "artifact.delete".',
+    });
+    expect(commandGuard).toHaveBeenCalledWith(
+      expect.objectContaining({visible: false}),
+    );
+    expect(commandGuard).toHaveBeenCalledWith(
+      expect.objectContaining({enabled: false}),
+    );
+  });
+
+  it('returns a custom guard refusal before confirmation or invocation', async () => {
+    invokeCommandWithPolicy.mockClear();
+    const invokeCommand = jest.fn(async () => ({
+      success: true,
+      commandId: 'artifact.delete',
+    }));
+    const tools = createCommandState(invokeCommand, commandDescriptors, {
+      commandGuard: (descriptor: {id: string}) =>
+        descriptor.id === 'artifact.delete'
+          ? {
+              allowed: false,
+              code: 'use-artifact-agent',
+              message: 'Use the artifact agent to delete artifacts.',
+            }
+          : {allowed: true},
+    });
+
+    const result = await (tools.execute_command as any).execute({
+      commandId: 'artifact.delete',
+      input: {artifactId: 'artifact-1'},
+    });
+
+    expect(result).toEqual({
+      success: false,
+      commandId: 'artifact.delete',
+      errorMessage: 'Use the artifact agent to delete artifacts.',
+      result: {
+        code: 'use-artifact-agent',
+        message: 'Use the artifact agent to delete artifacts.',
+      },
+    });
+    expect(invokeCommandWithPolicy).not.toHaveBeenCalled();
+    expect(invokeCommand).not.toHaveBeenCalled();
+
+    await invokeCommand('artifact.delete', {artifactId: 'artifact-1'});
+    expect(invokeCommand).toHaveBeenCalledWith('artifact.delete', {
+      artifactId: 'artifact-1',
+    });
+  });
+
+  it('uses the default guard refusal when no reason is supplied', async () => {
+    invokeCommandWithPolicy.mockClear();
+    const invokeCommand = jest.fn();
+    const tools = createCommandState(invokeCommand, commandDescriptors, {
+      commandGuard: (descriptor: {id: string}) => ({
+        allowed: descriptor.id !== 'block-document.add-dashboard-block',
+      }),
+    });
+
+    const result = await (tools.execute_command as any).execute({
+      commandId: 'block-document.add-dashboard-block',
+    });
+
+    expect(result).toEqual({
+      success: false,
+      commandId: 'block-document.add-dashboard-block',
+      errorMessage:
+        'Command "block-document.add-dashboard-block" is not available to this caller.',
+      result: {
+        code: 'command-not-available-to-caller',
+        message:
+          'Command "block-document.add-dashboard-block" is not available to this caller.',
+      },
+    });
+    expect(invokeCommandWithPolicy).not.toHaveBeenCalled();
+    expect(invokeCommand).not.toHaveBeenCalled();
+  });
+
+  it('preserves command behavior when the guard is omitted', async () => {
+    const invokeCommand = jest.fn(async () => ({
+      success: true,
+      commandId: 'artifact.rename',
+    }));
+    const tools = createCommandState(invokeCommand, commandDescriptors);
+
+    const listResult = await (tools.list_commands as any).execute({
+      includeInvisible: true,
+      includeDisabled: true,
+      includeInputSchema: true,
+    });
+    const executionResult = await (tools.execute_command as any).execute({
+      commandId: 'artifact.rename',
+      input: {title: 'Renamed'},
+    });
+
+    expect(listResult.commands).toEqual(commandDescriptors);
+    expect(executionResult.success).toBe(true);
+    expect(invokeCommand).toHaveBeenCalled();
+  });
+
   it('honors the configured default surface for parsed discovery inputs', async () => {
     const invokeCommand = jest.fn();
     const listCommands = jest.fn(

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -26,6 +26,7 @@ export {
 export type {
   CommandToolDescriptor,
   CommandToolSearchDescriptor,
+  CommandGuardResult,
   CommandToolsOptions,
   DefaultCommandTools,
   ExecuteCommandToolLlmResult,

--- a/packages/ai/src/tools/commandTools.ts
+++ b/packages/ai/src/tools/commandTools.ts
@@ -204,6 +204,17 @@ type CommandToolExecutionContext = {
   metadata?: Record<string, unknown>;
 };
 
+/** The caller-scoped access decision for a room command descriptor. */
+export type CommandGuardResult = {
+  /** Whether the command tools may expose and execute the command. */
+  allowed: boolean;
+  /** Optional machine-readable refusal code returned by `execute_command`. */
+  code?: string;
+  /** Optional refusal or redirect message returned by `execute_command`. */
+  message?: string;
+};
+
+/** Options for configuring the model-facing room command tools. */
 export type CommandToolsOptions = {
   searchToolName?: string;
   getToolName?: string;
@@ -216,6 +227,12 @@ export type CommandToolsOptions = {
   defaultMetadata?: Record<string, unknown>;
   includeInvisibleCommandsByDefault?: boolean;
   includeDisabledCommandsInList?: boolean;
+  /**
+   * Restricts which commands this tool instance may expose or execute.
+   * Denied commands are omitted from discovery and details. Execution returns
+   * `command-not-available-to-caller` unless the decision supplies a code.
+   */
+  commandGuard?: (descriptor: CommandToolDescriptor) => CommandGuardResult;
 };
 
 const DEFAULT_SEARCH_TOOL_NAME = 'search_commands';
@@ -288,7 +305,10 @@ Use this for routine command discovery before calling ${getToolName} for the sel
           includeDisabled: params.includeDisabled,
           includeInputSchema: params.includeInputSchema,
         });
-        const rankedCommands = rankCommandDescriptors(descriptors, params);
+        const rankedCommands = rankCommandDescriptors(
+          filterGuardedCommandDescriptors(descriptors, options),
+          params,
+        );
 
         return {
           success: true,
@@ -334,7 +354,9 @@ Call this after ${searchToolName} and before ${executeToolName} when the command
           includeInputSchema: true,
         });
         const command = descriptors.find(
-          (descriptor) => descriptor.id === params.commandId,
+          (descriptor) =>
+            descriptor.id === params.commandId &&
+            isCommandAllowed(descriptor, options),
         );
         if (!command) {
           return {
@@ -366,17 +388,20 @@ For routine command use, prefer ${searchToolName}, then ${getToolName} for the s
           } satisfies ListCommandsToolLlmResult;
         }
 
-        const descriptors = state.commands.listCommands({
-          ...createCommandToolInvocationOptions(
-            defaultSurface,
-            options,
-            context,
-            state,
-          ),
-          includeInvisible: params.includeInvisible,
-          includeDisabled: params.includeDisabled,
-          includeInputSchema: params.includeInputSchema,
-        });
+        const descriptors = filterGuardedCommandDescriptors(
+          state.commands.listCommands({
+            ...createCommandToolInvocationOptions(
+              defaultSurface,
+              options,
+              context,
+              state,
+            ),
+            includeInvisible: params.includeInvisible,
+            includeDisabled: params.includeDisabled,
+            includeInputSchema: params.includeInputSchema,
+          }),
+          options,
+        );
 
         return {
           success: true,
@@ -426,6 +451,23 @@ Call ${searchToolName} first to discover valid command IDs. Call ${getToolName} 
             includeInputSchema: false,
           })
           .find((command) => command.id === commandId);
+        const guardResult = descriptor
+          ? options?.commandGuard?.(descriptor)
+          : undefined;
+        if (guardResult && !guardResult.allowed) {
+          const message =
+            guardResult.message ??
+            `Command "${commandId}" is not available to this caller.`;
+          return {
+            success: false,
+            commandId,
+            errorMessage: message,
+            result: {
+              code: guardResult.code ?? 'command-not-available-to-caller',
+              message,
+            },
+          } satisfies ExecuteCommandToolLlmResult;
+        }
         if (
           descriptor &&
           !confirmed &&
@@ -486,6 +528,22 @@ Call ${searchToolName} first to discover valid command IDs. Call ${getToolName} 
     // ([searchToolName], [getToolName], [listToolName], [executeToolName]) to
     // their literal string types.
   } as DefaultCommandTools;
+}
+
+function filterGuardedCommandDescriptors(
+  descriptors: RoomCommandDescriptor[],
+  options: CommandToolsOptions | undefined,
+): RoomCommandDescriptor[] {
+  return options?.commandGuard
+    ? descriptors.filter((descriptor) => isCommandAllowed(descriptor, options))
+    : descriptors;
+}
+
+function isCommandAllowed(
+  descriptor: RoomCommandDescriptor,
+  options: CommandToolsOptions | undefined,
+): boolean {
+  return options?.commandGuard?.(descriptor).allowed ?? true;
 }
 
 type RankedCommandDescriptor = {


### PR DESCRIPTION
## Summary

- add an optional commandGuard policy to createCommandTools
- hide denied commands from search, list, and command details
- return structured guard refusals before confirmation, validation, or execution
- document the public API and preserve direct internal command invocation

## Verification

- workspace build
- @sqlrooms/ai full test suite (28 tests)
- @sqlrooms/ai typecheck and lint
- repository pre-push gates: knip, 90-package typecheck, circular dependency check, and full test suite

Closes #895

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional command access controls for AI command tools.
  - Hosts can limit which commands are searchable, listed, retrieved, or executable.
  - Blocked command executions return a clear refusal, with support for custom error codes and messages.
  - Custom guidance can direct the AI to an alternative owning tool.

- **Documentation**
  - Added usage guidance and an example for restricting commands based on their capabilities.

- **Compatibility**
  - Existing behavior remains unchanged when no command access control is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->