### PR TITLE
fix(cli): restore legacy workspaces without overwriting failed loads

### DIFF
--- a/apps/sqlrooms-cli-ui/README.md
+++ b/apps/sqlrooms-cli-ui/README.md
@@ -222,6 +222,8 @@ to `linkedAt`, removes the obsolete `linkType`, and moves pinned artifact IDs
 from `artifactAi` to `artifacts`. Saving stays disabled until the saved workspace
 has been successfully validated and restored. A loading failure shows an error
 and preserves the existing database snapshot for recovery.
+After successful restoration, migrations and startup changes retained by the
+merge are saved automatically if they differ from the loaded snapshot.
 
 Standalone chart blocks reuse the same Mosaic chart view and settings panel as
 dashboard charts. Charts with the same `selectionGroupId` in one Document share

--- a/apps/sqlrooms-cli-ui/README.md
+++ b/apps/sqlrooms-cli-ui/README.md
@@ -217,6 +217,12 @@ They can contain editable text, images, standalone Mosaic/vgplot chart blocks, a
 direct stateful blocks such as dashboards, pivot tables, Data Table Explorers,
 SQL queries, and Markdown documents.
 
+Workspace loading also migrates legacy AI/artifact associations from `createdAt`
+to `linkedAt`, removes the obsolete `linkType`, and moves pinned artifact IDs
+from `artifactAi` to `artifacts`. Saving stays disabled until the saved workspace
+has been successfully validated and restored. A loading failure shows an error
+and preserves the existing database snapshot for recovery.
+
 Standalone chart blocks reuse the same Mosaic chart view and settings panel as
 dashboard charts. Charts with the same `selectionGroupId` in one Document share
 a crossfilter selection; charts without a group are independent.

--- a/apps/sqlrooms-cli-ui/src/__tests__/migrateCliPersistedWorkspace.test.ts
+++ b/apps/sqlrooms-cli-ui/src/__tests__/migrateCliPersistedWorkspace.test.ts
@@ -1,4 +1,6 @@
 import {MarkdownDocumentsSliceConfig} from '@sqlrooms/documents';
+import {ArtifactsSliceConfig} from '@sqlrooms/artifacts';
+import {ArtifactAiConfigSchema} from '@sqlrooms/artifacts/ai';
 import {migrateCliPersistedWorkspace} from '../migrateCliPersistedWorkspace';
 
 type PersistedWorkspaceFixture = {
@@ -80,6 +82,79 @@ function persistedWorkspace(): PersistedWorkspaceFixture {
 }
 
 describe('migrateCliPersistedWorkspace', () => {
+  it('restores legacy session associations and pinned artifacts alongside documents', () => {
+    const persisted = {
+      ...persistedWorkspace(),
+      artifactAi: {
+        sessionArtifactLinks: [
+          {
+            sessionId: 'chat',
+            artifactId: 'legacyBlockDocument',
+            createdAt: 1786377310614,
+            linkType: 'attached',
+          },
+        ],
+        pinnedArtifactIds: ['legacyBlockDocument'],
+      },
+    };
+    const migrated = migrateCliPersistedWorkspace(persisted);
+    expect(ArtifactAiConfigSchema.parse(migrated.artifactAi)).toEqual({
+      sessionArtifactLinks: [
+        {
+          sessionId: 'chat',
+          artifactId: 'legacyBlockDocument',
+          linkedAt: 1786377310614,
+        },
+      ],
+    });
+    expect(ArtifactsSliceConfig.parse(migrated.artifacts)).toMatchObject({
+      pinnedArtifactIds: ['legacyBlockDocument'],
+      artifactsById: {legacyBlockDocument: {type: 'block-document'}},
+    });
+    expect(migrateCliPersistedWorkspace(migrated)).toEqual(migrated);
+    expect(persisted.artifactAi.sessionArtifactLinks[0]).toHaveProperty(
+      'createdAt',
+      1786377310614,
+    );
+  });
+
+  it('preserves canonical association timestamps and pins, including empty pins', () => {
+    const migrated = migrateCliPersistedWorkspace({
+      artifacts: {pinnedArtifactIds: []},
+      artifactAi: {
+        pinnedArtifactIds: ['old-pin'],
+        sessionArtifactLinks: [
+          {
+            sessionId: 'chat',
+            artifactId: 'doc',
+            linkedAt: 2,
+            createdAt: 1,
+            linkType: 'created',
+          },
+        ],
+      },
+    });
+    expect(ArtifactAiConfigSchema.parse(migrated.artifactAi)).toEqual({
+      sessionArtifactLinks: [
+        {sessionId: 'chat', artifactId: 'doc', linkedAt: 2},
+      ],
+    });
+    expect(
+      ArtifactsSliceConfig.parse(migrated.artifacts).pinnedArtifactIds,
+    ).toEqual([]);
+  });
+
+  it('keeps invalid legacy associations subject to schema validation', () => {
+    const migrated = migrateCliPersistedWorkspace({
+      artifactAi: {
+        sessionArtifactLinks: [
+          {sessionId: 'chat', artifactId: 'doc', linkType: 'attached'},
+        ],
+      },
+    });
+    expect(() => ArtifactAiConfigSchema.parse(migrated.artifactAi)).toThrow();
+  });
+
   it('uses backing state to migrate artifact and embedded block types', () => {
     const migrated = migrateCliPersistedWorkspace(persistedWorkspace());
     const artifacts = (

--- a/apps/sqlrooms-cli-ui/src/__tests__/serverApi.test.ts
+++ b/apps/sqlrooms-cli-ui/src/__tests__/serverApi.test.ts
@@ -1,11 +1,92 @@
 import {afterEach, describe, expect, jest, test} from '@jest/globals';
-import {fetchMcpStatus} from '../serverApi';
+import {createStore} from 'zustand/vanilla';
+import {persist} from 'zustand/middleware';
+import {createDuckDbPersistStorage, fetchMcpStatus} from '../serverApi';
 
 const originalFetch = globalThis.fetch;
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
   jest.useRealTimers();
+});
+
+describe('DuckDB workspace restoration', () => {
+  function createWorkspace(
+    failMerge: boolean,
+    saved: {documents: string[]} | null,
+  ) {
+    let body = saved === null ? null : JSON.stringify(saved);
+    const writes: string[] = [];
+    const storage = createDuckDbPersistStorage<{documents: string[]}>({
+      query: async (sql) => {
+        if (sql.startsWith('SELECT')) {
+          return {toArray: () => (body === null ? [] : [{payload_json: body}])};
+        }
+        if (sql.startsWith('INSERT')) writes.push(sql);
+      },
+    });
+    const store = createStore(
+      persist(() => ({documents: [] as string[]}), {
+        name: 'test',
+        storage,
+        skipHydration: true,
+        merge: (persisted, current) => {
+          if (failMerge) throw new Error('Invalid saved workspace');
+          return {...current, ...(persisted as typeof current)};
+        },
+        onRehydrateStorage: () => (state, error) => {
+          if (state && !error) storage.markStateSnapshotSaved(state);
+        },
+      }),
+    );
+    return {
+      store,
+      storage,
+      writes,
+      repair: () => {
+        failMerge = false;
+        body = JSON.stringify({documents: ['repaired']});
+      },
+    };
+  }
+
+  test('never overwrites a workspace after merge fails, even on final flush', async () => {
+    jest.useFakeTimers();
+    const {store, storage, writes, repair} = createWorkspace(true, {
+      documents: ['saved'],
+    });
+    await store.persist.rehydrate();
+    expect(store.persist.hasHydrated()).toBe(false);
+    store.setState({documents: []});
+    await jest.advanceTimersByTimeAsync(500);
+    await storage.flush();
+    expect(writes).toEqual([]);
+
+    repair();
+    await store.persist.rehydrate();
+    expect(store.getState().documents).toEqual(['repaired']);
+    store.setState({documents: ['edited']});
+    await storage.flush();
+    expect(writes).toHaveLength(1);
+  });
+
+  test.each([null, {documents: ['saved']}])(
+    'enables saving after successful restoration of %j',
+    async (saved) => {
+      const {store, storage, writes} = createWorkspace(false, saved);
+      store.setState({documents: ['initializing']});
+      await storage.flush();
+      expect(writes).toEqual([]);
+      await store.persist.rehydrate();
+      expect(store.persist.hasHydrated()).toBe(true);
+      await storage.flush();
+      expect(writes).toEqual([]);
+      store.setState({documents: ['edited']});
+      await storage.flush();
+      expect(writes).toHaveLength(1);
+      expect(writes[0]).toContain('edited');
+    },
+  );
 });
 
 describe('fetchMcpStatus', () => {

--- a/apps/sqlrooms-cli-ui/src/__tests__/serverApi.test.ts
+++ b/apps/sqlrooms-cli-ui/src/__tests__/serverApi.test.ts
@@ -11,22 +11,28 @@ afterEach(() => {
 });
 
 describe('DuckDB workspace restoration', () => {
+  type WorkspaceState = {documents: string[]; title?: string};
+
+  /** Creates a controllable database load and records every attempted save. */
   function createWorkspace(
     failMerge: boolean,
-    saved: {documents: string[]} | null,
+    saved: WorkspaceState | null,
+    loadPending?: Promise<void>,
+    synchronize?: (state: WorkspaceState) => WorkspaceState,
   ) {
     let body = saved === null ? null : JSON.stringify(saved);
     const writes: string[] = [];
-    const storage = createDuckDbPersistStorage<{documents: string[]}>({
+    const storage = createDuckDbPersistStorage<WorkspaceState>({
       query: async (sql) => {
         if (sql.startsWith('SELECT')) {
+          await loadPending;
           return {toArray: () => (body === null ? [] : [{payload_json: body}])};
         }
         if (sql.startsWith('INSERT')) writes.push(sql);
       },
     });
-    const store = createStore(
-      persist(() => ({documents: [] as string[]}), {
+    const store = createStore<WorkspaceState>()(
+      persist((): WorkspaceState => ({documents: []}), {
         name: 'test',
         storage,
         skipHydration: true,
@@ -35,7 +41,9 @@ describe('DuckDB workspace restoration', () => {
           return {...current, ...(persisted as typeof current)};
         },
         onRehydrateStorage: () => (state, error) => {
-          if (state && !error) storage.markStateSnapshotSaved(state);
+          if (!state || error) return;
+          if (synchronize) store.setState(synchronize(state));
+          storage.completeHydration(store.getState());
         },
       }),
     );
@@ -80,13 +88,63 @@ describe('DuckDB workspace restoration', () => {
       await store.persist.rehydrate();
       expect(store.persist.hasHydrated()).toBe(true);
       await storage.flush();
-      expect(writes).toEqual([]);
+      const initialWrites = saved === null ? 1 : 0;
+      expect(writes).toHaveLength(initialWrites);
       store.setState({documents: ['edited']});
       await storage.flush();
-      expect(writes).toHaveLength(1);
-      expect(writes[0]).toContain('edited');
+      expect(writes).toHaveLength(initialWrites + 1);
+      expect(writes[initialWrites]).toContain('edited');
     },
   );
+
+  test.each([null, {documents: ['saved']}])(
+    'saves startup changes retained by merge once after loading %j',
+    async (saved) => {
+      jest.useFakeTimers();
+      let finishLoad!: () => void;
+      const loadPending = new Promise<void>((resolve) => {
+        finishLoad = resolve;
+      });
+      const {store, storage, writes} = createWorkspace(
+        false,
+        saved,
+        loadPending,
+      );
+      const hydration = store.persist.rehydrate();
+      store.setState({title: 'Initialized title'});
+      await jest.advanceTimersByTimeAsync(500);
+      await storage.flush();
+      expect(writes).toEqual([]);
+
+      finishLoad();
+      await hydration;
+      expect(store.getState()).toEqual({
+        documents: saved?.documents ?? [],
+        title: 'Initialized title',
+      });
+      expect(storage.controller.getState().dirty).toBe(true);
+      await jest.advanceTimersByTimeAsync(500);
+      expect(writes).toHaveLength(1);
+      expect(writes[0]).toContain(JSON.stringify(store.getState()));
+      expect(storage.controller.getState().dirty).toBe(false);
+      await storage.flush();
+      expect(writes).toHaveLength(1);
+    },
+  );
+
+  test('saves post-load synchronization from the latest store state', async () => {
+    const {store, storage, writes} = createWorkspace(
+      false,
+      {documents: ['saved']},
+      undefined,
+      (state) => ({...state, title: 'Synchronized title'}),
+    );
+    await store.persist.rehydrate();
+    await storage.flush();
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toContain(JSON.stringify(store.getState()));
+    expect(writes[0]).toContain('Synchronized title');
+  });
 });
 
 describe('fetchMcpStatus', () => {

--- a/apps/sqlrooms-cli-ui/src/migrateCliPersistedWorkspace.ts
+++ b/apps/sqlrooms-cli-ui/src/migrateCliPersistedWorkspace.ts
@@ -66,9 +66,44 @@ function migrateBlockDocumentsSlice(value: unknown): unknown {
   };
 }
 
+function migrateArtifactAiAssociations(
+  workspace: UnknownRecord,
+): UnknownRecord {
+  const artifactAi = asRecord(workspace.artifactAi);
+  if (!artifactAi) return workspace;
+
+  const {pinnedArtifactIds, ...currentArtifactAi} = artifactAi;
+  if (Array.isArray(artifactAi.sessionArtifactLinks)) {
+    currentArtifactAi.sessionArtifactLinks =
+      artifactAi.sessionArtifactLinks.map((value) => {
+        const link = asRecord(value);
+        if (!link) return value;
+        const {createdAt, linkType: _linkType, ...association} = link;
+        return {
+          ...association,
+          linkedAt:
+            'linkedAt' in association ? association.linkedAt : createdAt,
+        };
+      });
+  }
+
+  const artifacts = asRecord(workspace.artifacts);
+  return {
+    ...workspace,
+    artifactAi: currentArtifactAi,
+    ...(pinnedArtifactIds !== undefined && {
+      artifacts: {
+        ...artifacts,
+        pinnedArtifactIds: artifacts?.pinnedArtifactIds ?? pinnedArtifactIds,
+      },
+    }),
+  };
+}
+
 function preprocessCliPersistedWorkspace(value: unknown): unknown {
-  const workspace = asRecord(value);
-  if (!workspace) return value;
+  const record = asRecord(value);
+  if (!record) return value;
+  const workspace = migrateArtifactAiAssociations(record);
 
   const legacy = asRecord(workspace.documents);
   const canonical = asRecord(workspace.markdownDocuments);
@@ -158,9 +193,9 @@ const CliPersistedWorkspaceRecord = z
   });
 
 /**
- * Migrates legacy CLI artifact discriminators with access to their backing
- * slices, then validates that each artifact has at most one document backing
- * state.
+ * Migrates legacy CLI artifact discriminators, AI associations, and pinned
+ * artifacts, then validates that each artifact has at most one document
+ * backing state.
  */
 export const CliPersistedWorkspaceSchema = z.preprocess(
   preprocessCliPersistedWorkspace,

--- a/apps/sqlrooms-cli-ui/src/migrateCliPersistedWorkspace.ts
+++ b/apps/sqlrooms-cli-ui/src/migrateCliPersistedWorkspace.ts
@@ -66,6 +66,7 @@ function migrateBlockDocumentsSlice(value: unknown): unknown {
   };
 }
 
+/** Converts legacy chat associations and pins while preserving canonical values. */
 function migrateArtifactAiAssociations(
   workspace: UnknownRecord,
 ): UnknownRecord {

--- a/apps/sqlrooms-cli-ui/src/serverApi.ts
+++ b/apps/sqlrooms-cli-ui/src/serverApi.ts
@@ -57,6 +57,9 @@ export function createDuckDbPersistStorage<TPersisted>(
   const namespace = options?.namespace || '__sqlrooms';
   let ensured: Promise<void> | null = null;
   let handlersRegistered = false;
+  // Loading the JSON is not enough: slice validation and merge must succeed
+  // before runtime changes are allowed to replace the saved workspace.
+  let hydrated = false;
   const ensure = () => {
     ensured = ensured ?? ensureUiStateTable(connector, namespace);
     return ensured;
@@ -121,9 +124,18 @@ export function createDuckDbPersistStorage<TPersisted>(
     ...persistence.storage,
     controller: persistence.controller,
     flush: persistence.flush,
-    markStateSnapshotSaved: persistence.markStateSnapshotSaved,
+    markStateSnapshotSaved: (state) => {
+      persistence.markStateSnapshotSaved(state);
+      hydrated = true;
+    },
+
+    getItem: async (...args) => {
+      hydrated = false;
+      return persistence.storage.getItem(...args);
+    },
 
     setItem: async (...args) => {
+      if (!hydrated) return;
       registerFlushHandlers();
       return persistence.storage.setItem(...args);
     },

--- a/apps/sqlrooms-cli-ui/src/serverApi.ts
+++ b/apps/sqlrooms-cli-ui/src/serverApi.ts
@@ -13,10 +13,12 @@ type DuckDbLikeConnector = {
 const UI_STATE_KEY = 'default';
 const PERSIST_DEBOUNCE_MS = 300;
 
+/** DuckDB persistence with an explicit successful-restoration boundary. */
 export type DuckDbPersistStorage<TPersisted> = PersistStorage<TPersisted> & {
   controller: PersistenceController<string>;
   flush: () => Promise<void>;
-  markStateSnapshotSaved: (state: TPersisted) => void;
+  /** Enables writes and schedules any changes retained by a successful restore. */
+  completeHydration: (state: TPersisted) => void;
 };
 
 function sanitizeIdent(ident: string): string {
@@ -50,6 +52,10 @@ function escapeLiteral(json: string) {
   return json.replace(/'/g, "''");
 }
 
+/**
+ * Creates debounced workspace storage that blocks writes until the caller
+ * completes validation, merging, and post-load synchronization successfully.
+ */
 export function createDuckDbPersistStorage<TPersisted>(
   connector: DuckDbLikeConnector,
   options?: {namespace?: string},
@@ -124,9 +130,12 @@ export function createDuckDbPersistStorage<TPersisted>(
     ...persistence.storage,
     controller: persistence.controller,
     flush: persistence.flush,
-    markStateSnapshotSaved: (state) => {
-      persistence.markStateSnapshotSaved(state);
+    completeHydration: (state) => {
+      // Keep the loaded snapshot as the saved baseline. Startup changes and
+      // migrations must reach DuckDB before they can be considered saved.
+      persistence.controller.setSnapshot(JSON.stringify(state), 'hydrate');
       hydrated = true;
+      registerFlushHandlers();
     },
 
     getItem: async (...args) => {

--- a/apps/sqlrooms-cli-ui/src/store.ts
+++ b/apps/sqlrooms-cli-ui/src/store.ts
@@ -662,8 +662,8 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
         }
         if (!state) return;
         state.artifactAi.syncCurrentArtifactAiSession();
-        cliUiPersistStorage.markStateSnapshotSaved(
-          persistHelpers.partialize(state),
+        cliUiPersistStorage.completeHydration(
+          persistHelpers.partialize(roomStore.getState()),
         );
       },
     },

--- a/apps/sqlrooms-cli-ui/src/store.ts
+++ b/apps/sqlrooms-cli-ui/src/store.ts
@@ -650,7 +650,16 @@ export const {roomStore, useRoomStore} = createRoomStore<RoomState>(
           currentState,
         );
       },
-      onRehydrateStorage: () => (state) => {
+      onRehydrateStorage: () => (state, error) => {
+        if (error) {
+          console.error('Failed to restore workspace', error);
+          toast.error('Failed to restore workspace', {
+            description:
+              'Saving is disabled to protect the existing workspace. Fix the loading error and reload to try again.',
+            duration: Infinity,
+          });
+          return;
+        }
         if (!state) return;
         state.artifactAi.syncCurrentArtifactAiSession();
         cliUiPersistStorage.markStateSnapshotSaved(


### PR DESCRIPTION
Opening an older CLI workspace can fail because saved AI/artifact associations still use `createdAt` and `linkType`, while the current schema requires `linkedAt`. That failure aborts restoration of every slice, and subsequent autosaves can replace the saved documents and maps with empty defaults.

Migrate legacy associations and pinned artifact IDs before validating the workspace. Keep saving disabled until restoration and post-load synchronization succeed, and show a persistent error if loading fails. After successful restoration, persist migrations and retained startup changes when they differ from the loaded snapshot. Existing document-type migrations continue to apply.

Validation:

- 18 regression tests passed across `migrateCliPersistedWorkspace.test.ts` and `serverApi.test.ts`, including migration idempotence, canonical-value precedence, failed restoration followed by autosave/final flush, successful retry, new-workspace saving, retained startup changes during delayed loading, and post-load synchronization.
- `pnpm --filter sqlrooms-cli-app typecheck` passed; formatting and `git diff --check` passed.
- Repository pre-push checks passed: Knip, workspace typechecking, circular-dependency checks, and the full test suite. The first full run hit Python server-startup timeouts; all 28 server tests passed in isolation, and the subsequent complete push hook passed.
- Validated an affected snapshot against all 19 current state schemas and verified a separate recovered DuckDB copy retained 26 block documents, 72 map configurations, and 42 chat associations. Document bodies and map configurations were unchanged. No user database files are included in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Legacy workspaces now restore AI/artifact links and pinned artifacts correctly when loaded.
  - Workspace data is protected from being overwritten while loading or if restoration fails.
  - Loading errors now display a warning and keep the existing saved workspace intact.
  - Saving becomes available again after successful workspace restoration and validation.
  - Startup changes and successful migrations are now saved automatically after restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
