### PR TITLE
fix(deck): stop AI from capping fit-to-data zoom

### DIFF
--- a/packages/deck/__tests__/mapResourceAuthoring.test.ts
+++ b/packages/deck/__tests__/mapResourceAuthoring.test.ts
@@ -850,6 +850,7 @@ describe('Deck map resource authoring contract', () => {
     expect(instructions).toContain('pointBinding');
     expect(instructions).toContain('Do not author transformSql');
     expect(instructions).toContain('COLOR SCALE FIELD VARIANCE');
+    expect(instructions).toContain('omit maxZoom');
     expect(instructions).toContain('min = max');
     expect(instructions).not.toContain('Mosaic');
   });

--- a/packages/deck/src/ai.ts
+++ b/packages/deck/src/ai.ts
@@ -70,7 +70,7 @@ ${getDeckMapSharedAiContractRules()}
 - IMPORTANT: If you are creating a structured table-backed map layer for a table that is NOT the currently selected dashboard table, you MUST switch the dashboard's selected table to that dataset BEFORE or WHEN calling create_dashboard_map (pass the correct tableName). Structured table-backed map panels resolve data from the dashboard's active table — if you don't switch it, the layer will query the wrong table and fail.
 - IMPORTANT: When referencing tables in tableName or sqlQuery, use ONLY the bare table name (e.g. "my_table") or schema-qualified name (e.g. "main.my_table"). NEVER include the database/catalog prefix (e.g. do NOT use "sqlrooms-cli.main.my_table") — the catalog does not exist in the query execution context.
 - IMPORTANT: For point data with longitude/latitude columns that should follow dashboard table switching, use source.tableName plus source.transformSql to create a geometry column, for example: "SELECT *, ST_AsWKB(ST_Point(\\"Longitude\\", \\"Latitude\\")) AS \\"__sqlrooms_geom\\" FROM ${DECK_TABLE_DATASET_SOURCE_RELATION} WHERE \\"Longitude\\" IS NOT NULL AND \\"Latitude\\" IS NOT NULL". Set geometryColumn to the same name used in the AS clause (e.g. "__sqlrooms_geom") and geometryEncodingHint to "wkb".
-- IMPORTANT: When providing fitToData, it MUST be a flat object (NOT nested by dataset ID). Include either longitudeColumn+latitudeColumn (for point data with separate coordinate columns) OR geometryColumn (for data with a WKB geometry column like GeoJSON). For H3 hexagon layers, just specify the dataset: "fitToData": {"dataset": "datasetId"} — the H3 column is auto-detected from the layer binding. For GeoJSON/spatial files with a "geom" column, use: "fitToData": {"dataset": "datasetId", "geometryColumn": "geom"}. For point data use: "fitToData": {"dataset": "datasetId", "longitudeColumn": "lon", "latitudeColumn": "lat"}. NEVER nest fitToData as {"datasetId": {...}} — always use a flat object with "dataset" as a string field.
+- IMPORTANT: When providing fitToData, it MUST be a flat object (NOT nested by dataset ID). Include either longitudeColumn+latitudeColumn (for point data with separate coordinate columns) OR geometryColumn (for data with a WKB geometry column like GeoJSON). For H3 hexagon layers, just specify the dataset: "fitToData": {"dataset": "datasetId"} — the H3 column is auto-detected from the layer binding. For GeoJSON/spatial files with a "geom" column, use: "fitToData": {"dataset": "datasetId", "geometryColumn": "geom"}. For point data use: "fitToData": {"dataset": "datasetId", "longitudeColumn": "lon", "latitudeColumn": "lat"}. NEVER nest fitToData as {"datasetId": {...}} — always use a flat object with "dataset" as a string field. Omit fitToData.maxZoom unless the user asks to limit zoom-in.
 - IMPORTANT: For GeoJSON or spatial files that already have a native geometry column (e.g. "geometry", "geom"), use the table directly with source.tableName (no sqlQuery needed), set the dataset's geometryColumn to "geom", set geometryEncodingHint to "wkb", and use fitToData with geometryColumn: {"dataset": "datasetId", "geometryColumn": "geom"}.
 - IMPORTANT: When a GeoJSON file (.geojson) is loaded as a table, DuckDB uses ST_Read to produce a table with a WKB "geom" column and all feature properties as columns. Use source.tableName, set geometryColumn to "geom" and geometryEncodingHint to "wkb". Use "fitToData": {"dataset": "datasetId", "geometryColumn": "geom"} to zoom to the data extent.
 - For data-driven color, use {"@@function":"colorScale", "field":"...", "type":"sequential"|"diverging"|"quantize"|"quantile"|"categorical", "scheme":"...", "domain":"auto"} on getFillColor / getLineColor / getColor / getSourceColor / getTargetColor. Key is "@@function" (not "@@type"); column goes in "field" (not "column"). Exact scheme names: ${COLOR_SCHEME_PROMPT_LISTS}. "field" must exist in the FINAL query output after any GROUP BY.
@@ -255,7 +255,12 @@ export const DeckMapDashboardConfigParameter = z.looseObject({
         .optional()
         .describe('H3 hex index column for computing bounds.'),
       padding: z.number().optional(),
-      maxZoom: z.number().optional(),
+      maxZoom: z
+        .number()
+        .optional()
+        .describe(
+          'Optional zoom cap after fitting bounds. Omit unless the user asks to limit zoom-in. Do not set 12 by default — that is city-scale and leaves neighborhood data looking far too zoomed out.',
+        ),
     })
     .optional()
     .describe(

--- a/packages/deck/src/mapAiConfig.ts
+++ b/packages/deck/src/mapAiConfig.ts
@@ -36,7 +36,12 @@ const DeckMapFitToDataConfig = z.looseObject({
   geometryColumns: z.array(z.string()).optional(),
   h3Column: z.string().optional(),
   padding: z.number().optional(),
-  maxZoom: z.number().optional(),
+  maxZoom: z
+    .number()
+    .optional()
+    .describe(
+      'Optional zoom cap after fitting bounds. Omit unless the user asks to limit zoom-in. Do not set 12 by default — that is city-scale and leaves neighborhood data looking far too zoomed out.',
+    ),
 });
 
 const DeckMapPointBindingParameter = z.object({

--- a/packages/deck/src/mapAiSharedInstructions.ts
+++ b/packages/deck/src/mapAiSharedInstructions.ts
@@ -13,5 +13,6 @@ export function getDeckMapSharedAiContractRules(): string {
 - GeoArrowH3HexagonLayer: set getHexagon to "@@=h3_column" (or _sqlroomsBinding.hexagonColumn). When aggregating lon/lat, prefer h3_h3_to_string(h3_latlng_to_cell(lat, lon, res)) AS h3_cell (lat before lon).
 - GeoArrowArcLayer: bind WKB via _sqlroomsBinding.sourceGeometryColumn / targetGeometryColumn only (do not set getSourcePosition/getTargetPosition). Use ST_AsWKB(ST_Point(...)); set geometryEncodingHint to "wkb".
 - GeoArrowTripsLayer = animated path over time; GeoArrowArcLayer = static OD curve. Prefer TripsLayer for animated/trips/moving routes.
+- fitToData: omit maxZoom unless the user asks to cap zoom-in. A low cap (e.g. 12) leaves local data (buildings, neighborhoods) looking far too zoomed out.
 - COLOR SCALE FIELD VARIANCE: Before choosing a numeric colorScale field, confirm it has real range (min < max / not all zeros or a single constant). Prefer SUMMARIZE table_name or SELECT min(col), max(col), count(DISTINCT col) FROM ... when unsure. Do NOT color by a flat column unless the user explicitly asks for that column by name. If no varying column exists, use a flat fill color instead of colorScale. Categorical fields need more than one distinct non-null value to be useful. Geometry, lon/lat, H3 index, and opaque ID columns are not useful color fields unless the user asks for them.`;
 }


### PR DESCRIPTION
## Summary
- Instruct map AI tools not to set `fitToData.maxZoom` unless the user asks to cap zoom-in.
- A default cap of 12 is city-scale and leaves neighborhood data (building footprints, a few blocks) looking several times too zoomed out.

## Test plan
- [x] Create a GeoJSON / buildings polygon map with the AI and confirm `fitToData` has no `maxZoom`
- [x] Confirm an explicit request to limit zoom still allows `maxZoom`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Map configuration generation now omits `maxZoom` unless a zoom-in limit is explicitly requested.
  - Prevents unnecessary default zoom caps that could make local data appear too zoomed out.

- **Tests**
  - Added coverage to verify the updated map authoring guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->