### PR TITLE
fix: update chart settings to accept null values for optional fields

### DIFF
--- a/packages/mosaic/README.md
+++ b/packages/mosaic/README.md
@@ -314,6 +314,17 @@ in its guidance, while tolerating omitted optional fields for model-provider
 compatibility. When `metric` is omitted, a provided `valueField` implies
 `"aggregate"`; otherwise the backwards-compatible default is `"count"`.
 
+**Optional chart settings accept `null`, not just omission.** Some model
+providers emit `null` for a field they mean to leave unset, so the optional
+inputs on the exported chart-settings schemas are `.nullish()` — they accept
+`null` in addition to `undefined`. This spans, for example, scatter `x`/`y`/`size`,
+heatmap and box-plot axes, histogram `field`/`color`, count-plot `field`/
+`valueField`/`leftMargin`, and line-chart `metric`/`yFields`/`xInterval`. A
+`null` is treated the same as an omitted value: it resolves to the field's
+documented default or auto behavior (e.g. line-chart `metric: null` →
+`"aggregate"`; count-plot `valueField: null` → row count; `leftMargin: null` →
+metadata-derived margin) rather than being rendered as a literal `null`.
+
 Count plots cap the visible categories instead of folding the hidden tail into
 `Others` so the generated vgplot spec continues to cross-filter against the
 source table without pre-aggregating the rendered values.

--- a/packages/mosaic/__tests__/chart-types/line-chart-metric-null.test.ts
+++ b/packages/mosaic/__tests__/chart-types/line-chart-metric-null.test.ts
@@ -1,0 +1,40 @@
+import {validateLineChartSettings} from '../../src/charts/chart-types/line-chart/validation';
+import {RequiredFieldsError} from '../../src/charts/chart-types/errors';
+
+// `metric` is `.nullish()`, so an LLM may send `metric: null`. A destructuring
+// default only covers `undefined`, so before the fix `null` slipped through:
+// the `metric === 'aggregate'` required-Y guard was skipped and the validator
+// returned `metric: null`, producing an empty series — a blank chart reported as
+// success. These lock in the `?? 'aggregate'` normalization.
+const dataTable = {
+  table: {database: 'd', schema: 'main', table: 't'},
+  columns: [
+    {name: 'x_num', type: 'DOUBLE'},
+    {name: 'val', type: 'DOUBLE'},
+  ],
+} as never;
+
+describe('validateLineChartSettings — null metric normalization', () => {
+  it('treats metric: null as aggregate and enforces the required Y-axis', () => {
+    expect(() =>
+      validateLineChartSettings({
+        dataTable,
+        settings: {x: 'x_num', metric: null, yFields: null} as never,
+      }),
+    ).toThrow(RequiredFieldsError);
+  });
+
+  it('resolves metric: null to aggregate when a numeric Y series is present', () => {
+    const out = validateLineChartSettings({
+      dataTable,
+      settings: {
+        x: 'x_num',
+        metric: null,
+        yFields: [{field: 'val', aggregate: 'sum'}],
+      } as never,
+    });
+    expect(out.metric).toBe('aggregate');
+    expect(out.yColumns).toHaveLength(1);
+    expect(out.yColumns[0]!.field).toBe('val');
+  });
+});

--- a/packages/mosaic/__tests__/chart-types/settings-null-coercion.test.ts
+++ b/packages/mosaic/__tests__/chart-types/settings-null-coercion.test.ts
@@ -1,5 +1,6 @@
 import {ScatterPlotToolInput} from '../../src/charts/chart-types/scatter-plot/tool';
 import {HeatmapToolInput} from '../../src/charts/chart-types/heatmap/tool';
+import {CountPlotToolInput} from '../../src/charts/chart-types/count-plot/tool';
 
 // LLMs frequently emit `null` for chart-settings fields they mean to omit. The
 // settings fields are `.nullish()` (accept null AND undefined), so a null no
@@ -23,5 +24,20 @@ describe('chart tool settings accept null (nullish)', () => {
       settings: {x: 'a', y: null},
     });
     expect(parsed.settings.y).toBeNull();
+  });
+
+  it('count-plot tool input accepts null for its optional fields (valueField, leftMargin)', () => {
+    // Regression: the count-plot AI input schema (`CountPlotToolSettings`) is
+    // separate from the display schema, and previously left these `.optional()`,
+    // so `{field, leftMargin: null}` was rejected at the tool boundary before any
+    // normalization ran.
+    const parsed = CountPlotToolInput.parse({
+      tableName: 't',
+      reasoning: 'r',
+      settings: {field: 'category', valueField: null, leftMargin: null},
+    });
+    expect(parsed.settings.valueField).toBeNull();
+    expect(parsed.settings.leftMargin).toBeNull();
+    expect(parsed.settings.field).toBe('category');
   });
 });

--- a/packages/mosaic/__tests__/chart-types/settings-null-coercion.test.ts
+++ b/packages/mosaic/__tests__/chart-types/settings-null-coercion.test.ts
@@ -1,0 +1,27 @@
+import {ScatterPlotToolInput} from '../../src/charts/chart-types/scatter-plot/tool';
+import {HeatmapToolInput} from '../../src/charts/chart-types/heatmap/tool';
+
+// LLMs frequently emit `null` for chart-settings fields they mean to omit. The
+// settings fields are `.nullish()` (accept null AND undefined), so a null no
+// longer rejects even though the tool inputs mark the settings `.required()`
+// (which keeps them nullable-but-present). These tests lock that in.
+describe('chart tool settings accept null (nullish)', () => {
+  it('scatter-plot accepts a null optional field (size)', () => {
+    const parsed = ScatterPlotToolInput.parse({
+      tableName: 't',
+      reasoning: 'r',
+      settings: {x: 'a', y: 'b', size: null},
+    });
+    expect(parsed.settings.size).toBeNull();
+    expect(parsed.settings.x).toBe('a');
+  });
+
+  it('heatmap accepts null for its axis fields', () => {
+    const parsed = HeatmapToolInput.parse({
+      tableName: 't',
+      reasoning: 'r',
+      settings: {x: 'a', y: null},
+    });
+    expect(parsed.settings.y).toBeNull();
+  });
+});

--- a/packages/mosaic/src/charts/chart-types/box-plot/BoxPlotSettings.tsx
+++ b/packages/mosaic/src/charts/chart-types/box-plot/BoxPlotSettings.tsx
@@ -10,14 +10,14 @@ export const BoxPlotSettingsComponent: FC = () => {
     <div className="space-y-4">
       <Field label="X Field (categorical)" required>
         <ColumnSelector.Categorical
-          value={config.settings.x}
+          value={config.settings.x ?? undefined}
           onChange={(x) => onChangeConfig('x', x)}
         />
       </Field>
 
       <Field label="Y Field (numeric)" required>
         <ColumnSelector.Numeric
-          value={config.settings.y}
+          value={config.settings.y ?? undefined}
           onChange={(y) => onChangeConfig('y', y)}
         />
       </Field>

--- a/packages/mosaic/src/charts/chart-types/box-plot/schema.ts
+++ b/packages/mosaic/src/charts/chart-types/box-plot/schema.ts
@@ -2,10 +2,10 @@ import {z} from 'zod';
 import {ChartDataPolicyOverrideConfig} from '../data-policy-schema';
 
 export const BoxPlotChartSettings = z.object({
-  x: z.string().optional().describe('Categorical column for grouping'),
+  x: z.string().nullish().describe('Categorical column for grouping'),
   y: z
     .string()
-    .optional()
+    .nullish()
     .describe('Numeric column for distribution statistics'),
 });
 

--- a/packages/mosaic/src/charts/chart-types/count-plot/CountPlotSettings.tsx
+++ b/packages/mosaic/src/charts/chart-types/count-plot/CountPlotSettings.tsx
@@ -65,7 +65,7 @@ export const CountPlotSettingsComponent: FC = () => {
     <div className="space-y-4">
       <Field label="Field" required>
         <ColumnSelector.Categorical
-          value={config.settings.field}
+          value={config.settings.field ?? undefined}
           onChange={(field) => onChangeConfig('field', field)}
         />
       </Field>
@@ -81,7 +81,7 @@ export const CountPlotSettingsComponent: FC = () => {
           <div className="flex items-end gap-2">
             <ColumnSelector.Numeric
               className="flex-1"
-              value={config.settings.valueField}
+              value={config.settings.valueField ?? undefined}
               onChange={(valueField) =>
                 onChangeConfig('valueField', valueField)
               }

--- a/packages/mosaic/src/charts/chart-types/count-plot/schema.ts
+++ b/packages/mosaic/src/charts/chart-types/count-plot/schema.ts
@@ -20,7 +20,7 @@ export const MAX_COUNT_PLOT_MAX_BARS = 100;
 export const CountPlotChartSettings = z.object({
   field: z
     .string()
-    .optional()
+    .nullish()
     .describe('Categorical column used to group the horizontal bars'),
   metric: CountPlotMetric.optional()
     .default('count')
@@ -29,7 +29,7 @@ export const CountPlotChartSettings = z.object({
     ),
   valueField: z
     .string()
-    .optional()
+    .nullish()
     .describe('Numeric measure column to aggregate when metric is aggregate'),
   aggregate: AggregateFunction.optional()
     .default('sum')
@@ -50,7 +50,7 @@ export const CountPlotChartSettings = z.object({
     .int()
     .min(0)
     .max(320)
-    .optional()
+    .nullish()
     .describe('Manual left margin in pixels; omit to auto-size from metadata'),
 });
 

--- a/packages/mosaic/src/charts/chart-types/count-plot/spec.ts
+++ b/packages/mosaic/src/charts/chart-types/count-plot/spec.ts
@@ -204,7 +204,7 @@ export function createCountPlotSpec(options: CreateCountPlotSpecOptions): Spec {
     yPaddingInner: DEFAULT_Y_PADDING_INNER,
     yPaddingOuter: DEFAULT_Y_PADDING_OUTER,
     margins: {
-      left: deriveLeftMargin(fieldColumn, settings.leftMargin),
+      left: deriveLeftMargin(fieldColumn, settings.leftMargin ?? undefined),
       right: 50,
       ...HEIGHT_MARGINS,
     },

--- a/packages/mosaic/src/charts/chart-types/count-plot/tool.ts
+++ b/packages/mosaic/src/charts/chart-types/count-plot/tool.ts
@@ -28,7 +28,7 @@ const CountPlotToolSettings = z.object({
   valueField: z
     .string()
     .min(1)
-    .optional()
+    .nullish()
     .describe(
       'Numeric measure column required when metric is aggregate. Its presence implies aggregate when metric is omitted.',
     ),
@@ -50,7 +50,7 @@ const CountPlotToolSettings = z.object({
     .int()
     .min(0)
     .max(320)
-    .optional()
+    .nullish()
     .describe('Manual left margin in pixels; omit to auto-size from metadata'),
 });
 
@@ -89,6 +89,11 @@ Do NOT use for: numeric distributions (use histogram), relationships between col
         const dataTable = ensureTable(databaseAdapter, tableName);
         const normalizedSettings = CountPlotChartSettings.parse({
           ...settings,
+          // The LLM may send `null` for these optional fields (now accepted by
+          // the schema); collapse to the no-value form so downstream sees clean
+          // values instead of a persisted `null` margin / measure column.
+          valueField: settings.valueField ?? undefined,
+          leftMargin: settings.leftMargin ?? undefined,
           metric:
             settings.metric ?? (settings.valueField ? 'aggregate' : 'count'),
         });

--- a/packages/mosaic/src/charts/chart-types/heatmap/HeatmapSettings.tsx
+++ b/packages/mosaic/src/charts/chart-types/heatmap/HeatmapSettings.tsx
@@ -10,14 +10,14 @@ export const HeatmapSettingsComponent: FC = () => {
     <div className="space-y-4">
       <Field label="X Field" required>
         <ColumnSelector.Numeric
-          value={config.settings.x}
+          value={config.settings.x ?? undefined}
           onChange={(x) => onChangeConfig('x', x)}
         />
       </Field>
 
       <Field label="Y Field" required>
         <ColumnSelector.Numeric
-          value={config.settings.y}
+          value={config.settings.y ?? undefined}
           onChange={(y) => onChangeConfig('y', y)}
         />
       </Field>

--- a/packages/mosaic/src/charts/chart-types/heatmap/schema.ts
+++ b/packages/mosaic/src/charts/chart-types/heatmap/schema.ts
@@ -2,8 +2,8 @@ import {z} from 'zod';
 import {ChartDataPolicyOverrideConfig} from '../data-policy-schema';
 
 export const HeatmapChartSettings = z.object({
-  x: z.string().optional().describe('Column for X axis'),
-  y: z.string().optional().describe('Column for Y axis'),
+  x: z.string().nullish().describe('Column for X axis'),
+  y: z.string().nullish().describe('Column for Y axis'),
 });
 
 export type HeatmapChartSettings = z.infer<typeof HeatmapChartSettings>;

--- a/packages/mosaic/src/charts/chart-types/histogram/HistogramSettings.tsx
+++ b/packages/mosaic/src/charts/chart-types/histogram/HistogramSettings.tsx
@@ -19,7 +19,7 @@ export const HistogramSettingsComponent: FC = () => {
         <div className="flex items-end gap-2">
           <ColumnSelector.Quantitative
             className="flex-1"
-            value={config.settings.field}
+            value={config.settings.field ?? undefined}
             onChange={(field) => onChangeConfig('field', field)}
           />
           <ColorSelector

--- a/packages/mosaic/src/charts/chart-types/histogram/schema.ts
+++ b/packages/mosaic/src/charts/chart-types/histogram/schema.ts
@@ -8,7 +8,7 @@ export const DEFAULT_BINS_COUNT = 20;
 export const HistogramChartSettings = z.object({
   field: z
     .string()
-    .optional()
+    .nullish()
     .describe('Numeric column to create histogram distribution for'),
   maxBins: z
     .number()
@@ -20,7 +20,7 @@ export const HistogramChartSettings = z.object({
     .describe(
       `Maximum number of bins for the histogram (default: ${DEFAULT_BINS_COUNT})`,
     ),
-  color: z.string().optional().describe('Optional color for histogram bars'),
+  color: z.string().nullish().describe('Optional color for histogram bars'),
 });
 
 export type HistogramChartSettings = z.infer<typeof HistogramChartSettings>;

--- a/packages/mosaic/src/charts/chart-types/line-chart/LineChartSettings.tsx
+++ b/packages/mosaic/src/charts/chart-types/line-chart/LineChartSettings.tsx
@@ -31,7 +31,7 @@ export const LineChartSettingsComponent: FC = () => {
             onChange({
               ...chartConfig,
               ...(value === 'count'
-                ? {lastAggregateYFields: config.settings.yFields}
+                ? {lastAggregateYFields: config.settings.yFields ?? undefined}
                 : {}),
               settings: {
                 ...config.settings,

--- a/packages/mosaic/src/charts/chart-types/line-chart/LineChartXFieldSelector.tsx
+++ b/packages/mosaic/src/charts/chart-types/line-chart/LineChartXFieldSelector.tsx
@@ -27,7 +27,7 @@ export const LineChartXFieldSelector: FC = () => {
       }}
     >
       <ColumnSelector.Quantitative
-        value={config.settings.x}
+        value={config.settings.x ?? undefined}
         onChange={(x) => {
           const selectedColumn = columns.find((column) => column.name === x);
           if (selectedColumn && isTemporalType(selectedColumn.type)) {
@@ -44,7 +44,7 @@ export const LineChartXFieldSelector: FC = () => {
       />
       {isXFieldTemporal && (
         <TemporalGranularitySelector
-          value={config.settings.xInterval}
+          value={config.settings.xInterval ?? undefined}
           onChange={(xInterval) => onChangeConfig('xInterval', xInterval)}
           xFieldType={xColumn.type}
         />

--- a/packages/mosaic/src/charts/chart-types/line-chart/schema.ts
+++ b/packages/mosaic/src/charts/chart-types/line-chart/schema.ts
@@ -5,7 +5,7 @@ import {TemporalInterval, AggregateFunction} from '../../../schemas';
 // Y-field configuration
 export const YFieldConfig = z.object({
   field: z.string().describe('Numeric column name to plot on Y axis'),
-  color: z.string().optional().describe('Optional color for this line'),
+  color: z.string().nullish().describe('Optional color for this line'),
   aggregate: AggregateFunction.optional()
     .default('sum')
     .describe('Aggregation function: sum, avg, min, or max'),
@@ -15,20 +15,20 @@ export type YFieldConfig = z.infer<typeof YFieldConfig>;
 export const LineChartSettings = z.object({
   metric: z
     .enum(['aggregate', 'count'])
-    .optional()
+    .nullish()
     .describe(
       'Use count for row counts (COUNT(*)) with no yFields, or aggregate for numeric Y fields. Omission preserves existing numeric-series behavior.',
     ),
   x: z
     .string()
-    .optional()
+    .nullish()
     .describe('Column for X axis, typically temporal (date/time)'),
-  xInterval: TemporalInterval.optional().describe(
+  xInterval: TemporalInterval.nullish().describe(
     'Temporal binning interval: year, month, day, hour, etc.',
   ),
   yFields: z
     .array(YFieldConfig)
-    .optional()
+    .nullish()
     .describe('Array of Y fields to plot, supports multiple lines'),
   showLegend: z
     .boolean()

--- a/packages/mosaic/src/charts/chart-types/line-chart/validation.ts
+++ b/packages/mosaic/src/charts/chart-types/line-chart/validation.ts
@@ -41,11 +41,15 @@ export function validateLineChartSettings({
     x,
     yFields: yFieldsInput,
     xInterval: xIntervalInput,
-    metric = 'aggregate',
+    metric: metricInput,
   },
 }: ValidateSpecOptions<LineChartSettings>): ValidatedLineChartSettings {
   // Nullish settings fields (the LLM may send `null`): normalize to the
-  // no-value form so the rest of the function works with clean values.
+  // no-value form so the rest of the function works with clean values. A
+  // destructuring default only covers `undefined`, so `metric: null` would slip
+  // through as `null` — skipping the required-Y check and producing a blank
+  // chart reported as success — hence the explicit `?? 'aggregate'`.
+  const metric = metricInput ?? 'aggregate';
   const yFields = yFieldsInput ?? [];
   const xInterval = xIntervalInput ?? undefined;
   // Basic validation for required fields

--- a/packages/mosaic/src/charts/chart-types/line-chart/validation.ts
+++ b/packages/mosaic/src/charts/chart-types/line-chart/validation.ts
@@ -37,8 +37,17 @@ export type ValidatedLineChartSettings = {
  */
 export function validateLineChartSettings({
   dataTable,
-  settings: {x, yFields = [], xInterval, metric = 'aggregate'},
+  settings: {
+    x,
+    yFields: yFieldsInput,
+    xInterval: xIntervalInput,
+    metric = 'aggregate',
+  },
 }: ValidateSpecOptions<LineChartSettings>): ValidatedLineChartSettings {
+  // Nullish settings fields (the LLM may send `null`): normalize to the
+  // no-value form so the rest of the function works with clean values.
+  const yFields = yFieldsInput ?? [];
+  const xInterval = xIntervalInput ?? undefined;
   // Basic validation for required fields
   if (!x || (metric === 'aggregate' && yFields.length === 0)) {
     throw new RequiredFieldsError([

--- a/packages/mosaic/src/charts/chart-types/scatter-plot/ScatterPlotSettings.tsx
+++ b/packages/mosaic/src/charts/chart-types/scatter-plot/ScatterPlotSettings.tsx
@@ -11,21 +11,21 @@ export const ScatterPlotSettingsComponent: FC = () => {
     <div className="space-y-4">
       <Field label="X Field" required>
         <ColumnSelector.Numeric
-          value={config.settings.x}
+          value={config.settings.x ?? undefined}
           onChange={(x) => onChangeConfig('x', x)}
         />
       </Field>
 
       <Field label="Y Field" required>
         <ColumnSelector.Numeric
-          value={config.settings.y}
+          value={config.settings.y ?? undefined}
           onChange={(y) => onChangeConfig('y', y)}
         />
       </Field>
 
       <Field label="Size Field">
         <ColumnSelector.Numeric
-          value={config.settings.size}
+          value={config.settings.size ?? undefined}
           onChange={(size) => onChangeConfig('size', size)}
           placeholder="(optional)"
         />

--- a/packages/mosaic/src/charts/chart-types/scatter-plot/schema.ts
+++ b/packages/mosaic/src/charts/chart-types/scatter-plot/schema.ts
@@ -2,11 +2,11 @@ import {z} from 'zod';
 import {ChartDataPolicyOverrideConfig} from '../data-policy-schema';
 
 export const ScatterPlotChartSettings = z.object({
-  x: z.string().optional().describe('Numeric column for X axis position'),
-  y: z.string().optional().describe('Numeric column for Y axis position'),
+  x: z.string().nullish().describe('Numeric column for X axis position'),
+  y: z.string().nullish().describe('Numeric column for Y axis position'),
   size: z
     .string()
-    .optional()
+    .nullish()
     .describe('Numeric column for point size (optional)'),
 });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chart settings now accept `null` for optional fields across scatter, heatmap, box, histogram, count, and line charts.
  * Null values are treated like omitted settings, applying documented defaults or automatic behavior instead of rendering literal `null`.
  * Improved handling of null chart fields in selectors and line-chart validation.

* **Documentation**
  * Documented nullable chart settings and their default behavior.

* **Tests**
  * Added regression coverage for null settings across supported chart types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->