### PR TITLE
fix: Remove shadow effect from header div

### DIFF
--- a/packages/ai-core/src/components/defaultChatRendering.tsx
+++ b/packages/ai-core/src/components/defaultChatRendering.tsx
@@ -663,7 +663,7 @@ export const DefaultChatTurn: React.FC<ChatTurnSlotProps> = ({turn}) => {
   const Actions = turn.actions.Content;
   return (
     <div className="group mb-4 flex w-full flex-col gap-2 pb-2 text-sm">
-      <div className="bg-background sticky top-0 z-10 mb-2 flex items-center gap-2 text-gray-700 shadow-[0_4px_6px_-1px_rgba(0,0,0,0.15)] dark:text-gray-100 dark:shadow-[0_4px_6px_-1px_rgba(0,0,0,0.4)]">
+      <div className="bg-background sticky top-0 z-10 mb-2 flex items-center gap-2 text-gray-700 dark:text-gray-100 dark:shadow-[0_4px_6px_-1px_rgba(0,0,0,0.4)]">
         <Prompt />
       </div>
       <div className="flex w-full flex-col gap-2">


### PR DESCRIPTION
Remove shadow box for the prompt
<img width="550" height="196" alt="Screenshot 2026-09-04 at 11 36 40" src="https://github.com/user-attachments/assets/17ee196c-6556-4e04-9267-bd9bd132db4f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the light-mode shadow from the sticky chat header.
  * Retained the dark-mode shadow for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->