### PR TITLE
fix(mosaic): support row-count line charts

### DIFF
--- a/packages/mosaic/README.md
+++ b/packages/mosaic/README.md
@@ -250,6 +250,27 @@ function CodeView({value}: {value: string}) {
 }
 ```
 
+### Line Chart Row Counts
+
+Line charts support `metric: "count"` for raw observations. This emits
+`COUNT(*)`, including rows whose identifiers are null; it does not sum or count
+a selected numeric column. For example:
+
+```ts
+const settings = {x: 'DateTime', xInterval: 'month', metric: 'count'};
+```
+
+Omit `yFields` in count mode. Numeric series alongside `metric: "count"` are
+rejected, rather than silently ignored. Without `xInterval`, counts group by
+the exact X value. Counts are aggregated over the full source, not subject to
+the unaggregated line-chart source-row limit.
+
+Existing configs remain numeric line charts when `metric` is omitted or is
+`"aggregate"`. They still use `yFields` with `sum`, `avg`, `min`, or `max` for
+temporal aggregation. For already summarized counts, select that numeric
+measure instead of counting the summary rows. Both the chart settings UI and
+the AI tools expose the same metric choice, including document chart tools.
+
 ### Count Plot Settings
 
 `count-plot` chart configs support categorical counts by default and can also

--- a/packages/mosaic/README.md
+++ b/packages/mosaic/README.md
@@ -262,14 +262,29 @@ const settings = {x: 'DateTime', xInterval: 'month', metric: 'count'};
 
 Omit `yFields` in count mode. Numeric series alongside `metric: "count"` are
 rejected, rather than silently ignored. Without `xInterval`, counts group by
-the exact X value. Counts are aggregated over the full source, not subject to
-the unaggregated line-chart source-row limit.
+the exact X value. Counts aggregate the full source without truncation, but
+retain the default **10,000 result-point limit**, including binned counts:
+distinct timestamps or overly fine bins can still produce too many points.
+Use a coarser temporal interval or reduce the distinct X values when the limit
+is exceeded. This limits rendered results, not the number of rows counted.
 
 Existing configs remain numeric line charts when `metric` is omitted or is
 `"aggregate"`. They still use `yFields` with `sum`, `avg`, `min`, or `max` for
 temporal aggregation. For already summarized counts, select that numeric
 measure instead of counting the summary rows. Both the chart settings UI and
 the AI tools expose the same metric choice, including document chart tools.
+
+Switching a populated chart to Row count preserves its numeric series in the
+chart-local `lastAggregateYFields` config field, outside active `settings`.
+Switching back to Numeric fields restores their fields, aggregations, and
+colors, even after saving and reopening the chart. The saved series are removed
+from that field on restoration and are never rendered or passed as count-mode
+Y fields. Count charts created without prior numeric series still require a Y
+selection when first switched to Numeric fields.
+
+The chart builder retains chart-local config options separately from active
+field values and carries them into the created chart. Resetting the builder or
+selecting another chart type clears those options.
 
 ### Count Plot Settings
 

--- a/packages/mosaic/README.md
+++ b/packages/mosaic/README.md
@@ -266,7 +266,9 @@ the exact X value. Counts aggregate the full source without truncation, but
 retain the default **10,000 result-point limit**, including binned counts:
 distinct timestamps or overly fine bins can still produce too many points.
 Use a coarser temporal interval or reduce the distinct X values when the limit
-is exceeded. This limits rendered results, not the number of rows counted.
+is exceeded. This limits rendered results, not the number of rows counted. AI
+tools persist the host-configured result limit in the chart config, so custom
+limits remain effective when the chart renders.
 
 Existing configs remain numeric line charts when `metric` is omitted or is
 `"aggregate"`. They still use `yFields` with `sum`, `avg`, `min`, or `max` for
@@ -281,6 +283,10 @@ colors, even after saving and reopening the chart. The saved series are removed
 from that field on restoration and are never rendered or passed as count-mode
 Y fields. Count charts created without prior numeric series still require a Y
 selection when first switched to Numeric fields.
+
+`xInterval` is valid only with a temporal X column. Numeric X columns group by
+their exact values and reject temporal intervals rather than silently ignoring
+the requested grouping.
 
 The chart builder retains chart-local config options separately from active
 field values and carries them into the created chart. Resetting the builder or

--- a/packages/mosaic/__tests__/block-document-ai.test.ts
+++ b/packages/mosaic/__tests__/block-document-ai.test.ts
@@ -26,6 +26,7 @@ describe('Mosaic block-document AI tools', () => {
           table: String(tableName),
         }),
         columns: [
+          {name: 'DateTime', type: 'TIMESTAMP'},
           {name: 'Depth', type: 'DOUBLE'},
           {name: 'magnitude', type: 'DOUBLE'},
         ],
@@ -51,6 +52,56 @@ describe('Mosaic block-document AI tools', () => {
   it('uses block-document chart tool names', () => {
     expect(BLOCK_DOCUMENT_CHART_TOOL_PREFIX).toBe(
       'create_block_document_chart_',
+    );
+  });
+
+  it('creates and then edits row-count charts in the bound document', async () => {
+    const {blockDocumentAdapter, addedBlocks} =
+      createMockBlockDocumentAdapter();
+    const updateBlock = jest.fn();
+    blockDocumentAdapter.updateBlock = updateBlock;
+    blockDocumentAdapter.getBlocks = () =>
+      addedBlocks.map(blockDocumentBlockToNode);
+    const tools = createBlockDocumentChartTools({
+      databaseAdapter: createMockDatabaseAdapter(),
+      blockDocumentAdapter,
+      blockDocumentId: 'document-counts',
+    });
+    const tool = tools.create_block_document_chart_line_chart as any;
+    const input = {
+      tableName: 'earthquakes',
+      reasoning: 'Count earthquakes by month.',
+      settings: {x: 'DateTime', xInterval: 'month', metric: 'count'},
+    };
+    expect((await tool.execute(input)).success).toBe(true);
+    expect(addedBlocks).toHaveLength(1);
+    const block = addedBlocks[0];
+    expect(block).toMatchObject({
+      type: 'chart',
+      tableName: '"main"."earthquakes"',
+      config: {chartType: 'line-chart', settings: input.settings},
+    });
+    expect(
+      (
+        await tool.execute({
+          ...input,
+          panelId: block.id,
+          title: 'Monthly count',
+        })
+      ).success,
+    ).toBe(true);
+    expect(addedBlocks).toHaveLength(1);
+    expect(updateBlock).toHaveBeenCalledWith(
+      'document-counts',
+      block.id,
+      expect.objectContaining({
+        id: block.id,
+        caption: 'Monthly count',
+        config: {
+          chartType: 'line-chart',
+          settings: {...input.settings, showLegend: true},
+        },
+      }),
     );
   });
 

--- a/packages/mosaic/__tests__/block-document-ai.test.ts
+++ b/packages/mosaic/__tests__/block-document-ai.test.ts
@@ -100,6 +100,7 @@ describe('Mosaic block-document AI tools', () => {
         config: {
           chartType: 'line-chart',
           settings: {...input.settings, showLegend: true},
+          dataPolicy: {maxRows: 10_000},
         },
       }),
     );

--- a/packages/mosaic/__tests__/chart-types/line-chart-count.test.ts
+++ b/packages/mosaic/__tests__/chart-types/line-chart-count.test.ts
@@ -4,7 +4,10 @@ import {makeQualifiedTableName, type DataTable} from '@sqlrooms/duckdb';
 import {createLineChartSpec} from '../../src/charts/chart-types/line-chart/spec';
 import {LineChartSettings} from '../../src/charts/chart-types/line-chart/schema';
 import {lineChartChartType} from '../../src/charts/chart-types/line-chart/definition';
-import {assertChartDataPolicy} from '../../src/chart-runtime';
+import {
+  assertChartDataPolicy,
+  resolveChartDataPolicy,
+} from '../../src/chart-runtime';
 import {DataPointLimitError} from '../../src/DataPointLimitError';
 import {
   createLineChartAiTool,
@@ -31,7 +34,6 @@ describe('line-chart row counts', () => {
     {x: 'time'},
     {x: 'amount'},
     {x: 'time', xInterval: 'month' as const},
-    {x: 'amount', xInterval: 'month' as const},
   ])('limits count result points, not source rows: %j', (settings) => {
     const policy = lineChartChartType.getDataPolicy?.({
       tableName: 'events',
@@ -155,9 +157,85 @@ describe('line-chart row counts', () => {
         config: {
           chartType: 'line-chart',
           settings: {...countSettings, showLegend: true},
+          dataPolicy: {maxRows: 10_000},
         },
       }),
     );
+  });
+
+  it.each([500, 25_000])(
+    'persists the host count-result limit in the rendered config: %i',
+    async (maxDataPoints) => {
+      const addChart = jest.fn(async () => 'chart-1');
+      const tool = createLineChartAiTool({
+        databaseAdapter: {getTables: () => [events], findTable: () => events},
+        addChart,
+        maxDataPoints,
+      });
+      const result = await (tool as any).execute({
+        tableName: 'events',
+        settings: countSettings,
+      });
+      expect(result).toMatchObject({
+        success: true,
+        data: {dataPolicy: {maxRows: maxDataPoints}},
+      });
+      const config = addChart.mock.calls[0]![0].config;
+      const defaultPolicy = lineChartChartType.getDataPolicy?.({
+        tableName: 'events',
+        config,
+      });
+      const resolvedPolicy = resolveChartDataPolicy(
+        defaultPolicy,
+        config.dataPolicy,
+      );
+      expect(resolvedPolicy).toMatchObject({
+        maxRows: maxDataPoints,
+      });
+      expect(() =>
+        assertChartDataPolicy(resolvedPolicy, {numRows: maxDataPoints}),
+      ).not.toThrow();
+      expect(() =>
+        assertChartDataPolicy(resolvedPolicy, {numRows: maxDataPoints + 1}),
+      ).toThrow(DataPointLimitError);
+    },
+  );
+
+  it.each([
+    {x: 'amount', xInterval: 'month' as const, metric: 'count' as const},
+    {
+      x: 'amount',
+      xInterval: 'month' as const,
+      metric: 'aggregate' as const,
+      yFields: [{field: 'amount', aggregate: 'sum' as const}],
+    },
+  ])('rejects a temporal interval on a numeric axis: %j', (settings) => {
+    expect(() => createLineChartSpec({dataTable: events, settings})).toThrow(
+      'xInterval',
+    );
+  });
+
+  it('rejects a temporal interval on a numeric count axis through the tool', async () => {
+    const addChart = jest.fn(async () => 'chart-1');
+    const tool = createLineChartAiTool({
+      databaseAdapter: {getTables: () => [events], findTable: () => events},
+      addChart,
+      maxDataPoints: 10_000,
+    });
+    expect(
+      await (tool as any).execute({
+        tableName: 'events',
+        settings: {
+          x: 'amount',
+          xInterval: 'month',
+          metric: 'count',
+        },
+      }),
+    ).toMatchObject({
+      success: false,
+      errorMessage: expect.stringContaining('xInterval'),
+    });
+    expect(addChart).not.toHaveBeenCalled();
   });
 
   it('rejects contradictory count plus numeric series instead of ignoring them', async () => {

--- a/packages/mosaic/__tests__/chart-types/line-chart-count.test.ts
+++ b/packages/mosaic/__tests__/chart-types/line-chart-count.test.ts
@@ -1,0 +1,186 @@
+import {jest} from '@jest/globals';
+import {astToESM, parseSpec} from '@uwdata/mosaic-spec';
+import {makeQualifiedTableName, type DataTable} from '@sqlrooms/duckdb';
+import {createLineChartSpec} from '../../src/charts/chart-types/line-chart/spec';
+import {LineChartSettings} from '../../src/charts/chart-types/line-chart/schema';
+import {lineChartChartType} from '../../src/charts/chart-types/line-chart/definition';
+import {
+  createLineChartAiTool,
+  LineChartToolInput,
+} from '../../src/charts/chart-types/line-chart/tool';
+
+const events: DataTable = {
+  tableName: 'events',
+  table: makeQualifiedTableName({schema: 'main', table: 'events'}),
+  columns: [
+    {name: 'time', type: 'TIMESTAMP'},
+    {name: 'event_id', type: 'VARCHAR'},
+    {name: 'amount', type: 'DOUBLE'},
+  ],
+};
+const countSettings = {
+  x: 'time',
+  xInterval: 'month' as const,
+  metric: 'count' as const,
+};
+
+describe('line-chart row counts', () => {
+  it('does not apply the unaggregated row limit to count charts', () => {
+    expect(
+      lineChartChartType.getDataPolicy?.({
+        tableName: 'events',
+        config: {
+          chartType: 'line-chart',
+          settings: {x: 'amount', metric: 'count', showLegend: true},
+        },
+      }),
+    ).toBeNull();
+    expect(
+      lineChartChartType.getDataPolicy?.({
+        tableName: 'events',
+        config: {
+          chartType: 'line-chart',
+          settings: {
+            x: 'time',
+            yFields: [{field: 'amount', aggregate: 'sum'}],
+            showLegend: true,
+          },
+        },
+      }),
+    ).toMatchObject({maxRows: 10_000});
+  });
+  it('accepts row counts without inventing a numeric Y field', () => {
+    expect(
+      LineChartToolInput.safeParse({
+        tableName: 'events',
+        reasoning: 'Count events by month.',
+        settings: countSettings,
+      }).success,
+    ).toBe(true);
+    expect(LineChartSettings.parse(countSettings)).toMatchObject(countSettings);
+  });
+
+  it('compiles row counts to zero-argument count, including rows with null IDs', () => {
+    const spec = createLineChartSpec({
+      dataTable: events,
+      settings: {...countSettings, showLegend: false},
+    });
+    expect(spec).toMatchObject({
+      yLabel: 'Count',
+      colorDomain: ['Count'],
+      plot: [
+        {
+          mark: 'lineY',
+          data: {from: '"main"."events"', filterBy: '$brush'},
+          x: {bin: 'time', interval: 'month'},
+          y: {count: null},
+        },
+      ],
+    });
+    // Compile through Mosaic, not a hand-written evaluator of the settings.
+    const code = astToESM(parseSpec(spec));
+    expect(code).toContain('count()');
+    expect(code).not.toContain('sum(');
+    expect(code).not.toContain('event_id');
+  });
+
+  it('counts by the exact X value when no temporal interval is selected', () => {
+    const spec = createLineChartSpec({
+      dataTable: events,
+      settings: {x: 'time', metric: 'count', showLegend: false},
+    });
+    expect(spec).toMatchObject({plot: [{x: 'time', y: {count: null}}]});
+  });
+
+  it('preserves the existing numeric aggregate path when metric is omitted', () => {
+    const spec = createLineChartSpec({
+      dataTable: events,
+      settings: {
+        x: 'time',
+        xInterval: 'month',
+        yFields: [{field: 'amount', aggregate: 'avg'}],
+        showLegend: false,
+      },
+    });
+    expect(spec).toMatchObject({plot: [{y: {avg: 'amount'}}]});
+  });
+
+  it('creates a count chart with the same settings the renderer consumes', async () => {
+    const addChart = jest.fn(async () => 'chart-1');
+    const tool = createLineChartAiTool({
+      databaseAdapter: {getTables: () => [events], findTable: () => events},
+      addChart,
+      maxDataPoints: 10_000,
+    });
+    const result = await (tool as any).execute({
+      tableName: 'events',
+      settings: countSettings,
+    });
+    expect(result.success).toBe(true);
+    expect(addChart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: {
+          chartType: 'line-chart',
+          settings: {...countSettings, showLegend: true},
+        },
+      }),
+    );
+  });
+
+  it('rejects contradictory count plus numeric series instead of ignoring them', async () => {
+    const addChart = jest.fn(async () => 'chart-1');
+    const tool = createLineChartAiTool({
+      databaseAdapter: {getTables: () => [events], findTable: () => events},
+      addChart,
+      maxDataPoints: 10_000,
+    });
+    const result = await (tool as any).execute({
+      tableName: 'events',
+      settings: {
+        ...countSettings,
+        yFields: [{field: 'amount', aggregate: 'sum'}],
+      },
+    });
+    expect(result).toMatchObject({
+      success: false,
+      errorMessage: expect.stringContaining('yFields'),
+    });
+    expect(addChart).not.toHaveBeenCalled();
+  });
+
+  it('keeps a single count legend entry and the brush interaction', () => {
+    const spec = createLineChartSpec({
+      dataTable: events,
+      settings: countSettings,
+      selectionName: 'linked-document',
+    }) as any;
+    expect(spec.vconcat[0].colorDomain).toEqual(['Count']);
+    expect(spec.vconcat[0].plot).toContainEqual({
+      select: 'intervalX',
+      as: '$brush',
+    });
+    expect(spec.vconcat[1]).toMatchObject({legend: 'color', columns: 1});
+  });
+
+  it.each([
+    {x: undefined, metric: 'count'},
+    {x: 'missing', metric: 'count'},
+    {x: 'event_id', metric: 'count'},
+    {x: 'time', metric: 'aggregate'},
+    {x: 'time', metric: 'unsupported'},
+  ])(
+    'rejects invalid settings without creating a chart: %j',
+    async (settings) => {
+      const addChart = jest.fn(async () => 'chart-1');
+      const tool = createLineChartAiTool({
+        databaseAdapter: {getTables: () => [events], findTable: () => events},
+        addChart,
+        maxDataPoints: 10_000,
+      });
+      expect(
+        await (tool as any).execute({tableName: 'events', settings}),
+      ).toMatchObject({success: false});
+      expect(addChart).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/mosaic/__tests__/chart-types/line-chart-count.test.ts
+++ b/packages/mosaic/__tests__/chart-types/line-chart-count.test.ts
@@ -4,6 +4,8 @@ import {makeQualifiedTableName, type DataTable} from '@sqlrooms/duckdb';
 import {createLineChartSpec} from '../../src/charts/chart-types/line-chart/spec';
 import {LineChartSettings} from '../../src/charts/chart-types/line-chart/schema';
 import {lineChartChartType} from '../../src/charts/chart-types/line-chart/definition';
+import {assertChartDataPolicy} from '../../src/chart-runtime';
+import {DataPointLimitError} from '../../src/DataPointLimitError';
 import {
   createLineChartAiTool,
   LineChartToolInput,
@@ -25,16 +27,33 @@ const countSettings = {
 };
 
 describe('line-chart row counts', () => {
-  it('does not apply the unaggregated row limit to count charts', () => {
-    expect(
-      lineChartChartType.getDataPolicy?.({
-        tableName: 'events',
-        config: {
-          chartType: 'line-chart',
-          settings: {x: 'amount', metric: 'count', showLegend: true},
-        },
-      }),
-    ).toBeNull();
+  it.each([
+    {x: 'time'},
+    {x: 'amount'},
+    {x: 'time', xInterval: 'month' as const},
+    {x: 'amount', xInterval: 'month' as const},
+  ])('limits count result points, not source rows: %j', (settings) => {
+    const policy = lineChartChartType.getDataPolicy?.({
+      tableName: 'events',
+      config: {
+        chartType: 'line-chart',
+        settings: {...settings, metric: 'count', showLegend: true},
+      },
+    });
+    expect(policy).toMatchObject({maxRows: 10_000});
+    expect(() => assertChartDataPolicy(policy, {numRows: 10_001})).toThrow(
+      DataPointLimitError,
+    );
+    expect(() =>
+      assertChartDataPolicy(policy, {numRows: 10_000}),
+    ).not.toThrow();
+    // Any number of source observations can aggregate into a small result.
+    expect(() =>
+      assertChartDataPolicy(policy, [{x: 1, y: 100_000}]),
+    ).not.toThrow();
+  });
+
+  it('preserves the legacy numeric-series data policies', () => {
     expect(
       lineChartChartType.getDataPolicy?.({
         tableName: 'events',
@@ -48,6 +67,20 @@ describe('line-chart row counts', () => {
         },
       }),
     ).toMatchObject({maxRows: 10_000});
+    expect(
+      lineChartChartType.getDataPolicy?.({
+        tableName: 'events',
+        config: {
+          chartType: 'line-chart',
+          settings: {
+            x: 'time',
+            xInterval: 'month',
+            yFields: [{field: 'amount', aggregate: 'sum'}],
+            showLegend: true,
+          },
+        },
+      }),
+    ).toBeNull();
   });
   it('accepts row counts without inventing a numeric Y field', () => {
     expect(

--- a/packages/mosaic/__tests__/chart-types/line-chart-settings.test.tsx
+++ b/packages/mosaic/__tests__/chart-types/line-chart-settings.test.tsx
@@ -1,0 +1,224 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options {"customExportConditions": ["node", "node-addons"]}
+ */
+import {afterAll, beforeAll, jest} from '@jest/globals';
+import {TransformStream} from 'node:stream/web';
+import {useState, type ReactElement} from 'react';
+import {fireEvent, render, screen} from '@testing-library/react';
+import {makeQualifiedTableName} from '@sqlrooms/duckdb';
+import {MosaicChartSettingsProvider} from '../../src/charts/chart-settings/MosaicChartSettingsContext';
+import {LineChartSettingsComponent} from '../../src/charts/chart-types/line-chart/LineChartSettings';
+import {LineChartConfig} from '../../src/charts/chart-types/line-chart/schema';
+import {validateLineChartSettings} from '../../src/charts/chart-types/line-chart/validation';
+import type {ChartConfig} from '../../src/charts/chart-types';
+import {ChartBuilderContext} from '../../src/chart-builders/ChartBuilderContext';
+import {ChartBuilderFields} from '../../src/chart-builders/ChartBuilderFields';
+import {ChartBuilderActions} from '../../src/chart-builders/ChartBuilderActions';
+import {createChartBuilderStore} from '../../src/chart-builders/createChartBuilderStore';
+
+const originalResizeObserver = globalThis.ResizeObserver;
+const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+const originalTransformStream = globalThis.TransformStream;
+beforeAll(() => {
+  Object.assign(globalThis, {TransformStream});
+  // JSDOM has no layout observation or scrolling; keep the real menu handlers.
+  globalThis.ResizeObserver = class {
+    observe(): void {
+      /* No layout observation in JSDOM. */
+    }
+    unobserve(): void {
+      /* No layout observation in JSDOM. */
+    }
+    disconnect(): void {
+      /* No layout observation in JSDOM. */
+    }
+  };
+  HTMLElement.prototype.scrollIntoView = jest.fn();
+});
+afterAll(() => {
+  globalThis.ResizeObserver = originalResizeObserver;
+  HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+  globalThis.TransformStream = originalTransformStream;
+});
+
+const columns = [
+  {name: 'time', type: 'TIMESTAMP'},
+  {name: 'amount', type: 'DOUBLE'},
+  {name: 'value', type: 'DOUBLE'},
+];
+const numericConfig: LineChartConfig = {
+  chartType: 'line-chart',
+  settings: {
+    x: 'time',
+    xInterval: 'month',
+    showLegend: true,
+    yFields: [
+      {field: 'amount', aggregate: 'avg', color: '#123456'},
+      {field: 'value', aggregate: 'max', color: '#abcdef'},
+    ],
+  },
+};
+
+function Settings({
+  initialConfig,
+  onChange,
+}: {
+  initialConfig: LineChartConfig;
+  onChange: (config: LineChartConfig) => void;
+}): ReactElement {
+  const [config, setConfig] = useState(initialConfig);
+  return (
+    <MosaicChartSettingsProvider
+      config={config}
+      columns={columns}
+      onChange={(next) => {
+        const parsed = LineChartConfig.parse(next);
+        setConfig(parsed);
+        onChange(parsed);
+      }}
+    >
+      <LineChartSettingsComponent />
+    </MosaicChartSettingsProvider>
+  );
+}
+
+async function selectMetric(from: string, to: string): Promise<void> {
+  fireEvent.click(screen.getByText(from));
+  fireEvent.click(await screen.findByRole('option', {name: to}));
+}
+
+it('restores all numeric series after count mode and a serialized settings remount', async () => {
+  const onChange = jest.fn<(config: LineChartConfig) => void>();
+  const view = render(
+    <Settings initialConfig={numericConfig} onChange={onChange} />,
+  );
+  await selectMetric('Numeric fields', 'Row count');
+  const countConfig = onChange.mock.calls.at(-1)![0];
+  expect(countConfig.settings).toMatchObject({metric: 'count', yFields: []});
+  expect(() =>
+    validateLineChartSettings({
+      dataTable: {
+        tableName: 'events',
+        table: makeQualifiedTableName({schema: 'main', table: 'events'}),
+        columns,
+      },
+      settings: countConfig.settings,
+    }),
+  ).not.toThrow();
+  view.unmount();
+  // Reopening a persisted chart must not depend on component-local state.
+  render(
+    <Settings
+      initialConfig={LineChartConfig.parse(
+        JSON.parse(JSON.stringify(countConfig)),
+      )}
+      onChange={onChange}
+    />,
+  );
+  await selectMetric('Row count', 'Numeric fields');
+  const restored = onChange.mock.calls.at(-1)![0];
+  expect(restored.settings.yFields).toEqual(numericConfig.settings.yFields);
+  expect(restored.settings).toMatchObject({
+    x: 'time',
+    xInterval: 'month',
+    metric: 'aggregate',
+  });
+  expect(restored).not.toHaveProperty('lastAggregateYFields');
+  await selectMetric('Numeric fields', 'Row count');
+  await selectMetric('Row count', 'Numeric fields');
+  expect(onChange.mock.calls.at(-1)![0].settings.yFields).toEqual(
+    numericConfig.settings.yFields,
+  );
+});
+
+it('does not carry saved series into another count chart', async () => {
+  const onChange = jest.fn<(config: LineChartConfig) => void>();
+  const view = render(
+    <Settings initialConfig={numericConfig} onChange={onChange} />,
+  );
+  await selectMetric('Numeric fields', 'Row count');
+  view.unmount();
+  render(
+    <Settings
+      initialConfig={{
+        chartType: 'line-chart',
+        settings: {x: 'time', metric: 'count', showLegend: true},
+      }}
+      onChange={onChange}
+    />,
+  );
+  await selectMetric('Row count', 'Numeric fields');
+  expect(onChange.mock.calls.at(-1)![0].settings.yFields ?? []).toEqual([]);
+});
+
+it('preserves numeric series through builder toggles and count-chart creation', async () => {
+  // Load the real chart definition after installing JSDOM's missing web stream.
+  const {lineChartChartType} =
+    await import('../../src/charts/chart-types/line-chart/definition');
+  const store = createChartBuilderStore();
+  store.getState().selectTemplate('line-chart');
+  Object.entries(numericConfig.settings).forEach(([key, value]) => {
+    store.getState().setFieldValue(key, value);
+  });
+  const onCreateChart = jest.fn<(title: string, config: ChartConfig) => void>();
+  const view = render(
+    <ChartBuilderContext.Provider
+      value={{
+        tableName: 'events',
+        columns,
+        templates: [lineChartChartType],
+        availableTemplates: [lineChartChartType],
+        store,
+        onCreateChart,
+      }}
+    >
+      <ChartBuilderFields />
+      <ChartBuilderActions />
+    </ChartBuilderContext.Provider>,
+  );
+  await selectMetric('Numeric fields', 'Row count');
+  await selectMetric('Row count', 'Numeric fields');
+  expect(store.getState().fieldValues.yFields).toEqual(
+    numericConfig.settings.yFields,
+  );
+  expect(store.getState().chartOptions).not.toHaveProperty(
+    'lastAggregateYFields',
+  );
+  await selectMetric('Numeric fields', 'Row count');
+  fireEvent.click(screen.getByRole('button', {name: 'Create'}));
+  const created = LineChartConfig.parse(onCreateChart.mock.calls.at(-1)![1]);
+  expect(created.settings).toMatchObject({metric: 'count', yFields: []});
+  expect(created.lastAggregateYFields).toEqual(numericConfig.settings.yFields);
+  expect(store.getState().chartOptions).toEqual({});
+  view.unmount();
+  const onChange = jest.fn<(config: LineChartConfig) => void>();
+  render(<Settings initialConfig={created} onChange={onChange} />);
+  await selectMetric('Row count', 'Numeric fields');
+  expect(onChange.mock.calls.at(-1)![0].settings.yFields).toEqual(
+    numericConfig.settings.yFields,
+  );
+});
+
+it.each(['reset', 'selectTemplate'] as const)(
+  'clears saved builder options on %s',
+  (action) => {
+    const store = createChartBuilderStore();
+    store.getState().setConfig({
+      chartType: 'line-chart',
+      settings: {x: 'time', metric: 'count', showLegend: true},
+      lastAggregateYFields: numericConfig.settings.yFields,
+      dataPolicy: {maxRows: 500},
+    });
+    store.getState().setFieldValue('xInterval', 'month');
+    expect(store.getState().chartOptions).toMatchObject({
+      lastAggregateYFields: numericConfig.settings.yFields,
+      dataPolicy: {maxRows: 500},
+    });
+    if (action === 'selectTemplate')
+      store.getState().selectTemplate('histogram');
+    else store.getState().reset();
+    expect(store.getState().chartOptions).toEqual({});
+    expect(store.getState().fieldValues).toEqual({});
+  },
+);

--- a/packages/mosaic/__tests__/chart-types/line-chart-settings.test.tsx
+++ b/packages/mosaic/__tests__/chart-types/line-chart-settings.test.tsx
@@ -88,6 +88,32 @@ async function selectMetric(from: string, to: string): Promise<void> {
   fireEvent.click(await screen.findByRole('option', {name: to}));
 }
 
+async function selectXAxis(from: string, to: string): Promise<void> {
+  fireEvent.click(screen.getByText(from));
+  fireEvent.click(
+    await screen.findByRole('option', {name: new RegExp(to, 'i')}),
+  );
+}
+
+it('clears a temporal interval when switching to a numeric X field', async () => {
+  const onChange = jest.fn<(config: LineChartConfig) => void>();
+  render(<Settings initialConfig={numericConfig} onChange={onChange} />);
+  await selectXAxis('time', 'amount');
+  const changed = onChange.mock.calls.at(-1)![0];
+  expect(changed.settings).toMatchObject({x: 'amount'});
+  expect(changed.settings).not.toHaveProperty('xInterval');
+  expect(() =>
+    validateLineChartSettings({
+      dataTable: {
+        tableName: 'events',
+        table: makeQualifiedTableName({schema: 'main', table: 'events'}),
+        columns,
+      },
+      settings: changed.settings,
+    }),
+  ).not.toThrow();
+});
+
 it('restores all numeric series after count mode and a serialized settings remount', async () => {
   const onChange = jest.fn<(config: LineChartConfig) => void>();
   const view = render(

--- a/packages/mosaic/src/chart-builders/ChartBuilderActions.tsx
+++ b/packages/mosaic/src/chart-builders/ChartBuilderActions.tsx
@@ -19,6 +19,7 @@ export const ChartBuilderActions: FC<ChartBuilderActionsProps> = ({
     (state) => state.selectedTemplateId,
   );
   const fieldValues = useChartBuilderStore((state) => state.fieldValues);
+  const chartOptions = useChartBuilderStore((state) => state.chartOptions);
   const reset = useChartBuilderStore((state) => state.reset);
 
   const selectedTemplate = useMemo(
@@ -35,6 +36,7 @@ export const ChartBuilderActions: FC<ChartBuilderActionsProps> = ({
 
     const title = buildChartTypeTitle(selectedTemplate, fieldValues);
     onCreateChart(title, {
+      ...chartOptions,
       chartType: selectedTemplateId,
       settings: fieldValues,
     } as ChartConfig);
@@ -44,6 +46,7 @@ export const ChartBuilderActions: FC<ChartBuilderActionsProps> = ({
     canCreate,
     selectedTemplateId,
     fieldValues,
+    chartOptions,
     onCreateChart,
     reset,
   ]);

--- a/packages/mosaic/src/chart-builders/ChartBuilderFields.tsx
+++ b/packages/mosaic/src/chart-builders/ChartBuilderFields.tsx
@@ -1,5 +1,5 @@
 import {cn} from '@sqlrooms/ui';
-import {FC, useCallback, useMemo} from 'react';
+import {FC, useMemo} from 'react';
 import {
   useChartBuilderContext,
   useChartBuilderStore,
@@ -19,23 +19,12 @@ export const ChartBuilderFields: FC<ChartBuilderFieldsProps> = ({
     (state) => state.selectedTemplateId,
   );
   const fieldValues = useChartBuilderStore((state) => state.fieldValues);
-  const setFieldValue = useChartBuilderStore((state) => state.setFieldValue);
+  const chartOptions = useChartBuilderStore((state) => state.chartOptions);
+  const setConfig = useChartBuilderStore((state) => state.setConfig);
 
   const chartTypeDefinition = useMemo(
     () => templates.find((template) => template.id === chartTypeDefinitionId),
     [templates, chartTypeDefinitionId],
-  );
-
-  const handleChange = useCallback(
-    (config: ChartConfig) => {
-      // Update all changed values from settings
-      Object.entries(config.settings).forEach(([key, value]) => {
-        if (fieldValues[key] !== value) {
-          setFieldValue(key, value);
-        }
-      });
-    },
-    [fieldValues, setFieldValue],
   );
 
   // Create a config object for the context
@@ -47,10 +36,11 @@ export const ChartBuilderFields: FC<ChartBuilderFieldsProps> = ({
       };
     }
     return {
+      ...chartOptions,
       chartType: chartTypeDefinition.id,
       settings: fieldValues,
     } as ChartConfig;
-  }, [chartTypeDefinition, fieldValues]);
+  }, [chartTypeDefinition, fieldValues, chartOptions]);
 
   if (!chartTypeDefinition) {
     return null;
@@ -62,7 +52,7 @@ export const ChartBuilderFields: FC<ChartBuilderFieldsProps> = ({
       <MosaicChartSettingsProvider
         config={config}
         columns={columns}
-        onChange={handleChange}
+        onChange={setConfig}
       >
         <SettingsComponent />
       </MosaicChartSettingsProvider>

--- a/packages/mosaic/src/chart-builders/createChartBuilderStore.ts
+++ b/packages/mosaic/src/chart-builders/createChartBuilderStore.ts
@@ -1,13 +1,17 @@
 import {produce} from 'immer';
 import {createStore} from 'zustand/vanilla';
-import {ChartType} from '../charts/chart-types';
+import {ChartConfig, ChartType} from '../charts/chart-types';
 
 export type ChartBuilderStoreState = {
   selectedTemplateId?: ChartType;
   fieldValues: Record<string, unknown>;
+  /** Chart-local options outside active settings, preserved through creation. */
+  chartOptions: Partial<ChartConfig>;
   reset: () => void;
   selectTemplate: (templateId: ChartType) => void;
   setFieldValue: (fieldKey: string, value: unknown) => void;
+  /** Replace a draft without discarding chart-specific options. */
+  setConfig: (config: ChartConfig) => void;
 };
 
 export type ChartBuilderStore = ReturnType<typeof createChartBuilderStore>;
@@ -16,11 +20,13 @@ export function createChartBuilderStore() {
   return createStore<ChartBuilderStoreState>((set) => ({
     selectedTemplateId: undefined,
     fieldValues: {},
+    chartOptions: {},
     reset: () => {
       set((state) =>
         produce(state, (draft) => {
           draft.selectedTemplateId = undefined;
           draft.fieldValues = {};
+          draft.chartOptions = {};
         }),
       );
     },
@@ -29,6 +35,7 @@ export function createChartBuilderStore() {
         produce(state, (draft) => {
           draft.selectedTemplateId = templateId;
           draft.fieldValues = {};
+          draft.chartOptions = {};
         }),
       );
     },
@@ -38,6 +45,9 @@ export function createChartBuilderStore() {
           draft.fieldValues[fieldKey] = value;
         }),
       );
+    },
+    setConfig: ({chartType, settings, ...chartOptions}) => {
+      set({selectedTemplateId: chartType, fieldValues: settings, chartOptions});
     },
   }));
 }

--- a/packages/mosaic/src/chart-builders/createChartBuilderStore.ts
+++ b/packages/mosaic/src/chart-builders/createChartBuilderStore.ts
@@ -2,6 +2,7 @@ import {produce} from 'immer';
 import {createStore} from 'zustand/vanilla';
 import {ChartConfig, ChartType} from '../charts/chart-types';
 
+/** State and actions for a chart-builder draft. */
 export type ChartBuilderStoreState = {
   selectedTemplateId?: ChartType;
   fieldValues: Record<string, unknown>;

--- a/packages/mosaic/src/charts/chart-types/line-chart/LineChartSettings.tsx
+++ b/packages/mosaic/src/charts/chart-types/line-chart/LineChartSettings.tsx
@@ -7,7 +7,8 @@ import {LineChartXFieldSelector} from './LineChartXFieldSelector';
 
 /**
  * Explicit settings component for line chart.
- * Composes primitive and compound components for full control over the UI.
+ * Numeric series are saved in the chart config while count mode is active, so
+ * switching back restores aggregations and colors even after reopening it.
  */
 export const LineChartSettingsComponent: FC = () => {
   const {onChange, onChangeConfig, config} =
@@ -25,12 +26,20 @@ export const LineChartSettingsComponent: FC = () => {
           value={metric}
           onChange={(value) => {
             if (value !== 'count' && value !== 'aggregate') return;
+            if (value === metric) return;
+            const {lastAggregateYFields, ...chartConfig} = config;
             onChange({
-              ...config,
+              ...chartConfig,
+              ...(value === 'count'
+                ? {lastAggregateYFields: config.settings.yFields}
+                : {}),
               settings: {
                 ...config.settings,
                 metric: value,
-                ...(value === 'count' ? {yFields: []} : {}),
+                yFields:
+                  value === 'count'
+                    ? []
+                    : (lastAggregateYFields ?? config.settings.yFields),
               },
             });
           }}

--- a/packages/mosaic/src/charts/chart-types/line-chart/LineChartSettings.tsx
+++ b/packages/mosaic/src/charts/chart-types/line-chart/LineChartSettings.tsx
@@ -1,6 +1,6 @@
 import {type FC} from 'react';
 import {Field} from '../../../components/Field';
-import {Switch} from '@sqlrooms/ui';
+import {Combobox, Switch} from '@sqlrooms/ui';
 import {useMosaicChartSettingsContext} from '../../chart-settings/MosaicChartSettingsContext';
 import {LineChartYFieldsSelector} from './LineChartYFieldsSelector';
 import {LineChartXFieldSelector} from './LineChartXFieldSelector';
@@ -10,7 +10,9 @@ import {LineChartXFieldSelector} from './LineChartXFieldSelector';
  * Composes primitive and compound components for full control over the UI.
  */
 export const LineChartSettingsComponent: FC = () => {
-  const {onChangeConfig, config} = useMosaicChartSettingsContext('line-chart');
+  const {onChange, onChangeConfig, config} =
+    useMosaicChartSettingsContext('line-chart');
+  const metric = config.settings.metric ?? 'aggregate';
 
   return (
     <div className="space-y-4">
@@ -18,9 +20,36 @@ export const LineChartSettingsComponent: FC = () => {
         <LineChartXFieldSelector />
       </Field>
 
-      <Field label="Y Axis" required>
-        <LineChartYFieldsSelector />
+      <Field label="Y Metric">
+        <Combobox
+          value={metric}
+          onChange={(value) => {
+            if (value !== 'count' && value !== 'aggregate') return;
+            onChange({
+              ...config,
+              settings: {
+                ...config.settings,
+                metric: value,
+                ...(value === 'count' ? {yFields: []} : {}),
+              },
+            });
+          }}
+        >
+          <Combobox.Trigger className="shadow-none">
+            {metric === 'count' ? 'Row count' : 'Numeric fields'}
+          </Combobox.Trigger>
+          <Combobox.Content>
+            <Combobox.Item value="aggregate">Numeric fields</Combobox.Item>
+            <Combobox.Item value="count">Row count</Combobox.Item>
+          </Combobox.Content>
+        </Combobox>
       </Field>
+
+      {metric === 'aggregate' && (
+        <Field label="Y Axis" required>
+          <LineChartYFieldsSelector />
+        </Field>
+      )}
 
       <label className="flex cursor-pointer items-center gap-2">
         <Switch

--- a/packages/mosaic/src/charts/chart-types/line-chart/LineChartXFieldSelector.tsx
+++ b/packages/mosaic/src/charts/chart-types/line-chart/LineChartXFieldSelector.tsx
@@ -10,7 +10,8 @@ import {useMosaicChartSettingsContext} from '../../chart-settings/MosaicChartSet
  * Includes temporal granularity selector when X field is temporal.
  */
 export const LineChartXFieldSelector: FC = () => {
-  const {onChangeConfig, config} = useMosaicChartSettingsContext('line-chart');
+  const {onChange, onChangeConfig, config} =
+    useMosaicChartSettingsContext('line-chart');
 
   const {columns} = useColumnsContext();
   const xColumn = columns.find((c) => c.name === config.settings.x);
@@ -27,7 +28,19 @@ export const LineChartXFieldSelector: FC = () => {
     >
       <ColumnSelector.Quantitative
         value={config.settings.x}
-        onChange={(x) => onChangeConfig('x', x)}
+        onChange={(x) => {
+          const selectedColumn = columns.find((column) => column.name === x);
+          if (selectedColumn && isTemporalType(selectedColumn.type)) {
+            onChange({
+              ...config,
+              settings: {...config.settings, x},
+            });
+            return;
+          }
+          const settings = {...config.settings};
+          delete settings.xInterval;
+          onChange({...config, settings: {...settings, x}});
+        }}
       />
       {isXFieldTemporal && (
         <TemporalGranularitySelector

--- a/packages/mosaic/src/charts/chart-types/line-chart/definition.ts
+++ b/packages/mosaic/src/charts/chart-types/line-chart/definition.ts
@@ -19,13 +19,15 @@ export const lineChartChartType: SpecChartTypeDefinition<LineChartConfig> = {
   settingsComponent: LineChartSettingsComponent,
   buildTitle: titleFromDescription(DESCRIPTION),
   createTool: createLineChartAiTool,
+  // Count queries can still return one point per distinct X value. Limit the
+  // result, even with an interval: binning does not guarantee low cardinality.
   getDataPolicy: ({config}) =>
-    config.settings.metric === 'count' || config.settings.xInterval
+    config.settings.metric !== 'count' && config.settings.xInterval
       ? null
       : {
           maxRows: DEFAULT_CHART_MAX_DATA_POINTS,
           reason:
-            'Unaggregated line charts render source rows. Add a temporal interval or use an aggregated chart for larger datasets.',
+            'Line charts render one point per result row. Use a coarser temporal interval or reduce the distinct X values for larger results.',
         },
   createSpec: createLineChartSpec,
 };

--- a/packages/mosaic/src/charts/chart-types/line-chart/definition.ts
+++ b/packages/mosaic/src/charts/chart-types/line-chart/definition.ts
@@ -7,7 +7,7 @@ import {LineChart} from 'lucide-react';
 import {createLineChartSpec} from './spec';
 import {DEFAULT_CHART_MAX_DATA_POINTS} from '../../../chart-runtime';
 
-const DESCRIPTION = 'Create a line chart of two fields';
+const DESCRIPTION = 'Create a line chart of numeric measures or row counts';
 
 export const lineChartChartType: SpecChartTypeDefinition<LineChartConfig> = {
   id: 'line-chart',
@@ -20,7 +20,7 @@ export const lineChartChartType: SpecChartTypeDefinition<LineChartConfig> = {
   buildTitle: titleFromDescription(DESCRIPTION),
   createTool: createLineChartAiTool,
   getDataPolicy: ({config}) =>
-    config.settings.xInterval
+    config.settings.metric === 'count' || config.settings.xInterval
       ? null
       : {
           maxRows: DEFAULT_CHART_MAX_DATA_POINTS,

--- a/packages/mosaic/src/charts/chart-types/line-chart/schema.ts
+++ b/packages/mosaic/src/charts/chart-types/line-chart/schema.ts
@@ -13,6 +13,12 @@ export const YFieldConfig = z.object({
 export type YFieldConfig = z.infer<typeof YFieldConfig>;
 
 export const LineChartSettings = z.object({
+  metric: z
+    .enum(['aggregate', 'count'])
+    .optional()
+    .describe(
+      'Use count for row counts (COUNT(*)) with no yFields, or aggregate for numeric Y fields. Omission preserves existing numeric-series behavior.',
+    ),
   x: z
     .string()
     .optional()

--- a/packages/mosaic/src/charts/chart-types/line-chart/schema.ts
+++ b/packages/mosaic/src/charts/chart-types/line-chart/schema.ts
@@ -42,6 +42,8 @@ export type LineChartSettings = z.infer<typeof LineChartSettings>;
 export const LineChartConfig = z.object({
   chartType: z.literal('line-chart'),
   settings: LineChartSettings,
+  /** Chart-local UI memory, kept outside the active count-series settings. */
+  lastAggregateYFields: z.array(YFieldConfig).optional(),
   settingsOpen: z.boolean().optional(),
   dataPolicy: ChartDataPolicyOverrideConfig.optional(),
 });

--- a/packages/mosaic/src/charts/chart-types/line-chart/spec.ts
+++ b/packages/mosaic/src/charts/chart-types/line-chart/spec.ts
@@ -21,11 +21,29 @@ export function createLineChartSpec(
 ): Spec {
   const {dataTable, selectionName, settings} = options;
 
-  const {xColumn, yColumns, xInterval} = validateLineChartSettings(options);
+  const {metric, xColumn, yColumns, xInterval} =
+    validateLineChartSettings(options);
 
   const isXTemporal = isTemporalType(xColumn.type);
 
-  const plotMarks: unknown[] = [];
+  const hasTemporalAggregation = Boolean(isXTemporal && xInterval);
+  const series =
+    metric === 'count'
+      ? [
+          {
+            y: {count: null},
+            label: 'Count',
+            color: DEFAULT_CHART_FALLBACK_COLOR,
+          },
+        ]
+      : yColumns.map(({color, column, aggregate}) => ({
+          y: hasTemporalAggregation ? {[aggregate]: column.name} : column.name,
+          label: getLegendLabel(
+            {field: column.name, aggregate},
+            hasTemporalAggregation,
+          ),
+          color,
+        }));
 
   // Data source always includes filterBy for brush
   const dataSource = {
@@ -33,29 +51,15 @@ export function createLineChartSpec(
     filterBy: '$brush',
   };
 
-  // Generate lineY marks for each Y field
-  yColumns.forEach(({color, column, aggregate}) => {
-    // When temporal aggregation is active, use bin for X and aggregation for Y
-    if (isXTemporal && xInterval) {
-      // Use bin syntax for temporal aggregation
-      plotMarks.push({
-        mark: 'lineY',
-        data: dataSource,
-        x: {bin: xColumn.name, interval: xInterval},
-        y: {[aggregate]: column.name},
-        stroke: color,
-      });
-    } else {
-      // No aggregation - direct field references
-      plotMarks.push({
-        mark: 'lineY',
-        data: dataSource,
-        x: xColumn.name,
-        y: column.name,
-        stroke: color,
-      });
-    }
-  });
+  const plotMarks: unknown[] = series.map(({y, color}) => ({
+    mark: 'lineY',
+    data: dataSource,
+    x: hasTemporalAggregation
+      ? {bin: xColumn.name, interval: xInterval}
+      : xColumn.name,
+    y,
+    stroke: color,
+  }));
 
   // Add brush control only if selectionName is provided
   if (selectionName) {
@@ -68,22 +72,15 @@ export function createLineChartSpec(
     plot: plotMarks,
     name: 'lineChart',
     xLabel: xColumn.name,
-    yLabel: undefined,
+    yLabel: metric === 'count' ? 'Count' : undefined,
     margins: {
       left: 50,
       right: 20,
       top: 20,
       bottom: 50,
     },
-    colorDomain: yColumns.map((yColumn) =>
-      getLegendLabel(
-        {field: yColumn.column.name, aggregate: yColumn.aggregate},
-        Boolean(isXTemporal && xInterval),
-      ),
-    ),
-    colorRange: yColumns.map(
-      (yColumn) => yColumn.color ?? DEFAULT_CHART_FALLBACK_COLOR,
-    ),
+    colorDomain: series.map(({label}) => label),
+    colorRange: series.map(({color}) => color),
   };
 
   if (!showLegend) {
@@ -99,7 +96,7 @@ export function createLineChartSpec(
       {
         legend: 'color',
         for: 'lineChart',
-        columns: yColumns.length,
+        columns: series.length,
       },
     ],
     params: {brush: {select: 'crossfilter'}},

--- a/packages/mosaic/src/charts/chart-types/line-chart/spec.ts
+++ b/packages/mosaic/src/charts/chart-types/line-chart/spec.ts
@@ -6,6 +6,7 @@ import {CreateSpecOptions, getChartTableReference} from '../base-types';
 import {DEFAULT_CHART_FALLBACK_COLOR} from '../../../constants/chart-colors';
 import {validateLineChartSettings} from './validation';
 
+/** Include the aggregation in a numeric-series legend only when it is applied. */
 function getLegendLabel(
   yColumn: {field: string; aggregate?: AggregateFunction},
   hasAggregation: boolean,
@@ -16,6 +17,11 @@ function getLegendLabel(
   return yColumn.field;
 }
 
+/**
+ * Compile validated settings into a brushable Mosaic line chart. Count mode
+ * uses COUNT(*) per X value/bin; numeric mode retains the configured Y series.
+ * @throws When required fields, column types, or metric settings are invalid.
+ */
 export function createLineChartSpec(
   options: CreateSpecOptions<LineChartSettings>,
 ): Spec {

--- a/packages/mosaic/src/charts/chart-types/line-chart/tool.ts
+++ b/packages/mosaic/src/charts/chart-types/line-chart/tool.ts
@@ -21,6 +21,11 @@ export const LineChartToolInput = BaseChartToolInput.extend({
 
 export type LineChartToolInput = z.infer<typeof LineChartToolInput>;
 
+/**
+ * Create an AI tool that validates count/numeric settings before invoking the
+ * host's chart callback. Existing panel targets are forwarded for in-place
+ * editing; validation or host failures are returned as unsuccessful results.
+ */
 export function createLineChartAiTool({
   databaseAdapter,
   addChart,
@@ -37,6 +42,7 @@ Required:
 
 Metric decision:
 - For event counts/frequency over time on raw observations, set metric: "count" and omit yFields. This counts ALL rows using COUNT(*), including rows with null identifiers. Example: {x: "DateTime", xInterval: "month", metric: "count"}.
+- Count charts retain the ${maxDataPoints.toLocaleString()} result-point limit. An interval groups source rows but may still yield too many points; use a coarser temporal interval or fewer distinct X values if needed.
 - For numeric measures or already summarized counts, use metric: "aggregate" (the default) with yFields: array of {field: string (numeric: ${NUMERIC_COLUMN_TYPES.join(', ')}), aggregate?: ${AGGREGATE_FUNCTIONS.join('|')}}.
 - Never sum an event ID or other identifier to represent a count. Do not put aggregate: "count" in yFields; row counts use metric: "count" instead.
 

--- a/packages/mosaic/src/charts/chart-types/line-chart/tool.ts
+++ b/packages/mosaic/src/charts/chart-types/line-chart/tool.ts
@@ -16,7 +16,7 @@ const AGGREGATE_FUNCTIONS = AggregateFunction.options;
 const TEMPORAL_INTERVALS = TemporalInterval.options;
 
 export const LineChartToolInput = BaseChartToolInput.extend({
-  settings: LineChartSettings.required(),
+  settings: LineChartSettings.required({x: true}),
 });
 
 export type LineChartToolInput = z.infer<typeof LineChartToolInput>;
@@ -34,7 +34,11 @@ Example queries: "population growth over time", "temperature trend by month", "s
 
 Required:
 - x: quantitative column (${QUANTITATIVE_COLUMN_TYPES.join(', ')})
-- yFields: array of {field: string (numeric: ${NUMERIC_COLUMN_TYPES.join(', ')}), aggregate?: ${AGGREGATE_FUNCTIONS.join('|')}}
+
+Metric decision:
+- For event counts/frequency over time on raw observations, set metric: "count" and omit yFields. This counts ALL rows using COUNT(*), including rows with null identifiers. Example: {x: "DateTime", xInterval: "month", metric: "count"}.
+- For numeric measures or already summarized counts, use metric: "aggregate" (the default) with yFields: array of {field: string (numeric: ${NUMERIC_COLUMN_TYPES.join(', ')}), aggregate?: ${AGGREGATE_FUNCTIONS.join('|')}}.
+- Never sum an event ID or other identifier to represent a count. Do not put aggregate: "count" in yFields; row counts use metric: "count" instead.
 
 Optional: xInterval for temporal grouping (${TEMPORAL_INTERVALS.join(', ')}) when x is temporal (${TEMPORAL_COLUMN_TYPES.join(', ')}).
 Multiple yFields create multi-line chart for comparing metrics.
@@ -46,15 +50,16 @@ Do NOT use for: single point distributions (use histogram), categorical counts (
     execute: async ({tableName, title, settings, panelId}) => {
       try {
         const dataTable = ensureTable(databaseAdapter, tableName);
+        const normalizedSettings = LineChartSettings.parse(settings);
 
         validateLineChartSettings({
           dataTable,
-          settings,
+          settings: normalizedSettings,
         });
 
         const chartConfig: LineChartConfig = {
           chartType: 'line-chart' as const,
-          settings,
+          settings: normalizedSettings,
         };
 
         await addChart({

--- a/packages/mosaic/src/charts/chart-types/line-chart/tool.ts
+++ b/packages/mosaic/src/charts/chart-types/line-chart/tool.ts
@@ -58,14 +58,17 @@ Do NOT use for: single point distributions (use histogram), categorical counts (
         const dataTable = ensureTable(databaseAdapter, tableName);
         const normalizedSettings = LineChartSettings.parse(settings);
 
-        validateLineChartSettings({
+        const validatedSettings = validateLineChartSettings({
           dataTable,
           settings: normalizedSettings,
         });
+        const shouldLimitResults =
+          validatedSettings.metric === 'count' || !validatedSettings.xInterval;
 
         const chartConfig: LineChartConfig = {
           chartType: 'line-chart' as const,
           settings: normalizedSettings,
+          ...(shouldLimitResults ? {dataPolicy: {maxRows: maxDataPoints}} : {}),
         };
 
         await addChart({

--- a/packages/mosaic/src/charts/chart-types/line-chart/validation.ts
+++ b/packages/mosaic/src/charts/chart-types/line-chart/validation.ts
@@ -1,6 +1,7 @@
 import {LineChartSettings} from './schema';
 import {ValidateSpecOptions} from '../base-types';
 import {
+  ChartSpecError,
   InvalidColumnTypeError,
   MissingColumnsError,
   RequiredFieldsError,
@@ -11,6 +12,7 @@ import {AggregateFunction, TemporalInterval} from '../../../schemas';
 import {DEFAULT_CHART_FALLBACK_COLOR} from '../../../constants/chart-colors';
 
 export type ValidatedLineChartSettings = {
+  metric: 'aggregate' | 'count';
   xColumn: TableColumn;
   yColumns: {
     field: string;
@@ -23,18 +25,30 @@ export type ValidatedLineChartSettings = {
 
 export function validateLineChartSettings({
   dataTable,
-  settings: {x, yFields = [], xInterval},
+  settings: {x, yFields = [], xInterval, metric = 'aggregate'},
 }: ValidateSpecOptions<LineChartSettings>): ValidatedLineChartSettings {
   // Basic validation for required fields
-  if (!x || yFields.length === 0) {
+  if (!x || (metric === 'aggregate' && yFields.length === 0)) {
     throw new RequiredFieldsError([
       ...(x ? [] : ['X-axis']),
-      ...(yFields.length > 0 ? [] : ['Y-axis']),
+      ...(metric === 'count' || yFields.length > 0 ? [] : ['Y-axis']),
     ]);
   }
 
   // Validate X and Y field existence
   const xColumn = dataTable.columns.find((col) => col.name === x);
+  if (!xColumn) throw new MissingColumnsError(['X-axis']);
+  if (!isQuantitativeType(xColumn.type)) {
+    throw new InvalidColumnTypeError(xColumn.name, 'quantitative');
+  }
+  if (metric === 'count') {
+    if (yFields.length > 0) {
+      throw new ChartSpecError(
+        'Row counts use COUNT(*). Omit yFields when metric is count; use metric aggregate for numeric series.',
+      );
+    }
+    return {metric, xColumn, yColumns: [], xInterval};
+  }
   const yColumns = yFields.map((y) => ({
     field: y.field,
     column: dataTable.columns.find((col) => col.name === y.field),
@@ -44,18 +58,11 @@ export function validateLineChartSettings({
 
   const missingYColumns = yColumns.filter((y) => !y.column);
 
-  if (!xColumn || missingYColumns.length > 0) {
-    throw new MissingColumnsError([
-      ...(xColumn ? [] : ['X-axis']),
-      ...missingYColumns.map((y) => y.field),
-    ]);
+  if (missingYColumns.length > 0) {
+    throw new MissingColumnsError(missingYColumns.map((y) => y.field));
   }
 
   // Validate X and Y field types
-  if (!isQuantitativeType(xColumn.type)) {
-    throw new InvalidColumnTypeError(xColumn.name, 'quantitative');
-  }
-
   const invalidYFields = yColumns.filter((y) => {
     return y.column && !isNumericType(y.column.type);
   });
@@ -68,6 +75,7 @@ export function validateLineChartSettings({
   }
 
   return {
+    metric,
     xColumn,
     yColumns,
     xInterval,

--- a/packages/mosaic/src/charts/chart-types/line-chart/validation.ts
+++ b/packages/mosaic/src/charts/chart-types/line-chart/validation.ts
@@ -11,6 +11,7 @@ import {TableColumn} from '@sqlrooms/duckdb';
 import {AggregateFunction, TemporalInterval} from '../../../schemas';
 import {DEFAULT_CHART_FALLBACK_COLOR} from '../../../constants/chart-colors';
 
+/** Resolved X/Y columns and metric used by the line-chart spec compiler. */
 export type ValidatedLineChartSettings = {
   metric: 'aggregate' | 'count';
   xColumn: TableColumn;
@@ -23,6 +24,13 @@ export type ValidatedLineChartSettings = {
   xInterval?: TemporalInterval;
 };
 
+/**
+ * Resolve chart fields against the source table and enforce the metric contract.
+ * Count mode requires quantitative X and no numeric Y series; numeric mode
+ * requires at least one numeric Y field and defaults to sum aggregation.
+ * @throws When fields are missing, column types are unsuitable, or count mode
+ * also supplies numeric Y series.
+ */
 export function validateLineChartSettings({
   dataTable,
   settings: {x, yFields = [], xInterval, metric = 'aggregate'},

--- a/packages/mosaic/src/charts/chart-types/line-chart/validation.ts
+++ b/packages/mosaic/src/charts/chart-types/line-chart/validation.ts
@@ -6,7 +6,11 @@ import {
   MissingColumnsError,
   RequiredFieldsError,
 } from '../errors';
-import {isNumericType, isQuantitativeType} from '../../../column-types-utils';
+import {
+  isNumericType,
+  isQuantitativeType,
+  isTemporalType,
+} from '../../../column-types-utils';
 import {TableColumn} from '@sqlrooms/duckdb';
 import {AggregateFunction, TemporalInterval} from '../../../schemas';
 import {DEFAULT_CHART_FALLBACK_COLOR} from '../../../constants/chart-colors';
@@ -48,6 +52,11 @@ export function validateLineChartSettings({
   if (!xColumn) throw new MissingColumnsError(['X-axis']);
   if (!isQuantitativeType(xColumn.type)) {
     throw new InvalidColumnTypeError(xColumn.name, 'quantitative');
+  }
+  if (xInterval && !isTemporalType(xColumn.type)) {
+    throw new ChartSpecError(
+      `xInterval requires a temporal X-axis column; ${xColumn.name} has type ${xColumn.type}.`,
+    );
   }
   if (metric === 'count') {
     if (yFields.length > 0) {


### PR DESCRIPTION
## Summary

Add first-class row counts to Mosaic line charts. Previously, the line-chart tool required a numeric Y field and the renderer supported only numeric measures, leaving no direct way to plot event frequency without preaggregating a table.

- Add optional `settings.metric: "count" | "aggregate"`; omission preserves existing numeric-series behavior.
- Compile row counts to Mosaic's zero-argument count transform (`COUNT(*)`), including rows with null identifiers. Count mode needs no Y field and rejects contradictory numeric series.
- Expose Row count / Numeric fields in the settings UI and document the same API for agent tools.
- Preserve numeric aggregates, brushes/legends, and target-bound document chart updates. Keep the 10,000-result-point guard for all count charts, including binned counts; this does not truncate input rows.

- Preserve fields, aggregations, and colors when switching back from Row count, including persisted-chart reopening. The generic builder now retains chart-local options through edits/creation and clears them on reset/template changes.
- Persist each host's configured result limit into tool-created count charts. Reject temporal intervals on numeric X axes, and atomically clear a stale interval when the settings UI switches from temporal to numeric X.

## Validation

- Mosaic: **26 suites / 165 tests passed**, including schema/tool/spec, data-policy, and bound-document create/edit regressions.
- `pnpm --filter @sqlrooms/mosaic build`: **passed**.
- Consumer integration exercises the production Mosaic query compiler against DuckDB: monthly counts are **3 / 2 / 1** with a null identifier; summing identifiers is rejected as an incorrect result, and valid preaggregation remains supported.
- Focused count/settings regressions: **2 suites / 27 tests passed**. Negative controls confirmed that the old guard and destructive toggle fail; dropping builder metadata, losing custom limits, silently ignoring numeric-axis intervals, and retaining a hidden stale interval all fail their new regressions.
- Mosaic-config ESLint on the changed files, Prettier, diff checks, and independent implementation review passed; no required findings remain.
- Desktop consumer: **47 suites / 528 tests**, **2 suites / 15 focused eval tests**, and web typecheck passed.
- Mock evals **9/9** (`eval-vwU-2026-09-03T14:20:53`); fresh uncached live PF-DOC-006 **1/1** (`eval-FB5-2026-09-03T14:22:11`, Claude Sonnet 4.5, concurrency 1), selected `metric: count` on raw earthquakes and produced **3 / 2 / 1** through `COUNT(*)`. These exercise the final model-facing changes, not the later builder-only UI adjustment; final deterministic suites include that adjustment.

Validation ran in the consuming workspace. Its dependency bootstrap built the required declarations but encountered pre-existing CodeMirror `string | MarkupContent` assignment errors. The Mosaic package build itself passed. Manual UI/packaging smoke testing was not performed; CI results are separate from this local evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Line charts now support a **Row count** metric, showing source-row totals over time or by X-axis value.
  - Count charts include rows with null identifiers and do not require a numeric Y-axis field.
  - Users can switch between row counts and numeric fields while preserving previous numeric selections.
  - Chart creation and AI tools validate metric-specific settings and retain chart options.
  - Existing numeric-field charts continue to work as before.
  - Count results aggregate the full source while retaining a 10,000-point display limit.

- **Documentation**
  - Added guidance on row-count behavior, grouping, configuration requirements, and result limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

