### PR TITLE
feat: add tool-call repair functionality to handle invalid tool inputs

### DIFF
--- a/packages/ai-core/README.md
+++ b/packages/ai-core/README.md
@@ -670,11 +670,13 @@ AI SDK aborts the run with an opaque `InvalidToolInputError`. The local chat
 transport heals this by default: it re-asks the model to correct the call
 (forcing a fresh call to the same tool, without running the tool's side
 effects) instead of failing the run. Each repair costs one extra LLM request, so
-apps that want to trade that resilience away can opt out per transport:
+apps that want to trade that resilience away can opt out — either through
+`createAiSlice` or directly on the transport factory:
 
 ```ts
-createLocalChatTransportFactory({
-  // ...
+createAiSlice({
+  tools,
+  getInstructions,
   repairInvalidToolCalls: false, // default: true
 });
 ```
@@ -688,14 +690,23 @@ import {createModelToolCallRepair} from '@sqlrooms/ai-core';
 new ToolLoopAgent({
   model,
   tools,
-  experimental_repairToolCall: createModelToolCallRepair(model),
+  experimental_repairToolCall: createModelToolCallRepair(model, {
+    abortSignal, // cancel a pending repair when the run is stopped
+    providerOptions, // inherit the run's caching/reasoning configuration
+    onRepairUsage: (usage) => accumulate(usage), // account repair tokens
+  }),
 });
 ```
 
-`createModelToolCallRepair(model, {maxRepairsPerTool})` never recurses into
-itself, never triggers tool side effects, leaves the outer step limit untouched,
-and stops after `maxRepairsPerTool` (default `2`) failures for the same tool so a
-persistently-invalid call cannot fan out into unbounded repair requests.
+`createModelToolCallRepair(model, options)` never recurses into itself, never
+triggers tool side effects (the failing tool is re-sent as a schema-only
+definition, stripped of `execute` and input-lifecycle/approval callbacks),
+leaves the outer step limit untouched, and stops after `maxRepairsPerTool`
+(default `2`) failures for the same tool so a persistently-invalid call cannot
+fan out into unbounded repair requests. The returned handler is single-run — its
+per-tool counter lives in the closure, so construct a fresh handler for each
+agent run. It never logs validation-error text or regenerated arguments, so user
+data does not leak into the console.
 
 Assistant messages can be forked into a new active chat through
 `ai.forkSessionFromMessage()`. The action snapshots the source session's

--- a/packages/ai-core/README.md
+++ b/packages/ai-core/README.md
@@ -663,6 +663,40 @@ client tools named by `remoteClientToolNames` whose remote definition omits
 `execute`. Remote endpoints remain responsible for enforcing timeouts around
 tools they execute server-side.
 
+### Tool-call repair
+
+When the model emits tool-call arguments that fail the tool's input schema, the
+AI SDK aborts the run with an opaque `InvalidToolInputError`. The local chat
+transport heals this by default: it re-asks the model to correct the call
+(forcing a fresh call to the same tool, without running the tool's side
+effects) instead of failing the run. Each repair costs one extra LLM request, so
+apps that want to trade that resilience away can opt out per transport:
+
+```ts
+createLocalChatTransportFactory({
+  // ...
+  repairInvalidToolCalls: false, // default: true
+});
+```
+
+The primitive is also exported for hosts that build their own `ToolLoopAgent`
+sub-agents:
+
+```ts
+import {createModelToolCallRepair} from '@sqlrooms/ai-core';
+
+new ToolLoopAgent({
+  model,
+  tools,
+  experimental_repairToolCall: createModelToolCallRepair(model),
+});
+```
+
+`createModelToolCallRepair(model, {maxRepairsPerTool})` never recurses into
+itself, never triggers tool side effects, leaves the outer step limit untouched,
+and stops after `maxRepairsPerTool` (default `2`) failures for the same tool so a
+persistently-invalid call cannot fan out into unbounded repair requests.
+
 Assistant messages can be forked into a new active chat through
 `ai.forkSessionFromMessage()`. The action snapshots the source session's
 `uiMessages` through the selected message or chat turn, inherits the source

--- a/packages/ai-core/README.md
+++ b/packages/ai-core/README.md
@@ -667,11 +667,13 @@ tools they execute server-side.
 
 When the model emits tool-call arguments that fail the tool's input schema, the
 AI SDK aborts the run with an opaque `InvalidToolInputError`. The local chat
-transport heals this by default: it re-asks the model to correct the call
-(forcing a fresh call to the same tool, without running the tool's side
-effects) instead of failing the run. Each repair costs one extra LLM request, so
-apps that want to trade that resilience away can opt out — either through
-`createAiSlice` or directly on the transport factory:
+transport attempts to heal this by default: it re-asks the model to correct the
+call (forcing a fresh call to the same tool, without running the tool's side
+effects). Repair is best-effort — if it fails, hits its per-tool limit, or
+produces no corrected call, the original `InvalidToolInputError` still surfaces.
+Each repair costs one extra LLM request, so apps that want to trade that
+resilience away can opt out — either through `createAiSlice` or directly on the
+transport factory:
 
 ```ts
 createAiSlice({

--- a/packages/ai-core/__tests__/createModelToolCallRepair.test.ts
+++ b/packages/ai-core/__tests__/createModelToolCallRepair.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Unit tests for the tool-call repair handler. Only `generateText` is stubbed
+ * (the rest of `ai` — including `NoSuchToolError` — stays real), so the test
+ * drives the re-ask logic without issuing a real model request.
+ */
+import {jest} from '@jest/globals';
+
+const actualAi = await import('ai');
+
+const generateText = jest.fn();
+
+jest.unstable_mockModule('ai', () => ({
+  ...actualAi,
+  generateText,
+}));
+
+const {NoSuchToolError} = actualAi;
+const {createModelToolCallRepair} =
+  await import('../src/agents/createModelToolCallRepair');
+
+const TOOL_NAME = 'create_block_document_chart_scatter_plot';
+
+function makeArgs(overrides: Record<string, unknown> = {}) {
+  return {
+    toolCall: {
+      type: 'tool-call' as const,
+      toolCallId: 'call-1',
+      toolName: TOOL_NAME,
+      input: '{"settings":{"x":"Depth","y":"Magnitude","size":null}}',
+    },
+    tools: {
+      [TOOL_NAME]: {
+        inputSchema: {},
+        execute: jest.fn(),
+        onInputAvailable: jest.fn(),
+      },
+    },
+    error: new Error('Type validation failed: aggregate'),
+    system: undefined,
+    messages: [],
+    ...overrides,
+  } as never;
+}
+
+describe('createModelToolCallRepair', () => {
+  beforeEach(() => {
+    generateText.mockReset();
+    generateText.mockResolvedValue({
+      toolCalls: [
+        {toolName: TOOL_NAME, input: {settings: {x: 'Depth', y: 'Magnitude'}}},
+      ],
+      totalUsage: {inputTokens: 10, outputTokens: 5, totalTokens: 15},
+    } as never);
+  });
+
+  it('re-asks the model and returns the corrected call as a JSON-string input', async () => {
+    const repair = createModelToolCallRepair('fake-model' as never);
+
+    const result = await repair(makeArgs());
+
+    expect(generateText).toHaveBeenCalledTimes(1);
+    const opts = generateText.mock.calls[0][0] as Record<string, any>;
+    // Repair forces a fresh call to the SAME tool.
+    expect(opts.toolChoice).toEqual({type: 'tool', toolName: TOOL_NAME});
+    expect(result).toEqual({
+      type: 'tool-call',
+      toolCallId: 'call-1',
+      toolName: TOOL_NAME,
+      input: JSON.stringify({settings: {x: 'Depth', y: 'Magnitude'}}),
+    });
+  });
+
+  it('passes the failing tool as a schema-only definition (no execute or input-lifecycle callbacks)', async () => {
+    const repair = createModelToolCallRepair('fake-model' as never);
+
+    await repair(makeArgs());
+
+    const opts = generateText.mock.calls[0][0] as Record<string, any>;
+    const repairTool = opts.tools[TOOL_NAME];
+    expect(repairTool.execute).toBeUndefined();
+    expect(repairTool.onInputAvailable).toBeUndefined();
+    expect(repairTool.onInputStart).toBeUndefined();
+    expect(repairTool.needsApproval).toBeUndefined();
+  });
+
+  it('forwards abortSignal and providerOptions to the repair request', async () => {
+    const abortSignal = new AbortController().signal;
+    const providerOptions = {openai: {reasoningEffort: 'low'}};
+    const repair = createModelToolCallRepair('fake-model' as never, {
+      abortSignal,
+      providerOptions: providerOptions as never,
+    });
+
+    await repair(makeArgs());
+
+    const opts = generateText.mock.calls[0][0] as Record<string, any>;
+    expect(opts.abortSignal).toBe(abortSignal);
+    expect(opts.providerOptions).toEqual(providerOptions);
+  });
+
+  it('reports repair token usage through onRepairUsage', async () => {
+    const onRepairUsage = jest.fn();
+    const repair = createModelToolCallRepair('fake-model' as never, {
+      onRepairUsage: onRepairUsage as never,
+    });
+
+    await repair(makeArgs());
+
+    expect(onRepairUsage).toHaveBeenCalledWith({
+      inputTokens: 10,
+      outputTokens: 5,
+      totalTokens: 15,
+    });
+  });
+
+  it('does not attempt to repair an unknown tool name', async () => {
+    const repair = createModelToolCallRepair('fake-model' as never);
+
+    const result = await repair(
+      makeArgs({error: new NoSuchToolError({toolName: 'nope'} as never)}),
+    );
+
+    expect(result).toBeNull();
+    expect(generateText).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the tool is not in the tool set', async () => {
+    const repair = createModelToolCallRepair('fake-model' as never);
+
+    const result = await repair(makeArgs({tools: {}}));
+
+    expect(result).toBeNull();
+    expect(generateText).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the re-ask produces no corrected call', async () => {
+    generateText.mockResolvedValueOnce({
+      toolCalls: [],
+      totalUsage: {inputTokens: 3, outputTokens: 0, totalTokens: 3},
+    } as never);
+    const repair = createModelToolCallRepair('fake-model' as never);
+
+    expect(await repair(makeArgs())).toBeNull();
+  });
+
+  it('still accounts usage when the repair produced no corrected call', async () => {
+    generateText.mockResolvedValueOnce({
+      toolCalls: [],
+      totalUsage: {inputTokens: 3, outputTokens: 0, totalTokens: 3},
+    } as never);
+    const onRepairUsage = jest.fn();
+    const repair = createModelToolCallRepair('fake-model' as never, {
+      onRepairUsage: onRepairUsage as never,
+    });
+
+    await repair(makeArgs());
+
+    expect(onRepairUsage).toHaveBeenCalledWith({
+      inputTokens: 3,
+      outputTokens: 0,
+      totalTokens: 3,
+    });
+  });
+
+  it('surfaces the original error (returns null) when the repair request throws', async () => {
+    generateText.mockRejectedValueOnce(new Error('provider down') as never);
+    const repair = createModelToolCallRepair('fake-model' as never);
+
+    expect(await repair(makeArgs())).toBeNull();
+  });
+
+  it('stops repairing the same tool after the per-tool cap and stops calling the model', async () => {
+    const repair = createModelToolCallRepair('fake-model' as never, {
+      maxRepairsPerTool: 2,
+    });
+
+    // First two failures for the same tool are repaired...
+    expect(await repair(makeArgs())).not.toBeNull();
+    expect(await repair(makeArgs())).not.toBeNull();
+    expect(generateText).toHaveBeenCalledTimes(2);
+
+    // ...the third gives up without another repair sub-request.
+    expect(await repair(makeArgs())).toBeNull();
+    expect(generateText).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/ai-core/__tests__/createModelToolCallRepair.test.ts
+++ b/packages/ai-core/__tests__/createModelToolCallRepair.test.ts
@@ -113,6 +113,27 @@ describe('createModelToolCallRepair', () => {
     });
   });
 
+  it('still returns the corrected call when onRepairUsage throws', async () => {
+    const onRepairUsage = jest.fn(() => {
+      throw new Error('accounting blew up');
+    });
+    const repair = createModelToolCallRepair('fake-model' as never, {
+      onRepairUsage: onRepairUsage as never,
+    });
+
+    // A throwing usage callback must not discard the valid repair nor let the
+    // original validation error resurface.
+    const result = await repair(makeArgs());
+
+    expect(onRepairUsage).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      type: 'tool-call',
+      toolCallId: 'call-1',
+      toolName: TOOL_NAME,
+      input: JSON.stringify({settings: {x: 'Depth', y: 'Magnitude'}}),
+    });
+  });
+
   it('does not attempt to repair an unknown tool name', async () => {
     const repair = createModelToolCallRepair('fake-model' as never);
 

--- a/packages/ai-core/src/AiSlice.ts
+++ b/packages/ai-core/src/AiSlice.ts
@@ -382,6 +382,13 @@ export interface AiSliceOptions<TTools extends ToolSet = ToolSet> {
    * These are runtime behavior and are not persisted in workspace config.
    */
   timeouts?: AiTimeoutOptions;
+  /**
+   * Let the model heal its own invalid tool calls instead of aborting the run
+   * (see `createModelToolCallRepair`). Enabled by default on the local chat
+   * transport. Each repair costs an extra LLM request; set to `false` to trade
+   * that resilience away.
+   */
+  repairInvalidToolCalls?: boolean;
   getApiKey?: (modelProvider: string) => string;
   getBaseUrl?: () => string;
   /** Optional remote endpoint to use for chat; if empty, local transport is used */
@@ -469,6 +476,7 @@ export function createAiSlice<TTools extends ToolSet = ToolSet>(
     getAvailableModels,
     getCustomModel,
     getProviderOptions,
+    repairInvalidToolCalls = true,
     chatEndPoint = '',
     chatHeaders = {},
     remoteClientToolNames = [],
@@ -2169,6 +2177,7 @@ export function createAiSlice<TTools extends ToolSet = ToolSet>(
             getCustomModel,
             sessionId,
             timeouts,
+            repairInvalidToolCalls,
           })();
         },
 

--- a/packages/ai-core/src/agents/createModelToolCallRepair.ts
+++ b/packages/ai-core/src/agents/createModelToolCallRepair.ts
@@ -1,0 +1,165 @@
+import {
+  generateText,
+  NoSuchToolError,
+  type LanguageModel,
+  type ToolCallRepairFunction,
+  type ToolSet,
+} from 'ai';
+
+/**
+ * How many times a single tool may be repaired within one agent run before the
+ * repair handler gives up and lets the original error surface. A model that
+ * keeps emitting the same invalid call should not spend an unbounded number of
+ * extra LLM requests trying to heal it.
+ */
+export const DEFAULT_MAX_REPAIRS_PER_TOOL = 2;
+
+export type ModelToolCallRepairOptions = {
+  /**
+   * Cap on repair attempts per tool name within the returned handler's lifetime
+   * (one agent run). Defaults to {@link DEFAULT_MAX_REPAIRS_PER_TOOL}.
+   */
+  maxRepairsPerTool?: number;
+};
+
+/**
+ * Builds an `experimental_repairToolCall` handler that lets a model heal its own
+ * invalid tool calls instead of crashing the (sub-)agent run.
+ *
+ * When the model emits tool-call arguments that fail the tool's input schema,
+ * the AI SDK raises `InvalidToolInputError`. Without a repair handler that error
+ * aborts the whole (sub-)agent with an opaque failure. This handler re-asks
+ * `model` to fix the call: it replays the conversation with the failed tool call
+ * and the validation error appended, forcing a fresh call to the SAME tool via
+ * `toolChoice`. Normal tool calling is used (not structured output) because some
+ * OpenAI-compatible endpoints — including Anthropic-via-LiteLLM proxies — do not
+ * support the JSON response-format schema that structured output requires.
+ *
+ * Boundaries that keep repair safe when enabled by default:
+ * - The repair sub-request is a plain `generateText` with NO repair handler of
+ *   its own, so repair never recurses into repair.
+ * - The failing tool is passed WITHOUT its `execute`, so regenerating the call
+ *   only produces arguments and never triggers the tool's side effects.
+ * - Repairs are capped per tool ({@link ModelToolCallRepairOptions.maxRepairsPerTool}),
+ *   so a persistently-failing tool cannot spend unbounded extra LLM requests.
+ * - The outer agent's own step limit is untouched; repair does not add steps.
+ *
+ * Unknown-tool errors, a missing tool, exceeding the per-tool cap, no
+ * regenerated call, or any failure of the repair request return `null`, letting
+ * the original error surface.
+ *
+ * @param model - Model used for the repair sub-request (typically the same model
+ *   the agent runs on).
+ * @param options - Optional tuning; see {@link ModelToolCallRepairOptions}.
+ */
+export function createModelToolCallRepair(
+  model: LanguageModel,
+  options?: ModelToolCallRepairOptions,
+): ToolCallRepairFunction<ToolSet> {
+  const maxRepairsPerTool =
+    options?.maxRepairsPerTool ?? DEFAULT_MAX_REPAIRS_PER_TOOL;
+  // Per-tool attempt counter for the lifetime of this handler (one agent run).
+  const repairsByTool = new Map<string, number>();
+
+  return async ({toolCall, tools, error, system, messages}) => {
+    // A wrong tool NAME cannot be fixed by correcting arguments.
+    if (NoSuchToolError.isInstance(error)) return null;
+
+    const tool = tools[toolCall.toolName];
+    if (!tool) return null;
+
+    // Stop repairing a tool that keeps failing, so one bad call cannot fan out
+    // into an unbounded series of repair sub-requests.
+    const priorRepairs = repairsByTool.get(toolCall.toolName) ?? 0;
+    if (priorRepairs >= maxRepairsPerTool) {
+      console.warn(
+        `[repairToolCall] giving up on "${toolCall.toolName}" after ${priorRepairs} repair attempt(s)`,
+      );
+      return null;
+    }
+    repairsByTool.set(toolCall.toolName, priorRepairs + 1);
+
+    // Diagnostic: an invalid tool call reached the repair path. The raw model
+    // arguments and validation error go to the console (not the parent model).
+    console.warn(
+      `[repairToolCall] repairing invalid call to "${toolCall.toolName}": ${error.message}`,
+    );
+
+    // `toolCall.input` is a JSON string; the assistant tool-call message part
+    // expects the parsed object (providers reject a raw string here). Schema
+    // validation, not JSON parsing, is what failed, so it still parses.
+    let failedInput: unknown;
+    try {
+      failedInput =
+        typeof toolCall.input === 'string'
+          ? JSON.parse(toolCall.input)
+          : toolCall.input;
+    } catch {
+      failedInput = {};
+    }
+
+    try {
+      const result = await generateText({
+        model,
+        system,
+        // Only the failing tool, and stripped of `execute` so regenerating the
+        // call cannot run the tool's side effects.
+        tools: {[toolCall.toolName]: {...tool, execute: undefined}},
+        toolChoice: {type: 'tool', toolName: toolCall.toolName},
+        messages: [
+          ...messages,
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: toolCall.toolCallId,
+                toolName: toolCall.toolName,
+                input: failedInput,
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: toolCall.toolCallId,
+                toolName: toolCall.toolName,
+                output: {
+                  type: 'error-text',
+                  value: `Your arguments failed schema validation and must be corrected: ${error.message}. Re-call the tool with corrected arguments that satisfy the schema and preserve the original intent.`,
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      const fixed = result.toolCalls.find(
+        (call) => call.toolName === toolCall.toolName,
+      );
+      if (!fixed) {
+        console.warn(
+          `[repairToolCall] repair of "${toolCall.toolName}" produced no corrected call`,
+        );
+        return null;
+      }
+
+      console.warn(
+        `[repairToolCall] repaired "${toolCall.toolName}" -> ${JSON.stringify(fixed.input)}`,
+      );
+      return {...toolCall, input: JSON.stringify(fixed.input)};
+    } catch (repairError) {
+      // Repair is best-effort: on failure, let the original error surface.
+      console.warn(
+        `[repairToolCall] repair of "${toolCall.toolName}" failed: ${
+          repairError instanceof Error
+            ? repairError.message
+            : String(repairError)
+        }`,
+      );
+      return null;
+    }
+  };
+}

--- a/packages/ai-core/src/agents/createModelToolCallRepair.ts
+++ b/packages/ai-core/src/agents/createModelToolCallRepair.ts
@@ -2,6 +2,7 @@ import {
   generateText,
   NoSuchToolError,
   type LanguageModel,
+  type LanguageModelUsage,
   type ToolCallRepairFunction,
   type ToolSet,
 } from 'ai';
@@ -17,9 +18,28 @@ export const DEFAULT_MAX_REPAIRS_PER_TOOL = 2;
 export type ModelToolCallRepairOptions = {
   /**
    * Cap on repair attempts per tool name within the returned handler's lifetime
-   * (one agent run). Defaults to {@link DEFAULT_MAX_REPAIRS_PER_TOOL}.
+   * (one agent run — see {@link createModelToolCallRepair}). Defaults to
+   * {@link DEFAULT_MAX_REPAIRS_PER_TOOL}.
    */
   maxRepairsPerTool?: number;
+  /**
+   * Abort signal for the repair sub-request. Pass the same signal the outer run
+   * uses so stopping the chat (or a run/idle timeout) also cancels a pending
+   * repair request instead of leaving it running and billable.
+   */
+  abortSignal?: AbortSignal;
+  /**
+   * Provider options for the repair sub-request. Pass the same options the outer
+   * run uses so the repair inherits caching/reasoning/tool-call configuration
+   * rather than falling back to provider defaults.
+   */
+  providerOptions?: Parameters<typeof generateText>[0]['providerOptions'];
+  /**
+   * Called with the token usage of each repair sub-request that runs, so callers
+   * can fold repair cost into the session's reported usage (the outer agent only
+   * accounts for its own steps).
+   */
+  onRepairUsage?: (usage: LanguageModelUsage) => void;
 };
 
 /**
@@ -38,11 +58,19 @@ export type ModelToolCallRepairOptions = {
  * Boundaries that keep repair safe when enabled by default:
  * - The repair sub-request is a plain `generateText` with NO repair handler of
  *   its own, so repair never recurses into repair.
- * - The failing tool is passed WITHOUT its `execute`, so regenerating the call
- *   only produces arguments and never triggers the tool's side effects.
+ * - The failing tool is passed as a schema-only definition (no `execute` and no
+ *   input-lifecycle/approval callbacks), so regenerating the call only produces
+ *   arguments and never triggers the tool's side effects.
  * - Repairs are capped per tool ({@link ModelToolCallRepairOptions.maxRepairsPerTool}),
  *   so a persistently-failing tool cannot spend unbounded extra LLM requests.
  * - The outer agent's own step limit is untouched; repair does not add steps.
+ * - The repair sub-request honors {@link ModelToolCallRepairOptions.abortSignal},
+ *   so cancelling the run cancels a pending repair.
+ *
+ * The returned handler is single-run: its per-tool counter lives in the closure,
+ * so construct a fresh handler for each agent run (both first-party call sites —
+ * the local chat transport and Desktop's per-invocation sub-agents — do exactly
+ * that).
  *
  * Unknown-tool errors, a missing tool, exceeding the per-tool cap, no
  * regenerated call, or any failure of the repair request return `null`, letting
@@ -58,6 +86,7 @@ export function createModelToolCallRepair(
 ): ToolCallRepairFunction<ToolSet> {
   const maxRepairsPerTool =
     options?.maxRepairsPerTool ?? DEFAULT_MAX_REPAIRS_PER_TOOL;
+  const {abortSignal, providerOptions, onRepairUsage} = options ?? {};
   // Per-tool attempt counter for the lifetime of this handler (one agent run).
   const repairsByTool = new Map<string, number>();
 
@@ -79,10 +108,11 @@ export function createModelToolCallRepair(
     }
     repairsByTool.set(toolCall.toolName, priorRepairs + 1);
 
-    // Diagnostic: an invalid tool call reached the repair path. The raw model
-    // arguments and validation error go to the console (not the parent model).
+    // Diagnostic only. Do NOT log the validation error text or the regenerated
+    // arguments: they can carry user data, and the original error still surfaces
+    // to the caller when repair returns null.
     console.warn(
-      `[repairToolCall] repairing invalid call to "${toolCall.toolName}": ${error.message}`,
+      `[repairToolCall] repairing invalid arguments for "${toolCall.toolName}"`,
     );
 
     // `toolCall.input` is a JSON string; the assistant tool-call message part
@@ -98,13 +128,25 @@ export function createModelToolCallRepair(
       failedInput = {};
     }
 
+    // Schema-only copy of the failing tool: no `execute` AND no input-lifecycle
+    // or approval callbacks, so producing the repaired call cannot run any tool
+    // side effects (`onInputAvailable`, approval prompts, etc.).
+    const schemaOnlyTool = {
+      ...tool,
+      execute: undefined,
+      onInputStart: undefined,
+      onInputDelta: undefined,
+      onInputAvailable: undefined,
+      needsApproval: undefined,
+    };
+
     try {
       const result = await generateText({
         model,
         system,
-        // Only the failing tool, and stripped of `execute` so regenerating the
-        // call cannot run the tool's side effects.
-        tools: {[toolCall.toolName]: {...tool, execute: undefined}},
+        abortSignal,
+        ...(providerOptions ? {providerOptions} : {}),
+        tools: {[toolCall.toolName]: schemaOnlyTool},
         toolChoice: {type: 'tool', toolName: toolCall.toolName},
         messages: [
           ...messages,
@@ -136,6 +178,10 @@ export function createModelToolCallRepair(
         ],
       });
 
+      // Account for the repair request's tokens even if it produced no usable
+      // call, so session usage does not undercount repaired turns.
+      if (result.totalUsage) onRepairUsage?.(result.totalUsage);
+
       const fixed = result.toolCalls.find(
         (call) => call.toolName === toolCall.toolName,
       );
@@ -146,18 +192,13 @@ export function createModelToolCallRepair(
         return null;
       }
 
-      console.warn(
-        `[repairToolCall] repaired "${toolCall.toolName}" -> ${JSON.stringify(fixed.input)}`,
-      );
+      console.warn(`[repairToolCall] repaired "${toolCall.toolName}"`);
       return {...toolCall, input: JSON.stringify(fixed.input)};
-    } catch (repairError) {
-      // Repair is best-effort: on failure, let the original error surface.
+    } catch {
+      // Repair is best-effort: on failure, let the original error surface. The
+      // repair error itself is intentionally not logged (it may carry payloads).
       console.warn(
-        `[repairToolCall] repair of "${toolCall.toolName}" failed: ${
-          repairError instanceof Error
-            ? repairError.message
-            : String(repairError)
-        }`,
+        `[repairToolCall] repair request for "${toolCall.toolName}" failed`,
       );
       return null;
     }

--- a/packages/ai-core/src/agents/createModelToolCallRepair.ts
+++ b/packages/ai-core/src/agents/createModelToolCallRepair.ts
@@ -179,8 +179,18 @@ export function createModelToolCallRepair(
       });
 
       // Account for the repair request's tokens even if it produced no usable
-      // call, so session usage does not undercount repaired turns.
-      if (result.totalUsage) onRepairUsage?.(result.totalUsage);
+      // call, so session usage does not undercount repaired turns. Isolated from
+      // the repair boundary: a throwing caller callback must NOT discard an
+      // otherwise-valid repaired call or swallow the original error.
+      if (result.totalUsage && onRepairUsage) {
+        try {
+          onRepairUsage(result.totalUsage);
+        } catch {
+          console.warn(
+            `[repairToolCall] onRepairUsage callback threw for "${toolCall.toolName}"`,
+          );
+        }
+      }
 
       const fixed = result.toolCalls.find(
         (call) => call.toolName === toolCall.toolName,

--- a/packages/ai-core/src/chatTransport.ts
+++ b/packages/ai-core/src/chatTransport.ts
@@ -305,8 +305,7 @@ export function withRunContextTools(
             const timeoutController =
               timeoutMs == null ? undefined : new AbortController();
             const incomingAbortSignal = options?.abortSignal as
-              | AbortSignal
-              | undefined;
+              AbortSignal | undefined;
             const abortSignal = mergeAbortSignals([
               incomingAbortSignal,
               timeoutController?.signal,
@@ -608,17 +607,36 @@ export function createLocalChatTransportFactory({
       const diagnosticsByStep: string[] = [];
       let completedDiagnosticStep = 0;
 
+      // Tokens spent by tool-call repair sub-requests. The outer agent only
+      // reports its own steps, so these are folded into the final usage below.
+      const repairUsage: MessageTokenUsage = {
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+      };
+
       const agent = new ToolLoopAgent({
         model,
         instructions: systemInstructions,
         tools,
         stopWhen: stepCountIs(maxSteps),
         // Heal invalid tool calls instead of aborting the run. Uses the same
-        // `model` resolved above so the repair request matches this run's
-        // configuration. Repair never recurses (its sub-request has no repair
-        // handler) and does not consume the agent's step budget.
+        // `model`, `abortSignal`, and `providerOptions` resolved above so the
+        // repair request matches this run's configuration and is cancelled with
+        // it. Repair never recurses (its sub-request has no repair handler) and
+        // does not consume the agent's step budget.
         ...(repairInvalidToolCalls
-          ? {experimental_repairToolCall: createModelToolCallRepair(model)}
+          ? {
+              experimental_repairToolCall: createModelToolCallRepair(model, {
+                abortSignal,
+                providerOptions,
+                onRepairUsage: (usage) => {
+                  repairUsage.inputTokens += usage.inputTokens ?? 0;
+                  repairUsage.outputTokens += usage.outputTokens ?? 0;
+                  repairUsage.totalTokens += usage.totalTokens ?? 0;
+                },
+              }),
+            }
           : {}),
         prepareStep: async ({stepNumber, messages}) => {
           const providerMessages = usesOpenAiCompatibleModel
@@ -725,6 +743,11 @@ export function createLocalChatTransportFactory({
               finishUsage.outputTokens > 0
                 ? finishUsage
                 : accumulatedUsage;
+            // Fold in tokens spent by tool-call repair sub-requests, which the
+            // agent's own usage does not include.
+            finalUsage.inputTokens += repairUsage.inputTokens;
+            finalUsage.outputTokens += repairUsage.outputTokens;
+            finalUsage.totalTokens += repairUsage.totalTokens;
             finalUsage.lastStepInputTokens = lastStepInputTokens;
             rememberSessionTokenUsage(sessionId, finalUsage);
             return {

--- a/packages/ai-core/src/chatTransport.ts
+++ b/packages/ai-core/src/chatTransport.ts
@@ -42,6 +42,7 @@ import {
   shouldEndAnalysis,
 } from './utils';
 import {formatAbortSnapshot} from './agents/AgentUtils';
+import {createModelToolCallRepair} from './agents/createModelToolCallRepair';
 import {
   ChatTimeoutError,
   createToolTimeoutError,
@@ -224,6 +225,12 @@ export type ChatTransportConfig = {
   getCustomModel?: () => LanguageModel | undefined;
   /** Optional timeout safety limits; all limits are disabled when omitted. */
   timeouts?: AiTimeoutOptions;
+  /**
+   * Let the model heal its own invalid tool calls instead of aborting the run
+   * (see {@link createModelToolCallRepair}). Enabled by default. Each repair
+   * costs an extra LLM request; set to `false` to trade that resilience away.
+   */
+  repairInvalidToolCalls?: boolean;
 };
 
 function getSessionById(
@@ -511,6 +518,7 @@ export function createLocalChatTransportFactory({
   getInstructions,
   getCustomModel,
   timeouts,
+  repairInvalidToolCalls = true,
 }: ChatTransportConfig) {
   return () => {
     const fetchImpl = async (_input: RequestInfo | URL, init?: RequestInit) => {
@@ -605,6 +613,13 @@ export function createLocalChatTransportFactory({
         instructions: systemInstructions,
         tools,
         stopWhen: stepCountIs(maxSteps),
+        // Heal invalid tool calls instead of aborting the run. Uses the same
+        // `model` resolved above so the repair request matches this run's
+        // configuration. Repair never recurses (its sub-request has no repair
+        // handler) and does not consume the agent's step budget.
+        ...(repairInvalidToolCalls
+          ? {experimental_repairToolCall: createModelToolCallRepair(model)}
+          : {}),
         prepareStep: async ({stepNumber, messages}) => {
           const providerMessages = usesOpenAiCompatibleModel
             ? prepareOpenAiCompatibleToolImages(messages)

--- a/packages/ai-core/src/chatTransport.ts
+++ b/packages/ai-core/src/chatTransport.ts
@@ -305,7 +305,8 @@ export function withRunContextTools(
             const timeoutController =
               timeoutMs == null ? undefined : new AbortController();
             const incomingAbortSignal = options?.abortSignal as
-              AbortSignal | undefined;
+              | AbortSignal
+              | undefined;
             const abortSignal = mergeAbortSignals([
               incomingAbortSignal,
               timeoutController?.signal,

--- a/packages/ai-core/src/index.ts
+++ b/packages/ai-core/src/index.ts
@@ -268,6 +268,11 @@ export {
   getSubAgentErrorMessage,
   SUB_AGENT_ERROR_MESSAGE,
 } from './agents/AgentUtils';
+export {
+  createModelToolCallRepair,
+  DEFAULT_MAX_REPAIRS_PER_TOOL,
+} from './agents/createModelToolCallRepair';
+export type {ModelToolCallRepairOptions} from './agents/createModelToolCallRepair';
 export type {
   AgentStreamOutput,
   AgentToolCall,

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -438,6 +438,31 @@ tools update the effective primary context with `setPrimaryRunContextItem`.
 Old contexts without `primaryItemId` remain valid; the first item is treated as
 primary. Artifact-specific context tools live in `@sqlrooms/artifacts/ai`.
 
+## Tool-call repair
+
+When the model emits tool-call arguments that fail a tool's input schema, the AI
+SDK aborts the run with an opaque `InvalidToolInputError`. The local chat
+transport heals this by default: it re-asks the model to correct the call
+(forcing a fresh call to the same tool, without running the tool's side effects)
+instead of failing the run. Each repair costs one extra LLM request, so apps can
+opt out via `createAiSlice`:
+
+```ts
+createAiSlice({
+  tools,
+  getInstructions,
+  repairInvalidToolCalls: false, // default: true
+})(set, get, store);
+```
+
+The underlying helper `createModelToolCallRepair` is re-exported for hosts that
+build their own `ToolLoopAgent` sub-agents (pass the same `model`, and optionally
+`abortSignal`, `providerOptions`, and an `onRepairUsage` callback so repair
+inherits the run's configuration, is cancelled with it, and its tokens are
+accounted). It never recurses, never triggers tool side effects, caps repairs
+per tool (`maxRepairsPerTool`, default `2`), and never logs user data. See the
+[`@sqlrooms/ai-core` README](../ai-core/README.md#tool-call-repair) for details.
+
 ## Use remote endpoint mode
 
 If you want server-side model calls, set `chatEndPoint` and optional `chatHeaders`:

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -442,10 +442,11 @@ primary. Artifact-specific context tools live in `@sqlrooms/artifacts/ai`.
 
 When the model emits tool-call arguments that fail a tool's input schema, the AI
 SDK aborts the run with an opaque `InvalidToolInputError`. The local chat
-transport heals this by default: it re-asks the model to correct the call
-(forcing a fresh call to the same tool, without running the tool's side effects)
-instead of failing the run. Each repair costs one extra LLM request, so apps can
-opt out via `createAiSlice`:
+transport attempts to heal this by default: it re-asks the model to correct the
+call (forcing a fresh call to the same tool, without running the tool's side
+effects). Repair is best-effort — if it fails, hits its per-tool limit, or
+produces no corrected call, the original `InvalidToolInputError` still surfaces.
+Each repair costs one extra LLM request, so apps can opt out via `createAiSlice`:
 
 ```ts
 createAiSlice({

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -153,7 +153,10 @@ export {
   streamSubAgent,
   updateAgentToolCallData,
   withRunContextTools,
+  createModelToolCallRepair,
+  DEFAULT_MAX_REPAIRS_PER_TOOL,
 } from '@sqlrooms/ai-core';
+export type {ModelToolCallRepairOptions} from '@sqlrooms/ai-core';
 export {
   getEffectiveSessionContextItemIds,
   getRunContextItemIds,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Invalid tool-call arguments are automatically repaired by default through an additional model request.
  * Added an option to disable automatic tool-call repair.
  * Added per-tool repair limits and a helper for custom repair workflows with cancellation and provider options.
  * Repair token usage is included in reported usage totals.
  * Repair remains best-effort; the original error is reported if correction fails or reaches its limit.

* **Documentation**
  * Clarified repair behavior, configuration, limits, usage reporting, and privacy safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->