### PR TITLE
fix(deck): include both arc endpoints in fit-to-bounds

### DIFF
--- a/packages/deck/__tests__/mapFit.test.ts
+++ b/packages/deck/__tests__/mapFit.test.ts
@@ -142,6 +142,41 @@ describe('Deck map fit core', () => {
     });
   });
 
+  test('skips an unrelated visible arc and still fits a later matching arc', () => {
+    expect(
+      resolveDeckMapFitToData({
+        spec: {
+          layers: [
+            {
+              '@@type': 'GeoArrowArcLayer',
+              _sqlroomsBinding: {
+                dataset: 'arcs',
+                sourceGeometryColumn: 'overlay_source',
+                targetGeometryColumn: 'overlay_target',
+              },
+            },
+            {
+              '@@type': 'GeoArrowArcLayer',
+              _sqlroomsBinding: {
+                dataset: 'arcs',
+                sourceGeometryColumn: 'source_geom',
+                targetGeometryColumn: 'target_geom',
+              },
+            },
+          ],
+        },
+        datasets: {
+          arcs: {source: {tableName: 'arcs'}},
+        },
+        fitToData: {dataset: 'arcs', geometryColumn: 'source_geom'},
+      }),
+    ).toEqual({
+      dataset: 'arcs',
+      geometryColumn: 'source_geom',
+      geometryColumns: ['source_geom', 'target_geom'],
+    });
+  });
+
   test('honors an explicit geometryColumn that is not an arc endpoint', () => {
     expect(
       resolveDeckMapFitToData({

--- a/packages/deck/__tests__/mapFit.test.ts
+++ b/packages/deck/__tests__/mapFit.test.ts
@@ -48,7 +48,7 @@ describe('Deck map fit core', () => {
     });
   });
 
-  test('honors explicit fitToData.geometryColumn over arc inference', () => {
+  test('upgrades a single arc endpoint geometryColumn to both endpoints', () => {
     expect(
       resolveDeckMapFitToData({
         spec: {
@@ -74,6 +74,97 @@ describe('Deck map fit core', () => {
     ).toEqual({
       dataset: 'arcs',
       geometryColumn: 'source_geom',
+      geometryColumns: ['source_geom', 'target_geom'],
+    });
+  });
+
+  test('upgrades source-only lon/lat fitToData to both arc endpoints', () => {
+    expect(
+      resolveDeckMapFitToData({
+        spec: {
+          layers: [
+            {
+              '@@type': 'GeoArrowArcLayer',
+              _sqlroomsBinding: {
+                dataset: 'arcs',
+                sourceGeometryColumn: 'source_geom',
+                targetGeometryColumn: 'target_geom',
+              },
+            },
+          ],
+        },
+        datasets: {
+          arcs: {source: {tableName: 'arcs'}},
+        },
+        fitToData: {
+          dataset: 'arcs',
+          longitudeColumn: 'source_lon',
+          latitudeColumn: 'source_lat',
+        },
+      }),
+    ).toEqual({
+      dataset: 'arcs',
+      longitudeColumn: 'source_lon',
+      latitudeColumn: 'source_lat',
+      geometryColumns: ['source_geom', 'target_geom'],
+    });
+  });
+
+  test('does not infer hidden arc endpoints over explicit lon/lat', () => {
+    expect(
+      resolveDeckMapFitToData({
+        spec: {
+          layers: [
+            {
+              '@@type': 'GeoArrowArcLayer',
+              visible: false,
+              _sqlroomsBinding: {
+                dataset: 'arcs',
+                sourceGeometryColumn: 'source_geom',
+                targetGeometryColumn: 'target_geom',
+              },
+            },
+          ],
+        },
+        datasets: {
+          arcs: {source: {tableName: 'arcs'}},
+        },
+        fitToData: {
+          dataset: 'arcs',
+          longitudeColumn: 'source_lon',
+          latitudeColumn: 'source_lat',
+        },
+      }),
+    ).toEqual({
+      dataset: 'arcs',
+      longitudeColumn: 'source_lon',
+      latitudeColumn: 'source_lat',
+    });
+  });
+
+  test('honors an explicit geometryColumn that is not an arc endpoint', () => {
+    expect(
+      resolveDeckMapFitToData({
+        spec: {
+          layers: [
+            {
+              '@@type': 'GeoArrowArcLayer',
+              _sqlroomsBinding: {
+                dataset: 'arcs',
+                sourceGeometryColumn: 'source_geom',
+                targetGeometryColumn: 'target_geom',
+              },
+            },
+          ],
+        },
+        datasets: {
+          arcs: {source: {tableName: 'arcs'}},
+        },
+        fitToData: {dataset: 'arcs', geometryColumn: 'overlay_geom'},
+      }),
+    ).toEqual({
+      dataset: 'arcs',
+      geometryColumn: 'overlay_geom',
     });
   });
 
@@ -257,7 +348,7 @@ describe('Deck map fit core', () => {
     expect(query).toContain('"latitude"');
   });
 
-  test('builds bounds SQL that unnests arc source and target geometries in one pass', () => {
+  test('builds bounds SQL that combines arc source and target extents in one pass', () => {
     const query = createDeckMapBoundsQuery({
       source: {
         tableName: 'arcs',
@@ -270,10 +361,12 @@ describe('Deck map fit core', () => {
       },
     });
 
-    expect(query).toContain('UNNEST([');
-    expect(query).toContain('"source_geom"');
-    expect(query).toContain('"target_geom"');
-    expect(query).toContain('ST_GeomFromWKB');
+    expect(query).toContain('list_min([');
+    expect(query).toContain('list_max([');
+    expect(query).toContain('ST_XMin(ST_GeomFromWKB("source_geom"))');
+    expect(query).toContain('ST_XMin(ST_GeomFromWKB("target_geom"))');
+    expect(query).toContain('ST_XMax(ST_GeomFromWKB("target_geom"))');
+    expect(query).not.toContain('UNNEST');
     expect(query).not.toContain('UNION ALL');
     // Source subquery should appear once (not once per geometry column).
     expect(query.match(/__sqlrooms_dashboard_map_geom"/g)).toHaveLength(1);

--- a/packages/deck/src/mapFit.ts
+++ b/packages/deck/src/mapFit.ts
@@ -52,9 +52,10 @@ function columnAliasProducedByStAsWkb(
 /**
  * Resolves the effective fit-to-data configuration for a Deck map.
  *
- * Explicit coordinate or geometry fields take precedence. Missing geometry and
- * H3 fields are inferred from dataset metadata, interaction configuration, and
- * layer bindings without consulting host-specific state.
+ * Explicit multi-column geometry takes precedence. A visible arc layer
+ * upgrades a single endpoint column or lon/lat pair to both source and
+ * target. Remaining missing geometry and H3 fields are inferred from
+ * dataset metadata, interaction configuration, and layer bindings.
  *
  * @param config - Durable Deck map configuration to inspect.
  * @returns A normalized fit configuration, or `null` when fitting is disabled.
@@ -65,13 +66,7 @@ export function resolveDeckMapFitToData(
   if (!config) return null;
   const fitToData = config.fitToData;
   if (!fitToData?.dataset) return null;
-  if (fitToData.longitudeColumn && fitToData.latitudeColumn) return fitToData;
   if (fitToData.geometryColumns && fitToData.geometryColumns.length > 0) {
-    return fitToData;
-  }
-
-  // Explicit geometryColumn wins over inferred arc/H3.
-  if (fitToData.geometryColumn) {
     return fitToData;
   }
 
@@ -81,7 +76,6 @@ export function resolveDeckMapFitToData(
       : (config.spec as Record<string, unknown>);
   const layers = Array.isArray(spec?.layers) ? spec.layers : [];
 
-  // Prefer both arc endpoints when fitToData did not name a single column.
   for (const layer of layers) {
     if (!layer || typeof layer !== 'object') continue;
     const layerRecord = layer as Record<string, unknown>;
@@ -99,15 +93,18 @@ export function resolveDeckMapFitToData(
       typeof binding.targetGeometryColumn === 'string' &&
       binding.targetGeometryColumn.trim()
     ) {
-      return {
-        ...fitToData,
-        geometryColumns: [
-          String(binding.sourceGeometryColumn),
-          String(binding.targetGeometryColumn),
-        ],
-      };
+      const source = String(binding.sourceGeometryColumn);
+      const target = String(binding.targetGeometryColumn);
+      const explicit = fitToData.geometryColumn?.trim();
+      if (explicit && explicit !== source && explicit !== target) {
+        break;
+      }
+      return {...fitToData, geometryColumns: [source, target]};
     }
   }
+
+  if (fitToData.longitudeColumn && fitToData.latitudeColumn) return fitToData;
+  if (fitToData.geometryColumn) return fitToData;
 
   // Dataset default geometry wins over inferred H3.
   const dataset = config.datasets[fitToData.dataset];
@@ -250,26 +247,15 @@ export function createDeckMapBoundsQuery(options: {
     `;
     }
 
-    // Multiple geom columns: unnest once so the source is scanned once.
-    const geomExprs = geometryColumns.map((col) => {
-      const column = escapeId(col);
-      return `CASE WHEN ${column} IS NOT NULL THEN ${asGeometry(col)} END`;
-    });
+    // Avoid UNNEST(GEOMETRY[]) — WASM spatial can drop all but the first endpoint.
+    const geoms = geometryColumns.map(asGeometry);
     return `
       SELECT
-        ST_XMin(extent) AS min_longitude,
-        ST_YMin(extent) AS min_latitude,
-        ST_XMax(extent) AS max_longitude,
-        ST_YMax(extent) AS max_latitude
-      FROM (
-        SELECT ST_Extent_Agg(geom) AS extent
-        FROM (
-          SELECT UNNEST([${geomExprs.join(', ')}]) AS geom
-          FROM (${baseSourceSql}) AS "__sqlrooms_dashboard_map_geom"
-        ) AS "__sqlrooms_dashboard_map_geoms"
-        WHERE geom IS NOT NULL
-      ) AS "__sqlrooms_dashboard_map_extent"
-      WHERE extent IS NOT NULL
+        list_min([${geoms.map((g) => `MIN(ST_XMin(${g}))`).join(', ')}]) AS min_longitude,
+        list_min([${geoms.map((g) => `MIN(ST_YMin(${g}))`).join(', ')}]) AS min_latitude,
+        list_max([${geoms.map((g) => `MAX(ST_XMax(${g}))`).join(', ')}]) AS max_longitude,
+        list_max([${geoms.map((g) => `MAX(ST_YMax(${g}))`).join(', ')}]) AS max_latitude
+      FROM (${baseSourceSql}) AS "__sqlrooms_dashboard_map_geom"
     `;
   }
 

--- a/packages/deck/src/mapFit.ts
+++ b/packages/deck/src/mapFit.ts
@@ -97,7 +97,7 @@ export function resolveDeckMapFitToData(
       const target = String(binding.targetGeometryColumn);
       const explicit = fitToData.geometryColumn?.trim();
       if (explicit && explicit !== source && explicit !== target) {
-        break;
+        continue;
       }
       return {...fitToData, geometryColumns: [source, target]};
     }


### PR DESCRIPTION
## Summary
- Fit-to-bounds for arc maps now frames both origin and destination points, not just starts.
- Bounds SQL aggregates each endpoint's min/max instead of `UNNEST(GEOMETRY[])`, which could drop target geometries.
- If an arc map authors a single `geometryColumn` or lon/lat pair, fit still upgrades to both source and target columns.

## Test plan
- [x] Create a map with `GeoArrowArcLayer` (source + target WKB) and click Fit to Bounds — both ends of the arcs should be in view.
- [x] Repeat with `fitToData.geometryColumns: ["source_geom", "target_geom"]` and with only `{"dataset": "..."}`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic map fitting for arc layers so both endpoints are included when appropriate.
  * Preserved explicit geometry-column selections, including non-endpoint columns and longitude/latitude settings.
  * Excluded hidden arc layers from automatic endpoint inference.
  * Fixed map fitting when a matching arc layer appears after another visible arc layer.
  * Improved bounds calculations to combine extents from multiple geometry columns reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->