### PR TITLE
ci: enforce Prettier formatting in pull requests

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -36,4 +36,4 @@ jobs:
         run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Check Prettier formatting
-        run: pnpm format:check
+        run: pnpm exec prettier --check "**/*.{ts,tsx,md}"

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,0 +1,39 @@
+name: Prettier
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  prettier:
+    name: Check formatting
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Check Prettier formatting
+        run: pnpm format:check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,10 @@ If you've added a new feature, changed the configuration or public methods, plea
 
 ## Pull Requests
 
+CI checks Prettier formatting for TypeScript, TSX, and Markdown files using the
+repository's Prettier configuration and ignore rules. Run `pnpm format:check`
+before submitting a PR, and use `pnpm format:ts` to fix formatting issues.
+
 We actively welcome pull requests. If you want to submit one, please follow the following process:
 
 1. Fork the repo and create your branch from `main`

--- a/dev-docs/contributing/typescript.md
+++ b/dev-docs/contributing/typescript.md
@@ -16,7 +16,6 @@
 - Prefer defining complex component props as separate `type` over defining inline
 - Prefer defining one component per one file, avoid creating files with many components
 
-
 # Vega
 
 - Use typings for Vega-specs

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,28 +1,28 @@
-import {createRequire} from "node:module";
-import {existsSync, readFileSync} from "node:fs";
-import {fileURLToPath} from "node:url";
-import {defineConfig} from "vitepress";
-import llmstxt from "vitepress-plugin-llms";
-import {apiSidebarConfig} from "./gen-api-sidebar.ts";
+import {createRequire} from 'node:module';
+import {existsSync, readFileSync} from 'node:fs';
+import {fileURLToPath} from 'node:url';
+import {defineConfig} from 'vitepress';
+import llmstxt from 'vitepress-plugin-llms';
+import {apiSidebarConfig} from './gen-api-sidebar.ts';
 
-const SITE_URL = "https://sqlrooms.org";
+const SITE_URL = 'https://sqlrooms.org';
 const require = createRequire(import.meta.url);
-const mermaidRequire = createRequire(require.resolve("mermaid/package.json"));
-const localVersion = require("../../lerna.json").version;
+const mermaidRequire = createRequire(require.resolve('mermaid/package.json'));
+const localVersion = require('../../lerna.json').version;
 
 function loadApiReleaseMetadata() {
   const metadataPath = fileURLToPath(
-    new URL("./api-release.generated.json", import.meta.url),
+    new URL('./api-release.generated.json', import.meta.url),
   );
 
   if (existsSync(metadataPath)) {
-    return JSON.parse(readFileSync(metadataPath, "utf8"));
+    return JSON.parse(readFileSync(metadataPath, 'utf8'));
   }
 
   return {
     version: localVersion,
     ref: `v${localVersion}`,
-    prerelease: localVersion.includes("-"),
+    prerelease: localVersion.includes('-'),
   };
 }
 
@@ -30,11 +30,11 @@ const apiRelease = loadApiReleaseMetadata();
 const apiReleaseUrl = `https://github.com/sqlrooms/sqlrooms/releases/tag/${apiRelease.ref}`;
 
 function publicUrl(relativePath?: string) {
-  const normalizedRelativePath = (relativePath || "").replace(/^\/+/, "");
+  const normalizedRelativePath = (relativePath || '').replace(/^\/+/, '');
 
   return `${SITE_URL}/${normalizedRelativePath}`
-    .replace(/index\.md$/, "")
-    .replace(/\.md$/, ".html");
+    .replace(/index\.md$/, '')
+    .replace(/\.md$/, '.html');
 }
 
 // https://vitepress.dev/reference/site-config
@@ -45,7 +45,7 @@ const config = defineConfig({
 
       md.renderer.rules.fence = (tokens, index, options, env, self) => {
         const token = tokens[index];
-        if (token.info.trim() === "mermaid") {
+        if (token.info.trim() === 'mermaid') {
           const encoded = encodeURIComponent(token.content);
           return `<MermaidDiagram encoded="${encoded}" />`;
         }
@@ -61,23 +61,23 @@ const config = defineConfig({
       alias: [
         {
           find: /^dayjs$/,
-          replacement: mermaidRequire.resolve("dayjs/esm/index.js"),
+          replacement: mermaidRequire.resolve('dayjs/esm/index.js'),
         },
         {
           find: /^@braintree\/sanitize-url$/,
-          replacement: mermaidRequire.resolve("@braintree/sanitize-url"),
+          replacement: mermaidRequire.resolve('@braintree/sanitize-url'),
         },
         {
           find: /^cytoscape$/,
-          replacement: mermaidRequire.resolve("cytoscape"),
+          replacement: mermaidRequire.resolve('cytoscape'),
         },
         {
           find: /^cytoscape-cose-bilkent$/,
-          replacement: mermaidRequire.resolve("cytoscape-cose-bilkent"),
+          replacement: mermaidRequire.resolve('cytoscape-cose-bilkent'),
         },
         {
           find: /^debug$/,
-          replacement: mermaidRequire.resolve("debug"),
+          replacement: mermaidRequire.resolve('debug'),
         },
       ],
     },
@@ -87,31 +87,31 @@ const config = defineConfig({
         domain: SITE_URL,
         ignoreFiles: [
           // Omit generated media and non-reference pages from all LLM outputs.
-          "api/**/_media/**",
-          "join-slack.md",
-          "packages.md",
+          'api/**/_media/**',
+          'join-slack.md',
+          'packages.md',
         ],
         ignoreFilesPerOutput: {
           // Keep summary bundles focused on package-level docs, while still
           // generating per-symbol .md pages so package references can link to
           // useful markdown targets.
           llmsTxt: [
-            "api/**/classes/**",
-            "api/**/functions/**",
-            "api/**/interfaces/**",
-            "api/**/type-aliases/**",
-            "api/**/variables/**",
-            "api/**/enumerations/**",
-            "api/**/namespaces/**",
+            'api/**/classes/**',
+            'api/**/functions/**',
+            'api/**/interfaces/**',
+            'api/**/type-aliases/**',
+            'api/**/variables/**',
+            'api/**/enumerations/**',
+            'api/**/namespaces/**',
           ],
           llmsFullTxt: [
-            "api/**/classes/**",
-            "api/**/functions/**",
-            "api/**/interfaces/**",
-            "api/**/type-aliases/**",
-            "api/**/variables/**",
-            "api/**/enumerations/**",
-            "api/**/namespaces/**",
+            'api/**/classes/**',
+            'api/**/functions/**',
+            'api/**/interfaces/**',
+            'api/**/type-aliases/**',
+            'api/**/variables/**',
+            'api/**/enumerations/**',
+            'api/**/namespaces/**',
           ],
         },
         customLLMsTxtTemplate: `# {title}
@@ -151,20 +151,20 @@ Canonical package combos:
     ],
   },
   ignoreDeadLinks: true,
-  title: "SQLRooms",
+  title: 'SQLRooms',
   description:
-    "An open source React toolkit for human + agent collaborative analytics apps",
-  base: "/",
+    'An open source React toolkit for human + agent collaborative analytics apps',
+  base: '/',
   sitemap: {
     hostname: SITE_URL,
   },
   head: [
-    ["link", {rel: "icon", href: "/logo.svg", type: "image/svg+xml"}],
+    ['link', {rel: 'icon', href: '/logo.svg', type: 'image/svg+xml'}],
     [
-      "meta",
+      'meta',
       {
-        name: "google-site-verification",
-        content: "x-FE_DDWM1BS8Eu4JOG0el7pL1gWJgIM-fwFl2EG4OU",
+        name: 'google-site-verification',
+        content: 'x-FE_DDWM1BS8Eu4JOG0el7pL1gWJgIM-fwFl2EG4OU',
       },
     ],
   ],
@@ -173,22 +173,22 @@ Canonical package combos:
       ...apiRelease,
       url: apiReleaseUrl,
     },
-    outline: "deep",
-    logo: "/logo.svg",
+    outline: 'deep',
+    logo: '/logo.svg',
     search: {
-      provider: "local",
+      provider: 'local',
     },
     // https://vitepress.dev/reference/default-theme-config
     nav: [
-      {text: "Home", link: "/"},
-      {text: "Overview", link: "/overview"},
+      {text: 'Home', link: '/'},
+      {text: 'Overview', link: '/overview'},
       //{text: 'Concepts', link: '/key-concepts'},
-      {text: "Examples", link: "/examples"},
-      {text: "Case Studies", link: "/case-studies"},
-      {text: "Get started", link: "/getting-started"},
+      {text: 'Examples', link: '/examples'},
+      {text: 'Case Studies', link: '/case-studies'},
+      {text: 'Get started', link: '/getting-started'},
       {
         text: `API v${apiRelease.version}`,
-        link: "/packages",
+        link: '/packages',
       },
       // {
       //   text: 'Join Slack',
@@ -199,109 +199,109 @@ Canonical package combos:
 
     sidebar: [
       {
-        text: "Introduction",
+        text: 'Introduction',
         items: [
           {
-            text: "Overview",
-            link: "/overview",
+            text: 'Overview',
+            link: '/overview',
           },
           {
-            text: "Key Concepts",
-            link: "/key-concepts",
+            text: 'Key Concepts',
+            link: '/key-concepts',
           },
           {
-            text: "Modular Architecture",
-            link: "/modular-architecture",
+            text: 'Modular Architecture',
+            link: '/modular-architecture',
           },
           {
-            text: "Deployment Scenarios",
-            link: "/deployment-scenarios",
+            text: 'Deployment Scenarios',
+            link: '/deployment-scenarios',
           },
           {
             text: "What's New",
-            link: "/whats-new",
+            link: '/whats-new',
           },
           {
-            text: "Upgrade Guide",
-            link: "/upgrade-guide",
+            text: 'Upgrade Guide',
+            link: '/upgrade-guide',
           },
         ],
       },
       {
-        text: "Developer Guide",
+        text: 'Developer Guide',
         items: [
           {
-            text: "Getting Started",
-            link: "/getting-started",
+            text: 'Getting Started',
+            link: '/getting-started',
           },
           {
-            text: "State Management",
-            link: "/state-management",
+            text: 'State Management',
+            link: '/state-management',
           },
           {
-            text: "Persistence",
-            link: "/persistence",
+            text: 'Persistence',
+            link: '/persistence',
           },
           {
-            text: "Artifacts",
-            link: "/artifacts",
+            text: 'Artifacts',
+            link: '/artifacts',
           },
           {
-            text: "Blocks and Block Documents",
-            link: "/blocks-and-documents",
+            text: 'Blocks and Block Documents',
+            link: '/blocks-and-documents',
           },
           {
-            text: "Commands",
-            link: "/commands",
+            text: 'Commands',
+            link: '/commands',
           },
           {
-            text: "Query Cancellation",
-            link: "/query-cancellation",
+            text: 'Query Cancellation',
+            link: '/query-cancellation',
           },
           {
-            text: "Theming",
-            link: "/theming",
+            text: 'Theming',
+            link: '/theming',
           },
           {
-            text: "Offline Use",
-            link: "/offline-use",
-          },
-        ],
-      },
-
-      {
-        text: "Examples",
-        items: [
-          {
-            text: "Example Apps",
-            link: "/examples",
-          },
-          {
-            text: "Case Studies",
-            link: "/case-studies",
+            text: 'Offline Use',
+            link: '/offline-use',
           },
         ],
       },
 
       {
-        text: "Reference",
+        text: 'Examples',
         items: [
           {
-            text: "Package Reference",
-            link: "/packages",
+            text: 'Example Apps',
+            link: '/examples',
+          },
+          {
+            text: 'Case Studies',
+            link: '/case-studies',
+          },
+        ],
+      },
+
+      {
+        text: 'Reference',
+        items: [
+          {
+            text: 'Package Reference',
+            link: '/packages',
           },
           ...apiSidebarConfig,
           {
-            text: "Docs for LLMs",
-            link: "/llms",
+            text: 'Docs for LLMs',
+            link: '/llms',
           },
         ],
       },
     ],
 
     socialLinks: [
-      {icon: "slack", link: "/join-slack"},
-      {icon: "github", link: "https://github.com/sqlrooms/sqlrooms"},
+      {icon: 'slack', link: '/join-slack'},
+      {icon: 'github', link: 'https://github.com/sqlrooms/sqlrooms'},
     ],
   },
   transformHead({pageData, siteData}: any) {
@@ -309,12 +309,12 @@ Canonical package combos:
 
     const frontmatter = pageData.frontmatter || {};
     const isHome =
-      frontmatter.layout === "home" || pageData.relativePath === "index.md";
+      frontmatter.layout === 'home' || pageData.relativePath === 'index.md';
 
     const hero = (frontmatter.hero as any) || {};
 
     const title = isHome
-      ? `${hero.name || siteData.title} – ${hero.text || ""}`.trim()
+      ? `${hero.name || siteData.title} – ${hero.text || ''}`.trim()
       : pageData.title || siteData.title;
 
     const description = isHome
@@ -324,15 +324,15 @@ Canonical package combos:
     const image = `${SITE_URL}/sqlrooms-og.webp`;
 
     return [
-      ["meta", {property: "og:type", content: "website"}],
-      ["meta", {property: "og:title", content: title}],
-      ["meta", {property: "og:description", content: description}],
-      ["meta", {property: "og:image", content: image}],
-      ["meta", {property: "og:url", content: url}],
-      ["meta", {name: "twitter:card", content: "summary_large_image"}],
-      ["meta", {name: "twitter:title", content: title}],
-      ["meta", {name: "twitter:description", content: description}],
-      ["meta", {name: "twitter:image", content: image}],
+      ['meta', {property: 'og:type', content: 'website'}],
+      ['meta', {property: 'og:title', content: title}],
+      ['meta', {property: 'og:description', content: description}],
+      ['meta', {property: 'og:image', content: image}],
+      ['meta', {property: 'og:url', content: url}],
+      ['meta', {name: 'twitter:card', content: 'summary_large_image'}],
+      ['meta', {name: 'twitter:title', content: title}],
+      ['meta', {name: 'twitter:description', content: description}],
+      ['meta', {name: 'twitter:image', content: image}],
     ];
   },
   transformPageData(pageData) {
@@ -344,13 +344,13 @@ Canonical package combos:
       : [];
 
     const hasCanonical = pageData.frontmatter.head.some(
-      (entry) => entry[0] === "link" && entry[1]?.rel === "canonical",
+      (entry) => entry[0] === 'link' && entry[1]?.rel === 'canonical',
     );
 
     if (!hasCanonical) {
       pageData.frontmatter.head.push([
-        "link",
-        {rel: "canonical", href: canonicalUrl},
+        'link',
+        {rel: 'canonical', href: canonicalUrl},
       ]);
     }
   },

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "evals:provider:build": "pnpm --filter sqlrooms-cli-app evals:provider:build",
     "evals:test": "turbo test --filter=@sqlrooms/evals --filter=sqlrooms-cli-app",
     "format": "pnpm format:ts && pnpm format:python",
+    "format:check": "prettier --check \"**/*.{ts,tsx,md}\"",
     "format:python": "uv run --project python ruff check --fix python && uv run --project python ruff format python",
     "format:ts": "prettier --write \"**/*.{ts,tsx,md}\"",
     "graph": "turbo run build --filter=@sqlrooms/* --graph | sed 's/\\[root\\] @sqlrooms\\///g' | sed 's/#build//g' | grep -v '___ROOT___'",

--- a/packages/ai-core/src/devtools/ChatSessionDebugView.tsx
+++ b/packages/ai-core/src/devtools/ChatSessionDebugView.tsx
@@ -147,7 +147,7 @@ const TimelineFilterBar: React.FC<{
   );
 
   return (
-    <div className="flex w-full [scrollbar-width:none] gap-2 overflow-x-auto px-3 pt-1 pb-2 [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
+    <div className="flex w-full gap-2 overflow-x-auto px-3 pt-1 pb-2 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
       <ToggleGroup
         type="multiple"
         value={filters}
@@ -519,7 +519,7 @@ export const ChatSessionDebugView: React.FC<ChatSessionDebugViewProps> = ({
         className="flex min-h-0 flex-1 flex-col"
       >
         <div className="flex items-center gap-1 px-2 pt-0 pb-1">
-          <TabsList className="h-8 min-w-0 flex-1 [scrollbar-width:none] justify-start overflow-x-auto bg-transparent p-0 [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
+          <TabsList className="h-8 min-w-0 flex-1 justify-start overflow-x-auto bg-transparent p-0 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
             <TabsTrigger value="timeline" className="h-7 px-2 text-xs">
               Timeline
             </TabsTrigger>

--- a/packages/ai-core/src/types.ts
+++ b/packages/ai-core/src/types.ts
@@ -390,7 +390,8 @@ export type ToolRendererProps<TOutput = unknown, TInput = unknown> = {
 type IsAny<T> = 0 extends 1 & T ? true : false;
 
 type RenderableComponent<TProps> =
-  ComponentType<TProps> | ExoticComponent<TProps>;
+  | ComponentType<TProps>
+  | ExoticComponent<TProps>;
 
 /**
  * Component type inferred from a tool or from explicit output/input.

--- a/packages/app-runtime/__tests__/html-app.test.ts
+++ b/packages/app-runtime/__tests__/html-app.test.ts
@@ -354,14 +354,10 @@ describe('html-app helpers', () => {
       {revisionId: 'rev-inventory', name: 'Inventory chart', createdAt: 20},
     );
 
-    const restored = restoreHtmlAppRevisionState(
-      inventory.app,
-      'rev-legacy',
-      {
-        revisionId: 'rev-restore',
-        createdAt: 30,
-      },
-    );
+    const restored = restoreHtmlAppRevisionState(inventory.app, 'rev-legacy', {
+      revisionId: 'rev-restore',
+      createdAt: 30,
+    });
 
     expect(restored?.app.intent).toBeUndefined();
     expect(restored?.revision.intent).toBeUndefined();

--- a/packages/sql-editor/src/SqlEditorSlice.tsx
+++ b/packages/sql-editor/src/SqlEditorSlice.tsx
@@ -709,7 +709,10 @@ export function createSqlEditorSlice({
               set((state) =>
                 produce(state, (draft) => {
                   const r = draft.sqlEditor.queryResultsById[queryId];
-                  if (r?.status === 'loading' && r.controller === queryController) {
+                  if (
+                    r?.status === 'loading' &&
+                    r.controller === queryController
+                  ) {
                     r.isWrite = isWrite;
                   }
                 }),


### PR DESCRIPTION
Prettier formatting was only enforced by the local pre-commit hook, so PR #905 passed CI even though `ChatMessagesContainer.tsx` fails the repository's Prettier rules.

Add a dedicated **Prettier / Check formatting** workflow for pull requests, pushes to `main`, and manual runs, including docs-only changes. It invokes `pnpm exec prettier --check "**/*.{ts,tsx,md}"` directly against the same TypeScript, TSX, and Markdown scope as `pnpm format:ts`, using the existing configuration and ignore rules. Dependencies are installed from the frozen lockfile with lifecycle scripts disabled.

Format the six existing noncompliant files on `main` so the check starts green, and document the check/fix commands in `CONTRIBUTING.md`.

Action SHA pinning is deferred to a separate repository-wide change so all workflows can use a consistent policy.

Validation:
- The direct CI Prettier command and workflow formatting pass locally.
- Full `format:check` script passes with the lockfile's Prettier 3.8.3 and Tailwind plugin 0.7.4. Local validation reused the existing checkout's dependencies with pnpm's automatic dependency installation disabled.
- Verified that the reported file from PR #905 at `236bc56fcad8cf86e47cb54681ba769808fd638e` fails Prettier and passes after formatting.
- Verified all six baseline fixes exactly match Prettier output.
- Workflow/package formatting, package script ordering, and `git diff --check` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added automated formatting checks for TypeScript, TSX, and Markdown changes on pushes, pull requests, and manual runs.
  - Added a package script to verify formatting locally before submission.
  - Standardized formatting across selected project files without changing functionality.

- **Documentation**
  - Updated contribution guidance with formatting requirements and commands for checking or fixing issues.
  - Tidied the TypeScript contribution guide and documentation configuration formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
